### PR TITLE
Expose resourceAttributes configure option

### DIFF
--- a/.changeset/resource-attributes-node-browser.md
+++ b/.changeset/resource-attributes-node-browser.md
@@ -1,0 +1,6 @@
+---
+'@pydantic/logfire-browser': minor
+'@pydantic/logfire-node': minor
+---
+
+Add a typed `resourceAttributes` configure option for setting stable OpenTelemetry resource attributes without using `OTEL_RESOURCE_ATTRIBUTES`.

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -27,6 +27,28 @@ Browser applications can use local managed variables from `logfire/vars` when
 the app already depends on the core `logfire` package. Do not configure the
 remote provider in browser bundles because it requires a Logfire API key.
 
+## Resource attributes
+
+Use `resourceAttributes` for stable browser application or session metadata that
+should be attached to all telemetry from the configured provider:
+
+```js
+import * as logfire from '@pydantic/logfire-browser'
+
+logfire.configure({
+  traceUrl: '/client-traces',
+  serviceName: 'browser-app',
+  resourceAttributes: {
+    'service.namespace': 'my-company',
+    'app.installation.id': installationId,
+  },
+})
+```
+
+Do not use resource attributes for per-request values or sensitive user data.
+First-class options such as `serviceName`, `serviceVersion`, and `environment`
+take precedence over conflicting `resourceAttributes` keys.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/pydantic/logfire-js/blob/main/CONTRIBUTING.md) for development instructions.

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -1,0 +1,170 @@
+/* eslint-disable import/first */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+const mocks = vi.hoisted(() => {
+  const webTracerProviderInstances: MockWebTracerProvider[] = []
+  let unregisterCalls = 0
+
+  class MockWebTracerProvider {
+    options: unknown
+    forceFlushCalls = 0
+    registerCalls = 0
+    shutdownCalls = 0
+
+    constructor(options: unknown) {
+      this.options = options
+      webTracerProviderInstances.push(this)
+    }
+
+    register(): void {
+      this.registerCalls++
+    }
+
+    async forceFlush(): Promise<void> {
+      this.forceFlushCalls++
+      return Promise.resolve()
+    }
+
+    async shutdown(): Promise<void> {
+      this.shutdownCalls++
+      return Promise.resolve()
+    }
+  }
+
+  return {
+    MockWebTracerProvider,
+    get unregisterCalls() {
+      return unregisterCalls
+    },
+    reset() {
+      unregisterCalls = 0
+      webTracerProviderInstances.length = 0
+    },
+    unregister() {
+      unregisterCalls++
+    },
+    webTracerProviderInstances,
+  }
+})
+
+vi.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
+  OTLPTraceExporter: class MockOTLPTraceExporter {
+    options: unknown
+
+    constructor(options: unknown) {
+      this.options = options
+    }
+  },
+}))
+
+vi.mock('@opentelemetry/instrumentation', () => ({
+  registerInstrumentations: () => () => {
+    mocks.unregister()
+  },
+}))
+
+vi.mock('@opentelemetry/sdk-trace-web', () => ({
+  BatchSpanProcessor: class MockBatchSpanProcessor {
+    exporter: unknown
+    config: unknown
+
+    constructor(exporter: unknown, config: unknown) {
+      this.exporter = exporter
+      this.config = config
+    }
+  },
+  ParentBasedSampler: class MockParentBasedSampler {
+    config: unknown
+
+    constructor(config: unknown) {
+      this.config = config
+    }
+  },
+  StackContextManager: class MockStackContextManager {
+    readonly name = 'mock-stack-context-manager'
+  },
+  TraceIdRatioBasedSampler: class MockTraceIdRatioBasedSampler {
+    ratio: number
+
+    constructor(ratio: number) {
+      this.ratio = ratio
+    }
+  },
+  WebTracerProvider: mocks.MockWebTracerProvider,
+}))
+
+import { configure } from './index'
+
+const originalNavigator = globalThis.navigator
+let cleanup: (() => Promise<void>) | undefined
+
+function getLatestResourceAttributes(): Record<string, unknown> {
+  const instance = mocks.webTracerProviderInstances[mocks.webTracerProviderInstances.length - 1]
+  expect(instance).toBeDefined()
+  if (instance === undefined) {
+    throw new Error('expected WebTracerProvider mock instance')
+  }
+  return (instance.options as { resource: { attributes: Record<string, unknown> } }).resource.attributes
+}
+
+describe('browser configure resource attributes', () => {
+  beforeEach(() => {
+    mocks.reset()
+    cleanup = undefined
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        language: 'en-US',
+        userAgent: 'test-browser',
+        userAgentData: undefined,
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await cleanup?.()
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('adds configured resource attributes to the WebTracerProvider resource', () => {
+    cleanup = configure({
+      resourceAttributes: {
+        'app.installation.id': 'install-123',
+        'service.namespace': 'my-company',
+      },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(getLatestResourceAttributes()).toMatchObject({
+      'app.installation.id': 'install-123',
+      'browser.language': 'en-US',
+      'service.name': 'logfire-browser',
+      'service.namespace': 'my-company',
+      'service.version': '0.0.1',
+      'telemetry.sdk.name': 'logfire-browser',
+    })
+  })
+
+  it('keeps browser defaults ahead of generic resource attributes', () => {
+    cleanup = configure({
+      resourceAttributes: {
+        'service.name': 'generic-service',
+        'service.version': '0.0.1',
+        'telemetry.sdk.name': 'custom-sdk',
+      },
+      serviceName: 'configured-service',
+      serviceVersion: '1.2.3',
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(getLatestResourceAttributes()).toMatchObject({
+      'service.name': 'configured-service',
+      'service.version': '1.2.3',
+      'telemetry.sdk.name': 'logfire-browser',
+    })
+  })
+})

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -1,4 +1,4 @@
-import type { ContextManager } from '@opentelemetry/api'
+import type { Attributes, ContextManager } from '@opentelemetry/api'
 import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { Instrumentation } from '@opentelemetry/instrumentation'
@@ -107,6 +107,12 @@ export interface LogfireConfigOptions {
    * Options for scrubbing sensitive data. Set to False to disable.
    */
   scrubbing?: false | ScrubbingOptions
+  /**
+   * Additional OpenTelemetry resource attributes for the entity producing telemetry.
+   *
+   * Use this for stable application or browser-session metadata, not per-request or sensitive user data.
+   */
+  resourceAttributes?: Attributes
 
   /**
    * Name of this service.
@@ -164,24 +170,28 @@ export function configure(options: LogfireConfigOptions): () => Promise<void> {
   }
   configureLogfireApi(apiConfig)
 
-  const resource = resourceFromAttributes({
-    [ATTR_BROWSER_LANGUAGE]: navigator.language,
-    [ATTR_SERVICE_NAME]: options.serviceName ?? 'logfire-browser',
-    [ATTR_SERVICE_VERSION]: options.serviceVersion ?? '0.0.1',
-    [ATTR_TELEMETRY_SDK_LANGUAGE]: TELEMETRY_SDK_LANGUAGE_VALUE_WEBJS,
-    [ATTR_TELEMETRY_SDK_NAME]: 'logfire-browser',
-    ...(options.environment !== undefined && options.environment !== '' ? { [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: options.environment } : {}),
-    [ATTR_TELEMETRY_SDK_VERSION]: PACKAGE_VERSION,
-    ...(navigator.userAgentData
-      ? {
-          [ATTR_BROWSER_BRANDS]: navigator.userAgentData.brands.map((brand) => `${brand.brand} ${brand.version}`),
-          [ATTR_BROWSER_MOBILE]: navigator.userAgentData.mobile,
-          [ATTR_BROWSER_PLATFORM]: navigator.userAgentData.platform,
-        }
-      : {
-          [ATTR_USER_AGENT_ORIGINAL]: navigator.userAgent,
-        }),
-  })
+  const resource = resourceFromAttributes(options.resourceAttributes ?? {}).merge(
+    resourceFromAttributes({
+      [ATTR_BROWSER_LANGUAGE]: navigator.language,
+      [ATTR_SERVICE_NAME]: options.serviceName ?? 'logfire-browser',
+      [ATTR_SERVICE_VERSION]: options.serviceVersion ?? '0.0.1',
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: TELEMETRY_SDK_LANGUAGE_VALUE_WEBJS,
+      [ATTR_TELEMETRY_SDK_NAME]: 'logfire-browser',
+      ...(options.environment !== undefined && options.environment !== ''
+        ? { [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: options.environment }
+        : {}),
+      [ATTR_TELEMETRY_SDK_VERSION]: PACKAGE_VERSION,
+      ...(navigator.userAgentData
+        ? {
+            [ATTR_BROWSER_BRANDS]: navigator.userAgentData.brands.map((brand) => `${brand.brand} ${brand.version}`),
+            [ATTR_BROWSER_MOBILE]: navigator.userAgentData.mobile,
+            [ATTR_BROWSER_PLATFORM]: navigator.userAgentData.platform,
+          }
+        : {
+            [ATTR_USER_AGENT_ORIGINAL]: navigator.userAgent,
+          }),
+    })
+  )
 
   diag.info('logfire-browser: starting')
 

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -56,6 +56,28 @@ logfire.info(
 Run the script with `node hello.js`, and you should see the span being logged in
 the live view of your Logfire project.
 
+## Resource attributes
+
+Use `resourceAttributes` to attach stable OpenTelemetry resource metadata to all
+telemetry emitted by this SDK:
+
+```js
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  token: 'my-write-token',
+  serviceName: 'example-node-script',
+  resourceAttributes: {
+    'service.namespace': 'my-company',
+    'service.instance.id': crypto.randomUUID(),
+  },
+})
+```
+
+First-class options such as `serviceName`, `serviceVersion`, and `environment`
+take precedence over conflicting `resourceAttributes` keys. Values from
+`OTEL_RESOURCE_ATTRIBUTES` still take precedence over code configuration.
+
 ## Evaluations
 
 `logfire/evals` provides offline + online evaluation primitives that emit OTel

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -8,7 +8,7 @@ vi.mock('../sdk', () => ({
   start: vi.fn<() => void>(),
 }))
 
-describe('managed variables config', () => {
+describe('logfire config', () => {
   const originalApiKey = process.env['LOGFIRE_API_KEY']
 
   beforeEach(async () => {
@@ -22,6 +22,7 @@ describe('managed variables config', () => {
     } else {
       process.env['LOGFIRE_API_KEY'] = originalApiKey
     }
+    logfireConfig.resourceAttributes = {}
     await shutdownVariables()
   })
 
@@ -69,6 +70,17 @@ describe('managed variables config', () => {
 
     configure({ variables: false })
     expect(logfireConfig.variables).toBe(false)
+  })
+
+  it('stores configured resource attributes', () => {
+    const resourceAttributes = {
+      'app.installation.id': 'install-123',
+      'service.namespace': 'my-company',
+    }
+
+    configure({ resourceAttributes })
+
+    expect(logfireConfig.resourceAttributes).toBe(resourceAttributes)
   })
 
   it('throws when explicit remote variables have no api key', () => {

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -4,7 +4,9 @@ import type { MockInstance } from 'vite-plus/test'
 
 const mocks = vi.hoisted(() => {
   const nodeSdkInstances: MockNodeSDK[] = []
+  const configureVariablesCalls: unknown[][] = []
   let logForceFlushCalls = 0
+  let shutdownVariablesCalls = 0
   let traceForceFlushCalls = 0
 
   const logProcessor = {
@@ -45,6 +47,7 @@ const mocks = vi.hoisted(() => {
   }
 
   return {
+    configureVariablesCalls,
     get logForceFlushCalls() {
       return logForceFlushCalls
     },
@@ -52,9 +55,18 @@ const mocks = vi.hoisted(() => {
     MockNodeSDK,
     nodeSdkInstances,
     reset() {
+      configureVariablesCalls.length = 0
       logForceFlushCalls = 0
+      shutdownVariablesCalls = 0
       traceForceFlushCalls = 0
       nodeSdkInstances.length = 0
+    },
+    get shutdownVariablesCalls() {
+      return shutdownVariablesCalls
+    },
+    shutdownVariables: async () => {
+      shutdownVariablesCalls++
+      return Promise.resolve()
     },
     get traceForceFlushCalls() {
       return traceForceFlushCalls
@@ -71,6 +83,13 @@ vi.mock('@opentelemetry/sdk-node', () => ({
   NodeSDK: mocks.MockNodeSDK,
 }))
 
+vi.mock('logfire/vars', () => ({
+  configureVariables: (...args: unknown[]) => {
+    mocks.configureVariablesCalls.push(args)
+  },
+  shutdownVariables: async () => mocks.shutdownVariables(),
+}))
+
 vi.mock('../logsExporter', () => ({
   logfireLogRecordProcessor: () => mocks.logProcessor,
 }))
@@ -84,19 +103,55 @@ vi.mock('../traceExporter', () => ({
 }))
 
 import { forceFlush, shutdown, start } from '../sdk'
+import { logfireConfig } from '../logfireConfig'
 
 let processOnSpy: MockInstance<typeof process.on>
 let processRemoveListenerSpy: MockInstance<typeof process.removeListener>
+const originalOtelResourceAttributes = process.env['OTEL_RESOURCE_ATTRIBUTES']
+
+function getLatestResourceAttributes(): Record<string, unknown> {
+  const instance = mocks.nodeSdkInstances[mocks.nodeSdkInstances.length - 1]
+  expect(instance).toBeDefined()
+  if (instance === undefined) {
+    throw new Error('expected NodeSDK mock instance')
+  }
+  return (instance.options as { resource: { attributes: Record<string, unknown> } }).resource.attributes
+}
+
+function getLatestVariablesRuntimeOptions(): { resourceAttributes: Record<string, unknown> } {
+  const call = mocks.configureVariablesCalls[mocks.configureVariablesCalls.length - 1]
+  expect(call).toBeDefined()
+  if (call === undefined) {
+    throw new Error('expected configureVariables call')
+  }
+  return call[1] as { resourceAttributes: Record<string, unknown> }
+}
 
 describe('sdk lifecycle helpers', () => {
   beforeEach(() => {
     mocks.reset()
+    delete process.env['OTEL_RESOURCE_ATTRIBUTES']
+    Object.assign(logfireConfig, {
+      apiKey: undefined,
+      codeSource: undefined,
+      deploymentEnvironment: undefined,
+      resourceAttributes: {},
+      serviceName: undefined,
+      serviceVersion: undefined,
+      variables: undefined,
+      variablesBaseUrl: undefined,
+    })
     processOnSpy = vi.spyOn(process, 'on').mockImplementation(() => process)
     processRemoveListenerSpy = vi.spyOn(process, 'removeListener').mockImplementation(() => process)
   })
 
   afterEach(async () => {
     await shutdown()
+    if (originalOtelResourceAttributes === undefined) {
+      delete process.env['OTEL_RESOURCE_ATTRIBUTES']
+    } else {
+      process.env['OTEL_RESOURCE_ATTRIBUTES'] = originalOtelResourceAttributes
+    }
     vi.restoreAllMocks()
   })
 
@@ -152,5 +207,66 @@ describe('sdk lifecycle helpers', () => {
       'uncaughtExceptionMonitor',
       'unhandledRejection',
     ])
+  })
+
+  it('adds configured resource attributes to the NodeSDK resource', () => {
+    Object.assign(logfireConfig, {
+      resourceAttributes: {
+        'app.installation.id': 'install-123',
+        'service.namespace': 'my-company',
+      },
+      serviceName: 'node-service',
+    })
+
+    start()
+
+    expect(getLatestResourceAttributes()).toMatchObject({
+      'app.installation.id': 'install-123',
+      'service.name': 'node-service',
+      'service.namespace': 'my-company',
+    })
+    expect(getLatestVariablesRuntimeOptions().resourceAttributes).toMatchObject({
+      'app.installation.id': 'install-123',
+      'service.name': 'node-service',
+      'service.namespace': 'my-company',
+    })
+  })
+
+  it('keeps first-class resource options ahead of generic resource attributes', () => {
+    Object.assign(logfireConfig, {
+      deploymentEnvironment: 'production',
+      resourceAttributes: {
+        'deployment.environment.name': 'staging',
+        'service.name': 'generic-service',
+        'service.version': '0.0.1',
+      },
+      serviceName: 'configured-service',
+      serviceVersion: '1.2.3',
+    })
+
+    start()
+
+    expect(getLatestResourceAttributes()).toMatchObject({
+      'deployment.environment.name': 'production',
+      'service.name': 'configured-service',
+      'service.version': '1.2.3',
+    })
+  })
+
+  it('keeps OTEL_RESOURCE_ATTRIBUTES ahead of configured resource attributes', () => {
+    process.env['OTEL_RESOURCE_ATTRIBUTES'] = 'service.namespace=env-company,app.installation.id=env-install'
+    Object.assign(logfireConfig, {
+      resourceAttributes: {
+        'app.installation.id': 'configured-install',
+        'service.namespace': 'configured-company',
+      },
+    })
+
+    start()
+
+    expect(getLatestResourceAttributes()).toMatchObject({
+      'app.installation.id': 'env-install',
+      'service.namespace': 'env-company',
+    })
   })
 })

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -1,7 +1,7 @@
 import type { SamplingOptions } from 'logfire'
 import type { VariablesConfigOptions } from 'logfire/vars'
 
-import type { DiagLogLevel } from '@opentelemetry/api'
+import type { Attributes, DiagLogLevel } from '@opentelemetry/api'
 import type { InstrumentationConfigMap } from '@opentelemetry/auto-instrumentations-node'
 import type { Instrumentation } from '@opentelemetry/instrumentation'
 import type { MetricReader } from '@opentelemetry/sdk-metrics'
@@ -100,6 +100,10 @@ export interface LogfireConfigOptions {
    */
   otelScope?: string
   /**
+   * Additional OpenTelemetry resource attributes for the entity producing telemetry.
+   */
+  resourceAttributes?: Attributes
+  /**
    * Sampling options for controlling which traces are exported.
    * `head` sets a probabilistic sample rate (0.0-1.0) at trace creation time.
    * `tail` provides a callback evaluated on every span to decide whether to keep the trace.
@@ -167,6 +171,7 @@ export interface LogfireConfig {
   metrics: false | MetricsOptions | undefined
   nodeAutoInstrumentations: InstrumentationConfigMap
   otelScope: string
+  resourceAttributes: Attributes
   sampling: SamplingOptions | undefined
   sendToLogfire: boolean
   serviceName: string | undefined
@@ -193,6 +198,7 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   metrics: undefined,
   nodeAutoInstrumentations: DEFAULT_AUTO_INSTRUMENTATION_CONFIG,
   otelScope: DEFAULT_OTEL_SCOPE,
+  resourceAttributes: {},
   sampling: undefined,
   sendToLogfire: false,
   serviceName: process.env['LOGFIRE_SERVICE_NAME'],
@@ -257,6 +263,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
     metricExporterUrl: `${baseUrl}/${METRIC_ENDPOINT_PATH}`,
     metrics: cnf.metrics,
     nodeAutoInstrumentations: cnf.nodeAutoInstrumentations ?? DEFAULT_AUTO_INSTRUMENTATION_CONFIG,
+    resourceAttributes: cnf.resourceAttributes ?? {},
     sampling: resolveSampling(sampling),
     sendToLogfire,
     serviceName,

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -95,20 +95,24 @@ export function start(): void {
     diag.setLogger(new DiagConsoleLogger(), logfireConfig.diagLogLevel)
   }
 
-  const resource = resourceFromAttributes(
-    removeEmptyKeys({
-      [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: logfireConfig.deploymentEnvironment,
-      [ATTR_SERVICE_NAME]: logfireConfig.serviceName,
-      [ATTR_SERVICE_VERSION]: logfireConfig.serviceVersion,
-      [ATTR_TELEMETRY_SDK_LANGUAGE]: TELEMETRY_SDK_LANGUAGE_VALUE_NODEJS,
-      [ATTR_TELEMETRY_SDK_NAME]: 'logfire',
-      [ATTR_TELEMETRY_SDK_VERSION]: PACKAGE_VERSION,
+  const resource = resourceFromAttributes(logfireConfig.resourceAttributes)
+    .merge(
+      resourceFromAttributes(
+        removeEmptyKeys({
+          [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: logfireConfig.deploymentEnvironment,
+          [ATTR_SERVICE_NAME]: logfireConfig.serviceName,
+          [ATTR_SERVICE_VERSION]: logfireConfig.serviceVersion,
+          [ATTR_TELEMETRY_SDK_LANGUAGE]: TELEMETRY_SDK_LANGUAGE_VALUE_NODEJS,
+          [ATTR_TELEMETRY_SDK_NAME]: 'logfire',
+          [ATTR_TELEMETRY_SDK_VERSION]: PACKAGE_VERSION,
 
-      [ATTR_VCS_REPOSITORY_REF_REVISION]: logfireConfig.codeSource?.revision,
-      [ATTR_VCS_REPOSITORY_URL_FULL]: logfireConfig.codeSource?.repository,
-      [RESOURCE_ATTRIBUTES_CODE_ROOT_PATH]: logfireConfig.codeSource?.rootPath,
-    })
-  ).merge(detectResources({ detectors: [envDetector] }))
+          [ATTR_VCS_REPOSITORY_REF_REVISION]: logfireConfig.codeSource?.revision,
+          [ATTR_VCS_REPOSITORY_URL_FULL]: logfireConfig.codeSource?.repository,
+          [RESOURCE_ATTRIBUTES_CODE_ROOT_PATH]: logfireConfig.codeSource?.rootPath,
+        })
+      )
+    )
+    .merge(detectResources({ detectors: [envDetector] }))
   configureVariables(logfireConfig.variables, {
     ...(logfireConfig.apiKey !== undefined && logfireConfig.apiKey !== '' ? { apiKey: logfireConfig.apiKey } : {}),
     ...(logfireConfig.variablesBaseUrl !== undefined ? { baseUrl: logfireConfig.variablesBaseUrl } : {}),

--- a/plans/001-resource-attributes-node-browser.md
+++ b/plans/001-resource-attributes-node-browser.md
@@ -1,0 +1,193 @@
+## Goal
+
+Expose a typed `resourceAttributes` configuration option in the Node.js and Browser Logfire SDKs so users can attach arbitrary OpenTelemetry resource attributes without mutating `OTEL_RESOURCE_ATTRIBUTES`.
+
+This PRP is intentionally scoped to:
+
+- `@pydantic/logfire-node`
+- `@pydantic/logfire-browser`
+
+Cloudflare Workers support and resource detector configuration are out of scope for this first pass.
+
+## Why
+
+- Users currently need to serialize and percent-encode `OTEL_RESOURCE_ATTRIBUTES` before `logfire.configure()` to set attributes such as `service.namespace`, `service.instance.id`, `process.pid`, or `app.installation.id`.
+- Logfire already exposes native columns for several resource attributes, so a typed SDK option improves ergonomics without introducing new telemetry semantics.
+- The Browser SDK already constructs an OpenTelemetry resource directly, so Node and Browser can share the same public option even though only Node supports environment-based resource detection.
+
+## Success Criteria
+
+- [ ] `@pydantic/logfire-node.configure()` accepts `resourceAttributes?: Attributes` from `@opentelemetry/api`.
+- [ ] Node-created resources include user-provided resource attributes on traces, logs, metrics, and the managed variables runtime context.
+- [ ] Node preserves existing `OTEL_RESOURCE_ATTRIBUTES` behavior: environment resource attributes continue to override code-provided resource attributes.
+- [ ] First-class Logfire options such as `serviceName`, `serviceVersion`, `environment`, and `codeSource` continue to work and take precedence over conflicting keys in `resourceAttributes`.
+- [ ] `@pydantic/logfire-browser.configure()` accepts `resourceAttributes?: Attributes` from `@opentelemetry/api`.
+- [ ] Browser-created resources include user-provided resource attributes while preserving existing browser, service, environment, and telemetry SDK defaults.
+- [ ] Tests cover Node and Browser resource composition.
+- [ ] Package documentation and release metadata mention the new option.
+
+## Context
+
+### Key Files
+
+- `packages/logfire-node/src/logfireConfig.ts` — Node public config types, internal resolved config, env resolution, and `configure()` storage.
+- `packages/logfire-node/src/sdk.ts` — Node OpenTelemetry `Resource` construction and the source of attributes passed to `NodeSDK`, `MeterProvider`, and `configureVariables()`.
+- `packages/logfire-node/src/__test__/logfireConfig.test.ts` — test file for `configure()` option storage and env interaction.
+- `packages/logfire-node/src/__test__/sdk.test.ts` — pattern for testing Node SDK startup with mocked `NodeSDK` instances.
+- `packages/logfire-browser/src/index.ts` — Browser public config type and `WebTracerProvider` resource construction.
+- `packages/logfire-node/README.md` — Node usage documentation.
+- `packages/logfire-browser/README.md` — Browser usage documentation.
+- `.changeset/` — add a changeset because this is a public package API addition; package changelogs are generated from changesets.
+
+### External References
+
+- [GitHub issue #113](https://github.com/pydantic/logfire-js/issues/113) — original feature request and example API shape.
+- [OpenTelemetry JavaScript resources docs](https://opentelemetry.io/docs/languages/js/resources/) — resources represent the entity producing telemetry; custom resources can be set in code; env-provided resource values take precedence over code-provided values.
+
+### Gotchas
+
+- Use `Attributes` from `@opentelemetry/api`, not `Record<string, unknown>`, so callers get OpenTelemetry attribute value typing.
+- Do not accept a full OpenTelemetry `Resource` object. That would let users replace SDK-owned telemetry attributes and would make Browser and Node behavior harder to keep aligned.
+- Preserve Node's existing `envDetector` merge semantics. `OTEL_RESOURCE_ATTRIBUTES` must still override code config.
+- `resourceAttributes` should be stable resource metadata. It should not be documented as the right place for per-span, per-request, or sensitive browser user data.
+- Node currently sets `autoDetectResources: false` and manually merges `envDetector`. Do not switch to `NodeSDK` auto detection as part of this change.
+- Browser tests will likely need to mock `WebTracerProvider`, `OTLPTraceExporter`, and `registerInstrumentations`, and stub `navigator`.
+
+## Implementation Blueprint
+
+### Data Models
+
+Add a shared public option shape independently in the Node and Browser config interfaces:
+
+```ts
+import type { Attributes } from '@opentelemetry/api'
+
+interface LogfireConfigOptions {
+  /**
+   * Additional OpenTelemetry resource attributes for the entity producing telemetry.
+   */
+  resourceAttributes?: Attributes
+}
+```
+
+For Node, also add the resolved internal field:
+
+```ts
+interface LogfireConfig {
+  resourceAttributes: Attributes
+}
+```
+
+### Tasks
+
+```yaml
+Task 1: Add Node config storage
+  MODIFY packages/logfire-node/src/logfireConfig.ts:
+    - Import type `Attributes` from `@opentelemetry/api`.
+    - Add `resourceAttributes?: Attributes` to `LogfireConfigOptions`.
+    - Add `resourceAttributes: Attributes` to `LogfireConfig`.
+    - Initialize `DEFAULT_LOGFIRE_CONFIG.resourceAttributes` to `{}`.
+    - Store `cnf.resourceAttributes ?? {}` in `configure()`.
+  PATTERN: packages/logfire-node/src/logfireConfig.ts currently resolves serviceName, serviceVersion, environment, and codeSource before assigning `logfireConfig`.
+
+Task 2: Merge Node resource attributes
+  MODIFY packages/logfire-node/src/sdk.ts:
+    - Build a user resource from `logfireConfig.resourceAttributes`.
+    - Build the existing Logfire resource from service/environment/codeSource/telemetry SDK attributes.
+    - Merge resources so first-class Logfire options override conflicting `resourceAttributes` keys when defined.
+    - Merge `detectResources({ detectors: [envDetector] })` last to preserve env precedence.
+    - Keep the final resource object as the single resource passed to `NodeSDK`, `MeterProvider`, and `configureVariables()`.
+  PATTERN: packages/logfire-node/src/sdk.ts:98 currently builds the resource and passes `resource.attributes` to managed variables.
+
+Task 3: Add Node tests
+  MODIFY packages/logfire-node/src/__test__/logfireConfig.test.ts:
+    - Assert `configure({ resourceAttributes })` stores the object on `logfireConfig`.
+  MODIFY packages/logfire-node/src/__test__/sdk.test.ts:
+    - Start the SDK with configured resource attributes.
+    - Assert the mocked `NodeSDK` receives a resource containing a custom attribute such as `service.namespace`.
+    - Assert a first-class option such as `serviceName` wins over conflicting `resourceAttributes['service.name']`.
+    - Assert an `OTEL_RESOURCE_ATTRIBUTES` value wins over code-provided attributes for the same key.
+
+Task 4: Add Browser config and merge logic
+  MODIFY packages/logfire-browser/src/index.ts:
+    - Import type `Attributes` from `@opentelemetry/api`.
+    - Add `resourceAttributes?: Attributes` to `LogfireConfigOptions`.
+    - Merge a resource built from `options.resourceAttributes ?? {}` into the existing browser resource.
+    - Preserve existing defaults for browser attributes, service name/version, environment, and telemetry SDK attributes.
+  PATTERN: packages/logfire-browser/src/index.ts:167 currently constructs the browser resource inline before passing it to `WebTracerProvider`.
+
+Task 5: Add Browser tests
+  CREATE packages/logfire-browser/src/index.test.ts:
+    - Mock `WebTracerProvider` to capture constructor options.
+    - Mock or no-op exporter/instrumentation classes enough to call `configure()`.
+    - Stub `navigator.language` and either `navigator.userAgentData` or `navigator.userAgent`.
+    - Assert a custom resource attribute is present on the captured provider resource.
+    - Assert default `service.name` / `service.version` behavior is unchanged.
+    - Assert `serviceName` wins over conflicting `resourceAttributes['service.name']`.
+
+Task 6: Update docs and release metadata
+  MODIFY packages/logfire-node/README.md:
+    - Add a short example showing `resourceAttributes` for `service.namespace` and `service.instance.id`.
+  MODIFY packages/logfire-browser/README.md:
+    - Mention `resourceAttributes` for stable browser application/session resource metadata.
+    - Warn against per-request or sensitive user data.
+  CREATE .changeset/<descriptive-name>.md:
+    - Minor bump for `@pydantic/logfire-node`.
+    - Minor bump for `@pydantic/logfire-browser`.
+    - Describe the new typed `resourceAttributes` configure option.
+```
+
+### Integration Points
+
+```yaml
+CONFIG:
+  - packages/logfire-node/src/logfireConfig.ts — new public and resolved config fields.
+  - packages/logfire-browser/src/index.ts — new public config field.
+
+RESOURCE CONSTRUCTION:
+  - packages/logfire-node/src/sdk.ts — final resource must feed traces, logs, metrics, and managed variables.
+  - packages/logfire-browser/src/index.ts — final resource must feed `WebTracerProvider`.
+
+PUBLIC API:
+  - packages/logfire-node/src/index.ts — re-exports `LogfireConfigOptions` from `logfireConfig.ts`; no separate export change expected.
+  - packages/logfire-browser/src/index.ts — interface is exported directly from the package entrypoint.
+
+RELEASE:
+  - .changeset/ — public option addition needs release metadata.
+```
+
+## Validation
+
+Run focused checks first:
+
+```bash
+vp run @pydantic/logfire-node#test
+vp run @pydantic/logfire-node#typecheck
+vp run @pydantic/logfire-browser#test
+vp run @pydantic/logfire-browser#typecheck
+```
+
+Run broader checks if the implementation touches shared code or test mocks in a way that could affect packaging:
+
+```bash
+pnpm run build
+pnpm run format-check
+```
+
+### Required Test Coverage
+
+- [ ] Node happy path: custom resource attributes appear on the resource passed to `NodeSDK`.
+- [ ] Node managed variables path: `configureVariables()` receives the final resource attributes including user-provided keys.
+- [ ] Node precedence: first-class code config wins over conflicting `resourceAttributes`; `OTEL_RESOURCE_ATTRIBUTES` wins over code config.
+- [ ] Browser happy path: custom resource attributes appear on the resource passed to `WebTracerProvider`.
+- [ ] Browser default preservation: default browser and telemetry SDK attributes still exist.
+- [ ] Browser precedence: `serviceName` and `serviceVersion` options win over conflicting generic resource keys.
+
+## Unknowns & Risks
+
+- Browser has no existing tests for `configure()`, so the first Browser test may require careful mocking of browser globals and OTel classes.
+- The exact resource merge API behavior should be verified against the installed `@opentelemetry/resources` version during implementation.
+- Detector support is deliberately excluded. If users need `processDetector`, `hostDetector`, or `serviceInstanceIdDetector`, add a later Node-only advanced option rather than broadening this PRP.
+- If the maintainers prefer `serviceNamespace` as a first-class option, that can be added later; it should not replace the generic `resourceAttributes` escape hatch.
+
+**Confidence: 8/10** for one-pass implementation success.


### PR DESCRIPTION
## Summary
- Adds typed `resourceAttributes` config to the Node and Browser SDKs.
- Merges custom resource attributes with existing SDK defaults while preserving first-class option precedence and Node `OTEL_RESOURCE_ATTRIBUTES` precedence.
- Passes the final Node resource attributes through to managed variables context.
- Adds resource composition tests, README examples, a changeset, and the implementation PRP.

Partially implements #113. This covers static `resourceAttributes` for Node and Browser; Cloudflare and detector configuration remain out of scope.

## Validation
- `pnpm --filter @pydantic/logfire-node test`
- `pnpm --filter @pydantic/logfire-node typecheck`
- `pnpm --filter @pydantic/logfire-browser test`
- `pnpm --filter @pydantic/logfire-browser typecheck`
- `pnpm run build`
- `pnpm run format-check`
- Pre-push hook ran package build and test tasks successfully after rebasing onto `origin/main`.