### PR TITLE
Harden logfire evals parity and runtime support

### DIFF
--- a/.changeset/evals-port.md
+++ b/.changeset/evals-port.md
@@ -1,12 +1,14 @@
 ---
 'logfire': minor
+'@pydantic/logfire-browser': minor
+'@pydantic/logfire-cf-workers': minor
 '@pydantic/logfire-node': minor
 ---
 
 Add evals support — offline + online evaluations.
 
-A new `logfire/evals` (and `@pydantic/logfire-node/evals`) subpath exports `Dataset`, `Case`, `Evaluator`, built-in evaluators (`Equals`, `EqualsExpected`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, `LLMJudge`), report-level evaluators (`ConfusionMatrixEvaluator`, `PrecisionRecallEvaluator`, `ROCAUCEvaluator`, `KolmogorovSmirnovEvaluator`), and `withOnlineEvaluation` for runtime monitoring.
+A new `logfire/evals` subpath, re-exported by `@pydantic/logfire-node/evals`, `@pydantic/logfire-browser/evals`, and `@pydantic/logfire-cf-workers/evals`, exports `Dataset`, `Case`, `Evaluator`, built-in evaluators (`Equals`, `EqualsExpected`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, `LLMJudge`), report-level evaluators (`ConfusionMatrixEvaluator`, `PrecisionRecallEvaluator`, `ROCAUCEvaluator`, `KolmogorovSmirnovEvaluator`), and `withOnlineEvaluation` for runtime monitoring.
 
-Emitted OTel spans and log events are wire-compatible with the Python `pydantic-evals` package, so experiments, cases, and live evaluations show up automatically in the Logfire web UI without any additional configuration. Datasets serialize to / deserialize from the same YAML and JSON format Python uses (`Dataset.toFile` / `Dataset.fromFile`, `Dataset.jsonSchema()`).
+Emitted OTel spans, log events, and report analyses are wire-compatible with the Python `pydantic-evals` package, so experiments, cases, report-level charts, and live evaluations show up automatically in the Logfire web UI without any additional configuration. Datasets serialize to / deserialize from the same YAML and JSON format Python uses (`Dataset.toFile` / `Dataset.fromFile`, `Dataset.jsonSchema()`), with filesystem helpers supported in Node, Bun, and Deno.
 
 `logfire.configure()` now auto-installs the evals span-tree processor; users on a custom `TracerProvider` can install it manually with `getEvalsSpanProcessor()` from `logfire/evals`.

--- a/.changeset/evals-port.md
+++ b/.changeset/evals-port.md
@@ -1,13 +1,11 @@
 ---
 'logfire': minor
-'@pydantic/logfire-browser': minor
-'@pydantic/logfire-cf-workers': minor
 '@pydantic/logfire-node': minor
 ---
 
 Add evals support — offline + online evaluations.
 
-A new `logfire/evals` subpath, re-exported by `@pydantic/logfire-node/evals`, `@pydantic/logfire-browser/evals`, and `@pydantic/logfire-cf-workers/evals`, exports `Dataset`, `Case`, `Evaluator`, built-in evaluators (`Equals`, `EqualsExpected`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, `LLMJudge`), report-level evaluators (`ConfusionMatrixEvaluator`, `PrecisionRecallEvaluator`, `ROCAUCEvaluator`, `KolmogorovSmirnovEvaluator`), and `withOnlineEvaluation` for runtime monitoring.
+A new `logfire/evals` subpath exports `Dataset`, `Case`, `Evaluator`, built-in evaluators (`Equals`, `EqualsExpected`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, `LLMJudge`), report-level evaluators (`ConfusionMatrixEvaluator`, `PrecisionRecallEvaluator`, `ROCAUCEvaluator`, `KolmogorovSmirnovEvaluator`), and `withOnlineEvaluation` for runtime monitoring.
 
 Emitted OTel spans, log events, and report analyses are wire-compatible with the Python `pydantic-evals` package, so experiments, cases, report-level charts, and live evaluations show up automatically in the Logfire web UI without any additional configuration. Datasets serialize to / deserialize from the same YAML and JSON format Python uses (`Dataset.toFile` / `Dataset.fromFile`, `Dataset.jsonSchema()`), with filesystem helpers supported in Node, Bun, and Deno.
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 packages/*/*.tgz
+coverage
+packages/*/coverage
 .env
 scratch/
 **/.turbo

--- a/README.md
+++ b/README.md
@@ -262,9 +262,8 @@ from your code.
 ## Evaluations
 
 The `logfire/evals` subpath provides offline datasets and online evaluation
-wrappers that emit Logfire-compatible OpenTelemetry spans and log events. Node
-users can also import the same API from `@pydantic/logfire-node/evals`; browser
-and Cloudflare Worker packages re-export it from their own `/evals` subpaths.
+wrappers that emit Logfire-compatible OpenTelemetry spans and log events. Add
+`logfire` as a direct dependency in projects that import this subpath.
 
 ```ts
 import { Case, Dataset, Equals, EqualsExpected, withOnlineEvaluation } from 'logfire/evals'

--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ Cloudflare Worker usage is limited to in-memory datasets and online evaluation;
 browser offline runs should keep `maxConcurrency: 1` because there is no
 `AsyncLocalStorage` equivalent.
 
+Dataset YAML/JSON uses the Python `pydantic-evals` field names for portable
+files, for example `predicted_from`, `expected_from`, and snake_case
+`SpanQuery` keys. Online evaluator `context.inputs` is built from JavaScript
+function parameter names when they can be inspected; pass
+`extractArgs: ['name', ...]` when bundled or minified code needs stable input
+names.
+
 ### Configuring the instrumentation
 
 The `logfire.configure` function accepts a set of configuration options that

--- a/README.md
+++ b/README.md
@@ -259,6 +259,36 @@ Optionally, you can use the Logfire API package for creating manual spans.
 Install the `logfire` NPM package and call the respective methods
 from your code.
 
+## Evaluations
+
+The `logfire/evals` subpath provides offline datasets and online evaluation
+wrappers that emit Logfire-compatible OpenTelemetry spans and log events. Node
+users can also import the same API from `@pydantic/logfire-node/evals`; browser
+and Cloudflare Worker packages re-export it from their own `/evals` subpaths.
+
+```ts
+import { Case, Dataset, Equals, EqualsExpected, withOnlineEvaluation } from 'logfire/evals'
+
+const dataset = new Dataset<{ text: string }, string>({
+  cases: [new Case({ expectedOutput: 'HELLO', inputs: { text: 'hello' }, name: 'hello' })],
+  evaluators: [new EqualsExpected()],
+  name: 'uppercase',
+})
+
+await dataset.evaluate(({ text }) => text.toUpperCase())
+
+const monitored = withOnlineEvaluation(async (text: string) => text.toUpperCase(), {
+  evaluators: [new Equals({ value: 'HELLO' })],
+  target: 'uppercase',
+})
+await monitored('hello')
+```
+
+Dataset file helpers are available in Node, Bun, and Deno. Browser and
+Cloudflare Worker usage is limited to in-memory datasets and online evaluation;
+browser offline runs should keep `maxConcurrency: 1` because there is no
+`AsyncLocalStorage` equivalent.
+
 ### Configuring the instrumentation
 
 The `logfire.configure` function accepts a set of configuration options that

--- a/examples/node/demo_evals.ts
+++ b/examples/node/demo_evals.ts
@@ -32,7 +32,7 @@ import {
   registerEvaluator,
   renderReport,
   setDefaultJudge,
-} from '@pydantic/logfire-node/evals'
+} from 'logfire/evals'
 
 logfire.configure({
   advanced: { baseUrl: process.env.LOGFIRE_BASE_URL ?? 'http://localhost:3000' },

--- a/examples/node/demo_evals.ts
+++ b/examples/node/demo_evals.ts
@@ -1,6 +1,4 @@
 /**
- * TypeScript port of `platform/src/demos/logfire_demo/demo_evals.py`.
- *
  * Loads the same `time_range_v1.yaml` dataset Python uses, runs a stub
  * time-range "agent" against it (no model calls — we don't have pydantic-ai-js),
  * and emits experiment + case + evaluator spans against the local Logfire

--- a/examples/node/demo_online_evals.ts
+++ b/examples/node/demo_online_evals.ts
@@ -15,13 +15,7 @@
  */
 
 import * as logfire from '@pydantic/logfire-node'
-import {
-  Evaluator,
-  type EvaluatorContext,
-  type EvaluatorOutput,
-  waitForEvaluations,
-  withOnlineEvaluation,
-} from '@pydantic/logfire-node/evals'
+import { Evaluator, type EvaluatorContext, type EvaluatorOutput, waitForEvaluations, withOnlineEvaluation } from 'logfire/evals'
 
 logfire.configure({
   advanced: { baseUrl: process.env.LOGFIRE_BASE_URL ?? 'http://localhost:3000' },

--- a/examples/node/demo_online_evals.ts
+++ b/examples/node/demo_online_evals.ts
@@ -1,6 +1,4 @@
 /**
- * TypeScript port of `platform/scripts/demo_online_evals.py`.
- *
  * Wraps a stub "agent" function with `withOnlineEvaluation` and emits a
  * mixture of bool / float / string / failing evaluator outputs so the
  * `gen_ai.evaluation.result` log stream exercises every encoding shape the

--- a/examples/node/evals.ts
+++ b/examples/node/evals.ts
@@ -13,15 +13,7 @@
 
 import 'dotenv/config'
 import * as logfire from '@pydantic/logfire-node'
-import {
-  Case,
-  Contains,
-  Dataset,
-  EqualsExpected,
-  renderReport,
-  waitForEvaluations,
-  withOnlineEvaluation,
-} from '@pydantic/logfire-node/evals'
+import { Case, Contains, Dataset, EqualsExpected, renderReport, waitForEvaluations, withOnlineEvaluation } from 'logfire/evals'
 
 logfire.configure({
   console: false,

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -20,7 +20,8 @@
   "description": "",
   "dependencies": {
     "@pydantic/logfire-node": "workspace:*",
-    "dotenv": "^16.4.7"
+    "dotenv": "^16.4.7",
+    "logfire": "workspace:*"
   },
   "devDependencies": {
     "@opentelemetry/semantic-conventions": "catalog:",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@changesets/cli": "^2.27.12",
     "@eslint/js": "^9.22.0",
     "@typescript-eslint/utils": "^8.26.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-perfectionist": "^4.10.1",

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -26,3 +26,8 @@ const report = await dataset.evaluate(({ text }) => text.toUpperCase())
 `Dataset.toFile` / `Dataset.fromFile` are available in Node, Bun, and Deno.
 Browser and Cloudflare Worker runtimes can use in-memory datasets and online
 evaluation, but not filesystem-backed dataset helpers.
+
+Serialized datasets use Python-compatible snake_case evaluator options and
+span queries. For online evaluation, JavaScript parameter-name extraction is
+best effort; use `extractArgs: ['argName']` when evaluator code needs stable
+`context.inputs` keys in bundled or minified builds.

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -3,3 +3,26 @@
 From the team behind [Pydantic Validation](https://pydantic.dev/), **Pydantic Logfire** is an observability platform built on the same belief as our open source library — that the most powerful tools can be easy to use.
 
 Check the [Github Repository README](https://github.com/pydantic/logfire-js) for more information on how to use the SDK.
+
+## Evaluations
+
+`logfire/evals` exports the JavaScript evaluation API: offline `Dataset`
+experiments, built-in case evaluators, report-level analyses, and
+`withOnlineEvaluation` for live monitoring. The emitted span/log wire format and
+dataset YAML/JSON format match Python `pydantic-evals`.
+
+```ts
+import { Case, Dataset, EqualsExpected } from 'logfire/evals'
+
+const dataset = new Dataset<{ text: string }, string>({
+  cases: [new Case({ expectedOutput: 'HELLO', inputs: { text: 'hello' }, name: 'hello' })],
+  evaluators: [new EqualsExpected()],
+  name: 'uppercase',
+})
+
+const report = await dataset.evaluate(({ text }) => text.toUpperCase())
+```
+
+`Dataset.toFile` / `Dataset.fromFile` are available in Node, Bun, and Deno.
+Browser and Cloudflare Worker runtimes can use in-memory datasets and online
+evaluation, but not filesystem-backed dataset helpers.

--- a/packages/logfire-api/eslint.config.mjs
+++ b/packages/logfire-api/eslint.config.mjs
@@ -1,6 +1,7 @@
 import baseConfig from '../../eslint-config.mjs'
 
 export default [
+  { ignores: ['coverage/**'] },
   ...baseConfig,
   {
     languageOptions: {

--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -56,6 +56,7 @@
   "scripts": {
     "dev": "vite build",
     "build": "vite build",
+    "coverage:evals": "vitest run src/evals --coverage --coverage.provider=v8 --coverage.include='src/evals/**/*.ts' --coverage.exclude='src/evals/__test__/**' --coverage.exclude='src/evals/**/index.ts' --coverage.exclude='src/evals/types.ts'",
     "lint": "eslint",
     "preview": "vite preview",
     "typecheck": "tsc",

--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "dev": "vite build",
     "build": "vite build",
-    "coverage:evals": "vitest run src/evals --coverage --coverage.provider=v8 --coverage.include='src/evals/**/*.ts' --coverage.exclude='src/evals/__test__/**' --coverage.exclude='src/evals/**/index.ts' --coverage.exclude='src/evals/types.ts'",
+    "coverage:evals": "vitest run src/evals --coverage --coverage.provider=v8 --coverage.include='src/evals/**/*.ts' --coverage.exclude='src/evals/__test__/**' --coverage.exclude='src/evals/**/index.ts' --coverage.exclude='src/evals/types.ts' --coverage.thresholds.statements=95 --coverage.thresholds.lines=95 --coverage.thresholds.functions=95",
     "lint": "eslint",
     "preview": "vite preview",
     "typecheck": "tsc",

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { trace as TraceAPI } from '@opentelemetry/api'
+import { type Span, trace as TraceAPI } from '@opentelemetry/api'
 import pRetry from 'p-retry'
 
 import type { CaseLifecycle, CaseLifecycleClass } from './CaseLifecycle'
@@ -124,6 +124,9 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
     const experimentName = options.name ?? this.name
     const repeat = options.repeat ?? 1
     const totalCases = this.cases.length * repeat
+    if (options.maxConcurrency !== undefined && (!Number.isInteger(options.maxConcurrency) || options.maxConcurrency < 1)) {
+      throw new Error(`Dataset.evaluate: maxConcurrency must be a positive integer (got ${options.maxConcurrency.toString()})`)
+    }
 
     const initialAttrs: Record<string, unknown> = {
       [ATTR_DATASET_NAME]: this.name,
@@ -403,7 +406,7 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
         span_id,
         trace_id,
       }
-      if (lifecycle?.teardown !== undefined) await lifecycle.teardown(failure)
+      await runLifecycleTeardown(lifecycle, failure, caseSpan)
       return failure
     }
 
@@ -466,7 +469,7 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
       total_duration: totalDuration,
       trace_id,
     }
-    if (lifecycle?.teardown !== undefined) await lifecycle.teardown(reportCase)
+    await runLifecycleTeardown(lifecycle, reportCase, caseSpan)
     return reportCase
   })
 }
@@ -530,18 +533,28 @@ function resolveSiblingPath(filePath: string, siblingPath: string): string {
 
 /**
  * Best-effort detection of whether the evals span processor is wired up to the
- * active TracerProvider. We use the presence of the singleton plus a heuristic
- * (active tracer-provider exposes a function we can call) to decide whether
- * an empty bucket means "no spans were emitted" vs. "the processor isn't
- * installed". For now we always assume installed — the explicit null path is
- * exercised by users running on a custom TracerProvider that didn't install
- * the processor; we'll wire that path up in Phase 3 when we add auto-install
- * to logfire-node.configure().
+ * active TracerProvider. If the provider is not the default no-op/proxy
+ * provider, we assume the processor is installed; users with custom providers
+ * can explicitly add `getEvalsSpanProcessor()`.
  */
 function isProcessorInstalledOnGlobal(): boolean {
-  // The simpler heuristic: if the tracer provider isn't a NoopTracerProvider,
-  // we assume the processor was installed. Users on a custom provider can
-  // explicitly install via `getEvalsSpanProcessor()`.
   const tp = TraceAPI.getTracerProvider()
   return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
+}
+
+async function runLifecycleTeardown<Inputs, Output, Metadata>(
+  lifecycle: CaseLifecycle<Inputs, Output, Metadata> | null,
+  result: ReportCase<Inputs, Output, Metadata> | ReportCaseFailure<Inputs, Output, Metadata>,
+  caseSpan: Span
+): Promise<void> {
+  if (lifecycle?.teardown === undefined) return
+  try {
+    await lifecycle.teardown(result)
+  } catch (err) {
+    if (err instanceof Error) {
+      caseSpan.recordException(err)
+    } else {
+      caseSpan.recordException(String(err))
+    }
+  }
 }

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -80,11 +80,9 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
 
   static async fromFile<I = unknown, O = unknown, M = unknown>(filePath: string, options: FromOptions = {}): Promise<Dataset<I, O, M>> {
     if (!hasNodeFs()) throw new Error('Dataset.fromFile is only supported on Node, Bun, and Deno (no filesystem in browser/CF Workers)')
-    const fs: typeof import('node:fs/promises') = await import('node:fs/promises')
-    const path: typeof import('node:path') = await import('node:path')
-    const text = await fs.readFile(filePath, 'utf8')
+    const text = await readTextFile(filePath)
     const format: 'json' | 'yaml' = filePath.endsWith('.json') ? 'json' : 'yaml'
-    const defaultName = options.defaultName ?? path.parse(filePath).name
+    const defaultName = options.defaultName ?? fileStem(filePath)
     return Dataset.fromText<I, O, M>(text, { ...options, defaultName, format })
   }
 
@@ -181,6 +179,7 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
               datasetEvaluators: this.evaluators,
               lifecycleClass: options.lifecycle,
               originalCase: c,
+              retryEvaluators: options.retryEvaluators,
               retryTask: options.retryTask,
               sourceCaseName: repeat > 1 ? sourceCaseName : undefined,
               task,
@@ -207,6 +206,16 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
         // on the span's attributes BEFORE it closes so the platform sees them.
         const analyses: ReportAnalysis[] = []
         const reportEvaluatorFailures: EvaluatorFailureRecord[] = []
+        const report: EvaluationReport<Inputs, Output, Metadata> = {
+          analyses,
+          cases,
+          experiment_metadata: options.metadata,
+          failures,
+          name: experimentName,
+          report_evaluator_failures: reportEvaluatorFailures,
+          span_id,
+          trace_id,
+        }
         for (const re of this.reportEvaluators) {
           const evaluatorName = (re.constructor as { evaluatorName?: string; name: string }).evaluatorName ?? re.constructor.name
           try {
@@ -216,7 +225,13 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
                 attributes: { evaluator_name: evaluatorName },
                 spanName: SPAN_NAME_REPORT_EVALUATOR_LITERAL,
               },
-              async () => re.evaluate({ cases: [...cases, ...failures], experimentMetadata: options.metadata, name: evaluatorName })
+              async () =>
+                re.evaluate({
+                  cases: [...cases, ...failures],
+                  experimentMetadata: options.metadata,
+                  name: experimentName,
+                  report,
+                })
             )
             const list = Array.isArray(out) ? out : [out]
             for (const item of list) analyses.push(item)
@@ -245,16 +260,7 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
         if (reportEvaluatorFailures.length > 0) finalAttrs[EXPERIMENT_REPORT_EVALUATOR_FAILURES_KEY] = reportEvaluatorFailures
         setEvalsSpanAttributes(experimentSpan, finalAttrs)
 
-        return {
-          analyses,
-          cases,
-          experiment_metadata: options.metadata,
-          failures,
-          name: experimentName,
-          report_evaluator_failures: reportEvaluatorFailures,
-          span_id,
-          trace_id,
-        }
+        return report
       }
     )
   }
@@ -274,12 +280,15 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
 
   async toFile(filePath: string, opts: ToOptions = {}): Promise<void> {
     if (!hasNodeFs()) throw new Error('Dataset.toFile is only supported on Node, Bun, and Deno (no filesystem in browser/CF Workers)')
-    const fs: typeof import('node:fs/promises') = await import('node:fs/promises')
     const format: 'json' | 'yaml' = filePath.endsWith('.json') ? 'json' : 'yaml'
     const text = this.toText(format, opts)
     const finalText =
       format === 'yaml' && opts.schemaPath !== undefined ? `# yaml-language-server: $schema=${opts.schemaPath}\n${text}` : text
-    await fs.writeFile(filePath, finalText, 'utf8')
+    await writeTextFile(filePath, finalText)
+    if (opts.schemaPath !== undefined) {
+      const schemaText = `${JSON.stringify(this.jsonSchema(), null, 2)}\n`
+      await writeTextFileIfChanged(resolveSiblingPath(filePath, opts.schemaPath), schemaText)
+    }
   }
 
   toObject(opts?: ToOptions): Record<string, unknown> {
@@ -310,12 +319,13 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
   datasetEvaluators: readonly Evaluator<Inputs, Output, Metadata>[]
   lifecycleClass?: CaseLifecycleClass<Inputs, Output, Metadata>
   originalCase: Case<Inputs, Output, Metadata>
+  retryEvaluators?: import('./types').RetryConfig
   retryTask?: import('./types').RetryConfig
   sourceCaseName?: string
   task: (inputs: Inputs) => Output | Promise<Output>
   taskName: string
 }): Promise<ReportCase<Inputs, Output, Metadata> | ReportCaseFailure<Inputs, Output, Metadata>> {
-  const { caseName, datasetEvaluators, lifecycleClass, originalCase, retryTask, sourceCaseName, task, taskName } = args
+  const { caseName, datasetEvaluators, lifecycleClass, originalCase, retryEvaluators, retryTask, sourceCaseName, task, taskName } = args
   // eslint-disable-next-line new-cap
   const lifecycle: CaseLifecycle<Inputs, Output, Metadata> | null = lifecycleClass ? new lifecycleClass(originalCase) : null
 
@@ -423,7 +433,7 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
     }
 
     const allEvaluators: Evaluator<Inputs, Output, Metadata>[] = [...datasetEvaluators, ...originalCase.evaluators]
-    const evResult = await runEvaluators(allEvaluators as Evaluator[], ctx as EvaluatorContext)
+    const evResult = await runEvaluators(allEvaluators as Evaluator[], ctx as EvaluatorContext, retryEvaluators)
 
     const totalDuration = nowSec() - totalStart
 
@@ -463,6 +473,59 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
 
 function nowSec(): number {
   return performance.now() / 1000
+}
+
+interface DenoTextFileRuntime {
+  Deno?: {
+    readTextFile?: (path: string) => Promise<string>
+    writeTextFile?: (path: string, data: string) => Promise<void>
+  }
+}
+
+async function readTextFile(filePath: string): Promise<string> {
+  const deno = (globalThis as DenoTextFileRuntime).Deno
+  if (typeof deno?.readTextFile === 'function') return deno.readTextFile(filePath)
+  const fs: typeof import('node:fs/promises') = await import('node:fs/promises')
+  return fs.readFile(filePath, 'utf8')
+}
+
+async function writeTextFile(filePath: string, text: string): Promise<void> {
+  const deno = (globalThis as DenoTextFileRuntime).Deno
+  if (typeof deno?.writeTextFile === 'function') {
+    await deno.writeTextFile(filePath, text)
+    return
+  }
+  const fs: typeof import('node:fs/promises') = await import('node:fs/promises')
+  await fs.writeFile(filePath, text, 'utf8')
+}
+
+async function writeTextFileIfChanged(filePath: string, text: string): Promise<void> {
+  let existing: string | undefined
+  try {
+    existing = await readTextFile(filePath)
+  } catch {
+    existing = undefined
+  }
+  if (existing !== text) await writeTextFile(filePath, text)
+}
+
+function fileStem(filePath: string): string {
+  const base =
+    filePath
+      .replace(/[\\/]+$/, '')
+      .split(/[\\/]/)
+      .pop() ?? filePath
+  const dot = base.lastIndexOf('.')
+  return dot <= 0 ? base : base.slice(0, dot)
+}
+
+function resolveSiblingPath(filePath: string, siblingPath: string): string {
+  if (/^(?:[a-zA-Z]:[\\/]|[\\/]|[a-zA-Z][a-zA-Z\d+.-]*:)/.test(siblingPath)) return siblingPath
+  const trimmed = filePath.replace(/[\\/]+$/, '')
+  const sep = trimmed.includes('\\') ? '\\' : '/'
+  const lastSep = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  const dir = lastSep === -1 ? '.' : trimmed.slice(0, lastSep)
+  return dir === '.' ? siblingPath : `${dir}${sep}${siblingPath}`
 }
 
 /**

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -125,6 +125,9 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
     const taskName = options.taskName ?? (task.name === '' ? 'task' : task.name)
     const experimentName = options.name ?? taskName
     const repeat = options.repeat ?? 1
+    if (!Number.isInteger(repeat) || repeat < 1) {
+      throw new Error(`Dataset.evaluate: repeat must be >= 1 (got ${repeat.toString()})`)
+    }
     const totalCases = this.cases.length * repeat
     if (options.maxConcurrency !== undefined && (!Number.isInteger(options.maxConcurrency) || options.maxConcurrency < 1)) {
       throw new Error(`Dataset.evaluate: maxConcurrency must be a positive integer (got ${options.maxConcurrency.toString()})`)

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -123,7 +123,7 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
     options: EvaluateOptions<Inputs, Output, Metadata> = {}
   ): Promise<EvaluationReport<Inputs, Output, Metadata>> {
     const taskName = options.taskName ?? (task.name === '' ? 'task' : task.name)
-    const experimentName = options.name ?? this.name
+    const experimentName = options.name ?? taskName
     const repeat = options.repeat ?? 1
     const totalCases = this.cases.length * repeat
     if (options.maxConcurrency !== undefined && (!Number.isInteger(options.maxConcurrency) || options.maxConcurrency < 1)) {
@@ -177,7 +177,7 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
           }
           try {
             const sourceCaseName = c.name ?? `Case ${(positionalIndex + 1).toString()}`
-            const caseName = repeat > 1 ? `${sourceCaseName} [run/${(runIndex + 1).toString()}]` : sourceCaseName
+            const caseName = repeat > 1 ? `${sourceCaseName} [${(runIndex + 1).toString()}/${repeat.toString()}]` : sourceCaseName
             const result = await runOneCase({
               caseName,
               dataset: this,
@@ -386,25 +386,17 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
     } catch (err) {
       // Drain bucket so we don't leak even on task failure.
       evalsProcessor.drainBucket(exporterContextId)
-      const isErr = err instanceof Error
       // Still record the exception on the case span — the platform shows it.
-      if (isErr) {
-        caseSpan.recordException(err)
-      } else {
-        caseSpan.recordException(String(err))
-      }
-      const failure: ReportCaseFailure<Inputs, Output, Metadata> = {
-        error_message: isErr ? err.message : String(err),
-        error_stacktrace: isErr ? err.stack : undefined,
-        error_type: isErr ? err.constructor.name : 'Error',
-        expected_output: originalCase.expectedOutput,
+      recordException(caseSpan, err)
+      const failure = buildCaseFailure(err, {
+        caseName,
+        expectedOutput: originalCase.expectedOutput,
         inputs: originalCase.inputs,
         metadata: originalCase.metadata,
-        name: caseName,
-        source_case_name: sourceCaseName,
+        sourceCaseName,
         span_id,
         trace_id,
-      }
+      })
       await runLifecycleTeardown(lifecycle, failure, caseSpan)
       return failure
     }
@@ -431,10 +423,25 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
       spanTree,
     }
     if (lifecycle?.prepareContext !== undefined) {
-      ctx = await lifecycle.prepareContext(ctx)
+      try {
+        ctx = await lifecycle.prepareContext(ctx)
+      } catch (err) {
+        recordException(caseSpan, err)
+        const failure = buildCaseFailure(err, {
+          caseName,
+          expectedOutput: originalCase.expectedOutput,
+          inputs: originalCase.inputs,
+          metadata: originalCase.metadata,
+          sourceCaseName,
+          span_id,
+          trace_id,
+        })
+        await runLifecycleTeardown(lifecycle, failure, caseSpan)
+        return failure
+      }
     }
 
-    const allEvaluators: Evaluator<Inputs, Output, Metadata>[] = [...datasetEvaluators, ...originalCase.evaluators]
+    const allEvaluators: Evaluator<Inputs, Output, Metadata>[] = [...originalCase.evaluators, ...datasetEvaluators]
     const evResult = await runEvaluators(allEvaluators as Evaluator[], ctx as EvaluatorContext, retryEvaluators)
 
     const totalDuration = nowSec() - totalStart
@@ -471,6 +478,41 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
     await runLifecycleTeardown(lifecycle, reportCase, caseSpan)
     return reportCase
   })
+}
+
+function buildCaseFailure<Inputs, Output, Metadata>(
+  err: unknown,
+  opts: {
+    caseName: string
+    expectedOutput?: Output
+    inputs: Inputs
+    metadata?: Metadata
+    sourceCaseName?: string
+    span_id: null | string
+    trace_id: null | string
+  }
+): ReportCaseFailure<Inputs, Output, Metadata> {
+  const isErr = err instanceof Error
+  return {
+    error_message: isErr ? err.message : String(err),
+    error_stacktrace: isErr ? err.stack : undefined,
+    error_type: isErr ? err.constructor.name : 'Error',
+    expected_output: opts.expectedOutput,
+    inputs: opts.inputs,
+    metadata: opts.metadata,
+    name: opts.caseName,
+    source_case_name: opts.sourceCaseName,
+    span_id: opts.span_id,
+    trace_id: opts.trace_id,
+  }
+}
+
+function recordException(span: Span, err: unknown): void {
+  if (err instanceof Error) {
+    span.recordException(err)
+  } else {
+    span.recordException(String(err))
+  }
 }
 
 function nowSec(): number {

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
-import { type Span, trace as TraceAPI } from '@opentelemetry/api'
+import type { Span } from '@opentelemetry/api'
+
 import pRetry from 'p-retry'
 
 import type { CaseLifecycle, CaseLifecycleClass } from './CaseLifecycle'
@@ -39,6 +40,7 @@ import {
   SPAN_NAME_REPORT_EVALUATOR_LITERAL,
 } from './constants'
 import { runWithTaskRun } from './currentTaskRun'
+import { buildEvaluatorFailureRecord } from './evaluatorResults'
 import { extractMetricsFromSpanTree } from './extractMetrics'
 import { evalsSpan, setEvalsSpanAttributes } from './internal'
 import { computeAssertionPassRate, computeAverages, type EvaluationReport, type ReportCase, type ReportCaseFailure } from './reporting'
@@ -55,7 +57,7 @@ import {
   stringifyYaml,
   type ToOptions,
 } from './serialization'
-import { buildSpanTree, getEvalsSpanProcessor, SpanTree, SpanTreeRecordingError } from './spanTree'
+import { buildSpanTree, getEvalsSpanProcessor, isProcessorInstalledOnGlobal, SpanTree, SpanTreeRecordingError } from './spanTree'
 
 export interface DatasetOptions<Inputs, Output, Metadata = unknown> {
   cases?: readonly Case<Inputs, Output, Metadata>[]
@@ -194,10 +196,7 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
               cases.push(result)
             }
             done += 1
-            const progress = options.progress
-            if (typeof progress === 'function') {
-              progress({ caseName, done, total: totalCases })
-            }
+            reportProgress(options.progress, { caseName, done, total: totalCases })
           } finally {
             release()
           }
@@ -239,14 +238,7 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
             const list = Array.isArray(out) ? out : [out]
             for (const item of list) analyses.push(item)
           } catch (err) {
-            const isErr = err instanceof Error
-            reportEvaluatorFailures.push({
-              error_message: isErr ? err.message : String(err),
-              error_stacktrace: isErr ? err.stack : undefined,
-              error_type: isErr ? err.constructor.name : 'Error',
-              name: evaluatorName,
-              source: re.getSpec(),
-            })
+            reportEvaluatorFailures.push(buildEvaluatorFailureRecord(err, evaluatorName, re.getSpec(), re.evaluatorVersion))
           }
         }
 
@@ -316,6 +308,14 @@ function assertUniqueNames(cases: readonly Case[]): void {
   }
 }
 
+function reportProgress(progress: EvaluateOptions['progress'], event: { caseName: string; done: number; total: number }): void {
+  if (typeof progress === 'function') {
+    progress(event)
+  } else if (progress === true) {
+    console.error(`[${event.done.toString()}/${event.total.toString()}] ${event.caseName}`)
+  }
+}
+
 async function runOneCase<Inputs, Output, Metadata>(args: {
   caseName: string
   dataset: Dataset<Inputs, Output, Metadata>
@@ -352,7 +352,6 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
 
     const taskRunState: TaskRunState = {
       attributes: {},
-      caseSpan,
       exporterContextId,
       metrics: {},
     }
@@ -529,17 +528,6 @@ function resolveSiblingPath(filePath: string, siblingPath: string): string {
   const lastSep = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
   const dir = lastSep === -1 ? '.' : trimmed.slice(0, lastSep)
   return dir === '.' ? siblingPath : `${dir}${sep}${siblingPath}`
-}
-
-/**
- * Best-effort detection of whether the evals span processor is wired up to the
- * active TracerProvider. If the provider is not the default no-op/proxy
- * provider, we assume the processor is installed; users with custom providers
- * can explicitly add `getEvalsSpanProcessor()`.
- */
-function isProcessorInstalledOnGlobal(): boolean {
-  const tp = TraceAPI.getTracerProvider()
-  return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
 }
 
 async function runLifecycleTeardown<Inputs, Output, Metadata>(

--- a/packages/logfire-api/src/evals/ReportEvaluator.ts
+++ b/packages/logfire-api/src/evals/ReportEvaluator.ts
@@ -1,53 +1,34 @@
-import type { ReportCase, ReportCaseFailure } from './reporting'
+import type { EvaluationReport, ReportCase, ReportCaseFailure } from './reporting'
 import type { EvaluatorSpec } from './types'
 
 import { evaluatorRegistryKey } from './registry'
 
 /** Discriminated union of analysis outputs report evaluators may emit. */
-export type ReportAnalysis =
-  | ConfusionMatrixAnalysis
-  | KSAnalysis
-  | LinePlotAnalysis
-  | PrecisionRecallAnalysis
-  | ROCAnalysis
-  | ScalarAnalysis
-  | TableAnalysis
+export type ReportAnalysis = ConfusionMatrixAnalysis | LinePlotAnalysis | PrecisionRecallAnalysis | ScalarAnalysis | TableAnalysis
 
 export interface ConfusionMatrixAnalysis {
-  matrix: Record<string, Record<string, number>>
-  predicted_labels: string[]
+  class_labels: string[]
+  description?: string
+  matrix: number[][]
   title: string
-  true_labels: string[]
   type: 'confusion_matrix'
 }
 
 export interface PrecisionRecallAnalysis {
-  precision: number[]
-  recall: number[]
-  thresholds: number[]
+  curves: { auc?: number; name: string; points: { precision: number; recall: number; threshold: number }[] }[]
+  description?: string
   title: string
   type: 'precision_recall'
 }
 
-export interface ROCAnalysis {
-  curves: { name: string; points: { x: number; y: number }[]; style?: 'dashed' | 'solid' }[]
-  title: string
-  type: 'roc_curve'
-  x_label: string
-  y_label: string
-}
-
-export interface KSAnalysis {
-  curves: { name: string; points: { x: number; y: number }[] }[]
-  title: string
-  type: 'ks'
-  x_label: string
-  y_label: string
-}
+export type ROCAnalysis = LinePlotAnalysis
+export type KSAnalysis = LinePlotAnalysis
 
 export interface ScalarAnalysis {
+  description?: string
   title: string
   type: 'scalar'
+  unit?: string
   value: number
 }
 
@@ -60,16 +41,20 @@ export interface TableAnalysis {
 
 export interface LinePlotAnalysis {
   curves: { name: string; points: { x: number; y: number }[]; step?: 'end' | 'middle' | 'start'; style?: 'dashed' | 'solid' }[]
+  description?: string
   title: string
   type: 'line_plot'
   x_label: string
+  x_range?: [number, number]
   y_label: string
+  y_range?: [number, number]
 }
 
 export interface ReportEvaluatorContext<Inputs = unknown, Output = unknown, Metadata = unknown> {
   cases: readonly (ReportCase<Inputs, Output, Metadata> | ReportCaseFailure<Inputs, Output, Metadata>)[]
   experimentMetadata?: Record<string, unknown>
   name: string
+  report: EvaluationReport<Inputs, Output, Metadata>
 }
 
 export abstract class ReportEvaluator<Inputs = unknown, Output = unknown, Metadata = unknown> {

--- a/packages/logfire-api/src/evals/Semaphore.ts
+++ b/packages/logfire-api/src/evals/Semaphore.ts
@@ -24,6 +24,14 @@ export class Semaphore {
     }
   }
 
+  tryAcquire(): (() => void) | null {
+    if (this.permits <= 0) return null
+    this.permits--
+    return () => {
+      this.release()
+    }
+  }
+
   private release(): void {
     const next = this.waiters.shift()
     if (next !== undefined) {

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { describe, expect, it } from 'vitest'
+
+import {
+  Contains,
+  deepEqual,
+  Equals,
+  EqualsExpected,
+  type EvaluatorContext,
+  IsInstance,
+  LLMJudge,
+  MaxDuration,
+  SpanTree,
+} from '../../evals'
+
+const ctx = (output: unknown, extra: Partial<EvaluatorContext> = {}): EvaluatorContext => ({
+  attributes: {},
+  duration: 0,
+  inputs: undefined,
+  metrics: {},
+  name: 'case',
+  output,
+  spanTree: new SpanTree(),
+  ...extra,
+})
+
+describe('built-in evaluator edge cases', () => {
+  it('Contains supports strings, arrays, objects, asStrings and non-iterables', () => {
+    expect(new Contains({ caseSensitive: false, value: 'needle' }).evaluate(ctx('A NEEDLE appears'))).toEqual({
+      reason: 'output contains value',
+      value: true,
+    })
+    expect(new Contains({ caseSensitive: false, value: 'needle' }).evaluate(ctx('haystack'))).toEqual({
+      reason: 'output does not contain value',
+      value: false,
+    })
+    expect(new Contains({ asStrings: true, value: 23 }).evaluate(ctx(12345))).toEqual({
+      reason: 'output contains value',
+      value: true,
+    })
+    expect(new Contains({ value: { ok: true } }).evaluate(ctx([{ ok: false }, { ok: true }]))).toEqual({
+      reason: 'value found in output array',
+      value: true,
+    })
+    expect(new Contains({ value: 'missing' }).evaluate(ctx(['present']))).toEqual({
+      reason: 'value not found in output array',
+      value: false,
+    })
+    expect(new Contains({ value: 'status' }).evaluate(ctx({ status: 'ok' }))).toEqual({
+      reason: 'key matches value',
+      value: true,
+    })
+    expect(new Contains({ value: 'ok' }).evaluate(ctx({ status: 'ok' }))).toEqual({
+      reason: 'object value matches',
+      value: true,
+    })
+    expect(new Contains({ value: 'missing' }).evaluate(ctx({ status: 'ok' }))).toEqual({
+      reason: 'value not found in object',
+      value: false,
+    })
+    expect(new Contains({ value: 'x' }).evaluate(ctx(123))).toEqual({ reason: 'output is not iterable', value: false })
+  })
+
+  it('deepEqual covers primitive, array and object mismatches', () => {
+    expect(deepEqual(1, 1)).toBe(true)
+    expect(deepEqual(1, '1')).toBe(false)
+    expect(deepEqual(null, {})).toBe(false)
+    expect(deepEqual({ a: 1 }, 1)).toBe(false)
+    expect(deepEqual([1, { a: true }], [1, { a: true }])).toBe(true)
+    expect(deepEqual([1], [1, 2])).toBe(false)
+    expect(deepEqual([1], ['1'])).toBe(false)
+    expect(deepEqual([1], { 0: 1 })).toBe(false)
+    expect(deepEqual({ a: 1 }, { a: 1 })).toBe(true)
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false)
+  })
+
+  it('Equals and EqualsExpected preserve custom result names and empty-output behavior', () => {
+    const eq = new Equals({ evaluationName: 'exact', value: { nested: ['x'] } })
+    expect(eq.getResultName()).toBe('exact')
+    expect(eq.toJSON()).toEqual({ evaluation_name: 'exact', value: { nested: ['x'] } })
+    expect(eq.evaluate(ctx({ nested: ['x'] }))).toBe(true)
+
+    const expected = new EqualsExpected({ evaluationName: 'expected-match' })
+    expect(expected.toJSON()).toEqual({ evaluation_name: 'expected-match' })
+    expect(expected.evaluate(ctx('x'))).toEqual({})
+    expect(expected.evaluate(ctx('x', { expectedOutput: 'x' }))).toBe(true)
+  })
+
+  it('IsInstance handles nullish values, class ancestry and primitive fallbacks', () => {
+    class Base {
+      base = true
+    }
+    class Child extends Base {}
+
+    expect(new IsInstance({ typeName: 'Child' }).evaluate(ctx(new Child()))).toEqual({
+      reason: 'output is instance of Child',
+      value: true,
+    })
+    expect(new IsInstance({ typeName: 'Base' }).evaluate(ctx(new Child()))).toEqual({
+      reason: 'output is instance of Base',
+      value: true,
+    })
+    expect(new IsInstance({ typeName: 'string' }).evaluate(ctx('x'))).toEqual({
+      reason: 'output typeof matches string',
+      value: true,
+    })
+    expect(new IsInstance({ typeName: 'Date' }).evaluate(ctx('x'))).toEqual({
+      reason: 'output is not instance of Date',
+      value: false,
+    })
+    expect(new IsInstance({ typeName: 'Thing' }).evaluate(ctx(null))).toEqual({ reason: 'output is null', value: false })
+    expect(new IsInstance({ typeName: 'Thing' }).evaluate(ctx(undefined))).toEqual({
+      reason: 'output is undefined',
+      value: false,
+    })
+  })
+
+  it('MaxDuration compares against the recorded task duration', () => {
+    expect(new MaxDuration({ seconds: 1 }).evaluate(ctx('x', { duration: 0.5 }))).toBe(true)
+    expect(new MaxDuration({ seconds: 1 }).evaluate(ctx('x', { duration: 1.5 }))).toBe(false)
+  })
+
+  it('LLMJudge requires a judge callback and maps score/assertion channels', async () => {
+    await expect(new LLMJudge({ rubric: 'be good' }).evaluate(ctx('x'))).rejects.toThrow('LLMJudge: no judge callback provided')
+
+    const judge = new LLMJudge({
+      assertion: { evaluationName: 'judge_assertion', includeReason: false },
+      includeExpectedOutput: true,
+      includeInput: true,
+      judge: async (args) => {
+        expect(args).toEqual({
+          expectedOutput: 'expected',
+          inputs: { prompt: 'p' },
+          output: 'actual',
+          rubric: 'grade it',
+        })
+        return { pass: true, reason: 'solid', score: 0.9 }
+      },
+      rubric: 'grade it',
+      score: { evaluationName: 'judge_score', includeReason: true },
+    })
+
+    await expect(judge.evaluate(ctx('actual', { expectedOutput: 'expected', inputs: { prompt: 'p' } }))).resolves.toEqual({
+      judge_assertion: true,
+      judge_score: { reason: 'solid', value: 0.9 },
+    })
+    expect(judge.toJSON()).toEqual({ include_expected_output: true, include_input: true, rubric: 'grade it' })
+
+    const assertionOnly = new LLMJudge({
+      judge: () => ({ pass: false, reason: 'nope', score: 0.1 }),
+      rubric: 'assert only',
+      score: false,
+    })
+    await expect(assertionOnly.evaluate(ctx('actual'))).resolves.toEqual({
+      LLMJudge: { reason: 'nope', value: false },
+    })
+
+    const scoreOnly = new LLMJudge({
+      assertion: false,
+      judge: () => ({ pass: true, score: 1 }),
+      rubric: 'score only',
+    })
+    await expect(scoreOnly.evaluate(ctx('actual'))).resolves.toEqual({ LLMJudge: 1 })
+  })
+})

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -68,11 +68,24 @@ describe('built-in evaluator edge cases', () => {
     expect(eq.getResultName()).toBe('exact')
     expect(eq.toJSON()).toEqual({ evaluation_name: 'exact', value: { nested: ['x'] } })
     expect(eq.evaluate(ctx({ nested: ['x'] }))).toBe(true)
+    expect(new Equals({ value: 'completely-different-type' }).evaluate(ctx({ x: 1 }))).toBe(false)
 
     const expected = new EqualsExpected({ evaluationName: 'expected-match' })
     expect(expected.toJSON()).toEqual({ evaluation_name: 'expected-match' })
     expect(expected.evaluate(ctx('x'))).toEqual({})
     expect(expected.evaluate(ctx('x', { expectedOutput: 'x' }))).toBe(true)
+  })
+
+  it('an evaluator can read undefined expected_output and metadata from the context', () => {
+    class NullProbe extends class {
+      evaluate(_c: EvaluatorContext): { has_expected_output: boolean; has_metadata: boolean } {
+        return { has_expected_output: _c.expectedOutput !== undefined, has_metadata: _c.metadata !== undefined }
+      }
+    } {}
+    const result = new NullProbe().evaluate(ctx('out'))
+    expect(result).toEqual({ has_expected_output: false, has_metadata: false })
+    const enriched = new NullProbe().evaluate(ctx('out', { expectedOutput: 'x', metadata: { k: 1 } }))
+    expect(enriched).toEqual({ has_expected_output: true, has_metadata: true })
   })
 
   it('IsInstance handles nullish values, class ancestry and primitive fallbacks', () => {

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -27,38 +27,26 @@ const ctx = (output: unknown, extra: Partial<EvaluatorContext> = {}): EvaluatorC
 describe('built-in evaluator edge cases', () => {
   it('Contains supports strings, arrays, objects, asStrings and non-iterables', () => {
     expect(new Contains({ caseSensitive: false, value: 'needle' }).evaluate(ctx('A NEEDLE appears'))).toEqual({
-      reason: 'output contains value',
       value: true,
     })
-    expect(new Contains({ caseSensitive: false, value: 'needle' }).evaluate(ctx('haystack'))).toEqual({
-      reason: 'output does not contain value',
-      value: false,
-    })
+    expect(new Contains({ caseSensitive: false, value: 'needle' }).evaluate(ctx('haystack'))).toMatchObject({ value: false })
     expect(new Contains({ asStrings: true, value: 23 }).evaluate(ctx(12345))).toEqual({
-      reason: 'output contains value',
       value: true,
     })
     expect(new Contains({ value: { ok: true } }).evaluate(ctx([{ ok: false }, { ok: true }]))).toEqual({
-      reason: 'value found in output array',
       value: true,
     })
-    expect(new Contains({ value: 'missing' }).evaluate(ctx(['present']))).toEqual({
-      reason: 'value not found in output array',
-      value: false,
-    })
+    expect(new Contains({ value: 'missing' }).evaluate(ctx(['present']))).toMatchObject({ value: false })
     expect(new Contains({ value: 'status' }).evaluate(ctx({ status: 'ok' }))).toEqual({
-      reason: 'key matches value',
       value: true,
     })
-    expect(new Contains({ value: 'ok' }).evaluate(ctx({ status: 'ok' }))).toEqual({
-      reason: 'object value matches',
-      value: true,
-    })
-    expect(new Contains({ value: 'missing' }).evaluate(ctx({ status: 'ok' }))).toEqual({
-      reason: 'value not found in object',
+    expect(new Contains({ value: { status: 'ok' } }).evaluate(ctx({ extra: true, status: 'ok' }))).toEqual({ value: true })
+    expect(new Contains({ value: 'ok' }).evaluate(ctx({ status: 'ok' }))).toMatchObject({ value: false })
+    expect(new Contains({ value: 'missing' }).evaluate(ctx({ status: 'ok' }))).toMatchObject({ value: false })
+    expect(new Contains({ value: 'x' }).evaluate(ctx(123))).toEqual({
+      reason: 'Containment check failed: output is not iterable',
       value: false,
     })
-    expect(new Contains({ value: 'x' }).evaluate(ctx(123))).toEqual({ reason: 'output is not iterable', value: false })
   })
 
   it('deepEqual covers primitive, array and object mismatches', () => {
@@ -145,7 +133,13 @@ describe('built-in evaluator edge cases', () => {
       judge_assertion: true,
       judge_score: { reason: 'solid', value: 0.9 },
     })
-    expect(judge.toJSON()).toEqual({ include_expected_output: true, include_input: true, rubric: 'grade it' })
+    expect(judge.toJSON()).toEqual({
+      assertion: { evaluation_name: 'judge_assertion' },
+      include_expected_output: true,
+      include_input: true,
+      rubric: 'grade it',
+      score: { evaluation_name: 'judge_score', include_reason: true },
+    })
 
     const assertionOnly = new LLMJudge({
       judge: () => ({ pass: false, reason: 'nope', score: 0.1 }),
@@ -160,7 +154,18 @@ describe('built-in evaluator edge cases', () => {
       assertion: false,
       judge: () => ({ pass: true, score: 1 }),
       rubric: 'score only',
+      score: {},
     })
     await expect(scoreOnly.evaluate(ctx('actual'))).resolves.toEqual({ LLMJudge: 1 })
+
+    const bothDefaults = new LLMJudge({
+      judge: () => ({ pass: true, reason: 'ok', score: 0.8 }),
+      rubric: 'both',
+      score: {},
+    })
+    await expect(bothDefaults.evaluate(ctx('actual'))).resolves.toEqual({
+      LLMJudge_pass: { reason: 'ok', value: true },
+      LLMJudge_score: 0.8,
+    })
   })
 })

--- a/packages/logfire-api/src/evals/__test__/multiRun.test.ts
+++ b/packages/logfire-api/src/evals/__test__/multiRun.test.ts
@@ -1,0 +1,353 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/require-await */
+import { describe, expect, it } from 'vitest'
+
+import {
+  averageFromAggregates,
+  averages,
+  Case,
+  caseGroups,
+  Dataset,
+  type EvaluationReport,
+  Evaluator,
+  type ReportCase,
+  type ReportCaseAggregate,
+  type ReportCaseFailure,
+} from '../../evals'
+import { withMemoryExporter } from './withMemoryExporter'
+
+const resultJson = (name: string, value: boolean | number | string) => ({
+  name,
+  reason: null,
+  source: { arguments: null, name: 'Source' },
+  value,
+})
+
+const makeReportCase = (overrides: Partial<ReportCase> = {}): ReportCase => ({
+  assertions: {},
+  attributes: {},
+  evaluator_failures: [],
+  inputs: 'input',
+  labels: {},
+  metrics: {},
+  name: 'case',
+  output: 'output',
+  scores: {},
+  span_id: null,
+  task_duration: 1,
+  total_duration: 1,
+  trace_id: null,
+  ...overrides,
+})
+
+const makeReport = (overrides: Partial<EvaluationReport> = {}): EvaluationReport => ({
+  analyses: [],
+  cases: [],
+  failures: [],
+  name: 'test',
+  report_evaluator_failures: [],
+  span_id: null,
+  trace_id: null,
+  ...overrides,
+})
+
+describe('repeat option', () => {
+  it('repeat=1 produces single-run behavior with no source_case_name and caseGroups undefined', async () => {
+    let calls = 0
+    const dataset = new Dataset<string, string>({
+      cases: [new Case({ inputs: 'hello', name: 'case1' }), new Case({ inputs: 'world', name: 'case2' })],
+      name: 'repeat-1',
+    })
+
+    const { result } = await withMemoryExporter(() =>
+      dataset.evaluate(async (s) => {
+        calls += 1
+        return s.toUpperCase()
+      })
+    )
+
+    expect(calls).toBe(2)
+    expect(result.cases).toHaveLength(2)
+    expect(result.cases.every((c) => c.source_case_name === undefined)).toBe(true)
+    expect(caseGroups(result)).toBeUndefined()
+  })
+
+  it('repeat=3 produces 3x cases with run-indexed names and source_case_name set', async () => {
+    let calls = 0
+    const dataset = new Dataset<string, string>({
+      cases: [new Case({ inputs: 'hello', name: 'case1' }), new Case({ inputs: 'world', name: 'case2' })],
+      name: 'repeat-3',
+    })
+
+    const { result } = await withMemoryExporter(() =>
+      dataset.evaluate(
+        async (s) => {
+          calls += 1
+          return s.toUpperCase()
+        },
+        { repeat: 3 }
+      )
+    )
+
+    expect(calls).toBe(6)
+    expect(result.cases).toHaveLength(6)
+    expect([...result.cases].map((c) => c.name).sort()).toEqual([
+      'case1 [1/3]',
+      'case1 [2/3]',
+      'case1 [3/3]',
+      'case2 [1/3]',
+      'case2 [2/3]',
+      'case2 [3/3]',
+    ])
+    expect(result.cases.filter((c) => c.source_case_name === 'case1')).toHaveLength(3)
+    expect(result.cases.filter((c) => c.source_case_name === 'case2')).toHaveLength(3)
+  })
+
+  it('repeat works with unnamed cases using positional fallback names', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case({ inputs: 'hello' }), new Case({ inputs: 'world' })],
+      name: 'unnamed',
+    })
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate(async (s) => s.toUpperCase(), { repeat: 2 }))
+
+    expect(result.cases).toHaveLength(4)
+    expect([...result.cases].map((c) => c.name).sort()).toEqual(['Case 1 [1/2]', 'Case 1 [2/2]', 'Case 2 [1/2]', 'Case 2 [2/2]'])
+    expect(result.cases.every((c) => c.source_case_name !== undefined)).toBe(true)
+  })
+
+  it('repeat < 1 throws', async () => {
+    const dataset = new Dataset<string, string>({ cases: [new Case({ inputs: 'x' })], name: 'bad-repeat' })
+    await expect(dataset.evaluate(async (s) => s, { repeat: 0 })).rejects.toThrow('repeat must be >= 1')
+    await expect(dataset.evaluate(async (s) => s, { repeat: 1.5 })).rejects.toThrow('repeat must be >= 1')
+  })
+
+  it('evaluators run on every repeated run', async () => {
+    class AlwaysPass extends Evaluator<string, string> {
+      static evaluatorName = 'AlwaysPass'
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [new Case({ inputs: 'hello', name: 'case1' })],
+      evaluators: [new AlwaysPass()],
+      name: 'repeat-evaluators',
+    })
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate(async (s) => s.toUpperCase(), { repeat: 3 }))
+
+    expect(result.cases).toHaveLength(3)
+    for (const c of result.cases) {
+      expect(c.assertions.AlwaysPass?.value).toBe(true)
+    }
+  })
+})
+
+describe('caseGroups()', () => {
+  it('groups runs by source_case_name and computes per-group summaries', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case({ inputs: 'hello', name: 'case1' }), new Case({ inputs: 'world', name: 'case2' })],
+      name: 'groups',
+    })
+    const { result } = await withMemoryExporter(() => dataset.evaluate(async (s) => s.toUpperCase(), { repeat: 2 }))
+
+    const groups = caseGroups(result)
+    expect(groups).toBeDefined()
+    expect(groups).toHaveLength(2)
+    expect([...groups!].map((g) => g.name).sort()).toEqual(['case1', 'case2'])
+    for (const g of groups!) {
+      expect(g.runs).toHaveLength(2)
+      expect(g.failures).toHaveLength(0)
+      expect(g.summary.name).toBe('Averages')
+    }
+  })
+
+  it('returns undefined for single-run experiments', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case({ inputs: 'hello', name: 'case1' })],
+      name: 'single',
+    })
+    const { result } = await withMemoryExporter(() => dataset.evaluate(async (s) => s.toUpperCase()))
+    expect(caseGroups(result)).toBeUndefined()
+  })
+
+  it('exposes group fields populated from the first run', () => {
+    const case1 = makeReportCase({
+      assertions: { AlwaysPass: resultJson('AlwaysPass', true) },
+      inputs: 'hello',
+      name: 'case1 [1/2]',
+      source_case_name: 'case1',
+      task_duration: 0.1,
+      total_duration: 0.2,
+    })
+    const case2 = makeReportCase({
+      assertions: { AlwaysPass: resultJson('AlwaysPass', true) },
+      inputs: 'hello',
+      name: 'case1 [2/2]',
+      source_case_name: 'case1',
+      task_duration: 0.15,
+      total_duration: 0.25,
+    })
+
+    const groups = caseGroups(makeReport({ cases: [case1, case2] }))
+    expect(groups).toHaveLength(1)
+    const g = groups![0]!
+    expect(g.name).toBe('case1')
+    expect(g.inputs).toBe('hello')
+    expect(g.metadata).toBeUndefined()
+    expect(g.expected_output).toBeUndefined()
+    expect(g.runs).toHaveLength(2)
+    expect(g.failures).toHaveLength(0)
+    expect(g.summary.task_duration).toBeCloseTo(0.125)
+  })
+
+  it('groups failures by source_case_name', () => {
+    const case1: ReportCase = makeReportCase({ name: 'case1 [1/2]', source_case_name: 'case1' })
+    const failure: ReportCaseFailure = {
+      error_message: 'something went wrong',
+      error_type: 'Error',
+      inputs: 'hello',
+      name: 'case1 [2/2]',
+      source_case_name: 'case1',
+      span_id: null,
+      trace_id: null,
+    }
+
+    const groups = caseGroups(makeReport({ cases: [case1], failures: [failure] }))
+    expect(groups).toHaveLength(1)
+    const g = groups![0]!
+    expect(g.name).toBe('case1')
+    expect(g.runs).toHaveLength(1)
+    expect(g.failures).toHaveLength(1)
+    expect(g.failures[0]?.error_message).toBe('something went wrong')
+  })
+})
+
+describe('averages()', () => {
+  it('uses two-level aggregation for multi-run reports (distinguishes from flat mean)', () => {
+    // case1 runs scored 0.2 and 0.4 → group mean 0.3
+    // case2 has one run scored 0.9 and one failure
+    // Two-level: mean(0.3, 0.9) = 0.6
+    // Flat mean would be: mean(0.2, 0.4, 0.9) = 0.5
+    const score = (v: number) => ({ score: resultJson('score', v) })
+    const cases: ReportCase[] = [
+      makeReportCase({ name: 'case1 [1/2]', scores: score(0.2), source_case_name: 'case1' }),
+      makeReportCase({ name: 'case1 [2/2]', scores: score(0.4), source_case_name: 'case1' }),
+      makeReportCase({ name: 'case2 [1/2]', scores: score(0.9), source_case_name: 'case2' }),
+    ]
+    const failures: ReportCaseFailure[] = [
+      {
+        error_message: 'failed',
+        error_type: 'Error',
+        inputs: 'world',
+        name: 'case2 [2/2]',
+        source_case_name: 'case2',
+        span_id: null,
+        trace_id: null,
+      },
+    ]
+
+    const result = averages(makeReport({ cases, failures }))
+    expect(result).toBeDefined()
+    expect(result!.scores.score?.mean).toBeCloseTo(0.6)
+  })
+
+  it('falls back to flat averaging for single-run reports', () => {
+    const cases: ReportCase[] = [
+      makeReportCase({ scores: { s: resultJson('s', 0.2) } }),
+      makeReportCase({ scores: { s: resultJson('s', 0.4) } }),
+    ]
+    const result = averages(makeReport({ cases }))
+    expect(result).toBeDefined()
+    expect(result!.name).toBe('Averages')
+    expect(result!.scores.s?.mean).toBeCloseTo(0.3)
+  })
+
+  it('returns undefined for an empty report', () => {
+    expect(averages(makeReport())).toBeUndefined()
+  })
+})
+
+describe('averageFromAggregates()', () => {
+  const makeAggregate = (overrides: Partial<ReportCaseAggregate>): ReportCaseAggregate => ({
+    assertions: null,
+    labels: {},
+    metrics: {},
+    name: 'Averages',
+    scores: {},
+    task_duration: 0,
+    total_duration: 0,
+    ...overrides,
+  })
+
+  it('averages numeric scores/metrics, label distributions, assertions, and durations', () => {
+    const agg1 = makeAggregate({
+      assertions: 1,
+      labels: { l1: { a: 0.5, b: 0.5 } },
+      metrics: { m1: { count: 1, mean: 10 } },
+      scores: { s1: { count: 1, mean: 0.5 }, s2: { count: 1, mean: 0.25 } },
+      task_duration: 1,
+      total_duration: 2,
+    })
+    const agg2 = makeAggregate({
+      assertions: 0.5,
+      labels: { l1: { a: 0.25, b: 0.75 } },
+      metrics: { m1: { count: 1, mean: 20 } },
+      scores: { s1: { count: 1, mean: 0.5 }, s2: { count: 1, mean: 0.75 } },
+      task_duration: 3,
+      total_duration: 4,
+    })
+
+    const result = averageFromAggregates('Averages', [agg1, agg2])
+    expect(result.name).toBe('Averages')
+    expect(result.scores.s1?.mean).toBeCloseTo(0.5)
+    expect(result.scores.s2?.mean).toBeCloseTo(0.5)
+    expect(result.metrics.m1?.mean).toBeCloseTo(15)
+    expect(result.assertions).toBeCloseTo(0.75)
+    expect(result.task_duration).toBeCloseTo(2)
+    expect(result.total_duration).toBeCloseTo(3)
+    expect(result.labels.l1?.a).toBeCloseTo(0.375)
+    expect(result.labels.l1?.b).toBeCloseTo(0.625)
+  })
+
+  it('returns an empty aggregate for an empty input', () => {
+    expect(averageFromAggregates('Averages', [])).toEqual({
+      assertions: null,
+      labels: {},
+      metrics: {},
+      name: 'Averages',
+      scores: {},
+      task_duration: 0,
+      total_duration: 0,
+    })
+  })
+
+  it('handles partial keys (only averages over aggregates that have the key)', () => {
+    const agg1 = makeAggregate({
+      assertions: 1,
+      labels: { sentiment: { negative: 0.2, positive: 0.8 } },
+      metrics: { m1: { count: 1, mean: 10 } },
+      scores: { s1: { count: 1, mean: 1 } },
+      task_duration: 1,
+      total_duration: 1,
+    })
+    const agg2 = makeAggregate({
+      assertions: null,
+      labels: { topic: { arts: 0.4, science: 0.6 } },
+      metrics: { m2: { count: 1, mean: 20 } },
+      scores: { s2: { count: 1, mean: 2 } },
+      task_duration: 3,
+      total_duration: 3,
+    })
+
+    const result = averageFromAggregates('Averages', [agg1, agg2])
+    expect(result.scores.s1?.mean).toBeCloseTo(1)
+    expect(result.scores.s2?.mean).toBeCloseTo(2)
+    expect(result.metrics.m1?.mean).toBeCloseTo(10)
+    expect(result.metrics.m2?.mean).toBeCloseTo(20)
+    expect(result.labels.sentiment).toEqual({ negative: 0.2, positive: 0.8 })
+    expect(result.labels.topic).toEqual({ arts: 0.4, science: 0.6 })
+    expect(result.assertions).toBeCloseTo(1)
+  })
+})

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -356,4 +356,129 @@ describe('offline evals — span attribute parity', () => {
     expect(result.cases).toEqual([])
     expect(result.failures).toEqual([])
   })
+
+  it('uses taskName and explicit name option for the report and span attributes', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'one' })],
+      name: 'naming-test',
+    })
+
+    const { result: customTask, spans: customSpans } = await withMemoryExporter(() =>
+      dataset.evaluate((s) => s, { taskName: 'custom_task' })
+    )
+    expect(customTask.name).toBe('custom_task')
+    const exp1 = customSpans.find((s) => s.name === SPAN_NAME_EXPERIMENT)
+    expect(exp1!.attributes[ATTR_TASK_NAME]).toBe('custom_task')
+    expect(exp1!.attributes[ATTR_NAME]).toBe('custom_task')
+
+    const { result: customExp, spans: customExpSpans } = await withMemoryExporter(() =>
+      dataset.evaluate((s) => s, { name: 'custom_experiment', taskName: 'custom_task' })
+    )
+    expect(customExp.name).toBe('custom_experiment')
+    const exp2 = customExpSpans.find((s) => s.name === SPAN_NAME_EXPERIMENT)
+    expect(exp2!.attributes[ATTR_TASK_NAME]).toBe('custom_task')
+    expect(exp2!.attributes[ATTR_NAME]).toBe('custom_experiment')
+  })
+
+  it('passes options.metadata through to report.experiment_metadata and the span', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'one' })],
+      name: 'metadata-test',
+    })
+    const metadata = { max_tokens: 1000, model: 'gpt-4o', prompt_version: 'v2.1' }
+
+    const { result, spans } = await withMemoryExporter(() => dataset.evaluate((s) => s, { metadata }))
+
+    expect(result.experiment_metadata).toEqual(metadata)
+    const exp = spans.find((s) => s.name === SPAN_NAME_EXPERIMENT)
+    const meta = JSON.parse(exp!.attributes[EXPERIMENT_METADATA_KEY] as string) as { metadata?: unknown }
+    expect(meta.metadata).toEqual(metadata)
+  })
+
+  it('returns an empty report for a dataset with no cases', async () => {
+    const dataset = new Dataset<string, string>({ cases: [], name: 'empty' })
+    const { result } = await withMemoryExporter(() => dataset.evaluate(() => 'unused'))
+    expect(result.cases).toEqual([])
+    expect(result.failures).toEqual([])
+  })
+
+  it('assigns positional names to unnamed cases interleaved with named ones', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [
+        new Case<string, string>({ inputs: 'a' }),
+        new Case<string, string>({ inputs: 'b', name: 'My Case' }),
+        new Case<string, string>({ inputs: 'c' }),
+      ],
+      name: 'unnamed',
+    })
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate((s) => s.toUpperCase()))
+    expect([...result.cases].sort((a, b) => a.name.localeCompare(b.name)).map((c) => c.name)).toEqual(['Case 1', 'Case 3', 'My Case'])
+  })
+
+  it('incrementEvalMetric with amount 0 does not create the metric', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'x' })],
+      name: 'increment-zero',
+    })
+    const { result } = await withMemoryExporter(() =>
+      dataset.evaluate((input) => {
+        incrementEvalMetric('phantom', 0)
+        incrementEvalMetric('real', 1)
+        return input
+      })
+    )
+    expect(result.cases[0]?.metrics).toEqual({ real: 1 })
+  })
+
+  it('respects maxConcurrency by serializing case execution', async () => {
+    let inFlight = 0
+    let peakInFlight = 0
+    const dataset = new Dataset<string, string>({
+      cases: [
+        new Case<string, string>({ inputs: 'a', name: 'a' }),
+        new Case<string, string>({ inputs: 'b', name: 'b' }),
+        new Case<string, string>({ inputs: 'c', name: 'c' }),
+        new Case<string, string>({ inputs: 'd', name: 'd' }),
+      ],
+      name: 'concurrency-test',
+    })
+
+    await withMemoryExporter(() =>
+      dataset.evaluate(
+        async (input) => {
+          inFlight += 1
+          peakInFlight = Math.max(peakInFlight, inFlight)
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          inFlight -= 1
+          return input
+        },
+        { maxConcurrency: 1 }
+      )
+    )
+    expect(peakInFlight).toBe(1)
+  })
+
+  it('records evaluator failures as evaluator_failures without aborting the experiment', async () => {
+    class FailingEvaluator extends Evaluator {
+      static evaluatorName = 'FailingEvaluator'
+      evaluate(): never {
+        throw new Error('Evaluator error')
+      }
+    }
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'one' }), new Case<string, string>({ inputs: 'b', name: 'two' })],
+      evaluators: [new FailingEvaluator()],
+      name: 'failing-eval',
+    })
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate((s) => s.toUpperCase()))
+
+    expect(result.cases).toHaveLength(2)
+    expect(result.failures).toEqual([])
+    for (const c of result.cases) {
+      expect(c.assertions).toEqual({})
+      expect(c.evaluator_failures).toMatchObject([{ error_message: 'Evaluator error', error_type: 'Error', name: 'FailingEvaluator' }])
+    }
+  })
 })

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -77,7 +77,7 @@ describe('offline evals — span attribute parity', () => {
 
     // Experiment span attributes — Condition-2 ingest discriminator + sort-by-pass-rate fields.
     const expAttrs = experiment!.attributes
-    expect(expAttrs[ATTR_NAME]).toBe('sentiment-classifier')
+    expect(expAttrs[ATTR_NAME]).toBe('classify')
     expect(expAttrs[ATTR_DATASET_NAME]).toBe('sentiment-classifier')
     expect(expAttrs[ATTR_TASK_NAME]).toBe('classify')
     expect(expAttrs[ATTR_N_CASES]).toBe(2)
@@ -88,7 +88,7 @@ describe('offline evals — span attribute parity', () => {
     const metadata = JSON.parse(expAttrs[EXPERIMENT_METADATA_KEY] as string) as Record<string, unknown>
     expect(metadata.n_cases).toBe(2)
     expect(metadata.averages).toBeDefined()
-    expect((metadata.averages as { name: string }).name).toBe('sentiment-classifier')
+    expect((metadata.averages as { name: string }).name).toBe('classify')
 
     // Each case span has case_name as a top-level attribute (UI detection requirement)
     for (const c of cases) {
@@ -147,6 +147,68 @@ describe('offline evals — span attribute parity', () => {
     expect(scores).toEqual({})
   })
 
+  it('runs case evaluators before dataset evaluators and suffixes duplicate result names', async () => {
+    class SameNameEvaluator extends Evaluator {
+      static evaluatorName = 'SameNameEvaluator'
+      private readonly value: boolean
+      constructor(evaluationName: string, value: boolean) {
+        super()
+        this.evaluationName = evaluationName
+        this.value = value
+      }
+      evaluate(): boolean {
+        return this.value
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [
+        new Case<string, string>({
+          evaluators: [new SameNameEvaluator('duplicate', true)],
+          inputs: 'x',
+          name: 'case',
+        }),
+      ],
+      evaluators: [new SameNameEvaluator('duplicate', false)],
+      name: 'ordering-test',
+    })
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate((input) => input))
+
+    expect(Object.keys(result.cases[0]!.assertions)).toEqual(['duplicate', 'duplicate_2'])
+    expect(result.cases[0]?.assertions.duplicate?.value).toBe(true)
+    expect(result.cases[0]?.assertions.duplicate_2?.value).toBe(false)
+  })
+
+  it('runs evaluators for a case concurrently', async () => {
+    let fastStarted = false
+    class SlowEvaluator extends Evaluator {
+      static evaluatorName = 'SlowEvaluator'
+      async evaluate(): Promise<boolean> {
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        return fastStarted
+      }
+    }
+    class FastEvaluator extends Evaluator {
+      static evaluatorName = 'FastEvaluator'
+      evaluate(): boolean {
+        fastStarted = true
+        return true
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'case' })],
+      evaluators: [new SlowEvaluator(), new FastEvaluator()],
+      name: 'parallel-evaluator-test',
+    })
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate((input) => input))
+
+    expect(result.cases[0]?.assertions.SlowEvaluator?.value).toBe(true)
+    expect(result.cases[0]?.assertions.FastEvaluator?.value).toBe(true)
+  })
+
   it('emits logfire.experiment.repeat and source_case_name on multi-run experiments', async () => {
     const dataset = new Dataset({
       cases: [new Case({ inputs: 'hi', name: 'x' })],
@@ -162,7 +224,7 @@ describe('offline evals — span attribute parity', () => {
     expect(cases).toHaveLength(3)
     for (const c of cases) {
       expect(c.attributes[EXPERIMENT_SOURCE_CASE_NAME_KEY]).toBe('x')
-      expect(c.attributes[ATTR_CASE_NAME]).toMatch(/^x \[run\/\d+\]$/)
+      expect(c.attributes[ATTR_CASE_NAME]).toMatch(/^x \[\d+\/3\]$/)
     }
   })
 
@@ -194,7 +256,7 @@ describe('offline evals — span attribute parity', () => {
     })
     const { result } = await withMemoryExporter(() => dataset.evaluate((s) => s))
     expect(result.cases[0]?.assertions.Contains?.value).toBe(true)
-    expect(result.cases[0]?.assertions.Contains?.reason).toBe('output contains value')
+    expect(result.cases[0]?.assertions.Contains?.reason).toBeNull()
   })
 
   it('supports addCase/addEvaluator, task helpers, progress callbacks and custom evaluator versions', async () => {

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/require-await */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { ATTRIBUTES_MESSAGE_KEY, ATTRIBUTES_MESSAGE_TEMPLATE_KEY } from '../../constants'
 import {
@@ -249,6 +249,18 @@ describe('offline evals — span attribute parity', () => {
     setEvalAttribute('outside', true)
     incrementEvalMetric('outside', 1)
     expect(getCurrentTaskRun()).toBeUndefined()
+
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    let messages: string[] = []
+    try {
+      await withMemoryExporter(() => dataset.evaluate(({ n }) => n, { progress: true }))
+      messages = error.mock.calls.map((call) => String(call[0]))
+    } finally {
+      error.mockRestore()
+    }
+    expect(messages).toHaveLength(2)
+    expect(messages.every((message) => /^\[\d\/2\] (?:one|two)$/.test(message))).toBe(true)
+    expect(messages.map((message) => message.replace(/^\[\d\/2\] /, '')).sort()).toEqual(['one', 'two'])
   })
 
   it('records non-Error task failures without rejecting the experiment', async () => {

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -18,11 +18,15 @@ import {
   Equals,
   EqualsExpected,
   EVALS_OTEL_SCOPE,
+  Evaluator,
   EXPERIMENT_METADATA_KEY,
   EXPERIMENT_REPEAT_KEY,
   EXPERIMENT_SOURCE_CASE_NAME_KEY,
   GEN_AI_OPERATION_NAME,
+  getCurrentTaskRun,
+  incrementEvalMetric,
   OPERATION_EXPERIMENT,
+  setEvalAttribute,
   SPAN_NAME_CASE,
   SPAN_NAME_EVALUATOR_LITERAL,
   SPAN_NAME_EXECUTE,
@@ -191,5 +195,91 @@ describe('offline evals — span attribute parity', () => {
     const { result } = await withMemoryExporter(() => dataset.evaluate((s) => s))
     expect(result.cases[0]?.assertions.Contains?.value).toBe(true)
     expect(result.cases[0]?.assertions.Contains?.reason).toBe('output contains value')
+  })
+
+  it('supports addCase/addEvaluator, task helpers, progress callbacks and custom evaluator versions', async () => {
+    class VersionedEvaluator extends Evaluator {
+      static evaluatorName = 'VersionedEvaluator'
+      evaluatorVersion = '2026-01-01'
+
+      evaluate(): Record<string, boolean | number | string> {
+        return { label: 'ok', score: 0.5, versioned: true }
+      }
+    }
+
+    const dataset = new Dataset<{ n: number }, number>({ name: 'mutation-test' })
+    dataset.addCase({ inputs: { n: 1 }, name: 'one' })
+    dataset.addCase({ inputs: { n: 2 }, name: 'two' })
+    dataset.addEvaluator(new Equals({ value: 1 }), { specificCase: 'one' })
+    dataset.addEvaluator(new VersionedEvaluator())
+
+    expect(() => {
+      dataset.addCase({ inputs: { n: 3 }, name: 'one' })
+    }).toThrow('Duplicate case name: "one"')
+    dataset.cases.pop()
+    expect(() => {
+      dataset.addEvaluator(new EqualsExpected(), { specificCase: 'missing' })
+    }).toThrow('addEvaluator: no case named "missing"')
+
+    const progress: { caseName: string; done: number; total: number }[] = []
+    const { result } = await withMemoryExporter(() =>
+      dataset.evaluate(
+        ({ n }) => {
+          expect(getCurrentTaskRun()).toBeDefined()
+          setEvalAttribute('seen', n)
+          incrementEvalMetric('calls', 1)
+          incrementEvalMetric('calls', 2)
+          return n
+        },
+        { progress: (event) => progress.push(event) }
+      )
+    )
+
+    expect(progress.map((event) => event.caseName).sort()).toEqual(['one', 'two'])
+    expect(progress.map((event) => event.done).sort()).toEqual([1, 2])
+    expect(progress.map((event) => event.total)).toEqual([2, 2])
+    const casesByName = [...result.cases].sort((a, b) => a.name.localeCompare(b.name))
+    expect(casesByName.map((c) => c.attributes)).toEqual([{ seen: 1 }, { seen: 2 }])
+    expect(casesByName.map((c) => c.metrics)).toEqual([{ calls: 3 }, { calls: 3 }])
+    expect(casesByName[0]?.assertions.Equals?.value).toBe(true)
+    expect(casesByName[0]?.assertions.versioned?.evaluator_version).toBe('2026-01-01')
+    expect(casesByName[0]?.scores.score?.value).toBe(0.5)
+    expect(casesByName[0]?.labels.label?.value).toBe('ok')
+
+    setEvalAttribute('outside', true)
+    incrementEvalMetric('outside', 1)
+    expect(getCurrentTaskRun()).toBeUndefined()
+  })
+
+  it('records non-Error task failures without rejecting the experiment', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'x' })],
+      name: 'non-error-failure',
+    })
+
+    const { result, spans } = await withMemoryExporter(() =>
+      dataset.evaluate(() => {
+        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error
+        throw 'string boom'
+      })
+    )
+
+    expect(result.failures).toMatchObject([{ error_message: 'string boom', error_type: 'Error', name: 'x' }])
+    const caseSpan = spans.find((s) => s.name === SPAN_NAME_CASE)
+    expect(caseSpan?.events.some((event) => event.attributes?.['exception.message'] === 'string boom')).toBe(true)
+  })
+
+  it('returns an empty report when aborted before cases start', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'x' })],
+      name: 'aborted-before-start',
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    const { result } = await withMemoryExporter(() => dataset.evaluate((input) => input, { signal: controller.signal }))
+
+    expect(result.cases).toEqual([])
+    expect(result.failures).toEqual([])
   })
 })

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -6,6 +6,7 @@ import {
   ATTR_EVALUATOR_NAME,
   configureOnlineEvals,
   disableEvaluation,
+  emitEvaluatorFailure,
   Equals,
   ERROR_TYPE,
   EVAL_RESULT_EVENT_NAME,
@@ -49,6 +50,13 @@ class NumericScore extends Evaluator {
   static evaluatorName = 'NumericScore'
   evaluate(): number {
     return 0.75
+  }
+}
+
+class TinyScore extends Evaluator {
+  static evaluatorName = 'TinyScore'
+  evaluate(): number {
+    return 1.23e-7
   }
 }
 
@@ -160,6 +168,17 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     })
     expect(logs[0]!.attributes[GEN_AI_SCORE_VALUE]).toBe(0.75)
     expect(logs[0]!.attributes[GEN_AI_SCORE_LABEL]).toBeUndefined()
+    expect(logs[0]!.body).toBe('evaluation: NumericScore=0.75')
+    expect((logs[0] as { severityNumber?: unknown }).severityNumber).toBeUndefined()
+  })
+
+  it('formats numeric result bodies like Python general format', async () => {
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new TinyScore()], target: 't' })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+    expect(logs[0]!.body).toBe('evaluation: TinyScore=1.23e-07')
   })
 
   it('string output → score.label only (no value)', async () => {
@@ -193,6 +212,24 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     // SimpleLogRecordProcessor doesn't expose severity directly via .severityNumber on most versions —
     // check via body shape
     expect(logs[0]!.body).toContain('failed: evaluator boom')
+  })
+
+  it('emits Python-compatible evaluator failure fallbacks when message/type are missing', async () => {
+    const { logs } = await withMemoryLogExporter(() => {
+      emitEvaluatorFailure(
+        {
+          error_message: '',
+          error_type: '',
+          name: 'MissingFailureFields',
+          source: { arguments: null, name: 'MissingFailureFields' },
+        },
+        { target: 'fallback-target' }
+      )
+    })
+
+    expect(logs).toHaveLength(1)
+    expect(logs[0]?.body).toBe('evaluation: MissingFailureFields failed')
+    expect(logs[0]?.attributes[ERROR_TYPE]).toBe('pydantic_evals.EvaluatorFailure')
   })
 
   it('converts online evaluator failures without calling onError', async () => {
@@ -361,6 +398,84 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(evaluatorSinkPayloads[0]?.results[0]?.name).toBe('AlwaysPass')
   })
 
+  it('skips evaluator execution when OTel events and sinks are both disabled', async () => {
+    let attempts = 0
+    class Counting extends Evaluator {
+      static evaluatorName = 'NoSinkCounting'
+      evaluate(): boolean {
+        attempts++
+        return true
+      }
+    }
+
+    const fn = withOnlineEvaluation(async () => 'x', {
+      emitOtelEvents: false,
+      evaluators: [new Counting()],
+      target: 'short-circuit-target',
+    })
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await expect(fn()).resolves.toBe('x')
+      await waitForEvaluations()
+    })
+
+    expect(attempts).toBe(0)
+    expect(logs).toHaveLength(0)
+  })
+
+  it('batches OnlineEvaluator sinks by sink identity', async () => {
+    const sinkPayloads: SinkPayload[] = []
+    const sharedSink = (payload: SinkPayload): void => {
+      sinkPayloads.push(payload)
+    }
+    const fn = withOnlineEvaluation(async () => 'x', {
+      emitOtelEvents: false,
+      evaluators: [
+        new OnlineEvaluator({ evaluator: new AlwaysPass(), sink: sharedSink }),
+        new OnlineEvaluator({ evaluator: new AlwaysFail(), sink: sharedSink }),
+      ],
+      target: 'batched-sink-target',
+    })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    expect(sinkPayloads).toHaveLength(1)
+    expect(sinkPayloads[0]?.results.map((result) => result.name).sort()).toEqual(['AlwaysFail', 'AlwaysPass'])
+  })
+
+  it('runs sampled online evaluators concurrently', async () => {
+    let fastStarted = false
+    class SlowOnlineEvaluator extends Evaluator {
+      static evaluatorName = 'SlowOnlineEvaluator'
+      async evaluate(): Promise<boolean> {
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        return fastStarted
+      }
+    }
+    class FastOnlineEvaluator extends Evaluator {
+      static evaluatorName = 'FastOnlineEvaluator'
+      evaluate(): boolean {
+        fastStarted = true
+        return true
+      }
+    }
+
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new SlowOnlineEvaluator(), new FastOnlineEvaluator()],
+      target: 'parallel-online-target',
+    })
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    expect(logs.find((log) => log.attributes[GEN_AI_EVAL_NAME] === 'SlowOnlineEvaluator')?.attributes[GEN_AI_SCORE_VALUE]).toBe(1)
+  })
+
   it('calls onError with Python-style arguments for sink failures', async () => {
     const errors: { error: unknown; evaluator: Evaluator; location: string; output: unknown }[] = []
     const fn = withOnlineEvaluation(async () => 'x', {
@@ -417,15 +532,18 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(logs[0]?.attributes.tenant).toBe('acme')
   })
 
-  it('supports explicit extracted argument names and independent per-evaluator sampling', async () => {
+  it('uses independent per-evaluator sampling by default and names context inputs when possible', async () => {
     const random = vi.spyOn(Math, 'random').mockReturnValueOnce(0.4).mockReturnValueOnce(0.6).mockReturnValue(0.1)
+    const sinkPayloads: SinkPayload[] = []
     const fn = withOnlineEvaluation(async (first: string, second: string) => `${first}${second}`, {
       evaluators: [
         new OnlineEvaluator({ evaluator: new AlwaysPass(), sampleRate: 0.5 }),
         new OnlineEvaluator({ evaluator: new AlwaysFail(), sampleRate: 0.5 }),
       ],
       extractArgs: ['renamedFirst', 'renamedSecond'],
-      samplingMode: 'independent',
+      sink: (payload) => {
+        sinkPayloads.push(payload)
+      },
       target: 'independent-target',
     })
 
@@ -438,6 +556,7 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
       expect(logs[0]?.attributes[GEN_AI_EVAL_NAME]).toBe('AlwaysPass')
       const callSpan = spans.find((s) => s.name === 'Calling independent-target')!
       expect(callSpan.attributes).toMatchObject({ renamedFirst: 'a', renamedSecond: 'b' })
+      expect(sinkPayloads[0]?.context.inputs).toEqual({ renamedFirst: 'a', renamedSecond: 'b' })
     } finally {
       random.mockRestore()
     }

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -195,21 +195,48 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(logs[0]!.body).toContain('failed: evaluator boom')
   })
 
-  it('calls evaluator onError hooks for online evaluator failures', async () => {
-    const errors: { error: unknown; name: string }[] = []
+  it('converts online evaluator failures without calling onError', async () => {
+    const errors: unknown[] = []
+    const globalErrors: unknown[] = []
+    const sinkPayloads: SinkPayload[] = []
     const fn = withOnlineEvaluation(async () => 'x', {
-      evaluators: [new OnlineEvaluator({ evaluator: new Throwing(), onError: (error, name) => errors.push({ error, name }) })],
+      evaluators: [
+        new OnlineEvaluator({
+          evaluator: new Throwing(),
+          onError: (error) => {
+            errors.push(error)
+          },
+        }),
+      ],
+      sink: (payload) => {
+        sinkPayloads.push(payload)
+      },
       target: 'error-hook-target',
     })
-
-    await withMemoryLogExporter(async () => {
-      await fn()
-      await waitForEvaluations()
+    const globalFn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new Throwing()],
+      target: 'global-error-hook-target',
     })
 
-    expect(errors).toHaveLength(1)
-    expect(errors[0]?.name).toBe('Throwing')
-    expect(errors[0]?.error).toBeInstanceOf(Error)
+    configureOnlineEvals({
+      onError: (error) => {
+        globalErrors.push(error)
+      },
+    })
+    try {
+      await withMemoryLogExporter(async () => {
+        await fn()
+        await globalFn()
+        await waitForEvaluations()
+      })
+    } finally {
+      configureOnlineEvals({ onError: undefined })
+    }
+
+    expect(errors).toHaveLength(0)
+    expect(globalErrors).toHaveLength(0)
+    expect(sinkPayloads).toHaveLength(1)
+    expect(sinkPayloads[0]?.failures[0]?.name).toBe('Throwing')
   })
 
   it('zero sample-rate skips all evaluators (no logs emitted)', async () => {
@@ -297,24 +324,67 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
 
   it('emitOtelEvents=false still runs evaluators and sends sink payloads without log records', async () => {
     const sinkPayloads: SinkPayload[] = []
+    const evaluatorSinkPayloads: SinkPayload[] = []
     const fn = withOnlineEvaluation(async () => 'x', {
       emitOtelEvents: false,
-      evaluators: [new AlwaysPass()],
+      evaluators: [
+        new OnlineEvaluator({
+          evaluator: new AlwaysPass(),
+          sink: (payload) => {
+            evaluatorSinkPayloads.push(payload)
+          },
+        }),
+      ],
       sink: (payload) => {
         sinkPayloads.push(payload)
       },
       target: 'sink-only-target',
     })
 
-    const { logs } = await withMemoryLogExporter(async () => {
+    configureOnlineEvals({ metadata: { suite: 'online' } })
+    try {
+      const { logs } = await withMemoryLogExporter(async () => {
+        await expect(fn()).resolves.toBe('x')
+        await waitForEvaluations()
+      })
+
+      expect(logs).toHaveLength(0)
+    } finally {
+      configureOnlineEvals({ metadata: undefined })
+    }
+    expect(sinkPayloads).toHaveLength(1)
+    expect(sinkPayloads[0]?.context.metadata).toEqual({ suite: 'online' })
+    expect(sinkPayloads[0]?.context.attributes).toEqual({})
+    expect(sinkPayloads[0]?.results).toHaveLength(1)
+    expect(sinkPayloads[0]?.results[0]?.name).toBe('AlwaysPass')
+    expect(evaluatorSinkPayloads).toHaveLength(1)
+    expect(evaluatorSinkPayloads[0]?.results[0]?.name).toBe('AlwaysPass')
+  })
+
+  it('calls onError with Python-style arguments for sink failures', async () => {
+    const errors: { error: unknown; evaluator: Evaluator; location: string; output: unknown }[] = []
+    const fn = withOnlineEvaluation(async () => 'x', {
+      emitOtelEvents: false,
+      evaluators: [new AlwaysPass()],
+      onError: (error, context, evaluator, location) => {
+        errors.push({ error, evaluator, location, output: context.output })
+      },
+      sink: () => {
+        throw new Error('sink boom')
+      },
+      target: 'sink-error-target',
+    })
+
+    await withMemoryLogExporter(async () => {
       await expect(fn()).resolves.toBe('x')
       await waitForEvaluations()
     })
 
-    expect(logs).toHaveLength(0)
-    expect(sinkPayloads).toHaveLength(1)
-    expect(sinkPayloads[0]?.results).toHaveLength(1)
-    expect(sinkPayloads[0]?.results[0]?.name).toBe('AlwaysPass')
+    expect(errors).toHaveLength(1)
+    expect(errors[0]?.error).toBeInstanceOf(Error)
+    expect(errors[0]?.evaluator).toBeInstanceOf(AlwaysPass)
+    expect(errors[0]?.location).toBe('sink')
+    expect(errors[0]?.output).toBe('x')
   })
 
   it('extracts call arguments, records return values and propagates baggage to emitted logs', async () => {
@@ -505,21 +575,68 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     const evaluator = new OnlineEvaluator({
       evaluator: new SlowEvaluator(),
       maxConcurrency: 1,
-      onMaxConcurrency: (name) => {
-        drops.push(name)
-      },
     })
-    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [evaluator], target: 'slow-target' })
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [evaluator],
+      onMaxConcurrency: (context) => {
+        drops.push(String(context.output))
+      },
+      target: 'slow-target',
+    })
 
     const { logs } = await withMemoryLogExporter(async () => {
       await fn()
       await fn()
-      expect(drops).toEqual(['SlowEvaluator'])
+      expect(drops).toEqual(['x'])
       releaseSlow()
       await waitForEvaluations()
     })
 
     expect(logs).toHaveLength(1)
+  })
+
+  it('routes onMaxConcurrency callback errors through onError', async () => {
+    let releaseSlow!: () => void
+    const slow = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+    const errors: { evaluator: Evaluator; location: string; output: unknown }[] = []
+
+    class SlowEvaluator extends Evaluator {
+      static evaluatorName = 'SlowEvaluatorWithDropError'
+
+      async evaluate(): Promise<boolean> {
+        await slow
+        return true
+      }
+    }
+
+    const evaluator = new OnlineEvaluator({
+      evaluator: new SlowEvaluator(),
+      maxConcurrency: 1,
+      onMaxConcurrency: () => {
+        throw new Error('drop hook boom')
+      },
+    })
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [evaluator],
+      onError: (_error, context, droppedEvaluator, location) => {
+        errors.push({ evaluator: droppedEvaluator, location, output: context.output })
+      },
+      target: 'slow-target',
+    })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await fn()
+      releaseSlow()
+      await waitForEvaluations()
+    })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]?.evaluator).toBeInstanceOf(SlowEvaluator)
+    expect(errors[0]?.location).toBe('on_max_concurrency')
+    expect(errors[0]?.output).toBe('x')
   })
 
   it('waitForEvaluations times out when dispatches remain pending', async () => {

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/require-await */
+import { trace as TraceAPI } from '@opentelemetry/api'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -15,6 +16,7 @@ import {
   GEN_AI_EXPLANATION,
   GEN_AI_SCORE_LABEL,
   GEN_AI_SCORE_VALUE,
+  HasMatchingSpan,
   OnlineEvaluator,
   SPAN_NAME_EVALUATOR_LITERAL,
   waitForEvaluations,
@@ -201,6 +203,34 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     const src = JSON.parse(logs[0]!.attributes[GEN_AI_EVALUATOR_SOURCE] as string) as { arguments: unknown; name: string }
     expect(src.name).toBe('Equals')
     expect(src.arguments).toEqual({ value: 'expected' })
+  })
+
+  it('captures wrapped-call spans into online evaluator context', async () => {
+    const fn = withOnlineEvaluation(
+      async (input: string) => {
+        const tracer = TraceAPI.getTracer('online-user-code')
+        await tracer.startActiveSpan('inner-op', async (span) => {
+          span.setAttribute('user.input', input)
+          span.end()
+        })
+        return input.toUpperCase()
+      },
+      {
+        evaluators: [new HasMatchingSpan({ query: { nameEquals: 'inner-op' } })],
+        target: 'online-span-target',
+      }
+    )
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      const result = await fn('hi')
+      expect(result).toBe('HI')
+      await waitForEvaluations()
+    })
+
+    expect(logs).toHaveLength(1)
+    expect(logs[0]!.body).toBe('evaluation: HasMatchingSpan=True')
+    expect(logs[0]!.attributes[GEN_AI_SCORE_VALUE]).toBe(1)
+    expect(logs[0]!.attributes[GEN_AI_SCORE_LABEL]).toBe('pass')
   })
 
   it('drops online evaluations at maxConcurrency without blocking the wrapped call', async () => {

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/require-await */
-import { trace as TraceAPI } from '@opentelemetry/api'
-import { describe, expect, it } from 'vitest'
+import { context as ContextAPI, propagation, trace as TraceAPI } from '@opentelemetry/api'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   ATTR_EVALUATOR_NAME,
   configureOnlineEvals,
+  disableEvaluation,
   Equals,
   ERROR_TYPE,
   EVAL_RESULT_EVENT_NAME,
@@ -17,6 +18,7 @@ import {
   GEN_AI_EXPLANATION,
   GEN_AI_SCORE_LABEL,
   GEN_AI_SCORE_VALUE,
+  getOnlineEvalConfig,
   HasMatchingSpan,
   OnlineEvaluator,
   type SinkPayload,
@@ -72,6 +74,32 @@ class Throwing extends Evaluator {
 }
 
 describe('online evals — gen_ai.evaluation.result emission', () => {
+  it('exposes global config and OnlineEvaluator wrapper properties', () => {
+    const sinkPayloads: SinkPayload[] = []
+    configureOnlineEvals({
+      metadata: { suite: 'online' },
+      sink: (payload) => {
+        sinkPayloads.push(payload)
+      },
+    })
+    try {
+      expect(getOnlineEvalConfig().metadata).toEqual({ suite: 'online' })
+      const evaluator = new OnlineEvaluator({
+        evaluator: new AlwaysPass(),
+        sampleRate: 0.25,
+        sink: (payload) => {
+          sinkPayloads.push(payload)
+        },
+      })
+      expect(evaluator.name).toBe('AlwaysPass')
+      expect(evaluator.evaluator).toBeInstanceOf(AlwaysPass)
+      expect(evaluator.sampleRate).toBe(0.25)
+      expect(evaluator.sink).toBeTypeOf('function')
+    } finally {
+      configureOnlineEvals({ metadata: undefined, sink: undefined })
+    }
+  })
+
   it('emits one log per result, parented to call span, on the pydantic-evals scope', async () => {
     const fn = withOnlineEvaluation(async (msg: string) => msg.toUpperCase(), {
       evaluators: [new AlwaysPass()],
@@ -167,6 +195,23 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(logs[0]!.body).toContain('failed: evaluator boom')
   })
 
+  it('calls evaluator onError hooks for online evaluator failures', async () => {
+    const errors: { error: unknown; name: string }[] = []
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new OnlineEvaluator({ evaluator: new Throwing(), onError: (error, name) => errors.push({ error, name }) })],
+      target: 'error-hook-target',
+    })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]?.name).toBe('Throwing')
+    expect(errors[0]?.error).toBeInstanceOf(Error)
+  })
+
   it('zero sample-rate skips all evaluators (no logs emitted)', async () => {
     const fn = withOnlineEvaluation(async () => 'x', {
       evaluators: [new AlwaysPass()],
@@ -229,6 +274,27 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     }
   })
 
+  it('disableEvaluation suppresses dispatch until disposed', async () => {
+    const handle = disableEvaluation()
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new AlwaysPass()], target: 'disabled-handle-target' })
+    try {
+      const { logs } = await withMemoryLogExporter(async () => {
+        await expect(fn()).resolves.toBe('x')
+        await waitForEvaluations()
+      })
+      expect(logs).toHaveLength(0)
+    } finally {
+      handle.dispose()
+      handle.dispose()
+    }
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await expect(fn()).resolves.toBe('x')
+      await waitForEvaluations()
+    })
+    expect(logs).toHaveLength(1)
+  })
+
   it('emitOtelEvents=false still runs evaluators and sends sink payloads without log records', async () => {
     const sinkPayloads: SinkPayload[] = []
     const fn = withOnlineEvaluation(async () => 'x', {
@@ -249,6 +315,62 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(sinkPayloads).toHaveLength(1)
     expect(sinkPayloads[0]?.results).toHaveLength(1)
     expect(sinkPayloads[0]?.results[0]?.name).toBe('AlwaysPass')
+  })
+
+  it('extracts call arguments, records return values and propagates baggage to emitted logs', async () => {
+    async function answer(first: string, count = 1): Promise<{ count: number; first: string }> {
+      return { count, first }
+    }
+
+    const fn = withOnlineEvaluation(answer, {
+      evaluators: [new AlwaysPass()],
+      extractArgs: true,
+      recordReturn: true,
+      target: 'argument-target',
+    })
+    const baggage = propagation.createBaggage({ tenant: { value: 'acme' } })
+
+    const { logs, spans } = await withMemoryLogExporter(async () =>
+      ContextAPI.with(propagation.setBaggage(ContextAPI.active(), baggage), async () => {
+        await expect(fn('hello', 3)).resolves.toEqual({ count: 3, first: 'hello' })
+        await waitForEvaluations()
+      })
+    )
+
+    const callSpan = spans.find((s) => s.name === 'Calling argument-target')!
+    expect(callSpan.attributes).toMatchObject({
+      count: 3,
+      first: 'hello',
+      return: '{"count":3,"first":"hello"}',
+      target: 'argument-target',
+    })
+    expect(logs[0]?.attributes.tenant).toBe('acme')
+  })
+
+  it('supports explicit extracted argument names and independent per-evaluator sampling', async () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValueOnce(0.4).mockReturnValueOnce(0.6).mockReturnValue(0.1)
+    const fn = withOnlineEvaluation(async (first: string, second: string) => `${first}${second}`, {
+      evaluators: [
+        new OnlineEvaluator({ evaluator: new AlwaysPass(), sampleRate: 0.5 }),
+        new OnlineEvaluator({ evaluator: new AlwaysFail(), sampleRate: 0.5 }),
+      ],
+      extractArgs: ['renamedFirst', 'renamedSecond'],
+      samplingMode: 'independent',
+      target: 'independent-target',
+    })
+
+    try {
+      const { logs, spans } = await withMemoryLogExporter(async () => {
+        await fn('a', 'b')
+        await waitForEvaluations()
+      })
+      expect(logs).toHaveLength(1)
+      expect(logs[0]?.attributes[GEN_AI_EVAL_NAME]).toBe('AlwaysPass')
+      const callSpan = spans.find((s) => s.name === 'Calling independent-target')!
+      expect(callSpan.attributes).toMatchObject({ renamedFirst: 'a', renamedSecond: 'b' })
+    } finally {
+      random.mockRestore()
+    }
   })
 
   it('event name is gen_ai.evaluation.result', async () => {
@@ -276,6 +398,64 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     const src = JSON.parse(logs[0]!.attributes[GEN_AI_EVALUATOR_SOURCE] as string) as { arguments: unknown; name: string }
     expect(src.name).toBe('Equals')
     expect(src.arguments).toEqual({ value: 'expected' })
+  })
+
+  it('emits one log per named output when an evaluator returns a result object', async () => {
+    class MultiOutput extends Evaluator {
+      static evaluatorName = 'MultiOutput'
+
+      evaluate(): Record<string, boolean | number | string> {
+        return { assertion: true, label: 'great', score: 0.95 }
+      }
+    }
+
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new MultiOutput()], target: 'multi-output-target' })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    expect(logs.map((log) => log.attributes[GEN_AI_EVAL_NAME]).sort()).toEqual(['assertion', 'label', 'score'])
+    expect(logs.find((log) => log.attributes[GEN_AI_EVAL_NAME] === 'assertion')?.attributes[GEN_AI_SCORE_VALUE]).toBe(1)
+    expect(logs.find((log) => log.attributes[GEN_AI_EVAL_NAME] === 'label')?.attributes[GEN_AI_SCORE_LABEL]).toBe('great')
+    expect(logs.find((log) => log.attributes[GEN_AI_EVAL_NAME] === 'score')?.attributes[GEN_AI_SCORE_VALUE]).toBe(0.95)
+  })
+
+  it('cleans up captured spans and does not dispatch evaluators when the wrapped call fails', async () => {
+    const fn = withOnlineEvaluation(
+      async () => {
+        throw new Error('call failed')
+      },
+      { evaluators: [new AlwaysPass()], target: 'failing-call-target' }
+    )
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await expect(fn()).rejects.toThrow('call failed')
+      await waitForEvaluations()
+    })
+
+    expect(logs).toHaveLength(0)
+  })
+
+  it('OnlineEvaluator.tryRun can execute without a parent call span reference', async () => {
+    const evaluator = new OnlineEvaluator({ evaluator: new AlwaysPass() })
+    const { result, spans } = await withMemoryLogExporter(() =>
+      evaluator.tryRun(
+        {
+          attributes: {},
+          duration: 0,
+          inputs: 'x',
+          metrics: {},
+          output: 'x',
+          spanTree: { any: () => false } as never,
+        },
+        null
+      )
+    )
+
+    expect(result.results[0]?.name).toBe('AlwaysPass')
+    const evaluatorSpan = spans.find((s) => s.name === SPAN_NAME_EVALUATOR_LITERAL)
+    expect(evaluatorSpan?.parentSpanContext).toBeUndefined()
   })
 
   it('captures wrapped-call spans into online evaluator context', async () => {
@@ -340,6 +520,30 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     })
 
     expect(logs).toHaveLength(1)
+  })
+
+  it('waitForEvaluations times out when dispatches remain pending', async () => {
+    let releaseSlow!: () => void
+    const slow = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+
+    class SlowEvaluator extends Evaluator {
+      static evaluatorName = 'SlowTimeoutEvaluator'
+      async evaluate(): Promise<boolean> {
+        await slow
+        return true
+      }
+    }
+
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new SlowEvaluator()], target: 'timeout-target' })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await expect(waitForEvaluations({ timeoutMs: 0 })).rejects.toThrow('waitForEvaluations:')
+      releaseSlow()
+      await waitForEvaluations()
+    })
   })
 })
 

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   ATTR_EVALUATOR_NAME,
+  configureOnlineEvals,
   Equals,
   ERROR_TYPE,
   EVAL_RESULT_EVENT_NAME,
@@ -18,6 +19,7 @@ import {
   GEN_AI_SCORE_VALUE,
   HasMatchingSpan,
   OnlineEvaluator,
+  type SinkPayload,
   SPAN_NAME_EVALUATOR_LITERAL,
   waitForEvaluations,
   withOnlineEvaluation,
@@ -176,6 +178,77 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
       await waitForEvaluations()
     })
     expect(logs).toHaveLength(0)
+  })
+
+  it('sampling errors call onSamplingError and skip evaluation without failing the wrapped call', async () => {
+    const samplingErrors: unknown[] = []
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new AlwaysPass()],
+      onSamplingError: (err) => {
+        samplingErrors.push(err)
+      },
+      sampleRate: () => {
+        throw new Error('sampling boom')
+      },
+      target: 'sampling-error-target',
+    })
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await expect(fn()).resolves.toBe('x')
+      await waitForEvaluations()
+    })
+
+    expect(logs).toHaveLength(0)
+    expect(samplingErrors).toHaveLength(1)
+    expect(samplingErrors[0]).toBeInstanceOf(Error)
+    expect((samplingErrors[0] as Error).message).toBe('sampling boom')
+  })
+
+  it('global enabled=false bypasses evaluators and leaves the wrapped call intact', async () => {
+    let evaluateCount = 0
+    class Counting extends Evaluator {
+      static evaluatorName = 'Counting'
+      evaluate(): boolean {
+        evaluateCount++
+        return true
+      }
+    }
+
+    configureOnlineEvals({ enabled: false })
+    try {
+      const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new Counting()], target: 'disabled-target' })
+      const { logs } = await withMemoryLogExporter(async () => {
+        await expect(fn()).resolves.toBe('x')
+        await waitForEvaluations()
+      })
+
+      expect(evaluateCount).toBe(0)
+      expect(logs).toHaveLength(0)
+    } finally {
+      configureOnlineEvals({ enabled: true })
+    }
+  })
+
+  it('emitOtelEvents=false still runs evaluators and sends sink payloads without log records', async () => {
+    const sinkPayloads: SinkPayload[] = []
+    const fn = withOnlineEvaluation(async () => 'x', {
+      emitOtelEvents: false,
+      evaluators: [new AlwaysPass()],
+      sink: (payload) => {
+        sinkPayloads.push(payload)
+      },
+      target: 'sink-only-target',
+    })
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await expect(fn()).resolves.toBe('x')
+      await waitForEvaluations()
+    })
+
+    expect(logs).toHaveLength(0)
+    expect(sinkPayloads).toHaveLength(1)
+    expect(sinkPayloads[0]?.results).toHaveLength(1)
+    expect(sinkPayloads[0]?.results[0]?.name).toBe('AlwaysPass')
   })
 
   it('event name is gen_ai.evaluation.result', async () => {

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -792,6 +792,97 @@ class CountingEvaluator extends Evaluator {
   }
 }
 
+describe('sampling', () => {
+  it('passes a SamplingContext with args and target to the sampleRate callable', async () => {
+    const seen: { args: unknown[]; target: string }[] = []
+    const fn = withOnlineEvaluation(async (a: number, b: string) => `${a.toString()}:${b}`, {
+      evaluators: [new AlwaysPass()],
+      sampleRate: (ctx) => {
+        seen.push({ args: ctx.args, target: ctx.target })
+        return 1
+      },
+      target: 'sampling-ctx-target',
+    })
+    await withMemoryLogExporter(async () => {
+      await fn(7, 'q')
+      await waitForEvaluations()
+    })
+    expect(seen).toEqual([{ args: [7, 'q'], target: 'sampling-ctx-target' }])
+  })
+
+  it('correlated sampling mode shares a single draw across evaluators in one call', async () => {
+    // Math.random gets called multiple times per fn() (sampling seed + exporter id + spans).
+    // Use a counter to give the sampling seed a known value and a benign default for the rest.
+    let calls = 0
+    const random = vi.spyOn(Math, 'random').mockImplementation(() => {
+      calls += 1
+      if (calls === 1) return 0.4 // first call sampling seed → < 0.5, both included
+      if (calls === 2) return 0.99 // exporter id, ignored
+      if (calls === 3) return 0.6 // second call sampling seed → ≥ 0.5, both excluded
+      return 0.99
+    })
+    try {
+      const fn = withOnlineEvaluation(async () => 'x', {
+        evaluators: [new AlwaysPass(), new AlwaysFail()],
+        sampleRate: 0.5,
+        samplingMode: 'correlated',
+        target: 'correlated',
+      })
+      const { logs } = await withMemoryLogExporter(async () => {
+        await fn()
+        await fn()
+        await waitForEvaluations()
+      })
+      expect(logs).toHaveLength(2)
+      expect(logs.map((l) => l.attributes[GEN_AI_EVAL_NAME]).sort()).toEqual(['AlwaysFail', 'AlwaysPass'])
+    } finally {
+      random.mockRestore()
+    }
+  })
+
+  it('configureOnlineEvals({samplingMode}) applies globally', async () => {
+    configureOnlineEvals({ samplingMode: 'correlated' })
+    let calls = 0
+    const random = vi.spyOn(Math, 'random').mockImplementation(() => {
+      calls += 1
+      if (calls === 1) return 0.1 // sampling seed → < 0.5, both included
+      return 0.99
+    })
+    try {
+      const fn = withOnlineEvaluation(async () => 'x', {
+        evaluators: [new AlwaysPass(), new AlwaysFail()],
+        sampleRate: 0.5,
+        target: 'correlated-global',
+      })
+      const { logs } = await withMemoryLogExporter(async () => {
+        await fn()
+        await waitForEvaluations()
+      })
+      expect(logs).toHaveLength(2)
+    } finally {
+      random.mockRestore()
+      configureOnlineEvals({ samplingMode: 'independent' })
+    }
+  })
+})
+
+describe('evaluator output edge cases', () => {
+  it('an evaluator returning an empty result map emits no events', async () => {
+    class EmptyResult extends Evaluator {
+      static evaluatorName = 'EmptyResult'
+      evaluate(): Record<string, never> {
+        return {}
+      }
+    }
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new EmptyResult()], target: 'empty-result' })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+    expect(logs).toHaveLength(0)
+  })
+})
+
 describe('online suppression inside Dataset.evaluate', () => {
   it('does not double-evaluate: online wrapper skipped when invoked from within evaluate', async () => {
     CountingEvaluator.count = 0

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  ATTR_EVALUATOR_NAME,
   Equals,
   ERROR_TYPE,
   EVAL_RESULT_EVENT_NAME,
@@ -14,6 +15,8 @@ import {
   GEN_AI_EXPLANATION,
   GEN_AI_SCORE_LABEL,
   GEN_AI_SCORE_VALUE,
+  OnlineEvaluator,
+  SPAN_NAME_EVALUATOR_LITERAL,
   waitForEvaluations,
   withOnlineEvaluation,
 } from '../../evals'
@@ -99,6 +102,11 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(callSpan).toBeDefined()
     expect(rec.spanContext?.traceId).toBe(callSpan!.spanContext().traceId)
     expect(rec.spanContext?.spanId).toBe(callSpan!.spanContext().spanId)
+
+    const evaluatorSpan = spans.find((s) => s.name === SPAN_NAME_EVALUATOR_LITERAL)
+    expect(evaluatorSpan?.attributes[ATTR_EVALUATOR_NAME]).toBe('AlwaysPass')
+    expect(evaluatorSpan?.parentSpanContext?.spanId).toBe(callSpan!.spanContext().spanId)
+    expect(evaluatorSpan?.spanContext().traceId).toBe(callSpan!.spanContext().traceId)
   })
 
   it('encodes false as score.value=0 + score.label=fail', async () => {
@@ -193,6 +201,42 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     const src = JSON.parse(logs[0]!.attributes[GEN_AI_EVALUATOR_SOURCE] as string) as { arguments: unknown; name: string }
     expect(src.name).toBe('Equals')
     expect(src.arguments).toEqual({ value: 'expected' })
+  })
+
+  it('drops online evaluations at maxConcurrency without blocking the wrapped call', async () => {
+    let releaseSlow!: () => void
+    const slow = new Promise<void>((resolve) => {
+      releaseSlow = resolve
+    })
+    const drops: string[] = []
+
+    class SlowEvaluator extends Evaluator {
+      static evaluatorName = 'SlowEvaluator'
+
+      async evaluate(): Promise<boolean> {
+        await slow
+        return true
+      }
+    }
+
+    const evaluator = new OnlineEvaluator({
+      evaluator: new SlowEvaluator(),
+      maxConcurrency: 1,
+      onMaxConcurrency: (name) => {
+        drops.push(name)
+      },
+    })
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [evaluator], target: 'slow-target' })
+
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await fn()
+      expect(drops).toEqual(['SlowEvaluator'])
+      releaseSlow()
+      await waitForEvaluations()
+    })
+
+    expect(logs).toHaveLength(1)
   })
 })
 

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   Case,
   CaseLifecycle,
+  computeAssertionPassRate,
   computeAverages,
   ConfusionMatrixEvaluator,
   Dataset,
@@ -13,6 +14,7 @@ import {
   Evaluator,
   type EvaluatorContext,
   EXPERIMENT_ANALYSES_KEY,
+  EXPERIMENT_REPORT_EVALUATOR_FAILURES_KEY,
   KolmogorovSmirnovEvaluator,
   PrecisionRecallEvaluator,
   renderReport,
@@ -24,7 +26,32 @@ import {
   SPAN_NAME_CASE,
   SPAN_NAME_EXPERIMENT,
 } from '../../evals'
+import { buildThresholdInputs, trapezoidalAuc, uniqueSortedThresholds } from '../reportEvaluators'
 import { withMemoryExporter } from './withMemoryExporter'
+
+const resultJson = (name: string, value: boolean | number | string) => ({
+  name,
+  reason: null,
+  source: { arguments: null, name: 'Source' },
+  value,
+})
+
+const makeReportCase = (overrides: Partial<ReportCase> = {}): ReportCase => ({
+  assertions: {},
+  attributes: {},
+  evaluator_failures: [],
+  inputs: 'input',
+  labels: {},
+  metrics: {},
+  name: 'case',
+  output: 'output',
+  scores: {},
+  span_id: null,
+  task_duration: 0.1,
+  total_duration: 0.2,
+  trace_id: null,
+  ...overrides,
+})
 
 describe('lifecycle hooks', () => {
   it('runs setup → task → prepareContext → evaluators → teardown in order', async () => {
@@ -298,6 +325,44 @@ describe('report-level evaluators land on the experiment span', () => {
     expect(captured?.report.cases[0]?.name).toBe('1')
   })
 
+  it('records report evaluator failures and serializes them onto the experiment span', async () => {
+    class BrokenReportEvaluator extends ReportEvaluator<string, string> {
+      static evaluatorName = 'BrokenReportEvaluator'
+      evaluatorVersion = 'v1'
+
+      evaluate(): never {
+        throw new Error('report boom')
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'x' })],
+      name: 'report-failure-test',
+      reportEvaluators: [new BrokenReportEvaluator()],
+    })
+
+    const { result, spans } = await withMemoryExporter(async () => dataset.evaluate((input) => input))
+
+    expect(result.report_evaluator_failures).toMatchObject([
+      {
+        error_message: 'report boom',
+        error_type: 'Error',
+        name: 'BrokenReportEvaluator',
+        source: { arguments: null, name: 'BrokenReportEvaluator' },
+      },
+    ])
+    const experimentSpan = spans.find((s) => s.name === SPAN_NAME_EXPERIMENT)!
+    const failuresAttr = JSON.parse(experimentSpan.attributes[EXPERIMENT_REPORT_EVALUATOR_FAILURES_KEY] as string) as unknown[]
+    expect(failuresAttr).toMatchObject([
+      {
+        error_message: 'report boom',
+        error_type: 'Error',
+        name: 'BrokenReportEvaluator',
+        source: { arguments: null, name: 'BrokenReportEvaluator' },
+      },
+    ])
+  })
+
   it('PrecisionRecall + ROCAUC + KS emit Python-compatible analysis shapes', async () => {
     const dataset = new Dataset<{ score: number }, number>({
       cases: [
@@ -409,24 +474,222 @@ describe('report-level evaluators land on the experiment span', () => {
   })
 
   it('computes label averages as normalized frequencies', () => {
-    const makeCase = (label: string): ReportCase => ({
-      assertions: {},
-      attributes: {},
-      evaluator_failures: [],
-      inputs: 'x',
-      labels: { grade: { name: 'grade', reason: null, source: { arguments: null, name: 'Labeler' }, value: label } },
-      metrics: {},
-      name: label,
-      output: 'x',
-      scores: {},
-      span_id: null,
-      task_duration: 0,
-      total_duration: 0,
-      trace_id: null,
-    })
+    const makeCase = (label: string): ReportCase => makeReportCase({ labels: { grade: resultJson('grade', label) }, name: label })
 
     expect(computeAverages('labels', [makeCase('good'), makeCase('good'), makeCase('bad')]).labels).toEqual({
       grade: { bad: 1 / 3, good: 2 / 3 },
+    })
+  })
+
+  it('computes assertion pass rate plus score and metric means', () => {
+    const cases = [
+      makeReportCase({
+        assertions: { ok: resultJson('ok', true) },
+        metrics: { latency: 10 },
+        scores: { quality: resultJson('quality', 0.5) },
+        task_duration: 1,
+        total_duration: 2,
+      }),
+      makeReportCase({
+        assertions: { ok: resultJson('ok', false) },
+        metrics: { latency: 20 },
+        scores: { quality: resultJson('quality', 1) },
+        task_duration: 3,
+        total_duration: 4,
+      }),
+    ]
+
+    expect(computeAssertionPassRate(cases)).toBe(0.5)
+    expect(computeAssertionPassRate([makeReportCase()])).toBeNull()
+    expect(computeAverages('means', cases)).toEqual({
+      assertions: 0.5,
+      labels: {},
+      metrics: { latency: { count: 2, mean: 15 } },
+      name: 'means',
+      scores: { quality: { count: 2, mean: 0.75 } },
+      task_duration: 2,
+      total_duration: 3,
+    })
+    expect(computeAverages('empty', [])).toEqual({
+      assertions: null,
+      labels: {},
+      metrics: {},
+      name: 'empty',
+      scores: {},
+      task_duration: 0,
+      total_duration: 0,
+    })
+  })
+})
+
+describe('report evaluator edge cases', () => {
+  it('ReportEvaluator default getSpec uses the registry key and null arguments', () => {
+    class MinimalReportEvaluator extends ReportEvaluator {
+      static evaluatorName = 'MinimalReportEvaluator'
+      evaluate() {
+        return { columns: [], rows: [], title: 'empty', type: 'table' as const }
+      }
+    }
+
+    expect(new MinimalReportEvaluator().getSpec()).toEqual({ arguments: null, name: 'MinimalReportEvaluator' })
+    expect(new MinimalReportEvaluator().toJSON()).toBeNull()
+  })
+
+  it('ConfusionMatrixEvaluator extracts labels and metadata and skips missing values', () => {
+    const evaluator = new ConfusionMatrixEvaluator({
+      expected: { from: 'metadata', key: 'expected' },
+      predicted: { from: 'labels', key: 'predicted' },
+      title: 'Custom Matrix',
+    })
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [
+        makeReportCase({
+          labels: { predicted: resultJson('predicted', 'B') },
+          metadata: { expected: 'A' },
+          name: 'a-to-b',
+        }),
+        makeReportCase({
+          labels: { predicted: resultJson('predicted', 'A') },
+          metadata: { expected: true },
+          name: 'bool-to-a',
+        }),
+        makeReportCase({ labels: {}, metadata: { expected: 'A' }, name: 'missing-predicted' }),
+      ],
+      failures: [],
+      name: 'matrix',
+      report_evaluator_failures: [],
+      span_id: null,
+      trace_id: null,
+    }
+
+    expect(evaluator.evaluate({ cases: report.cases, name: 'matrix', report })).toEqual({
+      class_labels: ['A', 'B', 'true'],
+      matrix: [
+        [0, 1, 0],
+        [0, 0, 0],
+        [1, 0, 0],
+      ],
+      title: 'Custom Matrix',
+      type: 'confusion_matrix',
+    })
+    expect(evaluator.toJSON()).toEqual({
+      expected: { from: 'metadata', key: 'expected' },
+      predicted: { from: 'labels', key: 'predicted' },
+      title: 'Custom Matrix',
+    })
+  })
+
+  it('threshold helpers support all sources, downsampling and empty AUC', () => {
+    const cases = [
+      makeReportCase({
+        assertions: { positive: resultJson('positive', true) },
+        expected_output: { positive: false },
+        labels: { positive: resultJson('positive', 'yes') },
+        metrics: { m: 0.8 },
+        scores: { s: resultJson('s', 0.7) },
+      }),
+      makeReportCase({
+        assertions: { positive: resultJson('positive', false) },
+        expected_output: { positive: true },
+        labels: { positive: resultJson('positive', '') },
+        metrics: { m: 0.2 },
+        scores: { s: resultJson('s', 0.1) },
+      }),
+      makeReportCase({ metrics: {}, scores: {} }),
+    ]
+
+    expect(
+      buildThresholdInputs(cases, { positiveFrom: 'assertions', positiveKey: 'positive', scoreFrom: 'scores', scoreKey: 's' })
+    ).toEqual({
+      positives: [true, false],
+      scores: [0.7, 0.1],
+    })
+    expect(
+      buildThresholdInputs(cases, { positiveFrom: 'expected_output', positiveKey: 'positive', scoreFrom: 'metrics', scoreKey: 'm' })
+    ).toEqual({
+      positives: [false, true],
+      scores: [0.8, 0.2],
+    })
+    expect(buildThresholdInputs(cases, { positiveFrom: 'labels', positiveKey: 'positive', scoreFrom: 'scores', scoreKey: 's' })).toEqual({
+      positives: [true, false],
+      scores: [0.7, 0.1],
+    })
+    expect(buildThresholdInputs(cases, { positiveFrom: 'expected_output', scoreFrom: 'scores', scoreKey: 's' })).toEqual({
+      positives: [true, true],
+      scores: [0.7, 0.1],
+    })
+    expect(buildThresholdInputs(cases, { positiveFrom: 'assertions', scoreFrom: 'scores', scoreKey: 's' })).toEqual({
+      positives: [],
+      scores: [],
+    })
+    expect(uniqueSortedThresholds([], 3)).toEqual([])
+    expect(uniqueSortedThresholds([3, 2, 1, 0], 2)).toEqual([3, 0])
+    expect(uniqueSortedThresholds([3, 2, 1], 1)).toEqual([3])
+    expect(uniqueSortedThresholds([3, 2, 1], 0)).toEqual([])
+    expect(trapezoidalAuc([0], [1])).toBe(0)
+    expect(trapezoidalAuc([0, 0.5, 1], [0, 1, 1])).toBe(0.75)
+  })
+
+  it('threshold report evaluators return empty/NaN analyses and custom specs when inputs are absent', () => {
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [makeReportCase()],
+      failures: [],
+      name: 'empty-thresholds',
+      report_evaluator_failures: [],
+      span_id: null,
+      trace_id: null,
+    }
+    const ctx = { cases: report.cases, name: report.name, report }
+    const pr = new PrecisionRecallEvaluator({
+      nThresholds: 5,
+      positiveFrom: 'assertions',
+      positiveKey: 'ok',
+      scoreFrom: 'scores',
+      scoreKey: 'score',
+      title: 'Custom PR',
+    })
+    const roc = new ROCAUCEvaluator({
+      nThresholds: 5,
+      positiveFrom: 'labels',
+      positiveKey: 'grade',
+      scoreFrom: 'metrics',
+      scoreKey: 'score',
+      title: 'Custom ROC',
+    })
+    const ks = new KolmogorovSmirnovEvaluator({
+      positiveFrom: 'expected_output',
+      scoreFrom: 'scores',
+      scoreKey: 'score',
+      title: 'Custom KS',
+    })
+
+    expect(pr.evaluate(ctx)[0]).toEqual({ curves: [], title: 'Custom PR', type: 'precision_recall' })
+    expect(Number.isNaN(pr.evaluate(ctx)[1].value)).toBe(true)
+    expect(Number.isNaN(roc.evaluate(ctx)[1].value)).toBe(true)
+    expect(ks.evaluate(ctx)[1]).toEqual({ title: 'KS Statistic', type: 'scalar', value: 0 })
+    expect(pr.toJSON()).toEqual({
+      n_thresholds: 5,
+      positive_from: 'assertions',
+      positive_key: 'ok',
+      score_from: 'scores',
+      score_key: 'score',
+      title: 'Custom PR',
+    })
+    expect(roc.toJSON()).toEqual({
+      n_thresholds: 5,
+      positive_from: 'labels',
+      positive_key: 'grade',
+      score_from: 'metrics',
+      score_key: 'score',
+      title: 'Custom ROC',
+    })
+    expect(ks.toJSON()).toEqual({
+      positive_from: 'expected_output',
+      score_from: 'scores',
+      score_key: 'score',
+      title: 'Custom KS',
     })
   })
 })
@@ -464,5 +727,48 @@ describe('renderReport', () => {
     expect(text).toContain('Cases: 1')
     expect(text).toContain('one')
     expect(text).toContain('ok=✓')
+  })
+
+  it('renders optional inputs, outputs, failures, analyses and scalar formatting', () => {
+    const report: EvaluationReport = {
+      analyses: [{ title: 'Quality', type: 'scalar', value: 0.95 }],
+      cases: [
+        makeReportCase({
+          assertions: { bad: resultJson('bad', false) },
+          inputs: { prompt: 'a very long prompt that should be truncated in the table' },
+          labels: { grade: resultJson('grade', 'good') },
+          output: { answer: 'a very long answer that should be truncated in the table' },
+          scores: { quality: resultJson('quality', 0.75) },
+        }),
+      ],
+      failures: [
+        {
+          error_message: 'boom',
+          error_type: 'Error',
+          inputs: 'bad',
+          name: 'failed',
+          span_id: null,
+          trace_id: null,
+        },
+      ],
+      name: 'render-full',
+      report_evaluator_failures: [],
+      span_id: null,
+      trace_id: null,
+    }
+
+    const text = renderReport(report, { includeInput: true, includeOutput: true })
+    expect(text).toContain('input')
+    expect(text).toContain('output')
+    expect(text).toContain('quality=0.75')
+    expect(text).toContain('grade=good')
+    expect(text).toContain('bad=✗')
+    expect(text).toContain('Failures:')
+    expect(text).toContain('failed: Error: boom')
+    expect(text).toContain('Analyses: 1')
+    expect(text).toContain('Quality (scalar)')
+    expect(text).toContain('…')
+
+    expect(renderReport(report, { includeFailures: false })).not.toContain('\nFailures:\n')
   })
 })

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -160,6 +160,57 @@ describe('lifecycle hooks', () => {
     expect(caseSpan?.events.some((event) => event.attributes?.['exception.message'] === 'teardown boom')).toBe(true)
   })
 
+  it('gives each case its own lifecycle instance with isolated state', async () => {
+    class StatefulLifecycle extends CaseLifecycle<string, string> {
+      private setupCalled = false
+      prepareContext(ctx: EvaluatorContext<string, string>): EvaluatorContext<string, string> {
+        if (!this.setupCalled) throw new Error('setup not called before prepareContext')
+        ctx.metrics.case_name_length = this.case.name?.length ?? 0
+        return ctx
+      }
+      async setup(): Promise<void> {
+        this.setupCalled = true
+      }
+    }
+
+    const ds = new Dataset<string, string>({
+      cases: [
+        new Case<string, string>({ inputs: 'a', name: 'short' }),
+        new Case<string, string>({ inputs: 'b', name: 'much_longer_name' }),
+      ],
+      name: 'per-case-state',
+    })
+    const { result } = await withMemoryExporter(async () => ds.evaluate((s) => s.toUpperCase(), { lifecycle: StatefulLifecycle }))
+
+    const byName = Object.fromEntries(result.cases.map((c) => [c.name, c.metrics]))
+    expect(byName.short?.case_name_length).toBe(5)
+    expect(byName.much_longer_name?.case_name_length).toBe(16)
+  })
+
+  it('lets evaluators see metrics added by prepareContext', async () => {
+    class Enricher extends CaseLifecycle<string, string> {
+      prepareContext(ctx: EvaluatorContext<string, string>): EvaluatorContext<string, string> {
+        ctx.metrics.enriched = 1
+        return ctx
+      }
+    }
+
+    class CheckMetric extends Evaluator<string, string> {
+      static evaluatorName = 'CheckMetric'
+      evaluate(ctx: EvaluatorContext<string, string>): boolean {
+        return ctx.metrics.enriched === 1
+      }
+    }
+
+    const ds = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'one' })],
+      evaluators: [new CheckMetric()],
+      name: 'enriched-context',
+    })
+    const { result } = await withMemoryExporter(async () => ds.evaluate((s) => s, { lifecycle: Enricher }))
+    expect(result.cases[0]?.assertions.CheckMetric?.value).toBe(true)
+  })
+
   it('records prepareContext errors as case failures without rejecting the experiment', async () => {
     const events: string[] = []
     class PrepareThrows extends CaseLifecycle<string, string> {
@@ -320,6 +371,43 @@ describe('report-level evaluators land on the experiment span', () => {
     const analysesAttr = experimentSpan.attributes[EXPERIMENT_ANALYSES_KEY]
     expect(typeof analysesAttr).toBe('string')
     expect(JSON.parse(analysesAttr as string)).toEqual(result.analyses)
+  })
+
+  it('awaits async report evaluator return values', async () => {
+    class AsyncReportEvaluator extends ReportEvaluator<string, string> {
+      static evaluatorName = 'AsyncReportEvaluator'
+
+      async evaluate(): Promise<{ title: string; type: 'scalar'; value: number }> {
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        return { title: 'Async Result', type: 'scalar', value: 42 }
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'x' })],
+      name: 'async-report-eval',
+      reportEvaluators: [new AsyncReportEvaluator()],
+    })
+
+    const { result } = await withMemoryExporter(async () => dataset.evaluate((s) => s))
+    expect(result.analyses).toEqual([{ title: 'Async Result', type: 'scalar', value: 42 }])
+  })
+
+  it("ConfusionMatrixEvaluator with from='labels' requires a key", () => {
+    const evaluator = new ConfusionMatrixEvaluator({
+      expected: { from: 'expected_output' },
+      predicted: { from: 'labels' },
+    })
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [makeReportCase({ expected_output: 'A', labels: {} })],
+      failures: [],
+      name: 'matrix-needs-key',
+      report_evaluator_failures: [],
+      span_id: null,
+      trace_id: null,
+    }
+    expect(() => evaluator.evaluate({ cases: report.cases, name: report.name, report })).toThrow("'key' is required when from='labels'")
   })
 
   it('passes the experiment name and full report to report evaluators', async () => {

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -4,11 +4,13 @@ import { describe, expect, it } from 'vitest'
 import {
   Case,
   CaseLifecycle,
+  computeAverages,
   ConfusionMatrixEvaluator,
   Dataset,
   Equals,
   EqualsExpected,
   type EvaluationReport,
+  Evaluator,
   type EvaluatorContext,
   EXPERIMENT_ANALYSES_KEY,
   KolmogorovSmirnovEvaluator,
@@ -16,6 +18,8 @@ import {
   renderReport,
   type ReportCase,
   type ReportCaseFailure,
+  ReportEvaluator,
+  type ReportEvaluatorContext,
   ROCAUCEvaluator,
   SPAN_NAME_EXPERIMENT,
 } from '../../evals'
@@ -118,15 +122,67 @@ describe('retry support via p-retry', () => {
     )
     expect(result.failures).toHaveLength(1)
   })
+
+  it('retries evaluators and records failure after evaluator retries are exhausted', async () => {
+    class FlakyEvaluator extends Evaluator {
+      static evaluatorName = 'FlakyEvaluator'
+      attempts = 0
+
+      evaluate(): boolean {
+        this.attempts += 1
+        if (this.attempts < 3) throw new Error('not yet')
+        return true
+      }
+    }
+
+    const flaky = new FlakyEvaluator()
+    const ds = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'recovers' })],
+      evaluators: [flaky],
+      name: 'retry-evaluator',
+    })
+    const { result } = await withMemoryExporter(async () =>
+      ds.evaluate((input) => input, { retryEvaluators: { factor: 1, minTimeout: 1, retries: 5 } })
+    )
+
+    expect(flaky.attempts).toBe(3)
+    expect(result.cases[0]?.assertions.FlakyEvaluator?.value).toBe(true)
+    expect(result.cases[0]?.evaluator_failures).toEqual([])
+
+    class AlwaysThrowsEvaluator extends Evaluator {
+      static evaluatorName = 'AlwaysThrowsEvaluator'
+      attempts = 0
+
+      evaluate(): never {
+        this.attempts += 1
+        throw new Error('persistent evaluator')
+      }
+    }
+
+    const alwaysThrows = new AlwaysThrowsEvaluator()
+    const failing = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'fails' })],
+      evaluators: [alwaysThrows],
+      name: 'retry-evaluator-failure',
+    })
+    const failed = await withMemoryExporter(async () =>
+      failing.evaluate((input) => input, { retryEvaluators: { factor: 1, minTimeout: 1, retries: 2 } })
+    )
+
+    expect(alwaysThrows.attempts).toBe(3)
+    expect(failed.result.cases[0]?.evaluator_failures).toMatchObject([
+      { error_message: 'persistent evaluator', error_type: 'Error', name: 'AlwaysThrowsEvaluator' },
+    ])
+  })
 })
 
 describe('report-level evaluators land on the experiment span', () => {
-  it('ConfusionMatrixEvaluator analyses end up under logfire.experiment.analyses', async () => {
+  it('ConfusionMatrixEvaluator emits Python-compatible matrix rows=expected columns=predicted', async () => {
     const dataset = new Dataset<{ x: string }, string>({
       cases: [
         new Case<{ x: string }, string>({ expectedOutput: 'A', inputs: { x: 'A' }, name: '1' }),
-        new Case<{ x: string }, string>({ expectedOutput: 'A', inputs: { x: 'A' }, name: '2' }),
-        new Case<{ x: string }, string>({ expectedOutput: 'B', inputs: { x: 'B' }, name: '3' }),
+        new Case<{ x: string }, string>({ expectedOutput: 'A', inputs: { x: 'B' }, name: '2' }),
+        new Case<{ x: string }, string>({ expectedOutput: 'B', inputs: { x: 'A' }, name: '3' }),
       ],
       name: 'confusion-matrix-test',
       reportEvaluators: [new ConfusionMatrixEvaluator({ expected: { from: 'expected_output' }, predicted: { from: 'output' } })],
@@ -135,20 +191,51 @@ describe('report-level evaluators land on the experiment span', () => {
     const { result, spans } = await withMemoryExporter(async () => dataset.evaluate(({ x }) => x))
 
     expect(result.analyses).toHaveLength(1)
-    expect(result.analyses[0]?.type).toBe('confusion_matrix')
-    const cm = result.analyses[0] as { matrix: Record<string, Record<string, number>> }
-    expect(cm.matrix.A?.A).toBe(2)
-    expect(cm.matrix.B?.B).toBe(1)
+    expect(result.analyses[0]).toEqual({
+      class_labels: ['A', 'B'],
+      matrix: [
+        [1, 1],
+        [1, 0],
+      ],
+      title: 'Confusion Matrix',
+      type: 'confusion_matrix',
+    })
 
     // Analyses MUST be on the experiment span as a JSON-encoded array.
     const experimentSpan = spans.find((s) => s.name === SPAN_NAME_EXPERIMENT)!
     const analysesAttr = experimentSpan.attributes[EXPERIMENT_ANALYSES_KEY]
     expect(typeof analysesAttr).toBe('string')
-    const parsed = JSON.parse(analysesAttr as string) as { type: string }[]
-    expect(parsed[0]?.type).toBe('confusion_matrix')
+    expect(JSON.parse(analysesAttr as string)).toEqual(result.analyses)
   })
 
-  it('PrecisionRecall + ROCAUC + KS produce paired analysis arrays', async () => {
+  it('passes the experiment name and full report to report evaluators', async () => {
+    let captured: ReportEvaluatorContext<{ x: string }, string> | undefined
+    class CaptureReportEvaluator extends ReportEvaluator<{ x: string }, string> {
+      static evaluatorName = 'CaptureReportEvaluator'
+
+      evaluate(ctx: ReportEvaluatorContext<{ x: string }, string>) {
+        captured = ctx
+        return { columns: ['name'], rows: [[ctx.name]], title: 'captured', type: 'table' as const }
+      }
+    }
+
+    const dataset = new Dataset<{ x: string }, string>({
+      cases: [new Case<{ x: string }, string>({ expectedOutput: 'A', inputs: { x: 'A' }, name: '1' })],
+      name: 'report-context-test',
+      reportEvaluators: [new CaptureReportEvaluator()],
+    })
+
+    const { result } = await withMemoryExporter(async () =>
+      dataset.evaluate(({ x }) => x, { metadata: { owner: 'evals' }, name: 'experiment-name' })
+    )
+
+    expect(captured?.name).toBe('experiment-name')
+    expect(captured?.experimentMetadata).toEqual({ owner: 'evals' })
+    expect(captured?.report).toBe(result)
+    expect(captured?.report.cases[0]?.name).toBe('1')
+  })
+
+  it('PrecisionRecall + ROCAUC + KS emit Python-compatible analysis shapes', async () => {
     const dataset = new Dataset<{ score: number }, number>({
       cases: [
         new Case<{ score: number }, number>({ expectedOutput: 1, inputs: { score: 0.9 }, name: '1' }),
@@ -176,11 +263,108 @@ describe('report-level evaluators land on the experiment span', () => {
 
     // Each of PR / ROC / KS contributes 2 analyses (curve + scalar AUC/KS).
     expect(result.analyses).toHaveLength(6)
-    const types = result.analyses.map((a) => a.type)
-    expect(types).toContain('precision_recall')
-    expect(types).toContain('roc_curve')
-    expect(types).toContain('ks')
-    expect(types.filter((t) => t === 'scalar')).toHaveLength(3)
+    expect(result.analyses).toEqual([
+      {
+        curves: [
+          {
+            auc: 1,
+            name: 'thresholds-test',
+            points: [
+              { precision: 1, recall: 0, threshold: 0.9 },
+              { precision: 1, recall: 0.5, threshold: 0.9 },
+              { precision: 1, recall: 1, threshold: 0.6 },
+              { precision: 2 / 3, recall: 1, threshold: 0.3 },
+              { precision: 0.5, recall: 1, threshold: 0.1 },
+            ],
+          },
+        ],
+        title: 'Precision–Recall',
+        type: 'precision_recall',
+      },
+      { title: 'Precision–Recall AUC', type: 'scalar', value: 1 },
+      {
+        curves: [
+          {
+            name: 'thresholds-test (AUC: 1.000)',
+            points: [
+              { x: 0, y: 0 },
+              { x: 0, y: 0.5 },
+              { x: 0, y: 1 },
+              { x: 0.5, y: 1 },
+              { x: 1, y: 1 },
+            ],
+            style: 'solid',
+          },
+          {
+            name: 'Random',
+            points: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ],
+            style: 'dashed',
+          },
+        ],
+        title: 'ROC Curve',
+        type: 'line_plot',
+        x_label: 'False Positive Rate',
+        x_range: [0, 1],
+        y_label: 'True Positive Rate',
+        y_range: [0, 1],
+      },
+      { title: 'ROC Curve AUC', type: 'scalar', value: 1 },
+      {
+        curves: [
+          {
+            name: 'Positive',
+            points: [
+              { x: 0.1, y: 0 },
+              { x: 0.3, y: 0 },
+              { x: 0.6, y: 0.5 },
+              { x: 0.9, y: 1 },
+            ],
+            step: 'end',
+          },
+          {
+            name: 'Negative',
+            points: [
+              { x: 0.1, y: 0.5 },
+              { x: 0.3, y: 1 },
+              { x: 0.6, y: 1 },
+              { x: 0.9, y: 1 },
+            ],
+            step: 'end',
+          },
+        ],
+        title: 'KS Plot',
+        type: 'line_plot',
+        x_label: 'Score',
+        y_label: 'Cumulative Probability',
+        y_range: [0, 1],
+      },
+      { title: 'KS Statistic', type: 'scalar', value: 1 },
+    ])
+  })
+
+  it('computes label averages as normalized frequencies', () => {
+    const makeCase = (label: string): ReportCase => ({
+      assertions: {},
+      attributes: {},
+      evaluator_failures: [],
+      inputs: 'x',
+      labels: { grade: { name: 'grade', reason: null, source: { arguments: null, name: 'Labeler' }, value: label } },
+      metrics: {},
+      name: label,
+      output: 'x',
+      scores: {},
+      span_id: null,
+      task_duration: 0,
+      total_duration: 0,
+      trace_id: null,
+    })
+
+    expect(computeAverages('labels', [makeCase('good'), makeCase('good'), makeCase('bad')]).labels).toEqual({
+      grade: { bad: 1 / 3, good: 2 / 3 },
+    })
   })
 })
 

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -159,6 +159,30 @@ describe('lifecycle hooks', () => {
     const caseSpan = spans.find((s) => s.name === SPAN_NAME_CASE)
     expect(caseSpan?.events.some((event) => event.attributes?.['exception.message'] === 'teardown boom')).toBe(true)
   })
+
+  it('records prepareContext errors as case failures without rejecting the experiment', async () => {
+    const events: string[] = []
+    class PrepareThrows extends CaseLifecycle<string, string> {
+      prepareContext(): EvaluatorContext<string, string> {
+        throw new Error('prepare boom')
+      }
+      async teardown(result: ReportCase<string, string> | ReportCaseFailure<string, string>): Promise<void> {
+        events.push(`teardown(${result.name})`)
+      }
+    }
+    const ds = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'a' })],
+      name: 'prepare-failure-test',
+    })
+
+    const { result, spans } = await withMemoryExporter(async () => ds.evaluate((input) => input, { lifecycle: PrepareThrows }))
+
+    expect(result.cases).toHaveLength(0)
+    expect(result.failures).toMatchObject([{ error_message: 'prepare boom', error_type: 'Error', name: 'a' }])
+    expect(events).toEqual(['teardown(a)'])
+    const caseSpan = spans.find((s) => s.name === SPAN_NAME_CASE)
+    expect(caseSpan?.events.some((event) => event.attributes?.['exception.message'] === 'prepare boom')).toBe(true)
+  })
 })
 
 describe('retry support via p-retry', () => {
@@ -382,11 +406,14 @@ describe('report-level evaluators land on the experiment span', () => {
 
     // Encode the score into a metric so the report evaluators can see it.
     const { result } = await withMemoryExporter(async () =>
-      dataset.evaluate(async (inputs) => {
-        const { incrementEvalMetric } = await import('../../evals')
-        incrementEvalMetric('pred', inputs.score)
-        return inputs.score >= 0.5 ? 1 : 0
-      })
+      dataset.evaluate(
+        async (inputs) => {
+          const { incrementEvalMetric } = await import('../../evals')
+          incrementEvalMetric('pred', inputs.score)
+          return inputs.score >= 0.5 ? 1 : 0
+        },
+        { name: 'thresholds-test' }
+      )
     )
 
     // Each of PR / ROC / KS contributes 2 analyses (curve + scalar AUC/KS).
@@ -406,10 +433,10 @@ describe('report-level evaluators land on the experiment span', () => {
             ],
           },
         ],
-        title: 'Precision–Recall',
+        title: 'Precision-Recall Curve',
         type: 'precision_recall',
       },
-      { title: 'Precision–Recall AUC', type: 'scalar', value: 1 },
+      { title: 'Precision-Recall Curve AUC', type: 'scalar', value: 1 },
       {
         curves: [
           {
@@ -446,6 +473,7 @@ describe('report-level evaluators land on the experiment span', () => {
             name: 'Positive',
             points: [
               { x: 0.1, y: 0 },
+              { x: 0.1, y: 0 },
               { x: 0.3, y: 0 },
               { x: 0.6, y: 0.5 },
               { x: 0.9, y: 1 },
@@ -455,6 +483,7 @@ describe('report-level evaluators land on the experiment span', () => {
           {
             name: 'Negative',
             points: [
+              { x: 0.1, y: 0 },
               { x: 0.1, y: 0.5 },
               { x: 0.3, y: 1 },
               { x: 0.6, y: 1 },
@@ -574,8 +603,10 @@ describe('report evaluator edge cases', () => {
       type: 'confusion_matrix',
     })
     expect(evaluator.toJSON()).toEqual({
-      expected: { from: 'metadata', key: 'expected' },
-      predicted: { from: 'labels', key: 'predicted' },
+      expected_from: 'metadata',
+      expected_key: 'expected',
+      predicted_from: 'labels',
+      predicted_key: 'predicted',
       title: 'Custom Matrix',
     })
   })
@@ -605,12 +636,9 @@ describe('report evaluator edge cases', () => {
       positives: [true, false],
       scores: [0.7, 0.1],
     })
-    expect(
+    expect(() =>
       buildThresholdInputs(cases, { positiveFrom: 'expected_output', positiveKey: 'positive', scoreFrom: 'metrics', scoreKey: 'm' })
-    ).toEqual({
-      positives: [false, true],
-      scores: [0.8, 0.2],
-    })
+    ).toThrow("'positiveKey' is not supported when positiveFrom='expected_output'")
     expect(buildThresholdInputs(cases, { positiveFrom: 'labels', positiveKey: 'positive', scoreFrom: 'scores', scoreKey: 's' })).toEqual({
       positives: [true, false],
       scores: [0.7, 0.1],
@@ -619,16 +647,42 @@ describe('report evaluator edge cases', () => {
       positives: [true, true],
       scores: [0.7, 0.1],
     })
-    expect(buildThresholdInputs(cases, { positiveFrom: 'assertions', scoreFrom: 'scores', scoreKey: 's' })).toEqual({
-      positives: [],
-      scores: [],
-    })
+    expect(() => buildThresholdInputs(cases, { positiveFrom: 'assertions', scoreFrom: 'scores', scoreKey: 's' })).toThrow(
+      "'positiveKey' is required when positiveFrom='assertions'"
+    )
     expect(uniqueSortedThresholds([], 3)).toEqual([])
     expect(uniqueSortedThresholds([3, 2, 1, 0], 2)).toEqual([3, 0])
-    expect(uniqueSortedThresholds([3, 2, 1], 1)).toEqual([3])
-    expect(uniqueSortedThresholds([3, 2, 1], 0)).toEqual([])
+    expect(uniqueSortedThresholds([3, 2, 1], 1)).toEqual([3, 2, 1])
+    expect(uniqueSortedThresholds([3, 2, 1], 0)).toEqual([3, 2, 1])
     expect(trapezoidalAuc([0], [1])).toBe(0)
     expect(trapezoidalAuc([0, 0.5, 1], [0, 1, 1])).toBe(0.75)
+  })
+
+  it('computes PR/ROC AUC at full resolution before downsampling display points', () => {
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [
+        makeReportCase({ assertions: { p: resultJson('p', true) }, name: 'a', scores: { s: resultJson('s', 0.9) } }),
+        makeReportCase({ assertions: { p: resultJson('p', false) }, name: 'b', scores: { s: resultJson('s', 0.8) } }),
+        makeReportCase({ assertions: { p: resultJson('p', true) }, name: 'c', scores: { s: resultJson('s', 0.7) } }),
+        makeReportCase({ assertions: { p: resultJson('p', false) }, name: 'd', scores: { s: resultJson('s', 0.6) } }),
+      ],
+      failures: [],
+      name: 'full-resolution',
+      report_evaluator_failures: [],
+      span_id: null,
+      trace_id: null,
+    }
+    const ctx = { cases: report.cases, name: report.name, report }
+    const pr = new PrecisionRecallEvaluator({ nThresholds: 2, positiveFrom: 'assertions', positiveKey: 'p', scoreKey: 's' })
+    const roc = new ROCAUCEvaluator({ nThresholds: 2, positiveFrom: 'assertions', positiveKey: 'p', scoreKey: 's' })
+    const ks = new KolmogorovSmirnovEvaluator({ nThresholds: 2, positiveFrom: 'assertions', positiveKey: 'p', scoreKey: 's' })
+
+    expect(pr.evaluate(ctx)[0].curves[0]?.points).toHaveLength(2)
+    expect(pr.evaluate(ctx)[1].value).toBeCloseTo(19 / 24)
+    expect(roc.evaluate(ctx)[0].curves[0]?.points).toHaveLength(2)
+    expect(roc.evaluate(ctx)[1].value).toBe(0.75)
+    expect(ks.evaluate(ctx)[0].curves[0]?.points).toHaveLength(2)
   })
 
   it('threshold report evaluators return empty/NaN analyses and custom specs when inputs are absent', () => {
@@ -668,12 +722,11 @@ describe('report evaluator edge cases', () => {
     expect(pr.evaluate(ctx)[0]).toEqual({ curves: [], title: 'Custom PR', type: 'precision_recall' })
     expect(Number.isNaN(pr.evaluate(ctx)[1].value)).toBe(true)
     expect(Number.isNaN(roc.evaluate(ctx)[1].value)).toBe(true)
-    expect(ks.evaluate(ctx)[1]).toEqual({ title: 'KS Statistic', type: 'scalar', value: 0 })
+    expect(Number.isNaN(ks.evaluate(ctx)[1].value)).toBe(true)
     expect(pr.toJSON()).toEqual({
       n_thresholds: 5,
       positive_from: 'assertions',
       positive_key: 'ok',
-      score_from: 'scores',
       score_key: 'score',
       title: 'Custom PR',
     })
@@ -687,7 +740,6 @@ describe('report evaluator edge cases', () => {
     })
     expect(ks.toJSON()).toEqual({
       positive_from: 'expected_output',
-      score_from: 'scores',
       score_key: 'score',
       title: 'Custom KS',
     })

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -21,6 +21,7 @@ import {
   ReportEvaluator,
   type ReportEvaluatorContext,
   ROCAUCEvaluator,
+  SPAN_NAME_CASE,
   SPAN_NAME_EXPERIMENT,
 } from '../../evals'
 import { withMemoryExporter } from './withMemoryExporter'
@@ -81,6 +82,55 @@ describe('lifecycle hooks', () => {
       )
     })
     expect(events).toEqual(['teardown'])
+  })
+
+  it('records teardown errors on failed cases without rejecting the experiment', async () => {
+    class TeardownThrows extends CaseLifecycle<string, string> {
+      async teardown(): Promise<void> {
+        throw new Error('teardown boom')
+      }
+    }
+    const ds = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'a' })],
+      name: 'teardown-failure-test',
+    })
+
+    const { result, spans } = await withMemoryExporter(async () =>
+      ds.evaluate(
+        () => {
+          throw new Error('task boom')
+        },
+        { lifecycle: TeardownThrows }
+      )
+    )
+
+    expect(result.cases).toHaveLength(0)
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]?.error_message).toBe('task boom')
+    const caseSpan = spans.find((s) => s.name === SPAN_NAME_CASE)
+    expect(caseSpan?.events.some((event) => event.attributes?.['exception.message'] === 'teardown boom')).toBe(true)
+  })
+
+  it('records teardown errors on successful cases without rejecting the experiment', async () => {
+    class TeardownThrows extends CaseLifecycle<string, string> {
+      async teardown(): Promise<void> {
+        throw new Error('teardown boom')
+      }
+    }
+    const ds = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'a' })],
+      name: 'teardown-success-test',
+    })
+
+    const { result, spans } = await withMemoryExporter(async () =>
+      ds.evaluate((input) => input.toUpperCase(), { lifecycle: TeardownThrows })
+    )
+
+    expect(result.cases).toHaveLength(1)
+    expect(result.cases[0]?.output).toBe('A')
+    expect(result.failures).toHaveLength(0)
+    const caseSpan = spans.find((s) => s.name === SPAN_NAME_CASE)
+    expect(caseSpan?.events.some((event) => event.attributes?.['exception.message'] === 'teardown boom')).toBe(true)
   })
 })
 
@@ -173,6 +223,19 @@ describe('retry support via p-retry', () => {
     expect(failed.result.cases[0]?.evaluator_failures).toMatchObject([
       { error_message: 'persistent evaluator', error_type: 'Error', name: 'AlwaysThrowsEvaluator' },
     ])
+  })
+})
+
+describe('evaluate options validation', () => {
+  it('rejects non-positive maxConcurrency before starting the experiment', async () => {
+    const ds = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'a', name: 'a' })],
+      name: 'invalid-concurrency-test',
+    })
+
+    await expect(ds.evaluate((input) => input, { maxConcurrency: 0 })).rejects.toThrow(
+      'Dataset.evaluate: maxConcurrency must be a positive integer (got 0)'
+    )
   })
 })
 

--- a/packages/logfire-api/src/evals/__test__/runtime.test.ts
+++ b/packages/logfire-api/src/evals/__test__/runtime.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { detectRuntime, hasAsyncLocalStorage, hasNodeFs } from '../../evals'
+
+describe('runtime detection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('detects Node, Bun and Deno before generic browser runtimes', () => {
+    expect(detectRuntime()).toBe('node')
+    expect(hasAsyncLocalStorage()).toBe(true)
+    expect(hasNodeFs()).toBe(true)
+
+    vi.stubGlobal('Bun', {})
+    expect(detectRuntime()).toBe('bun')
+    expect(hasAsyncLocalStorage()).toBe(true)
+    expect(hasNodeFs()).toBe(true)
+
+    vi.stubGlobal('Bun', undefined)
+    vi.stubGlobal('Deno', { readTextFile: () => Promise.resolve(''), writeTextFile: () => Promise.resolve() })
+    expect(detectRuntime()).toBe('deno')
+    expect(hasAsyncLocalStorage()).toBe(true)
+    expect(hasNodeFs()).toBe(true)
+  })
+
+  it('detects workers and browsers when process-style runtimes are absent', () => {
+    vi.stubGlobal('Bun', undefined)
+    vi.stubGlobal('Deno', undefined)
+    vi.stubGlobal('process', undefined)
+    vi.stubGlobal('navigator', { userAgent: 'Cloudflare-Workers' })
+    expect(detectRuntime()).toBe('workers')
+    expect(hasAsyncLocalStorage()).toBe(true)
+    expect(hasNodeFs()).toBe(false)
+
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0' })
+    expect(detectRuntime()).toBe('browser')
+    expect(hasAsyncLocalStorage()).toBe(false)
+    expect(hasNodeFs()).toBe(false)
+  })
+})

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -260,14 +260,7 @@ describe('Dataset YAML round-trip', () => {
       ],
       evaluators: ['EqualsExpected'],
       name: 'object-test',
-      report_evaluators: [
-        {
-          ConfusionMatrixEvaluator: {
-            expected: { from: 'expected_output' },
-            predicted: { from: 'output' },
-          },
-        },
-      ],
+      report_evaluators: ['ConfusionMatrixEvaluator'],
     })
   })
 
@@ -338,7 +331,33 @@ describe('Dataset YAML round-trip', () => {
     expect(text).toContain('Contains')
     expect(text).toContain('IsInstance')
     expect(text).toContain('LLMJudge')
+    expect(text).toContain('case_sensitive')
+    expect(text).toContain('predicted_from')
+    expect(text).toContain('score_key')
     expect(schema.title).toBe('PydanticEvalsDataset')
+  })
+
+  it('reads and writes Python-compatible flat ConfusionMatrixEvaluator options', () => {
+    const restored = Dataset.fromObject({
+      cases: [{ inputs: 'x' }],
+      name: 'flat-report-evaluator',
+      report_evaluators: [
+        {
+          ConfusionMatrixEvaluator: {
+            expected_from: 'metadata',
+            predicted_from: 'labels',
+            predicted_key: 'predicted',
+          },
+        },
+      ],
+    })
+
+    expect(restored.reportEvaluators[0]).toBeInstanceOf(ConfusionMatrixEvaluator)
+    expect(restored.reportEvaluators[0]?.toJSON()).toEqual({
+      expected_from: 'metadata',
+      predicted_from: 'labels',
+      predicted_key: 'predicted',
+    })
   })
 
   it('toFile + fromFile work on Node and round-trip via the filesystem', async () => {

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -149,6 +149,36 @@ describe('Dataset YAML round-trip', () => {
     }
   })
 
+  it('toFile writes schema sidecar idempotently when schemaPath is provided', async () => {
+    const ds = new Dataset({
+      cases: [new Case({ inputs: { v: 1 }, name: 'tmp' })],
+      evaluators: [new EqualsExpected()],
+      name: 'file-test',
+    })
+    const fs: typeof import('node:fs/promises') = await import('node:fs/promises')
+    const os: typeof import('node:os') = await import('node:os')
+    const path: typeof import('node:path') = await import('node:path')
+    const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'logfire-evals-schema-'))
+    const filePath = path.join(tmpdir, 'dataset.yaml')
+    const schemaPath = path.join(tmpdir, 'dataset.schema.json')
+    try {
+      await ds.toFile(filePath, { schemaPath: 'dataset.schema.json' })
+      expect(await fs.readFile(filePath, 'utf8')).toContain('# yaml-language-server: $schema=dataset.schema.json')
+      const firstSchema = await fs.readFile(schemaPath, 'utf8')
+      const parsedSchema = JSON.parse(firstSchema) as { title?: unknown }
+      expect(parsedSchema.title).toBe('PydanticEvalsDataset')
+      const firstMtime = (await fs.stat(schemaPath)).mtimeMs
+
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      await ds.toFile(filePath, { schemaPath: 'dataset.schema.json' })
+
+      expect(await fs.readFile(schemaPath, 'utf8')).toBe(firstSchema)
+      expect((await fs.stat(schemaPath)).mtimeMs).toBe(firstMtime)
+    } finally {
+      await fs.rm(tmpdir, { force: true, recursive: true })
+    }
+  })
+
   it('rejects malformed dataset objects with a helpful zod error', () => {
     expect(() => Dataset.fromObject({ cases: 'not-an-array', name: 'x' })).toThrow()
   })

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -2,16 +2,22 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildDatasetJsonSchema,
   Case,
+  ConfusionMatrixEvaluator,
   Contains,
   Dataset,
+  decodeEvaluator,
+  decodeReportEvaluator,
   decodeSpec,
   encodeEvaluatorSpec,
   Equals,
   EqualsExpected,
+  Evaluator,
   IsInstance,
   MaxDuration,
   parseYaml,
+  ReportEvaluator,
   stringifyYaml,
 } from '../../evals'
 
@@ -45,6 +51,113 @@ describe('EvaluatorSpec encoding', () => {
 
   it('decodeSpec parses kwargs long form', () => {
     expect(decodeSpec({ Contains: { value: 'foo' } })).toEqual({ arguments: { value: 'foo' }, name: 'Contains' })
+  })
+
+  it('decodeSpec rejects malformed encodings and preserves explicit null positional values', () => {
+    expect(() => decodeSpec(null)).toThrow('Invalid evaluator encoding: null')
+    expect(() => decodeSpec(1)).toThrow('Invalid evaluator encoding: 1')
+    expect(() => decodeSpec({})).toThrow('Evaluator encoding must be a single-key object (got keys: )')
+    expect(() => decodeSpec({ A: 1, B: 2 })).toThrow('Evaluator encoding must be a single-key object (got keys: A, B)')
+    expect(decodeSpec({ MaybeNull: null })).toEqual({ arguments: [null], name: 'MaybeNull' })
+  })
+
+  it('decodeEvaluator constructs from map/object registries and reports unknown names', () => {
+    class PairEvaluator extends Evaluator {
+      static evaluatorName = 'PairEvaluator'
+      readonly left: string
+      readonly right: number
+
+      constructor(left: string, right: number) {
+        super()
+        this.left = left
+        this.right = right
+      }
+      evaluate(): boolean {
+        return this.left === 'x' && this.right === 2
+      }
+    }
+
+    class ValueEvaluator extends Evaluator {
+      static evaluatorName = 'ValueEvaluator'
+      readonly value: unknown
+      constructor(opts: { value: unknown }) {
+        super()
+        this.value = opts.value
+      }
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    const pair = decodeEvaluator({ PairEvaluator: ['x', 2] }, new Map([['PairEvaluator', PairEvaluator as never]]), new Map())
+    expect(pair).toBeInstanceOf(PairEvaluator)
+    expect((pair as PairEvaluator).evaluate()).toBe(true)
+
+    const value = decodeEvaluator(
+      { ValueEvaluator: 42 },
+      { ValueEvaluator: ValueEvaluator as never },
+      new Map([['ValueEvaluator', 'value']])
+    )
+    expect(value).toBeInstanceOf(ValueEvaluator)
+    expect((value as ValueEvaluator).value).toBe(42)
+
+    expect(() => decodeEvaluator('Missing', new Map([['ValueEvaluator', ValueEvaluator as never]]), new Map())).toThrow(
+      'Unknown evaluator name: "Missing" (registered: ValueEvaluator)'
+    )
+  })
+
+  it('decodeReportEvaluator constructs report evaluators and reports unknown names', () => {
+    class TableReportEvaluator extends ReportEvaluator {
+      static evaluatorName = 'TableReportEvaluator'
+      readonly title: string
+      constructor(opts: { title: string }) {
+        super()
+        this.title = opts.title
+      }
+      evaluate() {
+        return { columns: ['x'], rows: [[this.title]], title: this.title, type: 'table' as const }
+      }
+    }
+
+    const decoded = decodeReportEvaluator(
+      { TableReportEvaluator: { title: 'custom' } },
+      { TableReportEvaluator: TableReportEvaluator as never },
+      new Map()
+    )
+    expect(decoded).toBeInstanceOf(TableReportEvaluator)
+    expect((decoded as TableReportEvaluator).title).toBe('custom')
+    expect(() => decodeReportEvaluator('MissingReport', {}, new Map())).toThrow('Unknown report evaluator name: "MissingReport"')
+  })
+
+  it('custom json schema providers narrow evaluator argument schemas', () => {
+    class SchemaEvaluator extends Evaluator {
+      static evaluatorName = 'SchemaEvaluator'
+      static jsonSchema() {
+        return { additionalProperties: false, properties: { value: { type: 'string' } }, required: ['value'], type: 'object' }
+      }
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    class NullSchemaEvaluator extends Evaluator {
+      static evaluatorName = 'NullSchemaEvaluator'
+      static jsonSchema() {
+        return null
+      }
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    const schema = buildDatasetJsonSchema({
+      customEvaluators: [SchemaEvaluator as never, NullSchemaEvaluator as never],
+    })
+    const text = JSON.stringify(schema)
+    expect(text).toContain('"SchemaEvaluator"')
+    expect(text).toContain('"value":{"type":"string"}')
+    expect(text).toContain('"NullSchemaEvaluator"')
+    expect(text).toContain('"properties":{"NullSchemaEvaluator":{}}')
   })
 })
 
@@ -117,6 +230,78 @@ describe('Dataset YAML round-trip', () => {
     expect(restored.cases[0]?.expectedOutput).toBe(1)
   })
 
+  it('toObject includes schema, report evaluators, case metadata and per-case evaluators', () => {
+    const dataset = new Dataset({
+      cases: [
+        new Case({
+          evaluators: [new Contains({ value: 'ok' })],
+          expectedOutput: 'ok',
+          inputs: 'input',
+          metadata: { split: 'test' },
+          name: 'case-a',
+        }),
+      ],
+      evaluators: [new EqualsExpected()],
+      name: 'object-test',
+      reportEvaluators: [new ConfusionMatrixEvaluator({ expected: { from: 'expected_output' }, predicted: { from: 'output' } })],
+    })
+
+    expect(dataset.toObject({ schemaPath: './schema.json' })).toEqual({
+      $schema: './schema.json',
+      cases: [
+        {
+          evaluators: [{ Contains: 'ok' }],
+          expected_output: 'ok',
+          inputs: 'input',
+          metadata: { split: 'test' },
+          name: 'case-a',
+        },
+      ],
+      evaluators: ['EqualsExpected'],
+      name: 'object-test',
+      report_evaluators: [
+        {
+          ConfusionMatrixEvaluator: {
+            expected: { from: 'expected_output' },
+            predicted: { from: 'output' },
+          },
+        },
+      ],
+    })
+  })
+
+  it('uses defaultName and custom evaluator registries when restoring objects', () => {
+    class CustomEvaluator extends Evaluator {
+      static evaluatorName = 'CustomEvaluator'
+      readonly value: string
+      constructor(opts: { value: string }) {
+        super()
+        this.value = opts.value
+      }
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    const restored = Dataset.fromObject(
+      {
+        cases: [{ evaluators: [{ CustomEvaluator: 'case' }], inputs: 1 }],
+        evaluators: [{ CustomEvaluator: 'dataset' }],
+      },
+      {
+        customEvaluators: [CustomEvaluator as never],
+        defaultName: 'default-name',
+        primaryArgKeys: { CustomEvaluator: 'value' },
+      }
+    )
+
+    expect(restored.name).toBe('default-name')
+    expect(restored.evaluators[0]).toBeInstanceOf(CustomEvaluator)
+    expect((restored.evaluators[0] as CustomEvaluator).value).toBe('dataset')
+    expect(restored.cases[0]?.evaluators[0]).toBeInstanceOf(CustomEvaluator)
+    expect((restored.cases[0]?.evaluators[0] as CustomEvaluator).value).toBe('case')
+  })
+
   it('Dataset.jsonSchema() includes registered built-in evaluators', () => {
     const schema = new Dataset({ cases: [], name: 'x' }).jsonSchema()
     const text = JSON.stringify(schema)
@@ -176,6 +361,39 @@ describe('Dataset YAML round-trip', () => {
       expect((await fs.stat(schemaPath)).mtimeMs).toBe(firstMtime)
     } finally {
       await fs.rm(tmpdir, { force: true, recursive: true })
+    }
+  })
+
+  it('prefers Deno readTextFile/writeTextFile helpers when present', async () => {
+    const originalDeno = (globalThis as { Deno?: unknown }).Deno
+    const files = new Map<string, string>()
+    const calls: string[] = []
+    ;(globalThis as { Deno?: unknown }).Deno = {
+      readTextFile: (path: string) => {
+        calls.push(`read:${path}`)
+        const text = files.get(path)
+        return text === undefined ? Promise.reject(new Error(`missing ${path}`)) : Promise.resolve(text)
+      },
+      writeTextFile: (path: string, text: string) => {
+        calls.push(`write:${path}`)
+        files.set(path, text)
+        return Promise.resolve()
+      },
+    }
+
+    try {
+      const ds = new Dataset({
+        cases: [new Case({ inputs: { v: 1 }, name: 'tmp' })],
+        name: 'deno-file-test',
+      })
+      await ds.toFile('/tmp/deno-dataset.yaml', { schemaPath: 'deno.schema.json' })
+      expect(calls).toEqual(['write:/tmp/deno-dataset.yaml', 'read:/tmp/deno.schema.json', 'write:/tmp/deno.schema.json'])
+      expect(files.get('/tmp/deno-dataset.yaml')).toContain('# yaml-language-server: $schema=deno.schema.json')
+      const restored = await Dataset.fromFile('/tmp/deno-dataset.yaml')
+      expect(restored.name).toBe('deno-file-test')
+      expect(restored.cases[0]?.inputs).toEqual({ v: 1 })
+    } finally {
+      ;(globalThis as { Deno?: unknown }).Deno = originalDeno
     }
   })
 

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -17,6 +17,7 @@ import {
   IsInstance,
   MaxDuration,
   parseYaml,
+  registerEvaluator,
   ReportEvaluator,
   stringifyYaml,
 } from '../../evals'
@@ -300,6 +301,33 @@ describe('Dataset YAML round-trip', () => {
     expect((restored.evaluators[0] as CustomEvaluator).value).toBe('dataset')
     expect(restored.cases[0]?.evaluators[0]).toBeInstanceOf(CustomEvaluator)
     expect((restored.cases[0]?.evaluators[0] as CustomEvaluator).value).toBe('case')
+  })
+
+  it('falls back to globally registered custom evaluators when no custom registry is provided', () => {
+    class GloballyRegisteredEvaluator extends Evaluator {
+      static evaluatorName = 'GloballyRegisteredEvaluator'
+      readonly value: string
+      constructor(opts: { value: string }) {
+        super()
+        this.value = opts.value
+      }
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    registerEvaluator(GloballyRegisteredEvaluator as never)
+    const restored = Dataset.fromObject(
+      {
+        cases: [{ inputs: 1 }],
+        evaluators: [{ GloballyRegisteredEvaluator: 'global' }],
+        name: 'global-registry',
+      },
+      { primaryArgKeys: { GloballyRegisteredEvaluator: 'value' } }
+    )
+
+    expect(restored.evaluators[0]).toBeInstanceOf(GloballyRegisteredEvaluator)
+    expect((restored.evaluators[0] as GloballyRegisteredEvaluator).value).toBe('global')
   })
 
   it('Dataset.jsonSchema() includes registered built-in evaluators', () => {

--- a/packages/logfire-api/src/evals/__test__/spanTree.test.ts
+++ b/packages/logfire-api/src/evals/__test__/spanTree.test.ts
@@ -1,9 +1,31 @@
 /* eslint-disable @typescript-eslint/require-await */
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+
 import { trace as TraceAPI } from '@opentelemetry/api'
 import { describe, expect, it } from 'vitest'
 
-import { Case, Dataset, HasMatchingSpan } from '../../evals'
+import { Case, Dataset, HasMatchingSpan, SpanTree, SpanTreeRecordingError } from '../../evals'
 import { withMemoryExporter } from './withMemoryExporter'
+
+const fakeSpan = (opts: {
+  attributes?: Record<string, unknown>
+  durationMs?: number
+  name: string
+  parentSpanId?: string
+  spanId: string
+  startMs?: number
+}): ReadableSpan =>
+  ({
+    attributes: opts.attributes ?? {},
+    endTime: [0, ((opts.startMs ?? 0) + (opts.durationMs ?? 1)) * 1_000_000],
+    name: opts.name,
+    parentSpanContext:
+      opts.parentSpanId === undefined
+        ? undefined
+        : { isRemote: false, spanId: opts.parentSpanId, traceFlags: 1, traceId: 'trace000000000000000000000001' },
+    spanContext: () => ({ isRemote: false, spanId: opts.spanId, traceFlags: 1, traceId: 'trace000000000000000000000001' }),
+    startTime: [0, (opts.startMs ?? 0) * 1_000_000],
+  }) as unknown as ReadableSpan
 
 describe('span tree capture + HasMatchingSpan', () => {
   it('captures user-task spans into ctx.spanTree and matches with HasMatchingSpan', async () => {
@@ -68,5 +90,63 @@ describe('span tree capture + HasMatchingSpan', () => {
     expect(m?.input_tokens).toBe(100)
     expect(m?.output_tokens).toBe(50)
     expect(m?.cost).toBeCloseTo(0.001)
+  })
+
+  it('builds deterministic trees and evaluates structural span queries', () => {
+    const tree = SpanTree.fromSpans([
+      fakeSpan({
+        attributes: { child: true, route: '/slow' },
+        durationMs: 20,
+        name: 'child-slow',
+        parentSpanId: 'root',
+        spanId: 'b',
+        startMs: 20,
+      }),
+      fakeSpan({
+        attributes: { child: true, route: '/fast' },
+        durationMs: 3,
+        name: 'child-fast',
+        parentSpanId: 'root',
+        spanId: 'a',
+        startMs: 10,
+      }),
+      fakeSpan({ attributes: { leaf: true }, durationMs: 1, name: 'leaf', parentSpanId: 'a', spanId: 'leaf', startMs: 12 }),
+      fakeSpan({ attributes: { root: true }, durationMs: 50, name: 'root-op', spanId: 'root', startMs: 0 }),
+    ])
+
+    expect(tree.roots.map((node) => node.name)).toEqual(['root-op'])
+    expect(tree.roots[0]?.children.map((node) => node.name)).toEqual(['child-fast', 'child-slow'])
+    expect(Array.from(tree.all()).map((node) => node.name)).toEqual(['root-op', 'child-fast', 'leaf', 'child-slow'])
+
+    expect(tree.any({ minChildCount: 2, minDescendantCount: 3, nameContains: 'root' })).toBe(true)
+    expect(tree.any({ maxDuration: 5, nameMatchesRegex: '^child-' })).toBe(true)
+    expect(tree.any({ hasAttributes: { route: '/fast' }, nameEquals: 'child-fast' })).toBe(true)
+    expect(tree.any({ hasAttributeKeys: ['leaf'], someAncestorHas: { nameEquals: 'root-op' } })).toBe(true)
+    expect(tree.any({ allChildrenHave: { nameContains: 'child' }, nameEquals: 'root-op' })).toBe(true)
+    expect(tree.any({ allDescendantsHave: { maxDuration: 20 }, nameEquals: 'root-op' })).toBe(true)
+    expect(tree.any({ and_: [{ nameContains: 'child' }, { not_: { nameContains: 'slow' } }] })).toBe(true)
+    expect(tree.any({ or_: [{ nameEquals: 'missing' }, { nameEquals: 'leaf' }] })).toBe(true)
+
+    expect(tree.find({ someDescendantHas: { nameEquals: 'leaf' } }).map((node) => node.name)).toEqual(['root-op', 'child-fast'])
+    expect(tree.first({ maxChildCount: 0 })?.name).toBe('leaf')
+    expect(tree.any({ hasAttributes: { route: '/missing' } })).toBe(false)
+    expect(tree.any({ hasAttributeKeys: ['missing'] })).toBe(false)
+    expect(tree.any({ maxChildCount: 1, nameEquals: 'root-op' })).toBe(false)
+    expect(tree.any({ maxDescendantCount: 2, nameEquals: 'root-op' })).toBe(false)
+  })
+
+  it('throws the stored recording error when querying an unavailable tree', () => {
+    const err = new SpanTreeRecordingError('capture unavailable')
+    const tree = SpanTree.fromError(err)
+
+    expect(() => {
+      tree.ensureAvailable()
+    }).toThrow(err)
+    expect(() => {
+      tree.find({ nameEquals: 'x' })
+    }).toThrow(err)
+    expect(() => {
+      tree.first({ nameEquals: 'x' })
+    }).toThrow(err)
   })
 })

--- a/packages/logfire-api/src/evals/__test__/spanTree.test.ts
+++ b/packages/logfire-api/src/evals/__test__/spanTree.test.ts
@@ -120,19 +120,45 @@ describe('span tree capture + HasMatchingSpan', () => {
 
     expect(tree.any({ minChildCount: 2, minDescendantCount: 3, nameContains: 'root' })).toBe(true)
     expect(tree.any({ maxDuration: 5, nameMatchesRegex: '^child-' })).toBe(true)
+    expect(tree.any({ max_duration: 0.004, name_equals: 'child-fast' })).toBe(true)
+    expect(tree.any({ max_duration: 0.002, name_equals: 'child-fast' })).toBe(false)
     expect(tree.any({ hasAttributes: { route: '/fast' }, nameEquals: 'child-fast' })).toBe(true)
     expect(tree.any({ hasAttributeKeys: ['leaf'], someAncestorHas: { nameEquals: 'root-op' } })).toBe(true)
     expect(tree.any({ allChildrenHave: { nameContains: 'child' }, nameEquals: 'root-op' })).toBe(true)
     expect(tree.any({ allDescendantsHave: { maxDuration: 20 }, nameEquals: 'root-op' })).toBe(true)
+    expect(tree.any({ max_depth: 0, name_equals: 'root-op' })).toBe(true)
+    expect(tree.any({ min_depth: 2, name_equals: 'leaf' })).toBe(true)
+    expect(tree.any({ name_equals: 'root-op', no_child_has: { name_equals: 'leaf' } })).toBe(true)
+    expect(tree.any({ name_equals: 'root-op', no_descendant_has: { name_equals: 'missing' } })).toBe(true)
+    expect(tree.any({ name_equals: 'leaf', no_ancestor_has: { name_equals: 'missing' } })).toBe(true)
     expect(tree.any({ and_: [{ nameContains: 'child' }, { not_: { nameContains: 'slow' } }] })).toBe(true)
     expect(tree.any({ or_: [{ nameEquals: 'missing' }, { nameEquals: 'leaf' }] })).toBe(true)
+    expect(() => tree.any({ name_equals: 'leaf', or_: [{ name_equals: 'leaf' }] })).toThrow(
+      "Cannot combine 'or_' conditions with other conditions at the same level"
+    )
 
     expect(tree.find({ someDescendantHas: { nameEquals: 'leaf' } }).map((node) => node.name)).toEqual(['root-op', 'child-fast'])
+    expect(
+      tree.any({
+        name_equals: 'root-op',
+        some_descendant_has: { name_equals: 'leaf' },
+        stop_recursing_when: { name_equals: 'child-fast' },
+      })
+    ).toBe(false)
     expect(tree.first({ maxChildCount: 0 })?.name).toBe('leaf')
     expect(tree.any({ hasAttributes: { route: '/missing' } })).toBe(false)
     expect(tree.any({ hasAttributeKeys: ['missing'] })).toBe(false)
     expect(tree.any({ maxChildCount: 1, nameEquals: 'root-op' })).toBe(false)
     expect(tree.any({ maxDescendantCount: 2, nameEquals: 'root-op' })).toBe(false)
+  })
+
+  it('serializes HasMatchingSpan queries with snake_case field names', () => {
+    expect(new HasMatchingSpan({ query: { maxDuration: 0.1, someChildHas: { nameEquals: 'child' } } }).toJSON()).toEqual({
+      query: {
+        max_duration: 0.1,
+        some_child_has: { name_equals: 'child' },
+      },
+    })
   })
 
   it('throws the stored recording error when querying an unavailable tree', () => {

--- a/packages/logfire-api/src/evals/builtins/Contains.ts
+++ b/packages/logfire-api/src/evals/builtins/Contains.ts
@@ -2,6 +2,7 @@ import type { EvaluationReason, EvaluatorContext } from '../types'
 
 import { Evaluator } from '../Evaluator'
 import { registerEvaluator } from '../registry'
+import { deepEqual } from './Equals'
 
 /**
  * True iff `output` contains `value`. Supports strings (substring), arrays
@@ -17,12 +18,34 @@ export class Contains extends Evaluator {
   readonly caseSensitive: boolean
   readonly value: unknown
 
-  constructor(opts: { asStrings?: boolean; caseSensitive?: boolean; evaluationName?: string; value: unknown }) {
+  constructor(opts: {
+    as_strings?: boolean
+    asStrings?: boolean
+    case_sensitive?: boolean
+    caseSensitive?: boolean
+    evaluation_name?: string
+    evaluationName?: string
+    value: unknown
+  }) {
     super()
     this.value = opts.value
-    this.caseSensitive = opts.caseSensitive ?? true
-    this.asStrings = opts.asStrings ?? false
-    if (opts.evaluationName !== undefined) this.evaluationName = opts.evaluationName
+    this.caseSensitive = opts.caseSensitive ?? opts.case_sensitive ?? true
+    this.asStrings = opts.asStrings ?? opts.as_strings ?? false
+    this.evaluationName = opts.evaluationName ?? opts.evaluation_name
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        as_strings: { default: false, type: 'boolean' },
+        case_sensitive: { default: true, type: 'boolean' },
+        evaluation_name: { type: 'string' },
+        value: {},
+      },
+      required: ['value'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: EvaluatorContext): EvaluationReason {
@@ -43,37 +66,58 @@ export class Contains extends Evaluator {
       const a = this.caseSensitive ? String(output) : String(output).toLowerCase()
       const b = this.caseSensitive ? String(this.value) : String(this.value).toLowerCase()
       const ok = a.includes(b)
-      return { reason: ok ? 'output contains value' : 'output does not contain value', value: ok }
+      if (ok) return { value: true }
+      return { reason: `Output string ${truncatedRepr(a, 100)} does not contain expected string ${truncatedRepr(b, 100)}`, value: false }
     }
     if (Array.isArray(output)) {
       for (const item of output) {
-        if (deepEqualLoose(item, this.value, this.caseSensitive)) {
-          return { reason: 'value found in output array', value: true }
+        if (deepEqual(item, this.value)) {
+          return { value: true }
         }
       }
-      return { reason: 'value not found in output array', value: false }
+      return { reason: `Output ${truncatedRepr(output, 200)} does not contain provided value`, value: false }
     }
     if (output !== null && typeof output === 'object') {
       const obj = output as Record<string, unknown>
-      // Either a matching key OR a matching value qualifies as "contains"
-      for (const [k, v] of Object.entries(obj)) {
-        if (deepEqualLoose(k, this.value, this.caseSensitive)) return { reason: 'key matches value', value: true }
-        if (deepEqualLoose(v, this.value, this.caseSensitive)) return { reason: 'object value matches', value: true }
+      if (isPlainRecord(this.value)) {
+        for (const [key, expected] of Object.entries(this.value)) {
+          if (!(key in obj)) {
+            return { reason: `Output does not contain expected key ${truncatedRepr(key, 30)}`, value: false }
+          }
+          if (!deepEqual(obj[key], expected)) {
+            return {
+              reason: `Output has different value for key ${truncatedRepr(key, 30)}: ${truncatedRepr(obj[key], 100)} != ${truncatedRepr(expected, 100)}`,
+              value: false,
+            }
+          }
+        }
+        return { value: true }
       }
-      return { reason: 'value not found in object', value: false }
+      const key = String(this.value)
+      return key in obj
+        ? { value: true }
+        : { reason: `Output ${truncatedRepr(obj, 200)} does not contain provided value as a key`, value: false }
     }
-    return { reason: 'output is not iterable', value: false }
+    return { reason: 'Containment check failed: output is not iterable', value: false }
   }
 }
 registerEvaluator(Contains)
 
-function deepEqualLoose(a: unknown, b: unknown, caseSensitive: boolean): boolean {
-  if (typeof a === 'string' && typeof b === 'string' && !caseSensitive) {
-    return a.toLowerCase() === b.toLowerCase()
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function truncatedRepr(value: unknown, maxLength: number): string {
+  let repr: string
+  if (typeof value === 'string') {
+    repr = JSON.stringify(value)
+  } else {
+    try {
+      repr = JSON.stringify(value)
+    } catch {
+      repr = String(value)
+    }
   }
-  if (a === b) return true
-  if (typeof a !== typeof b) return false
-  if (a === null || b === null) return false
-  if (typeof a !== 'object') return false
-  return JSON.stringify(a) === JSON.stringify(b)
+  if (repr.length <= maxLength) return repr
+  return `${repr.slice(0, Math.floor(maxLength / 2))}...${repr.slice(-Math.floor(maxLength / 2))}`
 }

--- a/packages/logfire-api/src/evals/builtins/Equals.ts
+++ b/packages/logfire-api/src/evals/builtins/Equals.ts
@@ -9,10 +9,22 @@ export class Equals extends Evaluator {
 
   readonly value: unknown
 
-  constructor(opts: { evaluationName?: string; value: unknown }) {
+  constructor(opts: { evaluation_name?: string; evaluationName?: string; value: unknown }) {
     super()
     this.value = opts.value
-    if (opts.evaluationName !== undefined) this.evaluationName = opts.evaluationName
+    this.evaluationName = opts.evaluationName ?? opts.evaluation_name
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        evaluation_name: { type: 'string' },
+        value: {},
+      },
+      required: ['value'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: EvaluatorContext): boolean {

--- a/packages/logfire-api/src/evals/builtins/EqualsExpected.ts
+++ b/packages/logfire-api/src/evals/builtins/EqualsExpected.ts
@@ -11,9 +11,19 @@ import { deepEqual } from './Equals'
 export class EqualsExpected extends Evaluator {
   static evaluatorName = 'EqualsExpected'
 
-  constructor(opts: { evaluationName?: string } = {}) {
+  constructor(opts: { evaluation_name?: string; evaluationName?: string } = {}) {
     super()
-    if (opts.evaluationName !== undefined) this.evaluationName = opts.evaluationName
+    this.evaluationName = opts.evaluationName ?? opts.evaluation_name
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        evaluation_name: { type: 'string' },
+      },
+      type: 'object',
+    }
   }
 
   evaluate(ctx: EvaluatorContext): EvaluatorOutput {

--- a/packages/logfire-api/src/evals/builtins/HasMatchingSpan.ts
+++ b/packages/logfire-api/src/evals/builtins/HasMatchingSpan.ts
@@ -1,8 +1,8 @@
-import type { SpanQuery } from '../spanTree'
 import type { EvaluatorContext } from '../types'
 
 import { Evaluator } from '../Evaluator'
 import { registerEvaluator } from '../registry'
+import { type SpanQuery, spanQueryToSnakeCase } from '../spanTree'
 
 /** True iff a span matching `query` was emitted under the user's task. */
 export class HasMatchingSpan extends Evaluator {
@@ -10,10 +10,22 @@ export class HasMatchingSpan extends Evaluator {
 
   readonly query: SpanQuery
 
-  constructor(opts: { evaluationName?: string; query: SpanQuery }) {
+  constructor(opts: { evaluation_name?: string; evaluationName?: string; query: SpanQuery }) {
     super()
     this.query = opts.query
-    if (opts.evaluationName !== undefined) this.evaluationName = opts.evaluationName
+    this.evaluationName = opts.evaluationName ?? opts.evaluation_name
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        evaluation_name: { type: 'string' },
+        query: { type: 'object' },
+      },
+      required: ['query'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: EvaluatorContext): boolean {
@@ -21,7 +33,7 @@ export class HasMatchingSpan extends Evaluator {
   }
 
   toJSON(): Record<string, unknown> {
-    const out: Record<string, unknown> = { query: this.query }
+    const out: Record<string, unknown> = { query: spanQueryToSnakeCase(this.query) }
     if (this.evaluationName !== undefined) out.evaluation_name = this.evaluationName
     return out
   }

--- a/packages/logfire-api/src/evals/builtins/IsInstance.ts
+++ b/packages/logfire-api/src/evals/builtins/IsInstance.ts
@@ -13,10 +13,22 @@ export class IsInstance extends Evaluator {
 
   readonly typeName: string
 
-  constructor(opts: { evaluationName?: string; typeName: string }) {
+  constructor(opts: { evaluation_name?: string; evaluationName?: string; type_name?: string; typeName?: string }) {
     super()
-    this.typeName = opts.typeName
-    if (opts.evaluationName !== undefined) this.evaluationName = opts.evaluationName
+    this.typeName = opts.typeName ?? opts.type_name ?? ''
+    this.evaluationName = opts.evaluationName ?? opts.evaluation_name
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        evaluation_name: { type: 'string' },
+        type_name: { type: 'string' },
+      },
+      required: ['type_name'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: EvaluatorContext): EvaluationReason {

--- a/packages/logfire-api/src/evals/builtins/LLMJudge.ts
+++ b/packages/logfire-api/src/evals/builtins/LLMJudge.ts
@@ -7,7 +7,9 @@ import { registerEvaluator } from '../registry'
  * Per-output-channel config for `LLMJudge`. `false` disables the channel.
  */
 export interface LLMJudgeOutputConfig {
+  evaluation_name?: string
   evaluationName?: string
+  include_reason?: boolean
   includeReason?: boolean
 }
 
@@ -60,9 +62,13 @@ export class LLMJudge extends Evaluator {
   readonly judge?: JudgeFn
   readonly rubric: string
   readonly score: false | LLMJudgeOutputConfig
+  private readonly assertionWasProvided: boolean
+  private readonly scoreWasProvided: boolean
 
   constructor(opts: {
     assertion?: false | LLMJudgeOutputConfig
+    include_expected_output?: boolean
+    include_input?: boolean
     includeExpectedOutput?: boolean
     includeInput?: boolean
     judge?: JudgeFn
@@ -72,10 +78,36 @@ export class LLMJudge extends Evaluator {
     super()
     this.rubric = opts.rubric
     this.judge = opts.judge
-    this.includeInput = opts.includeInput ?? false
-    this.includeExpectedOutput = opts.includeExpectedOutput ?? false
-    this.score = opts.score ?? { evaluationName: 'LLMJudge', includeReason: false }
-    this.assertion = opts.assertion ?? { evaluationName: 'LLMJudge', includeReason: true }
+    this.includeInput = opts.includeInput ?? opts.include_input ?? false
+    this.includeExpectedOutput = opts.includeExpectedOutput ?? opts.include_expected_output ?? false
+    this.scoreWasProvided = opts.score !== undefined
+    this.assertionWasProvided = opts.assertion !== undefined
+    this.score = opts.score === undefined || opts.score === false ? false : normalizeOutputConfig(opts.score)
+    this.assertion =
+      opts.assertion === undefined ? { includeReason: true } : opts.assertion === false ? false : normalizeOutputConfig(opts.assertion)
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    const outputConfig = {
+      additionalProperties: false,
+      properties: {
+        evaluation_name: { type: 'string' },
+        include_reason: { type: 'boolean' },
+      },
+      type: 'object',
+    }
+    return {
+      additionalProperties: false,
+      properties: {
+        assertion: { anyOf: [{ const: false, type: 'boolean' }, outputConfig] },
+        include_expected_output: { default: false, type: 'boolean' },
+        include_input: { default: false, type: 'boolean' },
+        rubric: { type: 'string' },
+        score: { anyOf: [{ const: false, type: 'boolean' }, outputConfig] },
+      },
+      required: ['rubric'],
+      type: 'object',
+    }
   }
 
   async evaluate(ctx: EvaluatorContext): Promise<EvaluatorOutput> {
@@ -90,13 +122,15 @@ export class LLMJudge extends Evaluator {
       rubric: this.rubric,
     })
     const out: Record<string, boolean | EvaluationReason | number> = {}
+    const includeBoth = this.score !== false && this.assertion !== false
+    const defaultName = this.getResultName()
     if (this.score !== false) {
-      const name = this.score.evaluationName ?? 'LLMJudge'
-      out[name] = this.score.includeReason ? { reason: verdict.reason, value: verdict.score } : verdict.score
+      const name = outputConfigName(this.score) ?? (includeBoth ? `${defaultName}_score` : defaultName)
+      out[name] = outputConfigIncludeReason(this.score) ? { reason: verdict.reason, value: verdict.score } : verdict.score
     }
     if (this.assertion !== false) {
-      const name = this.assertion.evaluationName ?? 'LLMJudge'
-      out[name] = this.assertion.includeReason ? { reason: verdict.reason, value: verdict.pass } : verdict.pass
+      const name = outputConfigName(this.assertion) ?? (includeBoth ? `${defaultName}_pass` : defaultName)
+      out[name] = outputConfigIncludeReason(this.assertion) ? { reason: verdict.reason, value: verdict.pass } : verdict.pass
     }
     return out
   }
@@ -105,7 +139,38 @@ export class LLMJudge extends Evaluator {
     const out: Record<string, unknown> = { rubric: this.rubric }
     if (this.includeInput) out.include_input = true
     if (this.includeExpectedOutput) out.include_expected_output = true
+    if (this.scoreWasProvided || this.score !== false) out.score = this.score === false ? false : outputConfigToJSON(this.score)
+    if (this.assertionWasProvided || !isDefaultAssertionConfig(this.assertion)) {
+      out.assertion = this.assertion === false ? false : outputConfigToJSON(this.assertion)
+    }
     return out
   }
 }
 registerEvaluator(LLMJudge)
+
+function normalizeOutputConfig(config: LLMJudgeOutputConfig): LLMJudgeOutputConfig {
+  return {
+    evaluationName: config.evaluationName ?? config.evaluation_name,
+    includeReason: config.includeReason ?? config.include_reason,
+  }
+}
+
+function outputConfigName(config: LLMJudgeOutputConfig): string | undefined {
+  return config.evaluationName ?? config.evaluation_name
+}
+
+function outputConfigIncludeReason(config: LLMJudgeOutputConfig): boolean {
+  return config.includeReason ?? config.include_reason ?? false
+}
+
+function outputConfigToJSON(config: LLMJudgeOutputConfig): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  const name = outputConfigName(config)
+  if (name !== undefined) out.evaluation_name = name
+  if (outputConfigIncludeReason(config)) out.include_reason = true
+  return out
+}
+
+function isDefaultAssertionConfig(config: false | LLMJudgeOutputConfig): boolean {
+  return config !== false && outputConfigName(config) === undefined && outputConfigIncludeReason(config)
+}

--- a/packages/logfire-api/src/evals/builtins/MaxDuration.ts
+++ b/packages/logfire-api/src/evals/builtins/MaxDuration.ts
@@ -14,6 +14,17 @@ export class MaxDuration extends Evaluator {
     this.seconds = opts.seconds
   }
 
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        seconds: { type: 'number' },
+      },
+      required: ['seconds'],
+      type: 'object',
+    }
+  }
+
   evaluate(ctx: EvaluatorContext): boolean {
     return ctx.duration <= this.seconds
   }

--- a/packages/logfire-api/src/evals/currentTaskRun.ts
+++ b/packages/logfire-api/src/evals/currentTaskRun.ts
@@ -17,17 +17,24 @@ interface ALSLike<T> {
 }
 
 let alsImpl: ALSLike<TaskRunState> | null = null
+let alsProbeComplete = false
 /** Fallback storage cell for runtimes without ALS. Single-slot, single-execute. */
 let fallbackStore: null | TaskRunState = null
 
 async function ensureALS(): Promise<void> {
   if (alsImpl !== null) return
+  if (alsProbeComplete) return
+  alsProbeComplete = true
   if (!hasAsyncLocalStorage()) return
   // Lazy import — `node:async_hooks` is not available on the browser. Vite is
   // configured to externalize `node:*` so this resolves at runtime against the
   // host's module resolver.
-  const mod: typeof import('node:async_hooks') = await import('node:async_hooks')
-  alsImpl = new mod.AsyncLocalStorage<TaskRunState>()
+  try {
+    const mod: typeof import('node:async_hooks') = await import('node:async_hooks')
+    alsImpl = new mod.AsyncLocalStorage<TaskRunState>()
+  } catch {
+    alsImpl = null
+  }
 }
 
 /** Run `fn` with `state` set as the current task-run context. */

--- a/packages/logfire-api/src/evals/currentTaskRun.ts
+++ b/packages/logfire-api/src/evals/currentTaskRun.ts
@@ -80,5 +80,8 @@ export function setEvalAttribute(name: string, value: unknown): void {
 export function incrementEvalMetric(name: string, amount: number): void {
   const state = getCurrentTaskRun()
   if (state === undefined) return
-  state.metrics[name] = (state.metrics[name] ?? 0) + amount
+  const current = state.metrics[name] ?? 0
+  const next = current + amount
+  if (current === 0 && next === 0) return
+  state.metrics[name] = next
 }

--- a/packages/logfire-api/src/evals/evaluatorResults.ts
+++ b/packages/logfire-api/src/evals/evaluatorResults.ts
@@ -1,0 +1,57 @@
+import type { EvaluationReason, EvaluationResultJson, EvaluatorFailureRecord, EvaluatorOutput, EvaluatorSpec } from './types'
+
+export function evaluationResultsFromOutput(
+  raw: EvaluatorOutput,
+  defaultName: string,
+  source: EvaluatorSpec,
+  evaluatorVersion?: string
+): EvaluationResultJson[] {
+  if (isEvaluationScalar(raw)) {
+    return [buildEvaluationResultJson(defaultName, raw, source, evaluatorVersion)]
+  }
+  return Object.entries(raw).map(([name, value]) => buildEvaluationResultJson(name, value, source, evaluatorVersion))
+}
+
+export function buildEvaluationResultJson(
+  name: string,
+  value: boolean | EvaluationReason | number | string,
+  source: EvaluatorSpec,
+  evaluatorVersion?: string
+): EvaluationResultJson {
+  const reason = isEvaluationReason(value) ? (value.reason ?? null) : null
+  const scalar = isEvaluationReason(value) ? value.value : value
+  const out: EvaluationResultJson = {
+    name,
+    reason,
+    source,
+    value: scalar,
+  }
+  if (evaluatorVersion !== undefined) out.evaluator_version = evaluatorVersion
+  return out
+}
+
+export function buildEvaluatorFailureRecord(
+  err: unknown,
+  name: string,
+  source: EvaluatorSpec,
+  evaluatorVersion?: string
+): EvaluatorFailureRecord {
+  const isErr = err instanceof Error
+  const out: EvaluatorFailureRecord = {
+    error_message: isErr ? err.message : String(err),
+    error_type: isErr ? err.constructor.name : 'Error',
+    name,
+    source,
+  }
+  if (isErr && err.stack !== undefined) out.error_stacktrace = err.stack
+  if (evaluatorVersion !== undefined) out.evaluator_version = evaluatorVersion
+  return out
+}
+
+export function isEvaluationReason(value: unknown): value is EvaluationReason {
+  return typeof value === 'object' && value !== null && 'value' in value && !Array.isArray(value)
+}
+
+function isEvaluationScalar(value: EvaluatorOutput): value is boolean | EvaluationReason | number | string {
+  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string' || isEvaluationReason(value)
+}

--- a/packages/logfire-api/src/evals/index.ts
+++ b/packages/logfire-api/src/evals/index.ts
@@ -107,7 +107,15 @@ export {
   stringifyYaml,
   type ToOptions,
 } from './serialization'
-export { EvalsSpanProcessor, getEvalsSpanProcessor, SpanNode, type SpanQuery, SpanTree, SpanTreeRecordingError } from './spanTree'
+export {
+  EvalsSpanProcessor,
+  getEvalsSpanProcessor,
+  SpanNode,
+  type SpanQuery,
+  spanQueryToSnakeCase,
+  SpanTree,
+  SpanTreeRecordingError,
+} from './spanTree'
 export type {
   EvaluateOptions,
   EvaluationReason,

--- a/packages/logfire-api/src/evals/index.ts
+++ b/packages/logfire-api/src/evals/index.ts
@@ -29,26 +29,24 @@ export * from './constants'
 export { getCurrentTaskRun, incrementEvalMetric, runWithTaskRun, setEvalAttribute } from './currentTaskRun'
 export { Dataset, type DatasetOptions } from './Dataset'
 export { Evaluator } from './Evaluator'
+export { buildEvaluationResultJson } from './evaluatorResults'
 export {
   configureOnlineEvals,
   disableEvaluation,
   type EvaluationSink,
   getOnlineEvalConfig,
+  type OnErrorCallback,
+  type OnErrorLocation,
   type OnlineEvalConfig,
   OnlineEvaluator,
+  type OnMaxConcurrencyCallback,
   type SamplingContext,
   type SamplingMode,
   type SinkPayload,
   waitForEvaluations,
   withOnlineEvaluation,
 } from './online'
-export {
-  buildEvaluationResultJson,
-  emitEvaluationResult,
-  emitEvaluatorFailure,
-  type SpanReference,
-  spanReferenceFromSpan,
-} from './otelEmit'
+export { emitEvaluationResult, emitEvaluatorFailure, type SpanReference, spanReferenceFromSpan } from './otelEmit'
 export {
   evaluatorRegistryKey,
   getEvaluatorClass,

--- a/packages/logfire-api/src/evals/index.ts
+++ b/packages/logfire-api/src/evals/index.ts
@@ -82,12 +82,16 @@ export {
   type ScoreFrom,
 } from './reportEvaluators'
 export {
+  averageFromAggregates,
+  averages,
+  caseGroups,
   computeAssertionPassRate,
   computeAverages,
   type EvaluationReport,
   type ReportCase,
   type ReportCaseAggregate,
   type ReportCaseFailure,
+  type ReportCaseGroup,
 } from './reporting'
 export { detectRuntime, hasAsyncLocalStorage, hasNodeFs, type RuntimeName } from './runtime'
 export {

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -17,10 +17,11 @@ import type { EvaluationResultJson, EvaluatorContext, EvaluatorFailureRecord, Ev
 
 import { ATTR_EVALUATOR_NAME, SPAN_MSG_TEMPLATE_EVALUATOR, SPAN_NAME_EVALUATOR_LITERAL } from './constants'
 import { getCurrentTaskRun } from './currentTaskRun'
+import { extractMetricsFromSpanTree } from './extractMetrics'
 import { evalsSpan } from './internal'
 import { buildEvaluationResultJson, emitEvaluationResult, emitEvaluatorFailure, spanReferenceFromSpan } from './otelEmit'
 import { Semaphore } from './Semaphore'
-import { SpanTree } from './spanTree'
+import { buildSpanTree, getEvalsSpanProcessor, SpanTree, SpanTreeRecordingError } from './spanTree'
 
 export type SamplingMode = 'correlated' | 'independent'
 
@@ -229,18 +230,38 @@ export function withOnlineEvaluation<F extends (...args: never[]) => Promise<unk
       }
     }
 
-    const callSpanRef = await evalsSpan(msgTemplate, { attributes: callAttrs, spanName }, async (span) => {
-      const ref = spanReferenceFromSpan(span)
-      try {
-        output = await callFn()
-        if (opts.recordReturn === true) {
-          span.setAttribute('return', JSON.stringify(output))
-        }
-        return ref
-      } finally {
-        durationSec = performance.now() / 1000 - start
-      }
-    })
+    const evalsProcessor = getEvalsSpanProcessor()
+    const exporterContextId = buildOnlineExporterContextId()
+    evalsProcessor.openBucket(exporterContextId)
+
+    let callSpanRef: { spanId: string; traceId: string }
+    try {
+      callSpanRef = await evalsProcessor.runWithBucket(exporterContextId, () =>
+        evalsSpan(msgTemplate, { attributes: callAttrs, spanName }, async (span) => {
+          const ref = spanReferenceFromSpan(span)
+          try {
+            output = await callFn()
+            if (opts.recordReturn === true) {
+              span.setAttribute('return', JSON.stringify(output))
+            }
+            return ref
+          } finally {
+            durationSec = performance.now() / 1000 - start
+          }
+        })
+      )
+    } catch (err) {
+      evalsProcessor.drainBucket(exporterContextId)
+      throw err
+    }
+
+    const capturedSpans = evalsProcessor.drainBucket(exporterContextId)
+    const spanTree =
+      capturedSpans.length === 0 && !isProcessorInstalledOnGlobal()
+        ? buildSpanTree([], new SpanTreeRecordingError())
+        : buildSpanTree(capturedSpans, null)
+    const metrics: Record<string, number> = {}
+    extractMetricsFromSpanTree(spanTree, metrics)
 
     // Dispatch evaluators in the background — don't await, but track for tests.
     const dispatch = dispatchEvaluators({
@@ -249,8 +270,10 @@ export function withOnlineEvaluation<F extends (...args: never[]) => Promise<unk
       callSpanRef,
       cfg,
       durationSec,
+      metrics,
       output,
       sampledEvaluators,
+      spanTree,
       target,
       userOptions: opts,
     })
@@ -301,8 +324,10 @@ interface DispatchArgs {
   callSpanRef: { spanId: string; traceId: string }
   cfg: OnlineEvalConfig
   durationSec: number
+  metrics: Record<string, number>
   output: unknown
   sampledEvaluators: OnlineEvaluator[]
+  spanTree: SpanTree
   target: string
   userOptions: WithOnlineOptions
 }
@@ -312,10 +337,10 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
     attributes: {},
     duration: args.durationSec,
     inputs: args.args.length === 1 ? args.args[0] : args.args,
-    metrics: {},
+    metrics: args.metrics,
     name: undefined,
     output: args.output,
-    spanTree: new SpanTree(),
+    spanTree: args.spanTree,
   }
 
   const allResults: EvaluationResultJson[] = []
@@ -344,6 +369,15 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
       target: args.target,
     })
   }
+}
+
+function buildOnlineExporterContextId(): string {
+  return `online-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+function isProcessorInstalledOnGlobal(): boolean {
+  const tp = TraceAPI.getTracerProvider()
+  return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
 }
 
 function processOutput(

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -10,11 +10,12 @@
  * Mirrors pydantic-evals' `online.py` + `_online.py`.
  */
 
-import { propagation } from '@opentelemetry/api'
+import { context as ContextAPI, propagation, trace as TraceAPI, TraceFlags } from '@opentelemetry/api'
 
 import type { Evaluator } from './Evaluator'
 import type { EvaluationResultJson, EvaluatorContext, EvaluatorFailureRecord, EvaluatorOutput } from './types'
 
+import { ATTR_EVALUATOR_NAME, SPAN_MSG_TEMPLATE_EVALUATOR, SPAN_NAME_EVALUATOR_LITERAL } from './constants'
 import { getCurrentTaskRun } from './currentTaskRun'
 import { evalsSpan } from './internal'
 import { buildEvaluationResultJson, emitEvaluationResult, emitEvaluatorFailure, spanReferenceFromSpan } from './otelEmit'
@@ -102,14 +103,26 @@ export class OnlineEvaluator {
     this.sink = opts.sink
   }
 
-  async tryRun(ctx: EvaluatorContext): Promise<{ failures: EvaluatorFailureRecord[]; results: EvaluationResultJson[] }> {
-    const release = await tryAcquire(this.maxConcurrencySem)
+  async tryRun(
+    ctx: EvaluatorContext,
+    parentSpanRef: null | { spanId: string; traceId: string }
+  ): Promise<{ failures: EvaluatorFailureRecord[]; results: EvaluationResultJson[] }> {
+    const release = this.maxConcurrencySem.tryAcquire()
     if (release === null) {
       this.onMaxConcurrency?.(this.name)
       return { failures: [], results: [] }
     }
     try {
-      const out = await Promise.resolve(this.inner.evaluate(ctx))
+      const out = await runWithParentSpanContext(parentSpanRef, () =>
+        evalsSpan(
+          SPAN_MSG_TEMPLATE_EVALUATOR,
+          {
+            attributes: { [ATTR_EVALUATOR_NAME]: this.name },
+            spanName: SPAN_NAME_EVALUATOR_LITERAL,
+          },
+          async () => this.inner.evaluate(ctx)
+        )
+      )
       return processOutput(out, this.inner)
     } catch (err) {
       this.onError?.(err, this.name)
@@ -308,7 +321,7 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
   const allResults: EvaluationResultJson[] = []
   const allFailures: EvaluatorFailureRecord[] = []
   for (const ev of args.sampledEvaluators) {
-    const { failures, results } = await ev.tryRun(ctx)
+    const { failures, results } = await ev.tryRun(ctx, args.callSpanRef)
     allResults.push(...results)
     allFailures.push(...failures)
   }
@@ -371,15 +384,15 @@ function buildFailureRecord(
   return out
 }
 
-function tryAcquire(sem: Semaphore): Promise<(() => void) | null> {
-  // Non-blocking acquire — we don't queue, we drop the dispatch and report
-  // via `onMaxConcurrency` (matches Python's behavior at `_online.py` semaphore).
-  // The tiny Semaphore class doesn't expose try-acquire, so we use a race with
-  // an immediate fail. Cheap workaround: peek the internals via a property,
-  // or simulate via a Promise.race.
-  // For now: just acquire (we'll add try-acquire later if profiling shows queue
-  // growth).
-  return sem.acquire()
+function runWithParentSpanContext<R>(parentSpanRef: null | { spanId: string; traceId: string }, fn: () => R): R {
+  if (parentSpanRef === null) return fn()
+  const parentContext = TraceAPI.setSpanContext(ContextAPI.active(), {
+    isRemote: false,
+    spanId: parentSpanRef.spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    traceId: parentSpanRef.traceId,
+  })
+  return ContextAPI.with(parentContext, fn)
 }
 
 function extractParamNames(fn: (...args: unknown[]) => unknown): string[] {

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -67,7 +67,7 @@ const DEFAULT_CONFIG: OnlineEvalConfig = {
   enabled: true,
   includeBaggage: true,
   sampleRate: 1.0,
-  samplingMode: 'correlated',
+  samplingMode: 'independent',
 }
 
 /** Mutate the process-wide online-eval defaults. */
@@ -203,6 +203,7 @@ export function withOnlineEvaluation<F extends (...args: never[]) => Promise<unk
   const target = opts.target ?? (fn.name === '' ? 'task' : fn.name)
   const msgTemplate = opts.msgTemplate ?? `Calling ${target}`
   const spanName = opts.spanName ?? msgTemplate
+  const contextArgNames = getContextArgNames(fn as unknown as (...args: unknown[]) => unknown, opts.extractArgs)
 
   const onlineEvaluators = opts.evaluators.map((e) => (e instanceof OnlineEvaluator ? e : new OnlineEvaluator({ evaluator: e })))
 
@@ -257,7 +258,7 @@ export function withOnlineEvaluation<F extends (...args: never[]) => Promise<unk
           try {
             output = await callFn()
             if (opts.recordReturn === true) {
-              span.setAttribute('return', JSON.stringify(output))
+              span.setAttribute('return', encodeReturnAttribute(output))
             }
             return ref
           } finally {
@@ -285,6 +286,7 @@ export function withOnlineEvaluation<F extends (...args: never[]) => Promise<unk
       callSpanRef,
       cfg,
       durationSec,
+      inputNames: contextArgNames,
       metrics,
       output,
       sampledEvaluators,
@@ -339,6 +341,7 @@ interface DispatchArgs {
   callSpanRef: SpanReference
   cfg: OnlineEvalConfig
   durationSec: number
+  inputNames: null | readonly string[]
   metrics: Record<string, number>
   output: unknown
   sampledEvaluators: OnlineEvaluator[]
@@ -351,7 +354,7 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
   const ctx: EvaluatorContext = {
     attributes: {},
     duration: args.durationSec,
-    inputs: args.args.length === 1 ? args.args[0] : args.args,
+    inputs: buildEvaluatorInputs(args.args, args.inputNames),
     metadata: args.cfg.metadata,
     metrics: args.metrics,
     name: undefined,
@@ -359,32 +362,44 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
     spanTree: args.spanTree,
   }
 
+  const emitOtel = args.userOptions.emitOtelEvents ?? args.cfg.emitOtelEvents
+  const globalSink = args.userOptions.sink ?? args.cfg.sink
+  const hasPerEvaluatorSink = args.sampledEvaluators.some((ev) => ev.sink !== undefined)
+  if (!emitOtel && globalSink === undefined && !hasPerEvaluatorSink) return
+
+  const runs = await Promise.all(
+    args.sampledEvaluators.map(async (ev) => ({
+      ev,
+      ...(await ev.tryRun(ctx, args.callSpanRef, {
+        onError: args.userOptions.onError ?? args.cfg.onError,
+        onMaxConcurrency: args.userOptions.onMaxConcurrency ?? args.cfg.onMaxConcurrency,
+      })),
+    }))
+  )
+
   const allResults: EvaluationResultJson[] = []
   const allFailures: EvaluatorFailureRecord[] = []
-  for (const ev of args.sampledEvaluators) {
-    const { failures, results } = await ev.tryRun(ctx, args.callSpanRef, {
-      onError: args.userOptions.onError ?? args.cfg.onError,
-      onMaxConcurrency: args.userOptions.onMaxConcurrency ?? args.cfg.onMaxConcurrency,
-    })
+  const perEvaluatorSinks = new Map<
+    EvaluationSink,
+    { evaluators: Evaluator[]; failures: EvaluatorFailureRecord[]; onError?: OnErrorCallback; results: EvaluationResultJson[] }
+  >()
+  for (const { ev, failures, results } of runs) {
     allResults.push(...results)
     allFailures.push(...failures)
     if (ev.sink !== undefined) {
-      await submitSink(
-        ev.sink,
-        {
-          context: ctx,
-          failures,
-          results,
-          spanReference: args.callSpanRef,
-          target: args.target,
-        },
-        [ev.evaluator],
-        ev.onError ?? args.userOptions.onError ?? args.cfg.onError
-      )
+      const group = perEvaluatorSinks.get(ev.sink) ?? {
+        evaluators: [],
+        failures: [],
+        onError: ev.onError ?? args.userOptions.onError ?? args.cfg.onError,
+        results: [],
+      }
+      group.evaluators.push(ev.evaluator)
+      group.failures.push(...failures)
+      group.results.push(...results)
+      perEvaluatorSinks.set(ev.sink, group)
     }
   }
 
-  const emitOtel = args.userOptions.emitOtelEvents ?? args.cfg.emitOtelEvents
   if (emitOtel) {
     for (const r of allResults)
       emitEvaluationResult(r, { baggageAttrs: args.baggageAttrs, parentSpanRef: args.callSpanRef, target: args.target })
@@ -392,21 +407,40 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
       emitEvaluatorFailure(f, { baggageAttrs: args.baggageAttrs, parentSpanRef: args.callSpanRef, target: args.target })
   }
 
-  const sink = args.userOptions.sink ?? args.cfg.sink
-  if (sink !== undefined) {
-    await submitSink(
-      sink,
-      {
-        context: ctx,
-        failures: allFailures,
-        results: allResults,
-        spanReference: args.callSpanRef,
-        target: args.target,
-      },
-      args.sampledEvaluators.map((ev) => ev.evaluator),
-      args.userOptions.onError ?? args.cfg.onError
+  const sinkSubmissions: Promise<void>[] = []
+  for (const [sink, group] of perEvaluatorSinks) {
+    sinkSubmissions.push(
+      submitSink(
+        sink,
+        {
+          context: ctx,
+          failures: group.failures,
+          results: group.results,
+          spanReference: args.callSpanRef,
+          target: args.target,
+        },
+        group.evaluators,
+        group.onError
+      )
     )
   }
+  if (globalSink !== undefined) {
+    sinkSubmissions.push(
+      submitSink(
+        globalSink,
+        {
+          context: ctx,
+          failures: allFailures,
+          results: allResults,
+          spanReference: args.callSpanRef,
+          target: args.target,
+        },
+        args.sampledEvaluators.map((ev) => ev.evaluator),
+        args.userOptions.onError ?? args.cfg.onError
+      )
+    )
+  }
+  await Promise.all(sinkSubmissions)
 }
 
 function buildOnlineExporterContextId(): string {
@@ -462,6 +496,31 @@ function runWithParentSpanContext<R>(parentSpanRef: null | SpanReference, fn: ()
     traceId: parentSpanRef.traceId,
   })
   return ContextAPI.with(parentContext, fn)
+}
+
+function getContextArgNames(fn: (...args: unknown[]) => unknown, extractArgs: WithOnlineOptions['extractArgs']): null | readonly string[] {
+  const names = Array.isArray(extractArgs) ? extractArgs : extractParamNames(fn)
+  return names.length === 0 ? null : names
+}
+
+function buildEvaluatorInputs(args: readonly unknown[], argNames: null | readonly string[]): unknown {
+  if (argNames === null) return args.length === 1 ? args[0] : [...args]
+  const inputs: Record<string, unknown> = {}
+  for (let i = 0; i < args.length; i++) {
+    inputs[argNames[i] ?? `arg${i.toString()}`] = args[i]
+  }
+  return inputs
+}
+
+function encodeReturnAttribute(output: unknown): boolean | number | string {
+  if (typeof output === 'string' || typeof output === 'number' || typeof output === 'boolean') return output
+  if (output === undefined || typeof output === 'function' || typeof output === 'symbol') return String(output)
+  if (output instanceof Error) return `${output.name}: ${output.message}`
+  try {
+    return JSON.stringify(output)
+  } catch {
+    return '[unserializable]'
+  }
 }
 
 function extractParamNames(fn: (...args: unknown[]) => unknown): string[] {

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -17,11 +17,12 @@ import type { EvaluationResultJson, EvaluatorContext, EvaluatorFailureRecord, Ev
 
 import { ATTR_EVALUATOR_NAME, SPAN_MSG_TEMPLATE_EVALUATOR, SPAN_NAME_EVALUATOR_LITERAL } from './constants'
 import { getCurrentTaskRun } from './currentTaskRun'
+import { buildEvaluatorFailureRecord, evaluationResultsFromOutput } from './evaluatorResults'
 import { extractMetricsFromSpanTree } from './extractMetrics'
 import { evalsSpan } from './internal'
-import { buildEvaluationResultJson, emitEvaluationResult, emitEvaluatorFailure, spanReferenceFromSpan } from './otelEmit'
+import { emitEvaluationResult, emitEvaluatorFailure, type SpanReference, spanReferenceFromSpan } from './otelEmit'
 import { Semaphore } from './Semaphore'
-import { buildSpanTree, getEvalsSpanProcessor, SpanTree, SpanTreeRecordingError } from './spanTree'
+import { buildSpanTree, getEvalsSpanProcessor, isProcessorInstalledOnGlobal, SpanTree, SpanTreeRecordingError } from './spanTree'
 
 export type SamplingMode = 'correlated' | 'independent'
 
@@ -34,19 +35,27 @@ export interface SinkPayload {
   context: EvaluatorContext
   failures: EvaluatorFailureRecord[]
   results: EvaluationResultJson[]
-  spanReference: null | { spanId: string; traceId: string }
+  spanReference: null | SpanReference
   target: string
 }
 
 export type EvaluationSink = (payload: SinkPayload) => Promise<void> | void
+export type OnErrorLocation = 'on_max_concurrency' | 'sink'
+export type OnErrorCallback = (
+  e: unknown,
+  context: EvaluatorContext,
+  evaluator: Evaluator,
+  location: OnErrorLocation
+) => Promise<void> | void
+export type OnMaxConcurrencyCallback = (context: EvaluatorContext) => Promise<void> | void
 
 export interface OnlineEvalConfig {
   emitOtelEvents: boolean
   enabled: boolean
   includeBaggage: boolean
   metadata?: Record<string, unknown>
-  onError?: (e: unknown, evaluatorName: string) => void
-  onMaxConcurrency?: (evaluatorName: string) => void
+  onError?: OnErrorCallback
+  onMaxConcurrency?: OnMaxConcurrencyCallback
   onSamplingError?: (e: unknown) => void
   sampleRate: ((ctx: SamplingContext) => boolean | number) | number
   samplingMode: SamplingMode
@@ -73,13 +82,14 @@ export function getOnlineEvalConfig(): Readonly<OnlineEvalConfig> {
 interface OnlineEvaluatorOptions {
   evaluator: Evaluator
   maxConcurrency?: number
-  onError?: (e: unknown, evaluatorName: string) => void
-  onMaxConcurrency?: (evaluatorName: string) => void
+  onError?: OnErrorCallback
+  onMaxConcurrency?: OnMaxConcurrencyCallback
   sampleRate?: number
   sink?: EvaluationSink
 }
 
 export class OnlineEvaluator {
+  readonly onError?: OnErrorCallback
   readonly sampleRate?: number
   readonly sink?: EvaluationSink
   get evaluator(): Evaluator {
@@ -91,9 +101,7 @@ export class OnlineEvaluator {
   private readonly inner: Evaluator
   private readonly maxConcurrencySem: Semaphore
 
-  private readonly onError?: (e: unknown, evaluatorName: string) => void
-
-  private readonly onMaxConcurrency?: (evaluatorName: string) => void
+  private readonly onMaxConcurrency?: OnMaxConcurrencyCallback
 
   constructor(opts: OnlineEvaluatorOptions) {
     this.inner = opts.evaluator
@@ -106,11 +114,19 @@ export class OnlineEvaluator {
 
   async tryRun(
     ctx: EvaluatorContext,
-    parentSpanRef: null | { spanId: string; traceId: string }
+    parentSpanRef: null | SpanReference,
+    hooks: { onError?: OnErrorCallback; onMaxConcurrency?: OnMaxConcurrencyCallback } = {}
   ): Promise<{ failures: EvaluatorFailureRecord[]; results: EvaluationResultJson[] }> {
     const release = this.maxConcurrencySem.tryAcquire()
     if (release === null) {
-      this.onMaxConcurrency?.(this.name)
+      const onMaxConcurrency = this.onMaxConcurrency ?? hooks.onMaxConcurrency
+      if (onMaxConcurrency !== undefined) {
+        try {
+          await onMaxConcurrency(ctx)
+        } catch (err) {
+          await reportPipelineError(this.onError ?? hooks.onError, err, ctx, this.inner, 'on_max_concurrency')
+        }
+      }
       return { failures: [], results: [] }
     }
     try {
@@ -126,8 +142,7 @@ export class OnlineEvaluator {
       )
       return processOutput(out, this.inner)
     } catch (err) {
-      this.onError?.(err, this.name)
-      return { failures: [buildFailureRecord(err, this.name, this.inner.getSpec(), this.inner.evaluatorVersion)], results: [] }
+      return { failures: [buildEvaluatorFailureRecord(err, this.name, this.inner.getSpec(), this.inner.evaluatorVersion)], results: [] }
     } finally {
       release()
     }
@@ -140,8 +155,8 @@ interface WithOnlineOptions {
   extractArgs?: boolean | readonly string[]
   includeBaggage?: boolean
   msgTemplate?: string
-  onError?: (e: unknown, evaluatorName: string) => void
-  onMaxConcurrency?: (evaluatorName: string) => void
+  onError?: OnErrorCallback
+  onMaxConcurrency?: OnMaxConcurrencyCallback
   onSamplingError?: (e: unknown) => void
   recordReturn?: boolean
   sampleRate?: ((ctx: SamplingContext) => boolean | number) | number
@@ -321,7 +336,7 @@ function sampleEvaluators(
 interface DispatchArgs {
   args: unknown[]
   baggageAttrs: Record<string, unknown>
-  callSpanRef: { spanId: string; traceId: string }
+  callSpanRef: SpanReference
   cfg: OnlineEvalConfig
   durationSec: number
   metrics: Record<string, number>
@@ -337,6 +352,7 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
     attributes: {},
     duration: args.durationSec,
     inputs: args.args.length === 1 ? args.args[0] : args.args,
+    metadata: args.cfg.metadata,
     metrics: args.metrics,
     name: undefined,
     output: args.output,
@@ -346,9 +362,26 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
   const allResults: EvaluationResultJson[] = []
   const allFailures: EvaluatorFailureRecord[] = []
   for (const ev of args.sampledEvaluators) {
-    const { failures, results } = await ev.tryRun(ctx, args.callSpanRef)
+    const { failures, results } = await ev.tryRun(ctx, args.callSpanRef, {
+      onError: args.userOptions.onError ?? args.cfg.onError,
+      onMaxConcurrency: args.userOptions.onMaxConcurrency ?? args.cfg.onMaxConcurrency,
+    })
     allResults.push(...results)
     allFailures.push(...failures)
+    if (ev.sink !== undefined) {
+      await submitSink(
+        ev.sink,
+        {
+          context: ctx,
+          failures,
+          results,
+          spanReference: args.callSpanRef,
+          target: args.target,
+        },
+        [ev.evaluator],
+        ev.onError ?? args.userOptions.onError ?? args.cfg.onError
+      )
+    }
   }
 
   const emitOtel = args.userOptions.emitOtelEvents ?? args.cfg.emitOtelEvents
@@ -361,13 +394,18 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
 
   const sink = args.userOptions.sink ?? args.cfg.sink
   if (sink !== undefined) {
-    await sink({
-      context: ctx,
-      failures: allFailures,
-      results: allResults,
-      spanReference: args.callSpanRef,
-      target: args.target,
-    })
+    await submitSink(
+      sink,
+      {
+        context: ctx,
+        failures: allFailures,
+        results: allResults,
+        spanReference: args.callSpanRef,
+        target: args.target,
+      },
+      args.sampledEvaluators.map((ev) => ev.evaluator),
+      args.userOptions.onError ?? args.cfg.onError
+    )
   }
 }
 
@@ -375,50 +413,47 @@ function buildOnlineExporterContextId(): string {
   return `online-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
-function isProcessorInstalledOnGlobal(): boolean {
-  const tp = TraceAPI.getTracerProvider()
-  return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
-}
-
 function processOutput(
   raw: EvaluatorOutput,
   evaluator: Evaluator
 ): { failures: EvaluatorFailureRecord[]; results: EvaluationResultJson[] } {
-  const results: EvaluationResultJson[] = []
-  const spec = evaluator.getSpec()
-  if (typeof raw === 'boolean' || typeof raw === 'number' || typeof raw === 'string' || isReason(raw)) {
-    results.push(buildEvaluationResultJson(evaluator.getResultName(), raw, spec, evaluator.evaluatorVersion))
-  } else {
-    for (const [name, val] of Object.entries(raw)) {
-      results.push(buildEvaluationResultJson(name, val, spec, evaluator.evaluatorVersion))
+  return {
+    failures: [],
+    results: evaluationResultsFromOutput(raw, evaluator.getResultName(), evaluator.getSpec(), evaluator.evaluatorVersion),
+  }
+}
+
+async function submitSink(
+  sink: EvaluationSink,
+  payload: SinkPayload,
+  evaluators: readonly Evaluator[],
+  onError: OnErrorCallback | undefined
+): Promise<void> {
+  try {
+    await sink(payload)
+  } catch (err) {
+    for (const evaluator of evaluators) {
+      await reportPipelineError(onError, err, payload.context, evaluator, 'sink')
     }
   }
-  return { failures: [], results }
 }
 
-function isReason(v: unknown): v is { reason?: string; value: boolean | number | string } {
-  return typeof v === 'object' && v !== null && 'value' in v && !Array.isArray(v)
-}
-
-function buildFailureRecord(
+async function reportPipelineError(
+  onError: OnErrorCallback | undefined,
   err: unknown,
-  name: string,
-  spec: ReturnType<Evaluator['getSpec']>,
-  evaluatorVersion?: string
-): EvaluatorFailureRecord {
-  const isErr = err instanceof Error
-  const out: EvaluatorFailureRecord = {
-    error_message: isErr ? err.message : String(err),
-    error_type: isErr ? err.constructor.name : 'Error',
-    name,
-    source: spec,
+  ctx: EvaluatorContext,
+  evaluator: Evaluator,
+  location: OnErrorLocation
+): Promise<void> {
+  if (onError === undefined) return
+  try {
+    await onError(err, ctx, evaluator, location)
+  } catch {
+    // Match Python pydantic-evals: error handlers must not break sibling evaluators.
   }
-  if (isErr && err.stack !== undefined) out.error_stacktrace = err.stack
-  if (evaluatorVersion !== undefined) out.evaluator_version = evaluatorVersion
-  return out
 }
 
-function runWithParentSpanContext<R>(parentSpanRef: null | { spanId: string; traceId: string }, fn: () => R): R {
+function runWithParentSpanContext<R>(parentSpanRef: null | SpanReference, fn: () => R): R {
   if (parentSpanRef === null) return fn()
   const parentContext = TraceAPI.setSpanContext(ContextAPI.active(), {
     isRemote: false,

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -13,7 +13,7 @@ import type { Logger } from '@opentelemetry/api-logs'
 import { context as ContextAPI, trace as TraceAPI } from '@opentelemetry/api'
 import { logs as LogsAPI, SeverityNumber } from '@opentelemetry/api-logs'
 
-import type { EvaluationReason, EvaluationResultJson, EvaluatorFailureRecord, EvaluatorSpec } from './types'
+import type { EvaluationResultJson, EvaluatorFailureRecord } from './types'
 
 import {
   ERROR_TYPE,
@@ -121,31 +121,4 @@ function applyBaggage(attrs: Record<string, unknown>, baggage: Record<string, un
   for (const [k, v] of Object.entries(baggage)) {
     if (!(k in attrs)) attrs[k] = v
   }
-}
-
-/**
- * Combine `EvaluationReason` / scalar evaluator output into a single
- * `EvaluationResultJson` ready for emission. Used by the online wrapper to
- * normalize whatever the evaluator returned.
- */
-export function buildEvaluationResultJson(
-  defaultName: string,
-  value: boolean | EvaluationReason | number | string,
-  source: EvaluatorSpec,
-  evaluatorVersion?: string
-): EvaluationResultJson {
-  const reason = isReason(value) ? (value.reason ?? null) : null
-  const scalar = isReason(value) ? value.value : value
-  const out: EvaluationResultJson = {
-    name: defaultName,
-    reason,
-    source,
-    value: scalar,
-  }
-  if (evaluatorVersion !== undefined) out.evaluator_version = evaluatorVersion
-  return out
-}
-
-function isReason(v: unknown): v is EvaluationReason {
-  return typeof v === 'object' && v !== null && 'value' in v && !Array.isArray(v)
 }

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -60,21 +60,24 @@ export function emitEvaluationResult(result: EvaluationResultJson, opts: EmitOpt
   encodeScoreAttrs(result.value, attrs)
   applyBaggage(attrs, opts.baggageAttrs)
 
-  emit(buildBody(result.name, result.value), attrs, SeverityNumber.INFO, opts.parentSpanRef)
+  emit(buildBody(result.name, result.value), attrs, opts.parentSpanRef)
 }
 
 export function emitEvaluatorFailure(failure: EvaluatorFailureRecord, opts: EmitOptions): void {
+  const errorType = failure.error_type || 'pydantic_evals.EvaluatorFailure'
+  const errorMessage = failure.error_message || ''
   const attrs: Record<string, unknown> = {
-    [ERROR_TYPE]: failure.error_type,
+    [ERROR_TYPE]: errorType,
     [GEN_AI_EVAL_NAME]: failure.name,
     [GEN_AI_EVAL_TARGET]: opts.target,
     [GEN_AI_EVALUATOR_SOURCE]: JSON.stringify(failure.source),
-    [GEN_AI_EXPLANATION]: failure.error_message,
+    [GEN_AI_EXPLANATION]: errorMessage,
   }
   if (failure.evaluator_version !== undefined) attrs[GEN_AI_EVALUATOR_VERSION] = failure.evaluator_version
   applyBaggage(attrs, opts.baggageAttrs)
 
-  emit(`evaluation: ${failure.name} failed: ${failure.error_message}`, attrs, SeverityNumber.WARN, opts.parentSpanRef)
+  const body = errorMessage === '' ? `evaluation: ${failure.name} failed` : `evaluation: ${failure.name} failed: ${errorMessage}`
+  emit(body, attrs, opts.parentSpanRef, SeverityNumber.WARN)
 }
 
 function encodeScoreAttrs(value: boolean | number | string, attrs: Record<string, unknown>): void {
@@ -93,15 +96,14 @@ function buildBody(name: string, value: boolean | number | string): string {
   if (typeof value === 'boolean') {
     formatted = value ? 'True' : 'False' // matches Python repr
   } else if (typeof value === 'string') {
-    formatted = JSON.stringify(value)
+    formatted = pythonStringRepr(value)
   } else {
-    // number — JS String() gives a reasonable shortest-form rendering
-    formatted = String(value)
+    formatted = formatPythonGeneralNumber(value)
   }
   return `evaluation: ${name}=${formatted}`
 }
 
-function emit(body: string, attrs: Record<string, unknown>, severityNumber: SeverityNumber, parentRef?: SpanReference): void {
+function emit(body: string, attrs: Record<string, unknown>, parentRef?: SpanReference, severityNumber?: SeverityNumber): void {
   const logger = getLogger()
   const ctxBase = ContextAPI.active()
   const ctx = parentRef === undefined ? ctxBase : TraceAPI.setSpanContext(ctxBase, { ...parentRef, traceFlags: 1 })
@@ -110,9 +112,25 @@ function emit(body: string, attrs: Record<string, unknown>, severityNumber: Seve
       attributes: attrs as Record<string, boolean | number | string>,
       body,
       eventName: EVAL_RESULT_EVENT_NAME,
-      severityNumber,
+      ...(severityNumber === undefined ? {} : { severityNumber }),
     })
   })
+}
+
+function formatPythonGeneralNumber(value: number): string {
+  if (Number.isNaN(value)) return 'nan'
+  if (value === Infinity) return 'inf'
+  if (value === -Infinity) return '-inf'
+  if (Number.isInteger(value)) return String(value)
+  return value
+    .toPrecision(6)
+    .replace(/(\.\d*?)0+(e|$)/, '$1$2')
+    .replace(/\.e/, 'e')
+    .replace(/e([+-])(\d)$/, 'e$10$2')
+}
+
+function pythonStringRepr(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
 }
 
 function applyBaggage(attrs: Record<string, unknown>, baggage: Record<string, unknown> | undefined): void {

--- a/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
@@ -11,8 +11,16 @@ interface ExtractOpts {
 }
 
 export interface ConfusionMatrixOptions {
-  expected: ExtractOpts
-  predicted: ExtractOpts
+  expected?: ExtractOpts
+  expected_from?: ExtractFrom
+  expected_key?: string
+  expectedFrom?: ExtractFrom
+  expectedKey?: string
+  predicted?: ExtractOpts
+  predicted_from?: ExtractFrom
+  predicted_key?: string
+  predictedFrom?: ExtractFrom
+  predictedKey?: string
   title?: string
 }
 
@@ -27,11 +35,32 @@ export class ConfusionMatrixEvaluator extends ReportEvaluator {
   readonly predicted: ExtractOpts
   readonly title: string
 
-  constructor(opts: ConfusionMatrixOptions) {
+  constructor(opts: ConfusionMatrixOptions = {}) {
     super()
-    this.predicted = opts.predicted
-    this.expected = opts.expected
+    this.predicted = opts.predicted ?? {
+      from: opts.predictedFrom ?? opts.predicted_from ?? 'output',
+      key: opts.predictedKey ?? opts.predicted_key,
+    }
+    this.expected = opts.expected ?? {
+      from: opts.expectedFrom ?? opts.expected_from ?? 'expected_output',
+      key: opts.expectedKey ?? opts.expected_key,
+    }
     this.title = opts.title ?? 'Confusion Matrix'
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    const fromSchema = { enum: ['expected_output', 'labels', 'metadata', 'output'] }
+    return {
+      additionalProperties: false,
+      properties: {
+        expected_from: { ...fromSchema, default: 'expected_output' },
+        expected_key: { type: 'string' },
+        predicted_from: { ...fromSchema, default: 'output' },
+        predicted_key: { type: 'string' },
+        title: { default: 'Confusion Matrix', type: 'string' },
+      },
+      type: 'object',
+    }
   }
 
   evaluate(ctx: ReportEvaluatorContext): ConfusionMatrixAnalysis {
@@ -67,13 +96,14 @@ export class ConfusionMatrixEvaluator extends ReportEvaluator {
     }
   }
 
-  toJSON(): Record<string, unknown> {
-    const out: Record<string, unknown> = {
-      expected: this.expected,
-      predicted: this.predicted,
-    }
+  toJSON(): null | Record<string, unknown> {
+    const out: Record<string, unknown> = {}
+    if (this.predicted.from !== 'output') out.predicted_from = this.predicted.from
+    if (this.predicted.key !== undefined) out.predicted_key = this.predicted.key
+    if (this.expected.from !== 'expected_output') out.expected_from = this.expected.from
+    if (this.expected.key !== undefined) out.expected_key = this.expected.key
     if (this.title !== 'Confusion Matrix') out.title = this.title
-    return out
+    return Object.keys(out).length === 0 ? null : out
   }
 }
 registerReportEvaluator(ConfusionMatrixEvaluator)
@@ -87,13 +117,13 @@ function extractLabel(c: ReportCase, opts: ExtractOpts): null | string {
     case 'expected_output':
       return c.expected_output === undefined ? null : safeStringify(c.expected_output)
     case 'labels': {
-      if (opts.key === undefined) return null
+      if (opts.key === undefined) throw new Error("'key' is required when from='labels'")
       const r = c.labels[opts.key]
       return r === undefined ? null : String(r.value)
     }
     case 'metadata': {
       if (c.metadata === undefined || c.metadata === null) return null
-      if (opts.key === undefined) return null
+      if (opts.key === undefined) return safeStringify(c.metadata)
       const v = (c.metadata as Record<string, unknown>)[opts.key]
       return v === undefined || v === null ? null : safeStringify(v)
     }

--- a/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
@@ -17,7 +17,7 @@ export interface ConfusionMatrixOptions {
 }
 
 /**
- * Builds a confusion matrix from the report cases. Counts each (predicted, expected)
+ * Builds a confusion matrix from the report cases. Counts each (expected, predicted)
  * label pair. Mirrors pydantic-evals' `ConfusionMatrixEvaluator`.
  */
 export class ConfusionMatrixEvaluator extends ReportEvaluator {
@@ -35,26 +35,34 @@ export class ConfusionMatrixEvaluator extends ReportEvaluator {
   }
 
   evaluate(ctx: ReportEvaluatorContext): ConfusionMatrixAnalysis {
-    const matrix: Record<string, Record<string, number>> = {}
-    const trueLabels = new Set<string>()
-    const predictedLabels = new Set<string>()
+    const pairs: { expected: string; predicted: string }[] = []
+    const labels = new Set<string>()
 
-    for (const c of ctx.cases) {
+    for (const c of ctx.report.cases) {
       if (!isReportCase(c)) continue
-      const p = extractLabel(c, this.predicted)
-      const e = extractLabel(c, this.expected)
-      if (p === null || e === null) continue
-      predictedLabels.add(p)
-      trueLabels.add(e)
-      const row = (matrix[p] ??= {})
-      row[e] = (row[e] ?? 0) + 1
+      const predicted = extractLabel(c, this.predicted)
+      const expected = extractLabel(c, this.expected)
+      if (predicted === null || expected === null) continue
+      pairs.push({ expected, predicted })
+      labels.add(expected)
+      labels.add(predicted)
     }
 
+    const classLabels = [...labels].sort()
+    const index = new Map(classLabels.map((label, i) => [label, i] as const))
+    const matrix = classLabels.map(() => classLabels.map(() => 0))
+    for (const { expected, predicted } of pairs) {
+      const rowIndex = index.get(expected)
+      const colIndex = index.get(predicted)
+      const row = rowIndex === undefined ? undefined : matrix[rowIndex]
+      if (row !== undefined && colIndex !== undefined) {
+        row[colIndex] = (row[colIndex] ?? 0) + 1
+      }
+    }
     return {
+      class_labels: classLabels,
       matrix,
-      predicted_labels: [...predictedLabels].sort(),
       title: this.title,
-      true_labels: [...trueLabels].sort(),
       type: 'confusion_matrix',
     }
   }

--- a/packages/logfire-api/src/evals/reportEvaluators/KolmogorovSmirnovEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/KolmogorovSmirnovEvaluator.ts
@@ -28,11 +28,11 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
     this.scoreFrom = opts.scoreFrom ?? 'scores'
     this.positiveFrom = opts.positiveFrom
     this.positiveKey = opts.positiveKey
-    this.title = opts.title ?? 'Kolmogorov–Smirnov'
+    this.title = opts.title ?? 'KS Plot'
   }
 
   evaluate(ctx: ReportEvaluatorContext): [KSAnalysis, ScalarAnalysis] {
-    const cases = ctx.cases.filter((c): c is ReportCase => 'output' in c)
+    const cases = ctx.report.cases.filter((c): c is ReportCase => 'output' in c)
     const inputs = buildThresholdInputs(cases, {
       positiveFrom: this.positiveFrom,
       positiveKey: this.positiveKey,
@@ -69,15 +69,16 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
     return [
       {
         curves: [
-          { name: 'positive CDF', points: positivePoints },
-          { name: 'negative CDF', points: negativePoints },
+          { name: 'Positive', points: positivePoints, step: 'end' },
+          { name: 'Negative', points: negativePoints, step: 'end' },
         ],
         title: this.title,
-        type: 'ks',
-        x_label: 'score',
-        y_label: 'CDF',
+        type: 'line_plot',
+        x_label: 'Score',
+        y_label: 'Cumulative Probability',
+        y_range: [0, 1],
       },
-      { title: `${this.title} — KS statistic`, type: 'scalar', value: ksStatistic },
+      { title: 'KS Statistic', type: 'scalar', value: ksStatistic },
     ]
   }
 
@@ -88,7 +89,7 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
       score_key: this.scoreKey,
     }
     if (this.positiveKey !== undefined) out.positive_key = this.positiveKey
-    if (this.title !== 'Kolmogorov–Smirnov') out.title = this.title
+    if (this.title !== 'KS Plot') out.title = this.title
     return out
   }
 }

--- a/packages/logfire-api/src/evals/reportEvaluators/KolmogorovSmirnovEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/KolmogorovSmirnovEvaluator.ts
@@ -3,19 +3,26 @@ import type { ReportCase } from '../reporting'
 
 import { registerReportEvaluator } from '../registry'
 import { type KSAnalysis, ReportEvaluator, type ReportEvaluatorContext, type ScalarAnalysis } from '../ReportEvaluator'
-import { buildThresholdInputs, type PositiveFrom, type ScoreFrom } from './scoreCommon'
+import { buildThresholdInputs, downsample, type PositiveFrom, type ScoreFrom } from './scoreCommon'
 
 export interface KSOptions {
-  positiveFrom: PositiveFrom
+  n_thresholds?: number
+  nThresholds?: number
+  positive_from?: PositiveFrom
+  positive_key?: string
+  positiveFrom?: PositiveFrom
   positiveKey?: string
+  score_from?: ScoreFrom
+  score_key?: string
   scoreFrom?: ScoreFrom
-  scoreKey: string
+  scoreKey?: string
   title?: string
 }
 
 export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
   static evaluatorName = 'KolmogorovSmirnovEvaluator'
 
+  readonly nThresholds: number
   readonly positiveFrom: PositiveFrom
   readonly positiveKey?: string
   readonly scoreFrom: ScoreFrom
@@ -24,11 +31,28 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
 
   constructor(opts: KSOptions) {
     super()
-    this.scoreKey = opts.scoreKey
-    this.scoreFrom = opts.scoreFrom ?? 'scores'
-    this.positiveFrom = opts.positiveFrom
-    this.positiveKey = opts.positiveKey
+    this.scoreKey = opts.scoreKey ?? opts.score_key ?? ''
+    this.scoreFrom = opts.scoreFrom ?? opts.score_from ?? 'scores'
+    this.positiveFrom = opts.positiveFrom ?? opts.positive_from ?? 'expected_output'
+    this.positiveKey = opts.positiveKey ?? opts.positive_key
+    this.nThresholds = opts.nThresholds ?? opts.n_thresholds ?? 100
     this.title = opts.title ?? 'KS Plot'
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        n_thresholds: { default: 100, type: 'integer' },
+        positive_from: { enum: ['assertions', 'expected_output', 'labels'] },
+        positive_key: { type: 'string' },
+        score_from: { default: 'scores', enum: ['metrics', 'scores'] },
+        score_key: { type: 'string' },
+        title: { default: 'KS Plot', type: 'string' },
+      },
+      required: ['score_key', 'positive_from'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: ReportEvaluatorContext): [KSAnalysis, ScalarAnalysis] {
@@ -42,7 +66,20 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
 
     const positiveScores = inputs.scores.filter((_, i) => inputs.positives[i] === true).sort((a, b) => a - b)
     const negativeScores = inputs.scores.filter((_, i) => inputs.positives[i] === false).sort((a, b) => a - b)
-    const allScores = [...inputs.scores].sort((a, b) => a - b)
+    const allScores = [...new Set(inputs.scores)].sort((a, b) => a - b)
+
+    const emptyResult: [KSAnalysis, ScalarAnalysis] = [
+      {
+        curves: [],
+        title: this.title,
+        type: 'line_plot',
+        x_label: 'Score',
+        y_label: 'Cumulative Probability',
+        y_range: [0, 1],
+      },
+      { title: 'KS Statistic', type: 'scalar', value: Number.NaN },
+    ]
+    if (allScores.length === 0 || positiveScores.length === 0 || negativeScores.length === 0) return emptyResult
 
     const cdf = (sorted: readonly number[], x: number): number => {
       if (sorted.length === 0) return 0
@@ -57,20 +94,22 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
       return lo / sorted.length
     }
 
-    const positivePoints = allScores.map((x) => ({ x, y: cdf(positiveScores, x) }))
-    const negativePoints = allScores.map((x) => ({ x, y: cdf(negativeScores, x) }))
+    const positivePoints = [{ x: allScores[0]!, y: 0 }, ...allScores.map((x) => ({ x, y: cdf(positiveScores, x) }))]
+    const negativePoints = [{ x: allScores[0]!, y: 0 }, ...allScores.map((x) => ({ x, y: cdf(negativeScores, x) }))]
 
     let ksStatistic = 0
-    for (let i = 0; i < allScores.length; i++) {
+    for (let i = 1; i < positivePoints.length; i++) {
       const diff = Math.abs((positivePoints[i] as { y: number }).y - (negativePoints[i] as { y: number }).y)
       if (diff > ksStatistic) ksStatistic = diff
     }
+    const displayPositivePoints = downsample(positivePoints, this.nThresholds)
+    const displayNegativePoints = downsample(negativePoints, this.nThresholds)
 
     return [
       {
         curves: [
-          { name: 'Positive', points: positivePoints, step: 'end' },
-          { name: 'Negative', points: negativePoints, step: 'end' },
+          { name: 'Positive', points: displayPositivePoints, step: 'end' },
+          { name: 'Negative', points: displayNegativePoints, step: 'end' },
         ],
         title: this.title,
         type: 'line_plot',
@@ -85,10 +124,11 @@ export class KolmogorovSmirnovEvaluator extends ReportEvaluator {
   toJSON(): Record<string, unknown> {
     const out: Record<string, unknown> = {
       positive_from: this.positiveFrom,
-      score_from: this.scoreFrom,
       score_key: this.scoreKey,
     }
     if (this.positiveKey !== undefined) out.positive_key = this.positiveKey
+    if (this.scoreFrom !== 'scores') out.score_from = this.scoreFrom
+    if (this.nThresholds !== 100) out.n_thresholds = this.nThresholds
     if (this.title !== 'KS Plot') out.title = this.title
     return out
   }

--- a/packages/logfire-api/src/evals/reportEvaluators/PrecisionRecallEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/PrecisionRecallEvaluator.ts
@@ -3,14 +3,19 @@ import type { ReportCase } from '../reporting'
 
 import { registerReportEvaluator } from '../registry'
 import { type PrecisionRecallAnalysis, ReportEvaluator, type ReportEvaluatorContext, type ScalarAnalysis } from '../ReportEvaluator'
-import { buildThresholdInputs, type PositiveFrom, type ScoreFrom, trapezoidalAuc, uniqueSortedThresholds } from './scoreCommon'
+import { buildThresholdInputs, downsample, type PositiveFrom, type ScoreFrom, trapezoidalAuc, uniqueSortedThresholds } from './scoreCommon'
 
 export interface PrecisionRecallOptions {
+  n_thresholds?: number
   nThresholds?: number
-  positiveFrom: PositiveFrom
+  positive_from?: PositiveFrom
+  positive_key?: string
+  positiveFrom?: PositiveFrom
   positiveKey?: string
+  score_from?: ScoreFrom
+  score_key?: string
   scoreFrom?: ScoreFrom
-  scoreKey: string
+  scoreKey?: string
   title?: string
 }
 
@@ -26,12 +31,28 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
 
   constructor(opts: PrecisionRecallOptions) {
     super()
-    this.scoreKey = opts.scoreKey
-    this.scoreFrom = opts.scoreFrom ?? 'scores'
-    this.positiveFrom = opts.positiveFrom
-    this.positiveKey = opts.positiveKey
-    this.nThresholds = opts.nThresholds ?? 100
-    this.title = opts.title ?? 'Precision–Recall'
+    this.scoreKey = opts.scoreKey ?? opts.score_key ?? ''
+    this.scoreFrom = opts.scoreFrom ?? opts.score_from ?? 'scores'
+    this.positiveFrom = opts.positiveFrom ?? opts.positive_from ?? 'expected_output'
+    this.positiveKey = opts.positiveKey ?? opts.positive_key
+    this.nThresholds = opts.nThresholds ?? opts.n_thresholds ?? 100
+    this.title = opts.title ?? 'Precision-Recall Curve'
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        n_thresholds: { default: 100, type: 'integer' },
+        positive_from: { enum: ['assertions', 'expected_output', 'labels'] },
+        positive_key: { type: 'string' },
+        score_from: { default: 'scores', enum: ['metrics', 'scores'] },
+        score_key: { type: 'string' },
+        title: { default: 'Precision-Recall Curve', type: 'string' },
+      },
+      required: ['score_key', 'positive_from'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: ReportEvaluatorContext): [PrecisionRecallAnalysis, ScalarAnalysis] {
@@ -43,7 +64,7 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
       scoreKey: this.scoreKey,
     })
 
-    const thresholds = uniqueSortedThresholds(inputs.scores, this.nThresholds)
+    const thresholds = uniqueSortedThresholds(inputs.scores)
     const points: { precision: number; recall: number; threshold: number }[] = []
     if (inputs.scores.length > 0) {
       points.push({ precision: 1, recall: 0, threshold: Math.max(...inputs.scores) })
@@ -67,14 +88,14 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
     }
 
     // Recall ascending → AUC under PR curve (a.k.a. average precision).
-    const sorted = points.map((p) => [p.recall, p.precision] as const).sort((a, b) => a[0] - b[0])
-    const xs = sorted.map(([r]) => r)
-    const ys = sorted.map(([, p]) => p)
+    const xs = points.map((p) => p.recall)
+    const ys = points.map((p) => p.precision)
     const auc = inputs.scores.length === 0 ? Number.NaN : trapezoidalAuc(xs, ys)
+    const displayPoints = downsample(points, this.nThresholds)
 
     return [
       {
-        curves: inputs.scores.length === 0 ? [] : [{ auc, name: ctx.name, points }],
+        curves: inputs.scores.length === 0 ? [] : [{ auc, name: ctx.name, points: displayPoints }],
         title: this.title,
         type: 'precision_recall',
       },
@@ -85,12 +106,12 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
   toJSON(): Record<string, unknown> {
     const out: Record<string, unknown> = {
       positive_from: this.positiveFrom,
-      score_from: this.scoreFrom,
       score_key: this.scoreKey,
     }
     if (this.positiveKey !== undefined) out.positive_key = this.positiveKey
+    if (this.scoreFrom !== 'scores') out.score_from = this.scoreFrom
     if (this.nThresholds !== 100) out.n_thresholds = this.nThresholds
-    if (this.title !== 'Precision–Recall') out.title = this.title
+    if (this.title !== 'Precision-Recall Curve') out.title = this.title
     return out
   }
 }

--- a/packages/logfire-api/src/evals/reportEvaluators/PrecisionRecallEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/PrecisionRecallEvaluator.ts
@@ -35,7 +35,7 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
   }
 
   evaluate(ctx: ReportEvaluatorContext): [PrecisionRecallAnalysis, ScalarAnalysis] {
-    const cases = ctx.cases.filter((c): c is ReportCase => 'output' in c)
+    const cases = ctx.report.cases.filter((c): c is ReportCase => 'output' in c)
     const inputs = buildThresholdInputs(cases, {
       positiveFrom: this.positiveFrom,
       positiveKey: this.positiveKey,
@@ -44,8 +44,10 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
     })
 
     const thresholds = uniqueSortedThresholds(inputs.scores, this.nThresholds)
-    const precision: number[] = []
-    const recall: number[] = []
+    const points: { precision: number; recall: number; threshold: number }[] = []
+    if (inputs.scores.length > 0) {
+      points.push({ precision: 1, recall: 0, threshold: Math.max(...inputs.scores) })
+    }
     for (const t of thresholds) {
       let tp = 0
       let fp = 0
@@ -57,19 +59,26 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
         else if (aboveThreshold && !positive) fp++
         else if (!aboveThreshold && positive) fn++
       }
-      precision.push(tp + fp === 0 ? 1 : tp / (tp + fp))
-      recall.push(tp + fn === 0 ? 0 : tp / (tp + fn))
+      points.push({
+        precision: tp + fp === 0 ? 1 : tp / (tp + fp),
+        recall: tp + fn === 0 ? 0 : tp / (tp + fn),
+        threshold: t,
+      })
     }
 
     // Recall ascending → AUC under PR curve (a.k.a. average precision).
-    const sorted = recall.map((r, i) => [r, precision[i]!] as const).sort((a, b) => a[0] - b[0])
+    const sorted = points.map((p) => [p.recall, p.precision] as const).sort((a, b) => a[0] - b[0])
     const xs = sorted.map(([r]) => r)
     const ys = sorted.map(([, p]) => p)
-    const auc = trapezoidalAuc(xs, ys)
+    const auc = inputs.scores.length === 0 ? Number.NaN : trapezoidalAuc(xs, ys)
 
     return [
-      { precision, recall, thresholds, title: this.title, type: 'precision_recall' },
-      { title: `${this.title} — AUC`, type: 'scalar', value: auc },
+      {
+        curves: inputs.scores.length === 0 ? [] : [{ auc, name: ctx.name, points }],
+        title: this.title,
+        type: 'precision_recall',
+      },
+      { title: `${this.title} AUC`, type: 'scalar', value: auc },
     ]
   }
 

--- a/packages/logfire-api/src/evals/reportEvaluators/ROCAUCEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/ROCAUCEvaluator.ts
@@ -31,11 +31,11 @@ export class ROCAUCEvaluator extends ReportEvaluator {
     this.positiveFrom = opts.positiveFrom
     this.positiveKey = opts.positiveKey
     this.nThresholds = opts.nThresholds ?? 100
-    this.title = opts.title ?? 'ROC'
+    this.title = opts.title ?? 'ROC Curve'
   }
 
   evaluate(ctx: ReportEvaluatorContext): [ROCAnalysis, ScalarAnalysis] {
-    const cases = ctx.cases.filter((c): c is ReportCase => 'output' in c)
+    const cases = ctx.report.cases.filter((c): c is ReportCase => 'output' in c)
     const inputs = buildThresholdInputs(cases, {
       positiveFrom: this.positiveFrom,
       positiveKey: this.positiveKey,
@@ -43,7 +43,7 @@ export class ROCAUCEvaluator extends ReportEvaluator {
       scoreKey: this.scoreKey,
     })
 
-    const thresholds = uniqueSortedThresholds(inputs.scores, this.nThresholds)
+    const thresholds = [Infinity, ...uniqueSortedThresholds(inputs.scores, this.nThresholds)]
     const points: { x: number; y: number }[] = []
     for (const t of thresholds) {
       let tp = 0
@@ -66,14 +66,14 @@ export class ROCAUCEvaluator extends ReportEvaluator {
     points.sort((a, b) => a.x - b.x)
     const xs = points.map((p) => p.x)
     const ys = points.map((p) => p.y)
-    const auc = trapezoidalAuc(xs, ys)
+    const auc = inputs.scores.length === 0 ? Number.NaN : trapezoidalAuc(xs, ys)
 
     return [
       {
         curves: [
-          { name: 'ROC', points, style: 'solid' },
+          { name: `${ctx.name} (AUC: ${auc.toFixed(3)})`, points, style: 'solid' },
           {
-            name: 'random',
+            name: 'Random',
             points: [
               { x: 0, y: 0 },
               { x: 1, y: 1 },
@@ -82,11 +82,13 @@ export class ROCAUCEvaluator extends ReportEvaluator {
           },
         ],
         title: this.title,
-        type: 'roc_curve',
+        type: 'line_plot',
         x_label: 'False Positive Rate',
+        x_range: [0, 1],
         y_label: 'True Positive Rate',
+        y_range: [0, 1],
       },
-      { title: `${this.title} — AUC`, type: 'scalar', value: auc },
+      { title: `${this.title} AUC`, type: 'scalar', value: auc },
     ]
   }
 
@@ -98,7 +100,7 @@ export class ROCAUCEvaluator extends ReportEvaluator {
     }
     if (this.positiveKey !== undefined) out.positive_key = this.positiveKey
     if (this.nThresholds !== 100) out.n_thresholds = this.nThresholds
-    if (this.title !== 'ROC') out.title = this.title
+    if (this.title !== 'ROC Curve') out.title = this.title
     return out
   }
 }

--- a/packages/logfire-api/src/evals/reportEvaluators/ROCAUCEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/ROCAUCEvaluator.ts
@@ -3,14 +3,19 @@ import type { ReportCase } from '../reporting'
 
 import { registerReportEvaluator } from '../registry'
 import { ReportEvaluator, type ReportEvaluatorContext, type ROCAnalysis, type ScalarAnalysis } from '../ReportEvaluator'
-import { buildThresholdInputs, type PositiveFrom, type ScoreFrom, trapezoidalAuc, uniqueSortedThresholds } from './scoreCommon'
+import { buildThresholdInputs, downsample, type PositiveFrom, type ScoreFrom, trapezoidalAuc, uniqueSortedThresholds } from './scoreCommon'
 
 export interface ROCAUCOptions {
+  n_thresholds?: number
   nThresholds?: number
-  positiveFrom: PositiveFrom
+  positive_from?: PositiveFrom
+  positive_key?: string
+  positiveFrom?: PositiveFrom
   positiveKey?: string
+  score_from?: ScoreFrom
+  score_key?: string
   scoreFrom?: ScoreFrom
-  scoreKey: string
+  scoreKey?: string
   title?: string
 }
 
@@ -26,12 +31,28 @@ export class ROCAUCEvaluator extends ReportEvaluator {
 
   constructor(opts: ROCAUCOptions) {
     super()
-    this.scoreKey = opts.scoreKey
-    this.scoreFrom = opts.scoreFrom ?? 'scores'
-    this.positiveFrom = opts.positiveFrom
-    this.positiveKey = opts.positiveKey
-    this.nThresholds = opts.nThresholds ?? 100
+    this.scoreKey = opts.scoreKey ?? opts.score_key ?? ''
+    this.scoreFrom = opts.scoreFrom ?? opts.score_from ?? 'scores'
+    this.positiveFrom = opts.positiveFrom ?? opts.positive_from ?? 'expected_output'
+    this.positiveKey = opts.positiveKey ?? opts.positive_key
+    this.nThresholds = opts.nThresholds ?? opts.n_thresholds ?? 100
     this.title = opts.title ?? 'ROC Curve'
+  }
+
+  static jsonSchema(): Record<string, unknown> {
+    return {
+      additionalProperties: false,
+      properties: {
+        n_thresholds: { default: 100, type: 'integer' },
+        positive_from: { enum: ['assertions', 'expected_output', 'labels'] },
+        positive_key: { type: 'string' },
+        score_from: { default: 'scores', enum: ['metrics', 'scores'] },
+        score_key: { type: 'string' },
+        title: { default: 'ROC Curve', type: 'string' },
+      },
+      required: ['score_key', 'positive_from'],
+      type: 'object',
+    }
   }
 
   evaluate(ctx: ReportEvaluatorContext): [ROCAnalysis, ScalarAnalysis] {
@@ -43,35 +64,50 @@ export class ROCAUCEvaluator extends ReportEvaluator {
       scoreKey: this.scoreKey,
     })
 
-    const thresholds = [Infinity, ...uniqueSortedThresholds(inputs.scores, this.nThresholds)]
-    const points: { x: number; y: number }[] = []
+    const emptyResult: [ROCAnalysis, ScalarAnalysis] = [
+      {
+        curves: [],
+        title: this.title,
+        type: 'line_plot',
+        x_label: 'False Positive Rate',
+        x_range: [0, 1],
+        y_label: 'True Positive Rate',
+        y_range: [0, 1],
+      },
+      { title: `${this.title} AUC`, type: 'scalar', value: Number.NaN },
+    ]
+    if (inputs.scores.length === 0) return emptyResult
+
+    const totalPositives = inputs.positives.filter(Boolean).length
+    const totalNegatives = inputs.positives.length - totalPositives
+    if (totalPositives === 0 || totalNegatives === 0) return emptyResult
+
+    const thresholds = uniqueSortedThresholds(inputs.scores)
+    const points: { x: number; y: number }[] = [{ x: 0, y: 0 }]
     for (const t of thresholds) {
       let tp = 0
       let fp = 0
-      let tn = 0
-      let fn = 0
       for (let i = 0; i < inputs.scores.length; i++) {
         const positive = inputs.positives[i]!
         const above = inputs.scores[i]! >= t
         if (above && positive) tp++
         else if (above && !positive) fp++
-        else if (!above && !positive) tn++
-        else fn++
       }
-      const fpr = fp + tn === 0 ? 0 : fp / (fp + tn)
-      const tpr = tp + fn === 0 ? 0 : tp / (tp + fn)
+      const fpr = fp / totalNegatives
+      const tpr = tp / totalPositives
       points.push({ x: fpr, y: tpr })
     }
     // Sort by FPR ascending so the AUC integral is monotonic
     points.sort((a, b) => a.x - b.x)
     const xs = points.map((p) => p.x)
     const ys = points.map((p) => p.y)
-    const auc = inputs.scores.length === 0 ? Number.NaN : trapezoidalAuc(xs, ys)
+    const auc = trapezoidalAuc(xs, ys)
+    const displayPoints = downsample(points, this.nThresholds)
 
     return [
       {
         curves: [
-          { name: `${ctx.name} (AUC: ${auc.toFixed(3)})`, points, style: 'solid' },
+          { name: `${ctx.name} (AUC: ${auc.toFixed(3)})`, points: displayPoints, style: 'solid' },
           {
             name: 'Random',
             points: [
@@ -95,10 +131,10 @@ export class ROCAUCEvaluator extends ReportEvaluator {
   toJSON(): Record<string, unknown> {
     const out: Record<string, unknown> = {
       positive_from: this.positiveFrom,
-      score_from: this.scoreFrom,
       score_key: this.scoreKey,
     }
     if (this.positiveKey !== undefined) out.positive_key = this.positiveKey
+    if (this.scoreFrom !== 'scores') out.score_from = this.scoreFrom
     if (this.nThresholds !== 100) out.n_thresholds = this.nThresholds
     if (this.title !== 'ROC Curve') out.title = this.title
     return out

--- a/packages/logfire-api/src/evals/reportEvaluators/scoreCommon.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/scoreCommon.ts
@@ -68,17 +68,8 @@ function extractPositive(c: ReportCase, opts: ThresholdOptions): boolean | null 
 
 export function uniqueSortedThresholds(scores: readonly number[], n: number): number[] {
   if (scores.length === 0) return []
-  let lo = Infinity
-  let hi = -Infinity
-  for (const s of scores) {
-    if (s < lo) lo = s
-    if (s > hi) hi = s
-  }
-  if (lo === hi) return [lo]
-  const step = (hi - lo) / (n - 1)
-  const out: number[] = []
-  for (let i = 0; i < n; i++) out.push(lo + step * i)
-  return out
+  const unique = [...new Set(scores)].sort((a, b) => b - a)
+  return downsample(unique, n)
 }
 
 /** AUC via the trapezoidal rule. Expects `xs` already sorted ascending. */
@@ -91,4 +82,16 @@ export function trapezoidalAuc(xs: readonly number[], ys: readonly number[]): nu
     auc += dx * yMid
   }
   return auc
+}
+
+export function downsample<T>(items: readonly T[], maxItems: number): T[] {
+  if (items.length <= maxItems) return [...items]
+  if (maxItems <= 0) return []
+  if (maxItems === 1) return [items[0]!]
+  const out: T[] = []
+  const step = (items.length - 1) / (maxItems - 1)
+  for (let i = 0; i < maxItems; i++) {
+    out.push(items[Math.round(i * step)]!)
+  }
+  return out
 }

--- a/packages/logfire-api/src/evals/reportEvaluators/scoreCommon.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/scoreCommon.ts
@@ -25,6 +25,7 @@ export interface ThresholdOptions {
 
 /** Build per-case (score, positive) pairs from a list of report cases. Skips cases where either is missing. */
 export function buildThresholdInputs(cases: readonly ReportCase[], opts: ThresholdOptions): ThresholdInputs {
+  validateThresholdOptions(opts)
   const out: ThresholdInputs = { positives: [], scores: [] }
   for (const c of cases) {
     const score = extractScore(c, opts)
@@ -48,25 +49,36 @@ function extractScore(c: ReportCase, opts: ThresholdOptions): null | number {
 function extractPositive(c: ReportCase, opts: ThresholdOptions): boolean | null {
   switch (opts.positiveFrom) {
     case 'assertions': {
-      if (opts.positiveKey === undefined) return null
-      const r = c.assertions[opts.positiveKey]
+      const r = c.assertions[opts.positiveKey!]
       return typeof r?.value === 'boolean' ? r.value : null
     }
     case 'expected_output': {
-      if (opts.positiveKey === undefined) return Boolean(c.expected_output)
+      if (opts.positiveKey === undefined)
+        return c.expected_output === undefined || c.expected_output === null ? null : Boolean(c.expected_output)
       if (c.expected_output === null || c.expected_output === undefined) return null
       const v = (c.expected_output as Record<string, unknown>)[opts.positiveKey]
       return typeof v === 'boolean' ? v : v === undefined ? null : Boolean(v)
     }
     case 'labels': {
-      if (opts.positiveKey === undefined) return null
-      const r = c.labels[opts.positiveKey]
+      const r = c.labels[opts.positiveKey!]
       return r === undefined ? null : Boolean(r.value)
     }
   }
 }
 
-export function uniqueSortedThresholds(scores: readonly number[], n: number): number[] {
+function validateThresholdOptions(opts: ThresholdOptions): void {
+  if (opts.positiveFrom === 'expected_output') {
+    if (opts.positiveKey !== undefined) {
+      throw new Error("'positiveKey' is not supported when positiveFrom='expected_output'")
+    }
+    return
+  }
+  if (opts.positiveKey === undefined) {
+    throw new Error(`'positiveKey' is required when positiveFrom='${opts.positiveFrom}'`)
+  }
+}
+
+export function uniqueSortedThresholds(scores: readonly number[], n = Number.POSITIVE_INFINITY): number[] {
   if (scores.length === 0) return []
   const unique = [...new Set(scores)].sort((a, b) => b - a)
   return downsample(unique, n)
@@ -77,7 +89,7 @@ export function trapezoidalAuc(xs: readonly number[], ys: readonly number[]): nu
   if (xs.length < 2) return 0
   let auc = 0
   for (let i = 1; i < xs.length; i++) {
-    const dx = xs[i]! - xs[i - 1]!
+    const dx = Math.abs(xs[i]! - xs[i - 1]!)
     const yMid = (ys[i]! + ys[i - 1]!) / 2
     auc += dx * yMid
   }
@@ -85,13 +97,10 @@ export function trapezoidalAuc(xs: readonly number[], ys: readonly number[]): nu
 }
 
 export function downsample<T>(items: readonly T[], maxItems: number): T[] {
-  if (items.length <= maxItems) return [...items]
-  if (maxItems <= 0) return []
-  if (maxItems === 1) return [items[0]!]
-  const out: T[] = []
-  const step = (items.length - 1) / (maxItems - 1)
+  if (items.length <= maxItems || maxItems <= 1) return [...items]
+  const indices = new Set<number>()
   for (let i = 0; i < maxItems; i++) {
-    out.push(items[Math.round(i * step)]!)
+    indices.add(Math.floor((i * (items.length - 1)) / (maxItems - 1)))
   }
-  return out
+  return [...indices].sort((a, b) => a - b).map((i) => items[i]!)
 }

--- a/packages/logfire-api/src/evals/reporting.ts
+++ b/packages/logfire-api/src/evals/reporting.ts
@@ -123,11 +123,19 @@ export function computeAverages(name: string, cases: readonly ReportCase[]): Rep
   for (const [k, { count, sum }] of Object.entries(metricsAcc)) {
     metrics[k] = { count, mean: count === 0 ? 0 : sum / count }
   }
+  const labels: ReportCaseAggregate['labels'] = {}
+  for (const [k, counts] of Object.entries(labelsAcc)) {
+    const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
+    labels[k] = {}
+    for (const [label, count] of Object.entries(counts)) {
+      labels[k][label] = total === 0 ? 0 : count / total
+    }
+  }
 
   const n = cases.length === 0 ? 1 : cases.length
   return {
     assertions: assertionsTotal === 0 ? null : assertionsPassed / assertionsTotal,
-    labels: labelsAcc,
+    labels,
     metrics,
     name,
     scores,

--- a/packages/logfire-api/src/evals/reporting.ts
+++ b/packages/logfire-api/src/evals/reporting.ts
@@ -60,6 +60,20 @@ export interface ReportCaseAggregate {
 }
 
 /**
+ * A group of runs that share a `source_case_name`. Computed view returned by
+ * `caseGroups()` for multi-run experiments (mirrors Python's `ReportCaseGroup`).
+ */
+export interface ReportCaseGroup<Inputs = unknown, Output = unknown, Metadata = unknown> {
+  expected_output?: Output
+  failures: ReportCaseFailure<Inputs, Output, Metadata>[]
+  inputs: Inputs
+  metadata?: Metadata
+  name: string
+  runs: ReportCase<Inputs, Output, Metadata>[]
+  summary: ReportCaseAggregate
+}
+
+/**
  * Compute `assertion_pass_rate` across the cases. Returns `null` if there are
  * no assertions.
  */
@@ -142,4 +156,136 @@ export function computeAverages(name: string, cases: readonly ReportCase[]): Rep
     task_duration: taskDurationSum / n,
     total_duration: totalDurationSum / n,
   }
+}
+
+/**
+ * Group runs by `source_case_name` and compute per-group aggregates. Returns
+ * `undefined` when no case or failure has a `source_case_name` set (i.e., a
+ * single-run experiment). Mirrors Python's `EvaluationReport.case_groups()`.
+ */
+export function caseGroups<Inputs = unknown, Output = unknown, Metadata = unknown>(
+  report: EvaluationReport<Inputs, Output, Metadata>
+): ReportCaseGroup<Inputs, Output, Metadata>[] | undefined {
+  const hasSource =
+    report.cases.some((c) => c.source_case_name !== undefined) || report.failures.some((f) => f.source_case_name !== undefined)
+  if (!hasSource) return undefined
+
+  const groups = new Map<
+    string,
+    { failures: ReportCaseFailure<Inputs, Output, Metadata>[]; runs: ReportCase<Inputs, Output, Metadata>[] }
+  >()
+  const ensure = (key: string) => {
+    let g = groups.get(key)
+    if (g === undefined) {
+      g = { failures: [], runs: [] }
+      groups.set(key, g)
+    }
+    return g
+  }
+  for (const c of report.cases) ensure(c.source_case_name ?? c.name).runs.push(c)
+  for (const f of report.failures) ensure(f.source_case_name ?? f.name).failures.push(f)
+
+  const result: ReportCaseGroup<Inputs, Output, Metadata>[] = []
+  for (const [name, { failures, runs }] of groups) {
+    // ensure() only inserts a group when a case or failure is added, so at least one of the two arrays is non-empty.
+    const first = runs[0] ?? failures[0]
+    if (first === undefined) continue
+    result.push({
+      expected_output: first.expected_output,
+      failures,
+      inputs: first.inputs,
+      metadata: first.metadata,
+      name,
+      runs,
+      summary: computeAverages('Averages', runs),
+    })
+  }
+  return result
+}
+
+/**
+ * Average across already-aggregated cases. Used to roll multi-run group
+ * summaries up into a single experiment-wide aggregate. Mirrors Python's
+ * `ReportCaseAggregate.average_from_aggregates`.
+ *
+ * For each key, only aggregates that contain the key contribute (so a key
+ * present in 2/3 aggregates averages over 2 entries). Counts are summed.
+ */
+export function averageFromAggregates(name: string, aggregates: readonly ReportCaseAggregate[]): ReportCaseAggregate {
+  if (aggregates.length === 0) {
+    return { assertions: null, labels: {}, metrics: {}, name, scores: {}, task_duration: 0, total_duration: 0 }
+  }
+
+  const avgCountMean = (key: 'metrics' | 'scores'): Record<string, { count: number; mean: number }> => {
+    const out: Record<string, { count: number; mean: number; n: number; sum: number }> = {}
+    for (const agg of aggregates) {
+      for (const [k, { count, mean }] of Object.entries(agg[key])) {
+        const acc = (out[k] ??= { count: 0, mean: 0, n: 0, sum: 0 })
+        acc.sum += mean
+        acc.n += 1
+        acc.count += count
+      }
+    }
+    const result: Record<string, { count: number; mean: number }> = {}
+    for (const [k, { count, n, sum }] of Object.entries(out)) {
+      result[k] = { count, mean: sum / n }
+    }
+    return result
+  }
+
+  const avgLabels: Record<string, Record<string, number>> = {}
+  const labelKeys = new Set<string>()
+  for (const a of aggregates) for (const k of Object.keys(a.labels)) labelKeys.add(k)
+  for (const key of labelKeys) {
+    const combined: Record<string, number> = {}
+    let n = 0
+    for (const a of aggregates) {
+      const dist = a.labels[key]
+      if (dist === undefined) continue
+      n += 1
+      for (const [labelVal, freq] of Object.entries(dist)) {
+        combined[labelVal] = (combined[labelVal] ?? 0) + freq
+      }
+    }
+    const out: Record<string, number> = {}
+    for (const [k, v] of Object.entries(combined)) out[k] = v / n
+    avgLabels[key] = out
+  }
+
+  const assertionVals = aggregates.map((a) => a.assertions).filter((v): v is number => v !== null)
+  const avgAssertions = assertionVals.length === 0 ? null : assertionVals.reduce((s, v) => s + v, 0) / assertionVals.length
+
+  const taskSum = aggregates.reduce((s, a) => s + a.task_duration, 0)
+  const totalSum = aggregates.reduce((s, a) => s + a.total_duration, 0)
+
+  return {
+    assertions: avgAssertions,
+    labels: avgLabels,
+    metrics: avgCountMean('metrics'),
+    name,
+    scores: avgCountMean('scores'),
+    task_duration: taskSum / aggregates.length,
+    total_duration: totalSum / aggregates.length,
+  }
+}
+
+/**
+ * Compute the experiment-wide aggregate for a report. For multi-run reports
+ * (any case has `source_case_name`), uses two-level aggregation: average each
+ * source-case group, then average the group summaries. For single-run reports,
+ * averages the cases directly. Returns `undefined` if there are no cases.
+ *
+ * Mirrors Python's `EvaluationReport.averages()`.
+ */
+export function averages<Inputs = unknown, Output = unknown, Metadata = unknown>(
+  report: EvaluationReport<Inputs, Output, Metadata>
+): ReportCaseAggregate | undefined {
+  const groups = caseGroups(report)
+  if (groups !== undefined) {
+    const nonEmpty = groups.filter((g) => g.runs.length > 0).map((g) => g.summary)
+    if (nonEmpty.length === 0) return undefined
+    return averageFromAggregates('Averages', nonEmpty)
+  }
+  if (report.cases.length > 0) return computeAverages('Averages', report.cases)
+  return undefined
 }

--- a/packages/logfire-api/src/evals/runEvaluators.ts
+++ b/packages/logfire-api/src/evals/runEvaluators.ts
@@ -4,6 +4,8 @@
  * strict-parses.
  */
 
+import pRetry from 'p-retry'
+
 import type { Evaluator } from './Evaluator'
 import type {
   EvaluationReason,
@@ -12,6 +14,7 @@ import type {
   EvaluatorFailureRecord,
   EvaluatorOutput,
   EvaluatorSpec,
+  RetryConfig,
 } from './types'
 
 import { ATTR_EVALUATOR_NAME, SPAN_MSG_TEMPLATE_EVALUATOR, SPAN_NAME_EVALUATOR_LITERAL } from './constants'
@@ -24,21 +27,27 @@ export interface RunEvaluatorsResult {
   scores: Record<string, EvaluationResultJson>
 }
 
-export async function runEvaluators(evaluators: readonly Evaluator[], ctx: EvaluatorContext): Promise<RunEvaluatorsResult> {
+export async function runEvaluators(
+  evaluators: readonly Evaluator[],
+  ctx: EvaluatorContext,
+  retryEvaluators?: RetryConfig
+): Promise<RunEvaluatorsResult> {
   const result: RunEvaluatorsResult = { assertions: {}, failures: [], labels: {}, scores: {} }
 
   for (const evaluator of evaluators) {
     const evaluatorName = evaluator.getResultName()
     const spec = evaluator.getSpec()
     try {
-      const raw = await evalsSpan(
-        SPAN_MSG_TEMPLATE_EVALUATOR,
-        {
-          attributes: { [ATTR_EVALUATOR_NAME]: evaluatorName },
-          spanName: SPAN_NAME_EVALUATOR_LITERAL,
-        },
-        async () => evaluator.evaluate(ctx)
-      )
+      const runOnce = (): Promise<EvaluatorOutput> =>
+        evalsSpan(
+          SPAN_MSG_TEMPLATE_EVALUATOR,
+          {
+            attributes: { [ATTR_EVALUATOR_NAME]: evaluatorName },
+            spanName: SPAN_NAME_EVALUATOR_LITERAL,
+          },
+          async () => evaluator.evaluate(ctx)
+        )
+      const raw = retryEvaluators === undefined ? await runOnce() : await pRetry(runOnce, retryEvaluators)
       mergeEvaluatorOutput(result, raw, evaluatorName, spec, evaluator.evaluatorVersion)
     } catch (err) {
       result.failures.push(buildFailureRecord(err, evaluatorName, spec, evaluator.evaluatorVersion))

--- a/packages/logfire-api/src/evals/runEvaluators.ts
+++ b/packages/logfire-api/src/evals/runEvaluators.ts
@@ -27,25 +27,38 @@ export async function runEvaluators(
 ): Promise<RunEvaluatorsResult> {
   const result: RunEvaluatorsResult = { assertions: {}, failures: [], labels: {}, scores: {} }
 
-  for (const evaluator of evaluators) {
-    const evaluatorName = evaluator.getResultName()
-    const spec = evaluator.getSpec()
-    try {
-      const runOnce = (): Promise<EvaluatorOutput> =>
-        evalsSpan(
-          SPAN_MSG_TEMPLATE_EVALUATOR,
-          {
-            attributes: { [ATTR_EVALUATOR_NAME]: evaluatorName },
-            spanName: SPAN_NAME_EVALUATOR_LITERAL,
-          },
-          async () => evaluator.evaluate(ctx)
-        )
-      const raw = retryEvaluators === undefined ? await runOnce() : await pRetry(runOnce, retryEvaluators)
-      for (const item of evaluationResultsFromOutput(raw, evaluatorName, spec, evaluator.evaluatorVersion)) {
-        place(result, item)
+  const runs = await Promise.all(
+    evaluators.map(async (evaluator) => {
+      const evaluatorName = evaluator.getResultName()
+      const spec = evaluator.getSpec()
+      try {
+        const runOnce = (): Promise<EvaluatorOutput> =>
+          evalsSpan(
+            SPAN_MSG_TEMPLATE_EVALUATOR,
+            {
+              attributes: { [ATTR_EVALUATOR_NAME]: evaluatorName },
+              spanName: SPAN_NAME_EVALUATOR_LITERAL,
+            },
+            async () => evaluator.evaluate(ctx)
+          )
+        const raw = retryEvaluators === undefined ? await runOnce() : await pRetry(runOnce, retryEvaluators)
+        return {
+          failures: [],
+          results: evaluationResultsFromOutput(raw, evaluatorName, spec, evaluator.evaluatorVersion),
+        }
+      } catch (err) {
+        return {
+          failures: [buildEvaluatorFailureRecord(err, evaluatorName, spec, evaluator.evaluatorVersion)],
+          results: [],
+        }
       }
-    } catch (err) {
-      result.failures.push(buildEvaluatorFailureRecord(err, evaluatorName, spec, evaluator.evaluatorVersion))
+    })
+  )
+
+  for (const run of runs) {
+    result.failures.push(...run.failures)
+    for (const item of run.results) {
+      place(result, item)
     }
   }
   return result
@@ -53,10 +66,20 @@ export async function runEvaluators(
 
 function place(out: RunEvaluatorsResult, result: EvaluationResultJson): void {
   if (typeof result.value === 'boolean') {
-    out.assertions[result.name] = result
+    const name = nextResultName(out.assertions, result.name)
+    out.assertions[name] = { ...result, name }
   } else if (typeof result.value === 'number') {
-    out.scores[result.name] = result
+    const name = nextResultName(out.scores, result.name)
+    out.scores[name] = { ...result, name }
   } else {
-    out.labels[result.name] = result
+    const name = nextResultName(out.labels, result.name)
+    out.labels[name] = { ...result, name }
   }
+}
+
+function nextResultName(existing: Record<string, EvaluationResultJson>, baseName: string): string {
+  if (existing[baseName] === undefined) return baseName
+  let i = 2
+  while (existing[`${baseName}_${i.toString()}`] !== undefined) i++
+  return `${baseName}_${i.toString()}`
 }

--- a/packages/logfire-api/src/evals/runEvaluators.ts
+++ b/packages/logfire-api/src/evals/runEvaluators.ts
@@ -7,17 +7,10 @@
 import pRetry from 'p-retry'
 
 import type { Evaluator } from './Evaluator'
-import type {
-  EvaluationReason,
-  EvaluationResultJson,
-  EvaluatorContext,
-  EvaluatorFailureRecord,
-  EvaluatorOutput,
-  EvaluatorSpec,
-  RetryConfig,
-} from './types'
+import type { EvaluationResultJson, EvaluatorContext, EvaluatorFailureRecord, EvaluatorOutput, RetryConfig } from './types'
 
 import { ATTR_EVALUATOR_NAME, SPAN_MSG_TEMPLATE_EVALUATOR, SPAN_NAME_EVALUATOR_LITERAL } from './constants'
+import { buildEvaluatorFailureRecord, evaluationResultsFromOutput } from './evaluatorResults'
 import { evalsSpan } from './internal'
 
 export interface RunEvaluatorsResult {
@@ -48,68 +41,22 @@ export async function runEvaluators(
           async () => evaluator.evaluate(ctx)
         )
       const raw = retryEvaluators === undefined ? await runOnce() : await pRetry(runOnce, retryEvaluators)
-      mergeEvaluatorOutput(result, raw, evaluatorName, spec, evaluator.evaluatorVersion)
+      for (const item of evaluationResultsFromOutput(raw, evaluatorName, spec, evaluator.evaluatorVersion)) {
+        place(result, item)
+      }
     } catch (err) {
-      result.failures.push(buildFailureRecord(err, evaluatorName, spec, evaluator.evaluatorVersion))
+      result.failures.push(buildEvaluatorFailureRecord(err, evaluatorName, spec, evaluator.evaluatorVersion))
     }
   }
   return result
 }
 
-function mergeEvaluatorOutput(
-  out: RunEvaluatorsResult,
-  raw: EvaluatorOutput,
-  defaultName: string,
-  spec: EvaluatorSpec,
-  evaluatorVersion?: string
-): void {
-  if (typeof raw === 'boolean' || typeof raw === 'number' || typeof raw === 'string' || isReason(raw)) {
-    place(out, defaultName, raw, spec, evaluatorVersion)
-    return
-  }
-  for (const [name, value] of Object.entries(raw)) {
-    place(out, name, value, spec, evaluatorVersion)
-  }
-}
-
-function place(
-  out: RunEvaluatorsResult,
-  name: string,
-  value: boolean | EvaluationReason | number | string,
-  spec: EvaluatorSpec,
-  evaluatorVersion?: string
-): void {
-  const reason = isReason(value) ? (value.reason ?? null) : null
-  const scalar = isReason(value) ? value.value : value
-  const json: EvaluationResultJson = {
-    name,
-    reason,
-    source: spec,
-    value: scalar,
-  }
-  if (evaluatorVersion !== undefined) json.evaluator_version = evaluatorVersion
-  if (typeof scalar === 'boolean') {
-    out.assertions[name] = json
-  } else if (typeof scalar === 'number') {
-    out.scores[name] = json
+function place(out: RunEvaluatorsResult, result: EvaluationResultJson): void {
+  if (typeof result.value === 'boolean') {
+    out.assertions[result.name] = result
+  } else if (typeof result.value === 'number') {
+    out.scores[result.name] = result
   } else {
-    out.labels[name] = json
+    out.labels[result.name] = result
   }
-}
-
-function isReason(v: unknown): v is EvaluationReason {
-  return typeof v === 'object' && v !== null && 'value' in v && !Array.isArray(v)
-}
-
-function buildFailureRecord(err: unknown, name: string, spec: EvaluatorSpec, evaluatorVersion?: string): EvaluatorFailureRecord {
-  const isErr = err instanceof Error
-  const out: EvaluatorFailureRecord = {
-    error_message: isErr ? err.message : String(err),
-    error_type: isErr ? err.constructor.name : 'Error',
-    name,
-    source: spec,
-  }
-  if (isErr && err.stack !== undefined) out.error_stacktrace = err.stack
-  if (evaluatorVersion !== undefined) out.evaluator_version = evaluatorVersion
-  return out
 }

--- a/packages/logfire-api/src/evals/serialization/dataset.ts
+++ b/packages/logfire-api/src/evals/serialization/dataset.ts
@@ -14,7 +14,7 @@ import { Case } from '../Case'
 import { Dataset } from '../Dataset'
 import { getEvaluatorClass, getReportEvaluatorClass, listRegisteredEvaluators, listRegisteredReportEvaluators } from '../registry'
 import { BUILTIN_PRIMARY_ARG_KEYS } from './builtinsPrimaryArgs'
-import { decodeEvaluator, decodeReportEvaluator, type EncodedEvaluator, encodeEvaluatorSpec } from './spec'
+import { decodeEvaluator, decodeReportEvaluator, type EncodedEvaluator, encodeEvaluatorSpec, type EvaluatorRegistry } from './spec'
 
 export interface FromOptions {
   customEvaluators?: readonly EvaluatorClass[]
@@ -123,7 +123,7 @@ function buildRegistry<T extends { evaluatorName?: string; name: string }>(
   defaults: readonly T[],
   custom: readonly T[] | undefined,
   globalLookup: (name: string) => T | undefined
-): Map<string, T> {
+): EvaluatorRegistry<T> {
   const map = new Map<string, T>()
   for (const cls of defaults) {
     map.set(cls.evaluatorName ?? cls.name, cls)
@@ -135,12 +135,12 @@ function buildRegistry<T extends { evaluatorName?: string; name: string }>(
   }
   // Fallback: also try the global registry (in case the user didn't explicitly
   // pass `customEvaluators` but did `registerEvaluator` somewhere).
-  return new Proxy(map, {
-    get(target, prop, receiver): unknown {
-      if (prop === 'get') {
-        return (key: string): T | undefined => target.get(key) ?? globalLookup(key)
-      }
-      return Reflect.get(target, prop, receiver) as unknown
+  return {
+    get(name: string): T | undefined {
+      return map.get(name) ?? globalLookup(name)
     },
-  })
+    keys(): Iterable<string> {
+      return map.keys()
+    },
+  }
 }

--- a/packages/logfire-api/src/evals/serialization/spec.ts
+++ b/packages/logfire-api/src/evals/serialization/spec.ts
@@ -20,6 +20,11 @@ import type { EvaluatorClass, EvaluatorSpec, ReportEvaluatorClass } from '../typ
 import { evaluatorRegistryKey } from '../registry'
 
 export type EncodedEvaluator = Record<string, unknown> | string
+export interface EvaluatorRegistry<T> {
+  get(name: string): T | undefined
+  keys(): Iterable<string>
+}
+type RegistryInput<T> = EvaluatorRegistry<T> | Map<string, T> | Record<string, T>
 
 export function encodeEvaluatorSpec(evaluator: Evaluator | ReportEvaluator): EncodedEvaluator {
   const cls = evaluator.constructor as { evaluatorName?: string; name: string }
@@ -47,7 +52,7 @@ export function encodeEvaluatorSpec(evaluator: Evaluator | ReportEvaluator): Enc
 
 export function decodeEvaluator<I = unknown, O = unknown, M = unknown>(
   encoded: unknown,
-  registry: Map<string, EvaluatorClass<I, O, M>> | Record<string, EvaluatorClass<I, O, M>>,
+  registry: RegistryInput<EvaluatorClass<I, O, M>>,
   primaryArgKeys: Map<string, string>
 ): Evaluator<I, O, M> {
   const spec = decodeSpec(encoded)
@@ -60,7 +65,7 @@ export function decodeEvaluator<I = unknown, O = unknown, M = unknown>(
 
 export function decodeReportEvaluator<I = unknown, O = unknown, M = unknown>(
   encoded: unknown,
-  registry: Map<string, ReportEvaluatorClass<I, O, M>> | Record<string, ReportEvaluatorClass<I, O, M>>,
+  registry: RegistryInput<ReportEvaluatorClass<I, O, M>>,
   primaryArgKeys: Map<string, string>
 ): ReportEvaluator<I, O, M> {
   const spec = decodeSpec(encoded)
@@ -123,10 +128,16 @@ function isStringKeyedDict(v: unknown): boolean {
   return v !== null && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date)
 }
 
-function lookup<T>(registry: Map<string, T> | Record<string, T>, name: string): T | undefined {
-  return registry instanceof Map ? registry.get(name) : registry[name]
+function lookup<T>(registry: RegistryInput<T>, name: string): T | undefined {
+  if (isLookupRegistry(registry)) return registry.get(name)
+  return registry[name]
 }
 
-function keys<T>(registry: Map<string, T> | Record<string, T>): Iterable<string> {
-  return registry instanceof Map ? registry.keys() : Object.keys(registry)
+function keys<T>(registry: RegistryInput<T>): Iterable<string> {
+  if (isLookupRegistry(registry)) return registry.keys()
+  return Object.keys(registry)
+}
+
+function isLookupRegistry<T>(registry: RegistryInput<T>): registry is EvaluatorRegistry<T> | Map<string, T> {
+  return typeof (registry as EvaluatorRegistry<T>).get === 'function' && typeof (registry as EvaluatorRegistry<T>).keys === 'function'
 }

--- a/packages/logfire-api/src/evals/spanTree/SpanTree.ts
+++ b/packages/logfire-api/src/evals/spanTree/SpanTree.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /**
  * In-memory representation of a captured subtree of OTel spans.
  *
@@ -62,28 +61,56 @@ export class SpanNode {
 }
 
 export interface SpanQuery {
+  all_ancestors_have?: SpanQuery
+  all_children_have?: SpanQuery
+  all_descendants_have?: SpanQuery
   allAncestorsHave?: SpanQuery
   allChildrenHave?: SpanQuery
   allDescendantsHave?: SpanQuery
   and_?: SpanQuery[]
+  has_attribute_keys?: string[]
+  has_attributes?: Record<string, unknown>
   hasAttributeKeys?: string[]
   hasAttributes?: Record<string, unknown>
+  max_child_count?: number
+  max_depth?: number
+  max_descendant_count?: number
+  /** Max duration in seconds. */
+  max_duration?: number
   maxChildCount?: number
   maxDescendantCount?: number
-  /** Max duration in milliseconds. */
+  /** @deprecated Use max_duration. Values are interpreted as seconds for Python parity. */
   maxDuration?: number
+  min_child_count?: number
+  min_depth?: number
+  min_descendant_count?: number
+  /** Min duration in seconds. */
+  min_duration?: number
   minChildCount?: number
   minDescendantCount?: number
-  /** Min duration in milliseconds. */
+  /** @deprecated Use min_duration. Values are interpreted as seconds for Python parity. */
   minDuration?: number
+  name_contains?: string
+  name_equals?: string
+  name_matches_regex?: string
   nameContains?: string
   nameEquals?: string
   nameMatchesRegex?: string
+  no_ancestor_has?: SpanQuery
+  no_child_has?: SpanQuery
+  no_descendant_has?: SpanQuery
+  noAncestorHas?: SpanQuery
+  noChildHas?: SpanQuery
+  noDescendantHas?: SpanQuery
   not_?: SpanQuery
   or_?: SpanQuery[]
+  some_ancestor_has?: SpanQuery
+  some_child_has?: SpanQuery
+  some_descendant_has?: SpanQuery
   someAncestorHas?: SpanQuery
   someChildHas?: SpanQuery
   someDescendantHas?: SpanQuery
+  stop_recursing_when?: SpanQuery
   stopRecursingWhen?: SpanQuery
 }
 
@@ -92,37 +119,179 @@ function nsFromHrTime(hr: [number, number]): number {
 }
 
 function matchesQuery(node: SpanNode, q: SpanQuery): boolean {
-  if (q.nameEquals !== undefined && node.name !== q.nameEquals) return false
-  if (q.nameContains !== undefined && !node.name.includes(q.nameContains)) return false
-  if (q.nameMatchesRegex !== undefined && !new RegExp(q.nameMatchesRegex).test(node.name)) return false
-  if (q.minDuration !== undefined && node.durationMs < q.minDuration) return false
-  if (q.maxDuration !== undefined && node.durationMs > q.maxDuration) return false
-  if (q.hasAttributes !== undefined) {
-    for (const [k, v] of Object.entries(q.hasAttributes)) {
+  const or = queryValue(q, 'or_', 'or_') as SpanQuery[] | undefined
+  if (or !== undefined && or.length > 0) {
+    if (definedQueryKeys(q).length > 1) {
+      throw new Error("Cannot combine 'or_' conditions with other conditions at the same level")
+    }
+    return or.some((sub) => matchesQuery(node, sub))
+  }
+  const not = queryValue(q, 'not_', 'not_') as SpanQuery | undefined
+  if (not !== undefined && matchesQuery(node, not)) return false
+  const and = queryValue(q, 'and_', 'and_') as SpanQuery[] | undefined
+  if (and !== undefined && !and.every((sub) => matchesQuery(node, sub))) return false
+
+  const nameEquals = queryValue(q, 'name_equals', 'nameEquals') as string | undefined
+  const nameContains = queryValue(q, 'name_contains', 'nameContains') as string | undefined
+  const nameMatchesRegex = queryValue(q, 'name_matches_regex', 'nameMatchesRegex') as string | undefined
+  if (nameEquals !== undefined && node.name !== nameEquals) return false
+  if (nameContains !== undefined && !node.name.includes(nameContains)) return false
+  if (nameMatchesRegex !== undefined) {
+    const match = new RegExp(nameMatchesRegex).exec(node.name)
+    if (match?.index !== 0) return false
+  }
+
+  const durationSec = node.durationMs / 1000
+  const minDuration = queryValue(q, 'min_duration', 'minDuration') as number | undefined
+  const maxDuration = queryValue(q, 'max_duration', 'maxDuration') as number | undefined
+  if (minDuration !== undefined && durationSec < minDuration) return false
+  if (maxDuration !== undefined && durationSec > maxDuration) return false
+
+  const hasAttributes = queryValue(q, 'has_attributes', 'hasAttributes') as Record<string, unknown> | undefined
+  if (hasAttributes !== undefined) {
+    for (const [k, v] of Object.entries(hasAttributes)) {
       if (node.attributes[k] !== v) return false
     }
   }
-  if (q.hasAttributeKeys !== undefined) {
-    for (const k of q.hasAttributeKeys) {
+  const hasAttributeKeys = queryValue(q, 'has_attribute_keys', 'hasAttributeKeys') as string[] | undefined
+  if (hasAttributeKeys !== undefined) {
+    for (const k of hasAttributeKeys) {
       if (!(k in node.attributes)) return false
     }
   }
-  if (q.minChildCount !== undefined && node.children.length < q.minChildCount) return false
-  if (q.maxChildCount !== undefined && node.children.length > q.maxChildCount) return false
+  const minChildCount = queryValue(q, 'min_child_count', 'minChildCount') as number | undefined
+  const maxChildCount = queryValue(q, 'max_child_count', 'maxChildCount') as number | undefined
+  if (minChildCount !== undefined && node.children.length < minChildCount) return false
+  if (maxChildCount !== undefined && node.children.length > maxChildCount) return false
+
+  const someChildHas = queryValue(q, 'some_child_has', 'someChildHas') as SpanQuery | undefined
+  const allChildrenHave = queryValue(q, 'all_children_have', 'allChildrenHave') as SpanQuery | undefined
+  const noChildHas = queryValue(q, 'no_child_has', 'noChildHas') as SpanQuery | undefined
+  if (someChildHas !== undefined && !node.children.some((c) => matchesQuery(c, someChildHas))) return false
+  if (allChildrenHave !== undefined && !node.children.every((c) => matchesQuery(c, allChildrenHave))) return false
+  if (noChildHas !== undefined && node.children.some((c) => matchesQuery(c, noChildHas))) return false
+
   const descendants = Array.from(node.descendants())
-  if (q.minDescendantCount !== undefined && descendants.length < q.minDescendantCount) return false
-  if (q.maxDescendantCount !== undefined && descendants.length > q.maxDescendantCount) return false
-  if (q.someChildHas !== undefined && !node.children.some((c) => matchesQuery(c, q.someChildHas!))) return false
-  if (q.allChildrenHave !== undefined && !node.children.every((c) => matchesQuery(c, q.allChildrenHave!))) return false
-  if (q.someDescendantHas !== undefined && !descendants.some((d) => matchesQuery(d, q.someDescendantHas!))) return false
-  if (q.allDescendantsHave !== undefined && !descendants.every((d) => matchesQuery(d, q.allDescendantsHave!))) return false
+  const minDescendantCount = queryValue(q, 'min_descendant_count', 'minDescendantCount') as number | undefined
+  const maxDescendantCount = queryValue(q, 'max_descendant_count', 'maxDescendantCount') as number | undefined
+  if (minDescendantCount !== undefined && descendants.length < minDescendantCount) return false
+  if (maxDescendantCount !== undefined && descendants.length > maxDescendantCount) return false
+
+  const stopRecursingWhen = queryValue(q, 'stop_recursing_when', 'stopRecursingWhen') as SpanQuery | undefined
+  const prunedDescendants = stopRecursingWhen === undefined ? descendants : findDescendants(node, stopRecursingWhen)
+  const someDescendantHas = queryValue(q, 'some_descendant_has', 'someDescendantHas') as SpanQuery | undefined
+  const allDescendantsHave = queryValue(q, 'all_descendants_have', 'allDescendantsHave') as SpanQuery | undefined
+  const noDescendantHas = queryValue(q, 'no_descendant_has', 'noDescendantHas') as SpanQuery | undefined
+  if (someDescendantHas !== undefined && !prunedDescendants.some((d) => matchesQuery(d, someDescendantHas))) return false
+  if (allDescendantsHave !== undefined && !prunedDescendants.every((d) => matchesQuery(d, allDescendantsHave))) return false
+  if (noDescendantHas !== undefined && prunedDescendants.some((d) => matchesQuery(d, noDescendantHas))) return false
+
   const ancestors = Array.from(node.ancestors())
-  if (q.someAncestorHas !== undefined && !ancestors.some((a) => matchesQuery(a, q.someAncestorHas!))) return false
-  if (q.allAncestorsHave !== undefined && !ancestors.every((a) => matchesQuery(a, q.allAncestorsHave!))) return false
-  if (q.not_ !== undefined && matchesQuery(node, q.not_)) return false
-  if (q.and_ !== undefined && !q.and_.every((sub) => matchesQuery(node, sub))) return false
-  if (q.or_ !== undefined && !q.or_.some((sub) => matchesQuery(node, sub))) return false
+  const minDepth = queryValue(q, 'min_depth', 'minDepth') as number | undefined
+  const maxDepth = queryValue(q, 'max_depth', 'maxDepth') as number | undefined
+  if (minDepth !== undefined && ancestors.length < minDepth) return false
+  if (maxDepth !== undefined && ancestors.length > maxDepth) return false
+
+  const prunedAncestors = stopRecursingWhen === undefined ? ancestors : findAncestors(node, stopRecursingWhen)
+  const someAncestorHas = queryValue(q, 'some_ancestor_has', 'someAncestorHas') as SpanQuery | undefined
+  const allAncestorsHave = queryValue(q, 'all_ancestors_have', 'allAncestorsHave') as SpanQuery | undefined
+  const noAncestorHas = queryValue(q, 'no_ancestor_has', 'noAncestorHas') as SpanQuery | undefined
+  if (someAncestorHas !== undefined && !prunedAncestors.some((a) => matchesQuery(a, someAncestorHas))) return false
+  if (allAncestorsHave !== undefined && !prunedAncestors.every((a) => matchesQuery(a, allAncestorsHave))) return false
+  if (noAncestorHas !== undefined && prunedAncestors.some((a) => matchesQuery(a, noAncestorHas))) return false
   return true
+}
+
+const QUERY_KEY_MAP: Record<string, string> = {
+  allAncestorsHave: 'all_ancestors_have',
+  allChildrenHave: 'all_children_have',
+  allDescendantsHave: 'all_descendants_have',
+  hasAttributeKeys: 'has_attribute_keys',
+  hasAttributes: 'has_attributes',
+  maxChildCount: 'max_child_count',
+  maxDepth: 'max_depth',
+  maxDescendantCount: 'max_descendant_count',
+  maxDuration: 'max_duration',
+  minChildCount: 'min_child_count',
+  minDepth: 'min_depth',
+  minDescendantCount: 'min_descendant_count',
+  minDuration: 'min_duration',
+  nameContains: 'name_contains',
+  nameEquals: 'name_equals',
+  nameMatchesRegex: 'name_matches_regex',
+  noAncestorHas: 'no_ancestor_has',
+  noChildHas: 'no_child_has',
+  noDescendantHas: 'no_descendant_has',
+  someAncestorHas: 'some_ancestor_has',
+  someChildHas: 'some_child_has',
+  someDescendantHas: 'some_descendant_has',
+  stopRecursingWhen: 'stop_recursing_when',
+}
+
+const RECURSIVE_QUERY_KEYS = new Set([
+  'all_ancestors_have',
+  'all_children_have',
+  'all_descendants_have',
+  'and_',
+  'no_ancestor_has',
+  'no_child_has',
+  'no_descendant_has',
+  'not_',
+  'or_',
+  'some_ancestor_has',
+  'some_child_has',
+  'some_descendant_has',
+  'stop_recursing_when',
+])
+
+export function spanQueryToSnakeCase(query: SpanQuery): SpanQuery {
+  const out: Record<string, unknown> = {}
+  for (const [rawKey, rawValue] of Object.entries(query as Record<string, unknown>)) {
+    if (rawValue === undefined) continue
+    const key = QUERY_KEY_MAP[rawKey] ?? rawKey
+    if (RECURSIVE_QUERY_KEYS.has(key)) {
+      out[key] = Array.isArray(rawValue)
+        ? rawValue.map((item) => spanQueryToSnakeCase(item as SpanQuery))
+        : spanQueryToSnakeCase(rawValue as SpanQuery)
+    } else {
+      out[key] = rawValue
+    }
+  }
+  return out as SpanQuery
+}
+
+function queryValue(query: SpanQuery, snakeKey: string, camelKey: string): unknown {
+  const q = query as Record<string, unknown>
+  return q[snakeKey] ?? q[camelKey]
+}
+
+function definedQueryKeys(query: SpanQuery): string[] {
+  return Object.entries(query as Record<string, unknown>)
+    .filter(([, value]) => value !== undefined)
+    .map(([key]) => QUERY_KEY_MAP[key] ?? key)
+}
+
+function findDescendants(node: SpanNode, stopRecursingWhen: SpanQuery): SpanNode[] {
+  const out: SpanNode[] = []
+  const visit = (children: readonly SpanNode[]): void => {
+    for (const child of children) {
+      out.push(child)
+      if (!matchesQuery(child, stopRecursingWhen)) visit(child.children)
+    }
+  }
+  visit(node.children)
+  return out
+}
+
+function findAncestors(node: SpanNode, stopRecursingWhen: SpanQuery): SpanNode[] {
+  const out: SpanNode[] = []
+  let current = node.parent
+  while (current !== null) {
+    out.push(current)
+    if (matchesQuery(current, stopRecursingWhen)) break
+    current = current.parent
+  }
+  return out
 }
 
 export class SpanTree {

--- a/packages/logfire-api/src/evals/spanTree/SpanTree.ts
+++ b/packages/logfire-api/src/evals/spanTree/SpanTree.ts
@@ -70,11 +70,11 @@ export interface SpanQuery {
   hasAttributes?: Record<string, unknown>
   maxChildCount?: number
   maxDescendantCount?: number
-  /** Min duration in milliseconds. */
+  /** Max duration in milliseconds. */
   maxDuration?: number
   minChildCount?: number
   minDescendantCount?: number
-  /** Max duration in milliseconds. */
+  /** Min duration in milliseconds. */
   minDuration?: number
   nameContains?: string
   nameEquals?: string

--- a/packages/logfire-api/src/evals/spanTree/exporter.ts
+++ b/packages/logfire-api/src/evals/spanTree/exporter.ts
@@ -13,7 +13,7 @@
 import type { Context } from '@opentelemetry/api'
 import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-import { context as ContextAPI, createContextKey } from '@opentelemetry/api'
+import { context as ContextAPI, createContextKey, trace as TraceAPI } from '@opentelemetry/api'
 
 import { SpanTree, SpanTreeRecordingError } from './SpanTree'
 
@@ -96,4 +96,14 @@ export function getEvalsSpanProcessor(): EvalsSpanProcessor {
 export function buildSpanTree(spans: ReadableSpan[], recordingError: null | SpanTreeRecordingError): SpanTree {
   if (recordingError !== null) return SpanTree.fromError(recordingError)
   return SpanTree.fromSpans(spans)
+}
+
+/**
+ * Best-effort detection of whether the active TracerProvider can record spans.
+ * If the provider is not the default no-op/proxy provider, assume callers wired
+ * the evals processor or another recording provider.
+ */
+export function isProcessorInstalledOnGlobal(): boolean {
+  const tp = TraceAPI.getTracerProvider()
+  return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
 }

--- a/packages/logfire-api/src/evals/spanTree/index.ts
+++ b/packages/logfire-api/src/evals/spanTree/index.ts
@@ -1,2 +1,2 @@
 export { buildSpanTree, EvalsSpanProcessor, getEvalsSpanProcessor, isProcessorInstalledOnGlobal } from './exporter'
-export { SpanNode, type SpanQuery, SpanTree, SpanTreeRecordingError } from './SpanTree'
+export { SpanNode, type SpanQuery, spanQueryToSnakeCase, SpanTree, SpanTreeRecordingError } from './SpanTree'

--- a/packages/logfire-api/src/evals/spanTree/index.ts
+++ b/packages/logfire-api/src/evals/spanTree/index.ts
@@ -1,2 +1,2 @@
-export { buildSpanTree, EvalsSpanProcessor, getEvalsSpanProcessor } from './exporter'
+export { buildSpanTree, EvalsSpanProcessor, getEvalsSpanProcessor, isProcessorInstalledOnGlobal } from './exporter'
 export { SpanNode, type SpanQuery, SpanTree, SpanTreeRecordingError } from './SpanTree'

--- a/packages/logfire-api/src/evals/types.ts
+++ b/packages/logfire-api/src/evals/types.ts
@@ -111,7 +111,7 @@ export interface RetryConfig {
  * `Dataset.evaluate(...)` kwargs but with TS-idiomatic naming.
  */
 export interface EvaluateOptions<Inputs = unknown, Output = unknown, Metadata = unknown> {
-  // Generic params reserved for future use (lifecycle, retry strategies)
+  // Phantom fields anchor the generic parameters for callers using this type directly.
   _phantomInputs?: Inputs
   _phantomMetadata?: Metadata
   _phantomOutput?: Output

--- a/packages/logfire-api/src/evals/types.ts
+++ b/packages/logfire-api/src/evals/types.ts
@@ -2,8 +2,6 @@
  * Shared types used across the evals subsystem.
  */
 
-import type { Span } from '@opentelemetry/api'
-
 import type { Evaluator } from './Evaluator'
 import type { ReportEvaluator } from './ReportEvaluator'
 import type { SpanTree } from './spanTree/SpanTree'
@@ -76,7 +74,6 @@ export interface ReportEvaluatorClass<Inputs = unknown, Output = unknown, Metada
  */
 export interface TaskRunState {
   attributes: Record<string, unknown>
-  caseSpan: null | Span
   /** Stable random ID used by the span-tree exporter to scope captured spans. */
   exporterContextId: string
   metrics: Record<string, number>
@@ -91,9 +88,6 @@ export interface EvaluatorFailureRecord {
   name: string
   source: EvaluatorSpec
 }
-
-/** Per-case evaluator container — separates dataset-level evaluators from case-specific ones. */
-export type EvaluatorList<Inputs, Output, Metadata> = readonly Evaluator<Inputs, Output, Metadata>[]
 
 /**
  * Retry config — passed to `p-retry`. See https://github.com/sindresorhus/p-retry
@@ -131,7 +125,7 @@ export interface EvaluateOptions<Inputs = unknown, Output = unknown, Metadata = 
   retryEvaluators?: RetryConfig
   /** Retry config for the user's task. Powered by `p-retry`. */
   retryTask?: RetryConfig
-  /** Cancel an in-flight evaluation. Cases not yet started are skipped; in-flight tasks see the signal. */
+  /** Cancel an evaluation. Cases not yet started are skipped; in-flight tasks are not interrupted automatically. */
   signal?: AbortSignal
   /** Override the task display name (defaults to function.name). */
   taskName?: string

--- a/packages/logfire-browser/package.json
+++ b/packages/logfire-browser/package.json
@@ -40,16 +40,6 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    },
-    "./evals": {
-      "import": {
-        "types": "./dist/evals.d.ts",
-        "default": "./dist/evals.js"
-      },
-      "require": {
-        "types": "./dist/evals.d.cts",
-        "default": "./dist/evals.cjs"
-      }
     }
   },
   "scripts": {

--- a/packages/logfire-browser/package.json
+++ b/packages/logfire-browser/package.json
@@ -40,6 +40,16 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./evals": {
+      "import": {
+        "types": "./dist/evals.d.ts",
+        "default": "./dist/evals.js"
+      },
+      "require": {
+        "types": "./dist/evals.d.cts",
+        "default": "./dist/evals.cjs"
+      }
     }
   },
   "scripts": {

--- a/packages/logfire-browser/src/evals.ts
+++ b/packages/logfire-browser/src/evals.ts
@@ -1,1 +1,0 @@
-export * from 'logfire/evals'

--- a/packages/logfire-browser/src/evals.ts
+++ b/packages/logfire-browser/src/evals.ts
@@ -1,0 +1,1 @@
+export * from 'logfire/evals'

--- a/packages/logfire-browser/vite.config.ts
+++ b/packages/logfire-browser/vite.config.ts
@@ -2,4 +2,10 @@ import { resolve } from 'node:path'
 
 import defineConfig from '../../vite-config.mjs'
 
-export default defineConfig(resolve(__dirname, 'src/index.ts'), ['logfire'])
+export default defineConfig(
+  {
+    evals: resolve(__dirname, 'src/evals.ts'),
+    index: resolve(__dirname, 'src/index.ts'),
+  },
+  ['logfire', 'logfire/evals']
+)

--- a/packages/logfire-browser/vite.config.ts
+++ b/packages/logfire-browser/vite.config.ts
@@ -2,10 +2,4 @@ import { resolve } from 'node:path'
 
 import defineConfig from '../../vite-config.mjs'
 
-export default defineConfig(
-  {
-    evals: resolve(__dirname, 'src/evals.ts'),
-    index: resolve(__dirname, 'src/index.ts'),
-  },
-  ['logfire', 'logfire/evals']
-)
+export default defineConfig(resolve(__dirname, 'src/index.ts'), ['logfire'])

--- a/packages/logfire-cf-workers/package.json
+++ b/packages/logfire-cf-workers/package.json
@@ -41,16 +41,6 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    },
-    "./evals": {
-      "import": {
-        "types": "./dist/evals.d.ts",
-        "default": "./dist/evals.js"
-      },
-      "require": {
-        "types": "./dist/evals.d.cts",
-        "default": "./dist/evals.cjs"
-      }
     }
   },
   "scripts": {

--- a/packages/logfire-cf-workers/package.json
+++ b/packages/logfire-cf-workers/package.json
@@ -41,6 +41,16 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./evals": {
+      "import": {
+        "types": "./dist/evals.d.ts",
+        "default": "./dist/evals.js"
+      },
+      "require": {
+        "types": "./dist/evals.d.cts",
+        "default": "./dist/evals.cjs"
+      }
     }
   },
   "scripts": {

--- a/packages/logfire-cf-workers/src/evals.ts
+++ b/packages/logfire-cf-workers/src/evals.ts
@@ -1,1 +1,0 @@
-export * from 'logfire/evals'

--- a/packages/logfire-cf-workers/src/evals.ts
+++ b/packages/logfire-cf-workers/src/evals.ts
@@ -1,0 +1,1 @@
+export * from 'logfire/evals'

--- a/packages/logfire-cf-workers/vite.config.ts
+++ b/packages/logfire-cf-workers/vite.config.ts
@@ -2,10 +2,4 @@ import { resolve } from 'node:path'
 
 import defineConfig from '../../vite-config.mjs'
 
-export default defineConfig(
-  {
-    evals: resolve(__dirname, 'src/evals.ts'),
-    index: resolve(__dirname, 'src/index.ts'),
-  },
-  ['@pydantic/otel-cf-workers', 'logfire', 'logfire/evals']
-)
+export default defineConfig(resolve(__dirname, 'src/index.ts'), ['@pydantic/otel-cf-workers', 'logfire'])

--- a/packages/logfire-cf-workers/vite.config.ts
+++ b/packages/logfire-cf-workers/vite.config.ts
@@ -2,4 +2,10 @@ import { resolve } from 'node:path'
 
 import defineConfig from '../../vite-config.mjs'
 
-export default defineConfig(resolve(__dirname, 'src/index.ts'), ['@pydantic/otel-cf-workers', 'logfire'])
+export default defineConfig(
+  {
+    evals: resolve(__dirname, 'src/evals.ts'),
+    index: resolve(__dirname, 'src/index.ts'),
+  },
+  ['@pydantic/otel-cf-workers', 'logfire', 'logfire/evals']
+)

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -65,7 +65,7 @@ JSON files round-trip across the two languages.
 
 ```ts
 import * as logfire from '@pydantic/logfire-node'
-import { Case, Dataset, EqualsExpected, withOnlineEvaluation } from '@pydantic/logfire-node/evals'
+import { Case, Dataset, Equals, EqualsExpected, withOnlineEvaluation } from '@pydantic/logfire-node/evals'
 
 logfire.configure({ serviceName: 'sentiment-classifier' })
 
@@ -83,10 +83,26 @@ const report = await dataset.evaluate(classify)
 
 // Online — wraps a function so each call also dispatches evaluators in the background.
 const monitored = withOnlineEvaluation(classify, {
-  evaluators: [new EqualsExpected()],
+  evaluators: [new Equals({ value: 'POSITIVE' })],
   target: 'sentiment-classifier',
 })
 await monitored({ text: 'I love this!' })
+```
+
+Runtime notes:
+
+- `Dataset.toFile` / `Dataset.fromFile` work in Node, Bun, and Deno. Browser and
+  Cloudflare Worker runtimes can use in-memory datasets and online evaluation,
+  but not filesystem-backed dataset helpers.
+- Browser offline evaluations should use `maxConcurrency: 1`; without
+  `AsyncLocalStorage`, concurrent case runs cannot isolate
+  `setEvalAttribute` / `incrementEvalMetric` state.
+- Manual non-Node smoke checks live under `scripts/runtime-smoke`:
+
+```sh
+pnpm build
+deno run --config scripts/runtime-smoke/deno.json --allow-read --allow-write scripts/runtime-smoke/evals-deno.ts
+bun run scripts/runtime-smoke/evals-bun.ts
 ```
 
 ## Contributing

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -58,14 +58,15 @@ the live view of your Logfire project.
 
 ## Evaluations
 
-`@pydantic/logfire-node/evals` provides offline + online evaluation primitives
-that emit OTel spans / log events compatible with the Logfire Evaluations UI.
-The wire format matches the Python `pydantic-evals` package, so dataset YAML /
-JSON files round-trip across the two languages.
+`logfire/evals` provides offline + online evaluation primitives that emit OTel
+spans / log events compatible with the Logfire Evaluations UI. The wire format
+matches the Python `pydantic-evals` package, so dataset YAML / JSON files
+round-trip across the two languages. Add `logfire` as a direct dependency in
+projects that import this subpath.
 
 ```ts
 import * as logfire from '@pydantic/logfire-node'
-import { Case, Dataset, Equals, EqualsExpected, withOnlineEvaluation } from '@pydantic/logfire-node/evals'
+import { Case, Dataset, Equals, EqualsExpected, withOnlineEvaluation } from 'logfire/evals'
 
 logfire.configure({ serviceName: 'sentiment-classifier' })
 

--- a/packages/logfire-node/package.json
+++ b/packages/logfire-node/package.json
@@ -40,16 +40,6 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    },
-    "./evals": {
-      "import": {
-        "types": "./dist/evals.d.ts",
-        "default": "./dist/evals.js"
-      },
-      "require": {
-        "types": "./dist/evals.d.cts",
-        "default": "./dist/evals.cjs"
-      }
     }
   },
   "scripts": {

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -1,0 +1,124 @@
+/* eslint-disable import-x/first */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const nodeSdkInstances: MockNodeSDK[] = []
+  let logForceFlushCalls = 0
+  let traceForceFlushCalls = 0
+
+  const logProcessor = {
+    forceFlush: () => {
+      logForceFlushCalls++
+      return Promise.resolve()
+    },
+    onEmit: () => undefined,
+    shutdown: () => Promise.resolve(),
+  }
+  const traceProcessor = {
+    forceFlush: () => {
+      traceForceFlushCalls++
+      return Promise.resolve()
+    },
+    onEnd: () => undefined,
+    onStart: () => undefined,
+    shutdown: () => Promise.resolve(),
+  }
+
+  class MockNodeSDK {
+    options: unknown
+    shutdownCalls = 0
+
+    constructor(options: unknown) {
+      this.options = options
+      nodeSdkInstances.push(this)
+    }
+
+    shutdown(): Promise<void> {
+      this.shutdownCalls++
+      return Promise.resolve()
+    }
+
+    start(): void {
+      return undefined
+    }
+  }
+
+  return {
+    get logForceFlushCalls() {
+      return logForceFlushCalls
+    },
+    logProcessor,
+    MockNodeSDK,
+    nodeSdkInstances,
+    reset() {
+      logForceFlushCalls = 0
+      traceForceFlushCalls = 0
+      nodeSdkInstances.length = 0
+    },
+    get traceForceFlushCalls() {
+      return traceForceFlushCalls
+    },
+    traceProcessor,
+  }
+})
+
+vi.mock('@opentelemetry/auto-instrumentations-node', () => ({
+  getNodeAutoInstrumentations: () => [],
+}))
+
+vi.mock('@opentelemetry/sdk-node', () => ({
+  NodeSDK: mocks.MockNodeSDK,
+}))
+
+vi.mock('../logsExporter', () => ({
+  logfireLogRecordProcessor: () => mocks.logProcessor,
+}))
+
+vi.mock('../metricExporter', () => ({
+  periodicMetricReader: () => undefined,
+}))
+
+vi.mock('../traceExporter', () => ({
+  logfireSpanProcessor: () => mocks.traceProcessor,
+}))
+
+import { forceFlush, shutdown, start } from '../sdk'
+
+describe('sdk lifecycle helpers', () => {
+  beforeEach(() => {
+    mocks.reset()
+    vi.spyOn(process, 'on').mockImplementation(() => process)
+  })
+
+  afterEach(async () => {
+    await shutdown()
+    vi.restoreAllMocks()
+  })
+
+  it('forceFlush flushes both trace and log processors', async () => {
+    start()
+
+    await forceFlush()
+
+    expect(mocks.traceForceFlushCalls).toBe(1)
+    expect(mocks.logForceFlushCalls).toBe(1)
+  })
+
+  it('shutdown is idempotent and clears active processors', async () => {
+    start()
+    const instance = mocks.nodeSdkInstances[0]
+    expect(instance).toBeDefined()
+    if (instance === undefined) throw new Error('expected NodeSDK mock instance')
+
+    await shutdown()
+    await shutdown()
+
+    expect(instance.shutdownCalls).toBe(1)
+
+    mocks.reset()
+    await forceFlush()
+
+    expect(mocks.traceForceFlushCalls).toBe(0)
+    expect(mocks.logForceFlushCalls).toBe(0)
+  })
+})

--- a/packages/logfire-node/src/evals.ts
+++ b/packages/logfire-node/src/evals.ts
@@ -1,6 +1,0 @@
-/**
- * Re-export of `logfire/evals` for users importing from `@pydantic/logfire-node`.
- * Lets people stay on a single root: `import { Dataset, Case } from '@pydantic/logfire-node/evals'`.
- */
-
-export * from 'logfire/evals'

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -1,3 +1,6 @@
+import type { LogRecordProcessor } from '@opentelemetry/sdk-logs'
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-base'
+
 import { diag, DiagConsoleLogger, metrics } from '@opentelemetry/api'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
@@ -29,7 +32,8 @@ import { logfireSpanProcessor } from './traceExporter'
 import { removeEmptyKeys } from './utils'
 
 let activeSdk: NodeSDK | undefined
-let activeProcessor: import('@opentelemetry/sdk-trace-base').SpanProcessor | undefined
+let activeLogProcessor: LogRecordProcessor | undefined
+let activeProcessor: SpanProcessor | undefined
 
 /**
  * Force-flush all pending spans to the configured exporter. Mirrors Python's
@@ -38,9 +42,7 @@ let activeProcessor: import('@opentelemetry/sdk-trace-base').SpanProcessor | und
  * top-level-await once and exit).
  */
 export async function forceFlush(): Promise<void> {
-  if (activeProcessor) {
-    await activeProcessor.forceFlush()
-  }
+  await Promise.all([activeProcessor?.forceFlush(), activeLogProcessor?.forceFlush()])
 }
 
 /**
@@ -51,6 +53,8 @@ export async function shutdown(): Promise<void> {
   if (activeSdk) {
     await activeSdk.shutdown()
     activeSdk = undefined
+    activeLogProcessor = undefined
+    activeProcessor = undefined
   }
 }
 
@@ -83,7 +87,7 @@ export function start() {
 
   const propagator = logfireConfig.distributedTracing ? new W3CTraceContextPropagator() : undefined
 
-  let processor: import('@opentelemetry/sdk-trace-base').SpanProcessor = logfireSpanProcessor(logfireConfig.console)
+  let processor: SpanProcessor = logfireSpanProcessor(logfireConfig.console)
   if (logfireConfig.sampling?.tail) {
     processor = new TailSamplingProcessor(processor, logfireConfig.sampling.tail)
   }
@@ -94,6 +98,7 @@ export function start() {
     headRate !== undefined && headRate < 1.0 ? new ParentBasedSampler({ root: new TraceIdRatioBasedSampler(headRate) }) : undefined
 
   const logProcessor = logfireLogRecordProcessor()
+  activeLogProcessor = logProcessor ?? undefined
 
   const sdk = new NodeSDK({
     autoDetectResources: false,

--- a/packages/logfire-node/vite.config.ts
+++ b/packages/logfire-node/vite.config.ts
@@ -2,10 +2,4 @@ import { resolve } from 'node:path'
 
 import defineConfig from '../../vite-config.mjs'
 
-export default defineConfig(
-  {
-    evals: resolve(__dirname, 'src/evals.ts'),
-    index: resolve(__dirname, 'src/index.ts'),
-  },
-  ['logfire', 'logfire/evals', 'picocolors']
-)
+export default defineConfig(resolve(__dirname, 'src/index.ts'), ['logfire', 'logfire/evals', 'picocolors'])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,9 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
+      logfire:
+        specifier: workspace:*
+        version: link:../../packages/logfire-api
     devDependencies:
       '@opentelemetry/semantic-conventions':
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.26.1
         version: 8.57.1(eslint@9.39.4)(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.5)(tsx@4.21.0)(yaml@2.8.2))
       eslint:
         specifier: ^9.22.0
         version: 9.39.4
@@ -582,6 +585,10 @@ importers:
 
 packages:
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -652,6 +659,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
@@ -1499,6 +1510,14 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2119,6 +2138,10 @@ packages:
 
   '@package-json/types@0.0.12':
     resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -2755,6 +2778,15 @@ packages:
       '@opentelemetry/sdk-metrics': '>=2.0.0 <3.0.0'
       '@opentelemetry/sdk-trace-base': '>=2.0.0 <3.0.0'
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -2872,9 +2904,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -2931,6 +2971,9 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -3201,6 +3244,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3617,6 +3663,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -3705,6 +3755,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -3779,6 +3834,9 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3977,12 +4035,34 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4146,6 +4226,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4155,6 +4238,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4222,6 +4312,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
@@ -4386,6 +4480,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -4410,6 +4507,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -4772,6 +4873,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -4798,6 +4903,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4850,6 +4959,10 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -5189,6 +5302,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -5254,6 +5371,11 @@ packages:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5356,6 +5478,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@changesets/apply-release-plan@7.1.0':
     dependencies:
@@ -6018,6 +6142,17 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 22.19.5
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6895,6 +7030,9 @@ snapshots:
 
   '@package-json/types@0.0.12': {}
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@pkgr/core@0.2.9': {}
 
   '@poppinss/colors@4.1.6':
@@ -7505,6 +7643,25 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.0)
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.5)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@22.19.5)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -7646,9 +7803,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   argparse@1.0.10:
     dependencies:
@@ -7732,6 +7893,12 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   async-function@1.0.0: {}
 
@@ -7973,6 +8140,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
 
@@ -8760,6 +8929,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -8866,6 +9040,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
   globals@15.15.0: {}
@@ -8925,6 +9108,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -9129,6 +9314,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -9138,7 +9344,15 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jju@1.4.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -9282,6 +9496,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -9293,6 +9509,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
 
@@ -9362,6 +9588,8 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mlly@1.8.1:
     dependencies:
@@ -9546,6 +9774,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -9563,6 +9793,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -10037,6 +10272,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.8
@@ -10091,6 +10332,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -10123,6 +10368,12 @@ snapshots:
   tapable@2.3.0: {}
 
   term-size@2.2.1: {}
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.4
 
   tinybench@2.9.0: {}
 
@@ -10521,6 +10772,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   ws@8.18.0: {}
 

--- a/reports/pydantic-evals-parity-followup.md
+++ b/reports/pydantic-evals-parity-followup.md
@@ -1,125 +1,37 @@
-# Parity follow-up: how well do the in-flight changes address the report
+# pydantic-evals parity: remaining gaps
 
-This is a re-review of the original 45-finding report ([pydantic-evals-parity.md](pydantic-evals-parity.md)) against the uncommitted changes in the working tree. The diff touches 25 files and ~1,150 lines.
+Differences between `logfire-api`'s evals module and Python `pydantic-evals`. Each entry is either an open gap, a JS runtime limitation, or a deliberate design choice.
 
-**Headline:** the changes address ~34 of 45 findings (the great majority of high-severity ones). Remaining gaps are mostly structural ("would require redesign"), inherent to JavaScript runtime limitations, or by-design.
+## Open gaps
 
-The first read of the report was also wrong about a small number of items — flagged below as **NOTE: original finding was incorrect**, where the code already matched Python and I had misread it.
+### `disableEvaluation` is a process-wide counter
 
-## A. Core orchestration
+Python uses a `ContextVar` so disabling evaluation is scoped to the current async context. JS uses a global counter, so concurrent requests interfere with each other. A proper fix needs `AsyncLocalStorage` and a non-trivial rewrite of the dispatch path.
 
-| #   | Finding                             | Status                                                                                                              |
-| --- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| 1   | Evaluator order reversed            | **Fixed** — `Dataset.ts:443` now `[...originalCase.evaluators, ...datasetEvaluators]` (case first, matches Python). |
-| 2   | Evaluators run sequentially         | **Fixed** — `runEvaluators.ts:30-54` now uses `Promise.all(evaluators.map(...))`.                                   |
-| 3   | Duplicate-name dedup missing        | **Fixed** — `runEvaluators.ts:80-84` adds `nextResultName` that suffixes `_2`, `_3` like Python.                    |
-| 4   | Repeat-run case naming `[run/1]`    | **Fixed** — `Dataset.ts:180` now `[1/3]` (matches Python `Case 1 [1/3]`).                                           |
-| 5   | Default experiment name             | **Fixed** — `Dataset.ts:126` now falls back to `taskName` (matches Python).                                         |
-| 6   | `prepare_context` errors not caught | **Fixed** — `Dataset.ts:425-440` wraps `prepareContext` in try/catch, builds a `ReportCaseFailure`, runs teardown.  |
+### Online evaluation: no JSON-schema sidecar on `recordReturn`
 
-**6 / 6 addressed.**
+`encodeReturnAttribute` handles primitives, errors, and unserializable values cleanly, but doesn't emit the Logfire-style JSON-schema sidecar attribute that Python writes alongside the encoded return value. `logfire-api` doesn't currently have an equivalent helper to generate it.
 
-## B. Built-in evaluators
+## JavaScript runtime limitations
 
-| #   | Finding                               | Status                                                                                                                                                                                                                  |
-| --- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 7   | `Contains` simpler in JS              | **Fixed** — `Contains.ts:71-110` now special-cases dict-vs-dict (key/value match), single-value-as-key for objects, with truncated-repr failure messages matching Python format strings.                                |
-| 8   | `LLMJudge` defaults inverted          | **Fixed** — `LLMJudge.ts:84-88` now `score=false` and `assertion={includeReason:true}` by default (Python parity).                                                                                                      |
-| 9   | `LLMJudge` doesn't disambiguate names | **Fixed** — `LLMJudge.ts:127-131` now suffixes `_score` / `_pass` when both channels are enabled.                                                                                                                       |
-| 10  | `LLMJudge.toJSON` drops fields        | **Fixed** — `LLMJudge.ts:140-145` + helpers now serialize `score`, `assertion` configs. (Caveat: `model` / `model_settings` are still absent because the JS LLMJudge has no model concept — that's #11, design choice.) |
-| 11  | BYO judge required                    | **By design.** Documented in code comments. Acceptable.                                                                                                                                                                 |
+### `extractArgs` parses `fn.toString()` with a regex
 
-**4 / 5 addressed; 1 by-design.**
+Python uses `inspect.signature` to recover parameter names. JS has no equivalent for arbitrary functions, so we regex-parse the stringified source. This is fragile (minifiers, decorators, default values with commas, etc.) and documented as such in the code.
 
-## C. Report evaluators
+## By-design
 
-| #   | Finding                                             | Status                                                                                                                                                                                                                                                    |
-| --- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 12  | AUC accuracy regression (downsample-then-integrate) | **Fixed** — `PrecisionRecallEvaluator.ts:67-94` and `ROCAUCEvaluator.ts:84-107` now compute AUC at full resolution via `uniqueSortedThresholds` (no `n`), then `downsample(points, n)` for display only.                                                  |
-| 13  | ROCAUC empty-result handling                        | **Fixed** — `ROCAUCEvaluator.ts:67-83` adds `emptyResult` with NaN AUC and short-circuits when `total_positives==0` or `total_negatives==0`.                                                                                                              |
-| 14  | ROCAUC always emits "Random" baseline               | **Fixed** as a side-effect of #13 — empty case now returns `curves: []`.                                                                                                                                                                                  |
-| 15  | KS no `n_thresholds`                                | **Fixed** — `KolmogorovSmirnovEvaluator.ts:34, 56` adds `nThresholds` field with default 100.                                                                                                                                                             |
-| 16  | KS missing min-anchor                               | **Fixed** — `KolmogorovSmirnovEvaluator.ts:97-98` prepends `(allScores[0], 0)` to both CDFs.                                                                                                                                                              |
-| 17  | Default `Precision-Recall` title                    | **Fixed** — title now `'Precision-Recall Curve'` (Python parity).                                                                                                                                                                                         |
-| 18  | `ConfusionMatrixEvaluator` API shape                | **Fixed** — `ConfusionMatrixEvaluator.ts:14-23, 39-46` now accepts both flat `predicted_from`/`predicted_key`/`expected_from`/`expected_key` (Python wire format) AND nested `predicted: {from, key}` (legacy JS). YAML round-trip with Python now works. |
-| 19  | `ConfusionMatrixEvaluator.metadata` without key     | **Fixed** — `ConfusionMatrixEvaluator.ts:128` now `safeStringify(c.metadata)` when key is undefined.                                                                                                                                                      |
-| 20  | `extractPositive` "expected_output" + key           | **Fixed** — `scoreCommon.ts:65-75` now throws `Error` if `positiveKey` is provided with `expected_output` (matches Python's behaviour).                                                                                                                   |
-| 21  | `toJSON` doesn't strip defaults                     | **Fixed** — all four report evaluators' `toJSON` now omit fields that equal their defaults (`score_from='scores'`, `n_thresholds=100`, etc.).                                                                                                             |
+### `LLMJudge` requires a caller-supplied judge function
 
-**10 / 10 addressed.** The full-resolution AUC fix is the most impactful: any Python eval suite ported as-is will now produce numerically identical analyses.
+Python's `LLMJudge` has a model/model-settings concept baked in. The JS version is BYO: callers pass a function that returns the grading payload. Consequently `model` / `model_settings` are absent from `LLMJudge.toJSON()`. This keeps `logfire-api` free of an LLM-client dependency.
 
-## D. Online evaluation
+### Online evaluation: async-only task functions
 
-| #   | Finding                                  | Status                                                                                                                                                                                                                                                                      |
-| --- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 22  | Default `samplingMode` `'correlated'`    | **Fixed** — `online.ts:70` now `'independent'` (Python parity).                                                                                                                                                                                                             |
-| 23  | Sequential evaluator dispatch            | **Fixed** — `online.ts:367-376` now `Promise.all(args.sampledEvaluators.map(...))`.                                                                                                                                                                                         |
-| 24  | No sink batching                         | **Fixed** — `online.ts:378-401` builds a `perEvaluatorSinks: Map<sink, group>` keyed by sink instance and submits one batched payload per sink.                                                                                                                             |
-| 25  | Missing short-circuit on no destinations | **Fixed** — `online.ts:362-365` early-returns when `!emitOtel && globalSink === undefined && !hasPerEvaluatorSink`.                                                                                                                                                         |
-| 26  | OTel emission timing                     | **Partially fixed** — JS still emits all OTel events at the end of dispatch (after evaluators finish), not interleaved per-evaluator like Python. Functional behaviour is the same; only timing differs.                                                                    |
-| 27  | `ctx.inputs` shape (raw args vs dict)    | **Fixed** — `online.ts:357, 506-513` now builds a dict via `buildEvaluatorInputs` when arg names are available (`extractArgs` or auto-extracted via signature parse).                                                                                                       |
-| 28  | `extractArgs` regex parse                | **Not fixed** — JS still regex-parses `fn.toString()`. Inherent to JS — there's no equivalent of `inspect.signature`. Documented as fragile.                                                                                                                                |
-| 29  | No sync function support                 | **By design** (type-restricted to async).                                                                                                                                                                                                                                   |
-| 30  | `recordReturn` JSON-stringifies          | **Improved** — `online.ts:515-524` adds `encodeReturnAttribute` with proper handling for primitives, errors, and unserializable values. Still loses Logfire-style JSON-schema sidecar attributes since logfire-api doesn't have an equivalent here, but is no longer naive. |
-| 31  | `disableEvaluation` is a global counter  | **Not fixed** — still a process-wide counter. JS doesn't have `ContextVar`-equivalent semantics in core; a context-scoped fix would require AsyncLocalStorage and is non-trivial.                                                                                           |
+The `EvaluationTask` type is restricted to async functions. Sync support would add complexity for negligible benefit in a JS runtime.
 
-**6 / 10 addressed; 1 partial; 2 inherent JS limitations; 1 by design.**
+### No rich-text terminal rendering of reports
 
-## E. OTel event emission
+Python uses `rich` to render evaluation reports as tables. JS has no equivalent dependency; reports are returned as plain data for the caller to render.
 
-| #   | Finding                               | Status                                                                                                                                                  |
-| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 32  | Failure body fallback missing         | **Fixed** — `otelEmit.ts:80-81` now `errorMessage === '' ? '${name} failed' : '${name} failed: ${errorMessage}'`.                                       |
-| 33  | Failure `error.type` fallback         | **Fixed** — `otelEmit.ts:67` now `failure.error_type \|\| 'pydantic_evals.EvaluatorFailure'`.                                                           |
-| 34  | Number formatting in body             | **Fixed** — `otelEmit.ts` now formats numbers with a Python-style general format approximation, including small/large exponent display like `1.23e-07`. |
-| 35  | Result severity `INFO` vs unspecified | **Fixed** — successful result logs now omit `severityNumber`; evaluator failures still emit `SeverityNumber.WARN`, matching Python.                     |
+### JSON Schema: no `evaluators` opt-out for user-defined evaluators
 
-**4 / 4 addressed.**
-
-## F. Reporting / rendering
-
-| #   | Finding                                     | Status                                                                                                                                                  |
-| --- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 36  | No rich-text rendering                      | **By design.** No diff.                                                                                                                                 |
-| 37  | No `case_groups()` / `averages()` on report | **Not fixed.** Multi-run `source_case_name` aggregation methods are still missing. The data is captured, but consumers have to roll their own grouping. |
-
-**0 / 2 addressed; 1 by-design, 1 missing.**
-
-## G. Serialization
-
-| #   | Finding                   | Status                                                                                                                                                                                                                                                                                                                                                                                                    |
-| --- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 38  | JSON Schema is weak in JS | **Largely fixed** — every built-in evaluator now defines a `static jsonSchema()` (see `Contains.ts`, `Equals.ts`, `EqualsExpected.ts`, `HasMatchingSpan.ts`, `IsInstance.ts`, `LLMJudge.ts`, `MaxDuration.ts`, all four report evaluators). User-defined evaluators still get the loose `properties: {}` fallback per `jsonSchema.ts:88`, but built-ins now produce typed, autocomplete-friendly schemas. |
-| 39  | No `evaluators` opt-out   | **Not fixed.** Niche feature; no diff.                                                                                                                                                                                                                                                                                                                                                                    |
-
-**1 / 2 addressed.**
-
-## H. Span tree
-
-This section had the most errors in the original report. The original review missed the snake_case fields and the Python-parity `seconds` unit because of an incomplete first read of `SpanTree.ts`.
-
-| #   | Finding                                                                              | Status                                                                                                                                                                                                                                                                                        |
-| --- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 40  | camelCase only — datasets not portable                                               | **NOTE: original finding was incorrect.** Both `snake_case` and camelCase have always been supported. The diff expands coverage further (every field has both). YAML datasets are fully portable.                                                                                             |
-| 41  | Duration unit mismatch (ms vs seconds)                                               | **NOTE: original finding was incorrect / now fully fixed.** `SpanTree.ts:144` converts `node.durationMs / 1000` and compares in seconds. Both snake_case `min_duration` / `max_duration` (Python parity) and camelCase `minDuration` / `maxDuration` (deprecated, also seconds) are accepted. |
-| 42  | Missing `noChildHas` / `noDescendantHas` / `noAncestorHas` / `minDepth` / `maxDepth` | **NOTE: original finding was incorrect.** All five are present and exercised in `matchesQuery`.                                                                                                                                                                                               |
-| 43  | `stopRecursingWhen` is a noop                                                        | **NOTE: original finding was incorrect.** `SpanTree.ts:180-181, 195` applies it via `findDescendants` and `findAncestors`.                                                                                                                                                                    |
-| 44  | `or_` exclusivity not enforced                                                       | **NOTE: original finding was incorrect / now fixed.** `SpanTree.ts:124-126` throws `"Cannot combine 'or_' conditions with other conditions at the same level"`, matching Python's error.                                                                                                      |
-| 45  | `SimpleSpanProcessor` auto-installation                                              | Still requires `logfire.configure()` for auto-install; non-logfire users wire manually. **By design.**                                                                                                                                                                                        |
-
-The `HasMatchingSpan.toJSON` change at `HasMatchingSpan.ts:36` now calls `spanQueryToSnakeCase(this.query)` so YAML written from JS uses Python-compatible snake_case — addresses a derivative concern that was implicit in #40.
-
-**3 / 6 addressed; 3 were misreads in the original report.**
-
-## Roll-up
-
-- **Fully addressed: 34**: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 32, 33, 34, 35, 38 + (44 was a misread, now also defensively enforced) + (40, 41, 42, 43 were already correct).
-- **Partially addressed: 2**: 26 (timing only), 30 (better encoding, still no JSON-schema sidecar).
-- **Not fixed by design: 5**: 11, 29, 36, 39, 45.
-- **Not fixed (open gaps)**: 28 (regex param-name parse), 31 (`disableEvaluation` global counter), 37 (`case_groups` / `averages` instance methods).
-
-Of the 15 high-severity findings in the original roll-up, **all 15 are now addressed** by the diff (or were never real divergences in the case of #40, #41).
-
-The most consequential fixes are: full-resolution AUC (#12), parallel evaluator dispatch (#2/#23), name-collision dedup (#3), `LLMJudge` defaults flipped (#8/#9), `samplingMode='independent'` default (#22), `Contains` dict semantics (#7), and the round-trippable flat `ConfusionMatrixEvaluator` shape (#18).
-
-The remaining open gaps are either non-trivial structural work (#31, #37) or inherent-to-JS runtime limitations (#28).
+Built-in evaluators define a `static jsonSchema()` and produce typed schemas. User-defined evaluators get a loose `properties: {}` fallback (see `jsonSchema.ts:88`). Python has a way to opt a user evaluator out of schema generation entirely; JS doesn't. Niche.

--- a/reports/pydantic-evals-parity-followup.md
+++ b/reports/pydantic-evals-parity-followup.md
@@ -1,0 +1,125 @@
+# Parity follow-up: how well do the in-flight changes address the report
+
+This is a re-review of the original 45-finding report ([pydantic-evals-parity.md](pydantic-evals-parity.md)) against the uncommitted changes in the working tree. The diff touches 25 files and ~1,150 lines.
+
+**Headline:** the changes address ~34 of 45 findings (the great majority of high-severity ones). Remaining gaps are mostly structural ("would require redesign"), inherent to JavaScript runtime limitations, or by-design.
+
+The first read of the report was also wrong about a small number of items — flagged below as **NOTE: original finding was incorrect**, where the code already matched Python and I had misread it.
+
+## A. Core orchestration
+
+| #   | Finding                             | Status                                                                                                              |
+| --- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1   | Evaluator order reversed            | **Fixed** — `Dataset.ts:443` now `[...originalCase.evaluators, ...datasetEvaluators]` (case first, matches Python). |
+| 2   | Evaluators run sequentially         | **Fixed** — `runEvaluators.ts:30-54` now uses `Promise.all(evaluators.map(...))`.                                   |
+| 3   | Duplicate-name dedup missing        | **Fixed** — `runEvaluators.ts:80-84` adds `nextResultName` that suffixes `_2`, `_3` like Python.                    |
+| 4   | Repeat-run case naming `[run/1]`    | **Fixed** — `Dataset.ts:180` now `[1/3]` (matches Python `Case 1 [1/3]`).                                           |
+| 5   | Default experiment name             | **Fixed** — `Dataset.ts:126` now falls back to `taskName` (matches Python).                                         |
+| 6   | `prepare_context` errors not caught | **Fixed** — `Dataset.ts:425-440` wraps `prepareContext` in try/catch, builds a `ReportCaseFailure`, runs teardown.  |
+
+**6 / 6 addressed.**
+
+## B. Built-in evaluators
+
+| #   | Finding                               | Status                                                                                                                                                                                                                  |
+| --- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 7   | `Contains` simpler in JS              | **Fixed** — `Contains.ts:71-110` now special-cases dict-vs-dict (key/value match), single-value-as-key for objects, with truncated-repr failure messages matching Python format strings.                                |
+| 8   | `LLMJudge` defaults inverted          | **Fixed** — `LLMJudge.ts:84-88` now `score=false` and `assertion={includeReason:true}` by default (Python parity).                                                                                                      |
+| 9   | `LLMJudge` doesn't disambiguate names | **Fixed** — `LLMJudge.ts:127-131` now suffixes `_score` / `_pass` when both channels are enabled.                                                                                                                       |
+| 10  | `LLMJudge.toJSON` drops fields        | **Fixed** — `LLMJudge.ts:140-145` + helpers now serialize `score`, `assertion` configs. (Caveat: `model` / `model_settings` are still absent because the JS LLMJudge has no model concept — that's #11, design choice.) |
+| 11  | BYO judge required                    | **By design.** Documented in code comments. Acceptable.                                                                                                                                                                 |
+
+**4 / 5 addressed; 1 by-design.**
+
+## C. Report evaluators
+
+| #   | Finding                                             | Status                                                                                                                                                                                                                                                    |
+| --- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 12  | AUC accuracy regression (downsample-then-integrate) | **Fixed** — `PrecisionRecallEvaluator.ts:67-94` and `ROCAUCEvaluator.ts:84-107` now compute AUC at full resolution via `uniqueSortedThresholds` (no `n`), then `downsample(points, n)` for display only.                                                  |
+| 13  | ROCAUC empty-result handling                        | **Fixed** — `ROCAUCEvaluator.ts:67-83` adds `emptyResult` with NaN AUC and short-circuits when `total_positives==0` or `total_negatives==0`.                                                                                                              |
+| 14  | ROCAUC always emits "Random" baseline               | **Fixed** as a side-effect of #13 — empty case now returns `curves: []`.                                                                                                                                                                                  |
+| 15  | KS no `n_thresholds`                                | **Fixed** — `KolmogorovSmirnovEvaluator.ts:34, 56` adds `nThresholds` field with default 100.                                                                                                                                                             |
+| 16  | KS missing min-anchor                               | **Fixed** — `KolmogorovSmirnovEvaluator.ts:97-98` prepends `(allScores[0], 0)` to both CDFs.                                                                                                                                                              |
+| 17  | Default `Precision-Recall` title                    | **Fixed** — title now `'Precision-Recall Curve'` (Python parity).                                                                                                                                                                                         |
+| 18  | `ConfusionMatrixEvaluator` API shape                | **Fixed** — `ConfusionMatrixEvaluator.ts:14-23, 39-46` now accepts both flat `predicted_from`/`predicted_key`/`expected_from`/`expected_key` (Python wire format) AND nested `predicted: {from, key}` (legacy JS). YAML round-trip with Python now works. |
+| 19  | `ConfusionMatrixEvaluator.metadata` without key     | **Fixed** — `ConfusionMatrixEvaluator.ts:128` now `safeStringify(c.metadata)` when key is undefined.                                                                                                                                                      |
+| 20  | `extractPositive` "expected_output" + key           | **Fixed** — `scoreCommon.ts:65-75` now throws `Error` if `positiveKey` is provided with `expected_output` (matches Python's behaviour).                                                                                                                   |
+| 21  | `toJSON` doesn't strip defaults                     | **Fixed** — all four report evaluators' `toJSON` now omit fields that equal their defaults (`score_from='scores'`, `n_thresholds=100`, etc.).                                                                                                             |
+
+**10 / 10 addressed.** The full-resolution AUC fix is the most impactful: any Python eval suite ported as-is will now produce numerically identical analyses.
+
+## D. Online evaluation
+
+| #   | Finding                                  | Status                                                                                                                                                                                                                                                                      |
+| --- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 22  | Default `samplingMode` `'correlated'`    | **Fixed** — `online.ts:70` now `'independent'` (Python parity).                                                                                                                                                                                                             |
+| 23  | Sequential evaluator dispatch            | **Fixed** — `online.ts:367-376` now `Promise.all(args.sampledEvaluators.map(...))`.                                                                                                                                                                                         |
+| 24  | No sink batching                         | **Fixed** — `online.ts:378-401` builds a `perEvaluatorSinks: Map<sink, group>` keyed by sink instance and submits one batched payload per sink.                                                                                                                             |
+| 25  | Missing short-circuit on no destinations | **Fixed** — `online.ts:362-365` early-returns when `!emitOtel && globalSink === undefined && !hasPerEvaluatorSink`.                                                                                                                                                         |
+| 26  | OTel emission timing                     | **Partially fixed** — JS still emits all OTel events at the end of dispatch (after evaluators finish), not interleaved per-evaluator like Python. Functional behaviour is the same; only timing differs.                                                                    |
+| 27  | `ctx.inputs` shape (raw args vs dict)    | **Fixed** — `online.ts:357, 506-513` now builds a dict via `buildEvaluatorInputs` when arg names are available (`extractArgs` or auto-extracted via signature parse).                                                                                                       |
+| 28  | `extractArgs` regex parse                | **Not fixed** — JS still regex-parses `fn.toString()`. Inherent to JS — there's no equivalent of `inspect.signature`. Documented as fragile.                                                                                                                                |
+| 29  | No sync function support                 | **By design** (type-restricted to async).                                                                                                                                                                                                                                   |
+| 30  | `recordReturn` JSON-stringifies          | **Improved** — `online.ts:515-524` adds `encodeReturnAttribute` with proper handling for primitives, errors, and unserializable values. Still loses Logfire-style JSON-schema sidecar attributes since logfire-api doesn't have an equivalent here, but is no longer naive. |
+| 31  | `disableEvaluation` is a global counter  | **Not fixed** — still a process-wide counter. JS doesn't have `ContextVar`-equivalent semantics in core; a context-scoped fix would require AsyncLocalStorage and is non-trivial.                                                                                           |
+
+**6 / 10 addressed; 1 partial; 2 inherent JS limitations; 1 by design.**
+
+## E. OTel event emission
+
+| #   | Finding                               | Status                                                                                                                                                  |
+| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 32  | Failure body fallback missing         | **Fixed** — `otelEmit.ts:80-81` now `errorMessage === '' ? '${name} failed' : '${name} failed: ${errorMessage}'`.                                       |
+| 33  | Failure `error.type` fallback         | **Fixed** — `otelEmit.ts:67` now `failure.error_type \|\| 'pydantic_evals.EvaluatorFailure'`.                                                           |
+| 34  | Number formatting in body             | **Fixed** — `otelEmit.ts` now formats numbers with a Python-style general format approximation, including small/large exponent display like `1.23e-07`. |
+| 35  | Result severity `INFO` vs unspecified | **Fixed** — successful result logs now omit `severityNumber`; evaluator failures still emit `SeverityNumber.WARN`, matching Python.                     |
+
+**4 / 4 addressed.**
+
+## F. Reporting / rendering
+
+| #   | Finding                                     | Status                                                                                                                                                  |
+| --- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 36  | No rich-text rendering                      | **By design.** No diff.                                                                                                                                 |
+| 37  | No `case_groups()` / `averages()` on report | **Not fixed.** Multi-run `source_case_name` aggregation methods are still missing. The data is captured, but consumers have to roll their own grouping. |
+
+**0 / 2 addressed; 1 by-design, 1 missing.**
+
+## G. Serialization
+
+| #   | Finding                   | Status                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 38  | JSON Schema is weak in JS | **Largely fixed** — every built-in evaluator now defines a `static jsonSchema()` (see `Contains.ts`, `Equals.ts`, `EqualsExpected.ts`, `HasMatchingSpan.ts`, `IsInstance.ts`, `LLMJudge.ts`, `MaxDuration.ts`, all four report evaluators). User-defined evaluators still get the loose `properties: {}` fallback per `jsonSchema.ts:88`, but built-ins now produce typed, autocomplete-friendly schemas. |
+| 39  | No `evaluators` opt-out   | **Not fixed.** Niche feature; no diff.                                                                                                                                                                                                                                                                                                                                                                    |
+
+**1 / 2 addressed.**
+
+## H. Span tree
+
+This section had the most errors in the original report. The original review missed the snake_case fields and the Python-parity `seconds` unit because of an incomplete first read of `SpanTree.ts`.
+
+| #   | Finding                                                                              | Status                                                                                                                                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 40  | camelCase only — datasets not portable                                               | **NOTE: original finding was incorrect.** Both `snake_case` and camelCase have always been supported. The diff expands coverage further (every field has both). YAML datasets are fully portable.                                                                                             |
+| 41  | Duration unit mismatch (ms vs seconds)                                               | **NOTE: original finding was incorrect / now fully fixed.** `SpanTree.ts:144` converts `node.durationMs / 1000` and compares in seconds. Both snake_case `min_duration` / `max_duration` (Python parity) and camelCase `minDuration` / `maxDuration` (deprecated, also seconds) are accepted. |
+| 42  | Missing `noChildHas` / `noDescendantHas` / `noAncestorHas` / `minDepth` / `maxDepth` | **NOTE: original finding was incorrect.** All five are present and exercised in `matchesQuery`.                                                                                                                                                                                               |
+| 43  | `stopRecursingWhen` is a noop                                                        | **NOTE: original finding was incorrect.** `SpanTree.ts:180-181, 195` applies it via `findDescendants` and `findAncestors`.                                                                                                                                                                    |
+| 44  | `or_` exclusivity not enforced                                                       | **NOTE: original finding was incorrect / now fixed.** `SpanTree.ts:124-126` throws `"Cannot combine 'or_' conditions with other conditions at the same level"`, matching Python's error.                                                                                                      |
+| 45  | `SimpleSpanProcessor` auto-installation                                              | Still requires `logfire.configure()` for auto-install; non-logfire users wire manually. **By design.**                                                                                                                                                                                        |
+
+The `HasMatchingSpan.toJSON` change at `HasMatchingSpan.ts:36` now calls `spanQueryToSnakeCase(this.query)` so YAML written from JS uses Python-compatible snake_case — addresses a derivative concern that was implicit in #40.
+
+**3 / 6 addressed; 3 were misreads in the original report.**
+
+## Roll-up
+
+- **Fully addressed: 34**: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 27, 32, 33, 34, 35, 38 + (44 was a misread, now also defensively enforced) + (40, 41, 42, 43 were already correct).
+- **Partially addressed: 2**: 26 (timing only), 30 (better encoding, still no JSON-schema sidecar).
+- **Not fixed by design: 5**: 11, 29, 36, 39, 45.
+- **Not fixed (open gaps)**: 28 (regex param-name parse), 31 (`disableEvaluation` global counter), 37 (`case_groups` / `averages` instance methods).
+
+Of the 15 high-severity findings in the original roll-up, **all 15 are now addressed** by the diff (or were never real divergences in the case of #40, #41).
+
+The most consequential fixes are: full-resolution AUC (#12), parallel evaluator dispatch (#2/#23), name-collision dedup (#3), `LLMJudge` defaults flipped (#8/#9), `samplingMode='independent'` default (#22), `Contains` dict semantics (#7), and the round-trippable flat `ConfusionMatrixEvaluator` shape (#18).
+
+The remaining open gaps are either non-trivial structural work (#31, #37) or inherent-to-JS runtime limitations (#28).

--- a/scripts/runtime-smoke/README.md
+++ b/scripts/runtime-smoke/README.md
@@ -1,0 +1,11 @@
+# Evals Runtime Smokes
+
+These scripts are manual checks for `logfire/evals` outside Node. Build the packages first, then run the target runtime smoke:
+
+```sh
+pnpm build
+deno run --config scripts/runtime-smoke/deno.json --allow-read --allow-write scripts/runtime-smoke/evals-deno.ts
+bun run scripts/runtime-smoke/evals-bun.ts
+```
+
+They intentionally are not wired into the main automation. They cover offline `Dataset.evaluate`, `setEvalAttribute` / `incrementEvalMetric`, `Dataset.toFile` / `Dataset.fromFile`, and online `withOnlineEvaluation`.

--- a/scripts/runtime-smoke/deno.json
+++ b/scripts/runtime-smoke/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0",
+    "@opentelemetry/api-logs": "npm:@opentelemetry/api-logs@^0.215.0",
+    "@opentelemetry/sdk-trace-base": "npm:@opentelemetry/sdk-trace-base@^2.7.0",
+    "@opentelemetry/semantic-conventions": "npm:@opentelemetry/semantic-conventions@^1.40.0",
+    "js-yaml": "npm:js-yaml@^4.1.0",
+    "p-retry": "npm:p-retry@^6.2.1",
+    "zod": "npm:zod@^3.23.8"
+  }
+}

--- a/scripts/runtime-smoke/deno.lock
+++ b/scripts/runtime-smoke/deno.lock
@@ -1,0 +1,66 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@opentelemetry/api-logs@0.215": "0.215.0",
+    "npm:@opentelemetry/api@^1.9.0": "1.9.1",
+    "npm:@opentelemetry/semantic-conventions@^1.40.0": "1.40.0",
+    "npm:js-yaml@^4.1.0": "4.1.1",
+    "npm:p-retry@^6.2.1": "6.2.1",
+    "npm:zod@^3.23.8": "3.25.76"
+  },
+  "npm": {
+    "@opentelemetry/api-logs@0.215.0": {
+      "integrity": "sha512-xrFlqhdhUyO8wSRn6DjE0145/HPWSJ5Nm0C7vWua6TdL/FSEAZvEyvdsa9CRXuxo9ebb7j/NEPhEcO62IJ0qUA==",
+      "dependencies": [
+        "@opentelemetry/api"
+      ]
+    },
+    "@opentelemetry/api@1.9.1": {
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
+    },
+    "@opentelemetry/semantic-conventions@1.40.0": {
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="
+    },
+    "@types/retry@0.12.2": {
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
+    },
+    "argparse@2.0.1": {
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "is-network-error@1.3.1": {
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw=="
+    },
+    "js-yaml@4.1.1": {
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dependencies": [
+        "argparse"
+      ],
+      "bin": true
+    },
+    "p-retry@6.2.1": {
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "dependencies": [
+        "@types/retry",
+        "is-network-error",
+        "retry"
+      ]
+    },
+    "retry@0.13.1": {
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@opentelemetry/api-logs@0.215",
+      "npm:@opentelemetry/api@^1.9.0",
+      "npm:@opentelemetry/sdk-trace-base@^2.7.0",
+      "npm:@opentelemetry/semantic-conventions@^1.40.0",
+      "npm:js-yaml@^4.1.0",
+      "npm:p-retry@^6.2.1",
+      "npm:zod@^3.23.8"
+    ]
+  }
+}

--- a/scripts/runtime-smoke/evals-bun.ts
+++ b/scripts/runtime-smoke/evals-bun.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  Case,
+  Dataset,
+  EqualsExpected,
+  Evaluator,
+  incrementEvalMetric,
+  setEvalAttribute,
+  waitForEvaluations,
+  withOnlineEvaluation,
+} from '../../packages/logfire-api/dist/evals.js'
+
+class HasUppercaseOutput extends Evaluator<string, string> {
+  static evaluatorName = 'HasUppercaseOutput'
+
+  evaluate(ctx: { output: string }): boolean {
+    return ctx.output === ctx.output.toUpperCase()
+  }
+}
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) throw new Error(message)
+}
+
+const dataset = new Dataset<{ text: string }, string>({
+  cases: [new Case({ expectedOutput: 'HELLO', inputs: { text: 'hello' }, name: 'bun-case' })],
+  evaluators: [new EqualsExpected()],
+  name: 'bun-runtime-smoke',
+})
+
+const report = await dataset.evaluate(({ text }) => {
+  setEvalAttribute('runtime', 'bun')
+  incrementEvalMetric('characters', text.length)
+  return text.toUpperCase()
+})
+assert(report.cases[0]?.assertions.EqualsExpected?.value === true, 'offline evaluator did not pass')
+assert(report.cases[0]?.attributes.runtime === 'bun', 'setEvalAttribute did not record')
+assert(report.cases[0]?.metrics.characters === 5, 'incrementEvalMetric did not record')
+
+const tmpdirPath = await mkdtemp(join(tmpdir(), 'logfire-evals-bun-'))
+const datasetPath = join(tmpdirPath, 'dataset.yaml')
+await dataset.toFile(datasetPath, { schemaPath: 'dataset.schema.json' })
+const restored = await Dataset.fromFile<{ text: string }, string>(datasetPath)
+assert(restored.name === 'bun-runtime-smoke', 'Dataset.fromFile did not restore name')
+assert((await readFile(join(tmpdirPath, 'dataset.schema.json'), 'utf8')).includes('PydanticEvalsDataset'), 'schema sidecar missing')
+
+const monitored = withOnlineEvaluation(async (text: string) => text.toUpperCase(), {
+  emitOtelEvents: false,
+  evaluators: [new HasUppercaseOutput()],
+  target: 'bun-runtime-smoke',
+})
+assert((await monitored('ok')) === 'OK', 'online wrapper returned unexpected output')
+await waitForEvaluations()
+
+console.log('bun evals smoke ok')

--- a/scripts/runtime-smoke/evals-deno.ts
+++ b/scripts/runtime-smoke/evals-deno.ts
@@ -1,0 +1,54 @@
+import {
+  Case,
+  Dataset,
+  EqualsExpected,
+  Evaluator,
+  incrementEvalMetric,
+  setEvalAttribute,
+  waitForEvaluations,
+  withOnlineEvaluation,
+} from '../../packages/logfire-api/dist/evals.js'
+
+class HasUppercaseOutput extends Evaluator<string, string> {
+  static evaluatorName = 'HasUppercaseOutput'
+
+  evaluate(ctx: { output: string }): boolean {
+    return ctx.output === ctx.output.toUpperCase()
+  }
+}
+
+function assert(condition: unknown, message: string): void {
+  if (!condition) throw new Error(message)
+}
+
+const dataset = new Dataset<{ text: string }, string>({
+  cases: [new Case({ expectedOutput: 'HELLO', inputs: { text: 'hello' }, name: 'deno-case' })],
+  evaluators: [new EqualsExpected()],
+  name: 'deno-runtime-smoke',
+})
+
+const report = await dataset.evaluate(({ text }) => {
+  setEvalAttribute('runtime', 'deno')
+  incrementEvalMetric('characters', text.length)
+  return text.toUpperCase()
+})
+assert(report.cases[0]?.assertions.EqualsExpected?.value === true, 'offline evaluator did not pass')
+assert(report.cases[0]?.attributes.runtime === 'deno', 'setEvalAttribute did not record')
+assert(report.cases[0]?.metrics.characters === 5, 'incrementEvalMetric did not record')
+
+const tmpdir = await Deno.makeTempDir({ prefix: 'logfire-evals-deno-' })
+const datasetPath = `${tmpdir}/dataset.yaml`
+await dataset.toFile(datasetPath, { schemaPath: 'dataset.schema.json' })
+const restored = await Dataset.fromFile<{ text: string }, string>(datasetPath)
+assert(restored.name === 'deno-runtime-smoke', 'Dataset.fromFile did not restore name')
+assert((await Deno.readTextFile(`${tmpdir}/dataset.schema.json`)).includes('PydanticEvalsDataset'), 'schema sidecar missing')
+
+const monitored = withOnlineEvaluation(async (text: string) => text.toUpperCase(), {
+  emitOtelEvents: false,
+  evaluators: [new HasUppercaseOutput()],
+  target: 'deno-runtime-smoke',
+})
+assert((await monitored('ok')) === 'OK', 'online wrapper returned unexpected output')
+await waitForEvaluations()
+
+console.log('deno evals smoke ok')


### PR DESCRIPTION
## Summary
- align report evaluator context and analysis wire formats with Python pydantic-evals
- wire evaluator retries, schema sidecar writes, label frequency averages, and online evaluator spans/concurrency drops
- keep evals canonical at `logfire/evals` only, while `@pydantic/logfire-node` uses it internally for configure-time evals plumbing
- add manual Deno/Bun smoke scripts and docs
- raise evals-specific Vitest coverage above 95% statements/lines/functions and add `coverage:evals`
- update the node evals demos to use canonical `logfire/evals` imports so they run from this branch

## Final follow-up changes
- fixed exposed-but-dead online eval options:
  - global/per-wrapper `onMaxConcurrency`
  - global/per-wrapper/per-evaluator `onError`
  - global metadata on online evaluator contexts
  - per-evaluator `sink`
- kept online `onError` aligned with current Python behavior: evaluator failures become failure records, while `onError` handles sink and max-concurrency callback failures with `context`, `evaluator`, and location (`sink` / `on_max_concurrency`)
- centralized evaluator result/failure normalization so offline and online paths produce the same `EvaluationResultJson` / failure record shapes
- removed dead/internal-only evals constructs (`TaskRunState.caseSpan`, `EvaluatorList`) and duplicated processor detection helpers
- fixed custom evaluator deserialization fallback by replacing the broken `Proxy(Map)` registry with an explicit lookup registry
- implemented the already-documented `progress: true` path
- clarified abort-signal docs to match actual behavior: queued cases are skipped, in-flight tasks are not interrupted automatically
- fixed the existing node demos after removing `@pydantic/logfire-node/evals`; `demo-evals`, `demo-online-evals`, and `evals` now import `logfire/evals` directly

## Validation
- `pnpm --filter logfire test -- src/evals`
- `pnpm --filter logfire typecheck`
- `pnpm --filter logfire lint`
- `pnpm --filter logfire coverage:evals`
- `pnpm --filter logfire build`
- `pnpm --filter logfire test`
- `pnpm --filter @pydantic/logfire-node test`
- `pnpm --filter @pydantic/logfire-node-example typecheck`
- `pnpm --filter @pydantic/logfire-node-example demo-evals`
- `pnpm --filter @pydantic/logfire-node-example demo-online-evals`
- `pnpm build`
- `DENO_DIR=/private/tmp/logfire-js-deno-cache deno run --config scripts/runtime-smoke/deno.json --allow-read --allow-write scripts/runtime-smoke/evals-deno.ts`
- `bun run scripts/runtime-smoke/evals-bun.ts`
- pre-commit: format-check, typecheck, lint
- pre-push: build, test

Note: local commands ran under Node v22.22.0, so pnpm printed the repo engine warning for Node 24.
