### PR TITLE
Add Logfire TypeScript SDK docs

### DIFF
--- a/docs/frameworks/deno.md
+++ b/docs/frameworks/deno.md
@@ -1,0 +1,34 @@
+---
+title: Deno
+description: Configure Deno OpenTelemetry export to Logfire and use the logfire package for manual spans.
+---
+
+# Deno
+
+Deno has built-in OpenTelemetry support. Configure Deno's OTLP exporter to point at Logfire, then optionally use the `logfire` package for manual spans and logs.
+
+## Runtime Export
+
+```bash
+OTEL_DENO=true \
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://logfire-api.pydantic.dev/v1/traces \
+OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token' \
+deno run --unstable-otel --allow-net main.ts
+```
+
+## Manual API
+
+When OpenTelemetry is configured, you can use the core package:
+
+```ts
+import * as logfire from 'npm:logfire'
+
+await logfire.span('deno task', {
+  attributes: { runtime: 'deno' },
+  callback: async () => {
+    logfire.info('running deno task')
+  },
+})
+```
+
+See `examples/deno-project` for a minimal example.

--- a/docs/frameworks/express.md
+++ b/docs/frameworks/express.md
@@ -1,0 +1,60 @@
+---
+title: Express
+description: Instrument an Express application with @pydantic/logfire-node.
+---
+
+# Express
+
+Express applications should configure Logfire before Express is imported, so OpenTelemetry can patch the framework and HTTP modules.
+
+## Install
+
+```bash
+npm install express @pydantic/logfire-node dotenv
+```
+
+## Instrumentation File
+
+```ts title="instrumentation.ts"
+import * as logfire from '@pydantic/logfire-node'
+import 'dotenv/config'
+
+logfire.configure({
+  serviceName: 'express-api',
+})
+```
+
+Put your token in `.env`:
+
+```bash title=".env"
+LOGFIRE_TOKEN=your-write-token
+```
+
+## App Code
+
+```ts title="app.ts"
+import express from 'express'
+import * as logfire from '@pydantic/logfire-node'
+
+const app = express()
+
+app.get('/rolldice', (_req, res) => {
+  logfire.info('rolling dice')
+  res.send(String(Math.floor(Math.random() * 6) + 1))
+})
+
+app.use((err: Error, _req: express.Request, res: express.Response, _next: () => unknown) => {
+  logfire.reportError('express request failed', err)
+  res.status(500).send('internal server error')
+})
+
+app.listen(8080)
+```
+
+Run with the instrumentation file loaded first:
+
+```bash
+node --import ./instrumentation.js app.js
+```
+
+For a complete project, see `examples/express`.

--- a/docs/frameworks/nextjs.md
+++ b/docs/frameworks/nextjs.md
@@ -1,0 +1,86 @@
+---
+title: Next.js
+description: Use Logfire with Next.js server-side OpenTelemetry and optional client-side browser tracing.
+---
+
+# Next.js
+
+Next.js can emit server-side OpenTelemetry through `@vercel/otel`. Client-side browser traces use `@pydantic/logfire-browser` and a proxy endpoint so the write token stays server-side.
+
+## Server-Side Tracing
+
+Install Vercel's OpenTelemetry package and the manual `logfire` API if you want to create spans in React Server Components, route handlers, or server actions:
+
+```bash
+npm install @vercel/otel logfire
+```
+
+Create `instrumentation.ts` in your project root or `src` directory:
+
+```ts title="instrumentation.ts"
+import { registerOTel } from '@vercel/otel'
+
+export function register() {
+  registerOTel({
+    serviceName: 'nextjs-app',
+  })
+}
+```
+
+Set OTLP export to Logfire:
+
+```bash title=".env.local"
+OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-api.pydantic.dev
+OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+```
+
+Then use the manual API where useful:
+
+```tsx
+import * as logfire from 'logfire'
+
+export default async function Page() {
+  return logfire.span('render home page', {
+    callback: async () => {
+      logfire.info('loading homepage data')
+      return <main>Hello</main>
+    },
+  })
+}
+```
+
+## Client-Side Tracing
+
+Install the browser package:
+
+```bash
+npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
+```
+
+Create a proxy route or middleware that forwards browser OTLP requests to Logfire with the `Authorization` header. Then configure the browser package in a client-only component:
+
+```tsx
+'use client'
+
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
+import * as logfire from '@pydantic/logfire-browser'
+import { useEffect } from 'react'
+
+export function ClientInstrumentation() {
+  useEffect(() => {
+    const shutdown = logfire.configure({
+      traceUrl: '/logfire-proxy/v1/traces',
+      serviceName: 'nextjs-browser',
+      instrumentations: [getWebAutoInstrumentations()],
+    })
+
+    return () => {
+      void shutdown()
+    }
+  }, [])
+
+  return null
+}
+```
+
+See `examples/nextjs` and `examples/nextjs-client-side-instrumentation` for working projects.

--- a/docs/frameworks/vercel-ai.md
+++ b/docs/frameworks/vercel-ai.md
@@ -1,0 +1,62 @@
+---
+title: Vercel AI SDK
+description: Capture Vercel AI SDK OpenTelemetry spans in Logfire from Node.js and Next.js applications.
+---
+
+# Vercel AI SDK
+
+The Vercel AI SDK can emit OpenTelemetry spans for model calls, tools, token usage, and streaming operations. Logfire can receive those spans through either `@pydantic/logfire-node` in Node.js scripts or `@vercel/otel` in Next.js applications.
+
+## Node.js Scripts
+
+```bash
+npm install @pydantic/logfire-node ai @ai-sdk/openai
+```
+
+Configure Logfire before importing the AI SDK:
+
+```ts title="instrumentation.ts"
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'ai-worker',
+})
+```
+
+Enable telemetry on AI SDK calls:
+
+```ts
+import './instrumentation.ts'
+import { openai } from '@ai-sdk/openai'
+import { generateText } from 'ai'
+
+const result = await generateText({
+  model: openai('gpt-4.1-mini'),
+  prompt: 'Write a short haiku about traces.',
+  experimental_telemetry: { isEnabled: true },
+})
+
+console.log(result.text)
+```
+
+## Next.js
+
+In Next.js, configure `@vercel/otel` as shown in [Next.js](nextjs.md), then enable the same `experimental_telemetry` option on AI SDK calls.
+
+## Metadata
+
+Use `functionId` and `metadata` to make traces easier to query:
+
+```ts
+await generateText({
+  model,
+  prompt,
+  experimental_telemetry: {
+    functionId: 'support-reply',
+    isEnabled: true,
+    metadata: {
+      tenant: 'acme',
+    },
+  },
+})
+```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,65 @@
+---
+title: Getting Started
+description: Install the Logfire TypeScript SDK, configure a write token, and send your first span from Node.js.
+---
+
+# Getting Started
+
+The fastest way to try the TypeScript SDK is a small Node.js script. You need a Logfire write token, Node.js 24 or newer, and a package manager such as npm or pnpm.
+
+## Install
+
+Create a project and install the Node package:
+
+```bash
+npm init -y
+npm install @pydantic/logfire-node
+```
+
+Set your Logfire write token in the environment:
+
+```bash
+export LOGFIRE_TOKEN="your-write-token"
+```
+
+## Send a Span
+
+Create `hello.mjs`:
+
+```js
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'hello-logfire-js',
+  serviceVersion: '1.0.0',
+})
+
+await logfire.span('calculate checkout total', {
+  attributes: { cart_id: 'cart_123', item_count: 3 },
+  callback: async () => {
+    logfire.info('checkout total calculated', { total: 42.5 })
+  },
+})
+
+await logfire.forceFlush()
+await logfire.shutdown()
+```
+
+Run it:
+
+```bash
+node hello.mjs
+```
+
+The span and nested log event will appear in your Logfire project.
+
+## Runtime Packages
+
+Use the package that owns SDK setup for your runtime:
+
+- Node.js scripts and servers: [`@pydantic/logfire-node`](packages/node.md)
+- Browser clients: [`@pydantic/logfire-browser`](packages/browser.md)
+- Cloudflare Workers: [`@pydantic/logfire-cf-workers`](packages/cloudflare.md)
+- Runtime-agnostic manual API only: [`logfire`](packages/logfire.md)
+
+`@pydantic/logfire-node` and `@pydantic/logfire-browser` re-export the `logfire` manual API, so a single import suffices in those runtimes. With `@pydantic/logfire-cf-workers`, import spans and logs from `logfire` alongside `instrument` from the Workers package.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,0 +1,81 @@
+---
+title: Configuration
+description: Configure Logfire TypeScript SDK runtime packages with tokens, service metadata, exporters, console output, and OpenTelemetry options.
+---
+
+# Configuration
+
+Runtime packages configure OpenTelemetry for their environment:
+
+- Node.js: `@pydantic/logfire-node`
+- Browser: `@pydantic/logfire-browser`
+- Cloudflare Workers: `@pydantic/logfire-cf-workers`
+
+The `logfire` package provides manual spans and logs but does not configure exporters by itself.
+
+## Service Metadata
+
+Set stable service metadata so traces are easy to filter:
+
+```ts
+logfire.configure({
+  environment: 'production',
+  serviceName: 'checkout-api',
+  serviceVersion: '1.0.0',
+})
+```
+
+In Node.js, these can also come from:
+
+```bash
+LOGFIRE_SERVICE_NAME=checkout-api
+LOGFIRE_SERVICE_VERSION=1.0.0
+LOGFIRE_ENVIRONMENT=production
+```
+
+## Tokens
+
+Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser code must not receive the token; use a backend proxy and configure `traceUrl` instead.
+
+## Console Output
+
+Enable console output while developing:
+
+```ts
+logfire.configure({
+  console: true,
+  serviceName: 'local-worker',
+})
+```
+
+In Node.js, `LOGFIRE_CONSOLE=true` has the same effect.
+
+## Sending Control
+
+Node.js defaults to sending telemetry when a token is present. You can override this:
+
+```ts
+logfire.configure({
+  sendToLogfire: false,
+  serviceName: 'local-test',
+})
+```
+
+Use `sendToLogfire: 'if-token-present'` when shared code should send only in environments that provide a token.
+
+## Advanced Base URL
+
+Use `LOGFIRE_BASE_URL` or `advanced.baseUrl` for self-hosted or local Logfire-compatible endpoints:
+
+```ts
+logfire.configure({
+  advanced: {
+    baseUrl: 'http://localhost:3000',
+  },
+  serviceName: 'local-test',
+})
+```
+
+## OpenTelemetry Extensions
+
+Node.js accepts additional span processors, metric readers, instrumentations, and custom ID generators. Browser accepts custom instrumentations, trace exporter headers, a context manager, and batch span processor options. Prefer the package-specific page when configuring runtime internals.

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -1,0 +1,73 @@
+---
+title: Evaluations
+description: Use logfire/evals for offline datasets, online evaluation, built-in evaluators, and Python-compatible dataset files.
+---
+
+# Evaluations
+
+`logfire/evals` provides JavaScript evaluation primitives that emit Logfire-compatible telemetry. The dataset YAML and JSON formats are compatible with Python `pydantic-evals`.
+
+## Install
+
+Add `logfire` as a direct dependency when importing the evals subpath:
+
+```bash
+npm install logfire
+```
+
+In Node.js applications, also configure `@pydantic/logfire-node` so evaluation spans are exported:
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'sentiment-evals',
+})
+```
+
+## Offline Evaluation
+
+```ts
+import { Case, Dataset, EqualsExpected } from 'logfire/evals'
+
+const dataset = new Dataset<{ text: string }, string>({
+  cases: [
+    new Case({
+      expectedOutput: 'POSITIVE',
+      inputs: { text: 'I love this' },
+      name: 'positive example',
+    }),
+  ],
+  evaluators: [new EqualsExpected()],
+  name: 'sentiment-classifier',
+})
+
+const report = await dataset.evaluate(({ text }) => {
+  return text.toLowerCase().includes('love') ? 'POSITIVE' : 'NEUTRAL'
+})
+```
+
+## Online Evaluation
+
+```ts
+import { Equals, withOnlineEvaluation } from 'logfire/evals'
+
+async function classify({ text }: { text: string }) {
+  return text.toLowerCase().includes('love') ? 'POSITIVE' : 'NEUTRAL'
+}
+
+const monitored = withOnlineEvaluation(classify, {
+  evaluators: [new Equals({ value: 'POSITIVE' })],
+  target: 'sentiment-classifier',
+})
+
+await monitored({ text: 'I love this' })
+```
+
+## Runtime Notes
+
+`Dataset.toFile()` and `Dataset.fromFile()` work in Node.js, Bun, and Deno. Browser and Cloudflare Worker runtimes can use in-memory datasets and online evaluation, but not filesystem-backed dataset helpers.
+
+Browser offline evaluations should use low concurrency because browsers do not have Node.js `AsyncLocalStorage`.
+
+See `examples/node/demo_evals.ts` and `examples/node/demo_online_evals.ts` for larger examples.

--- a/docs/guides/managed-variables.md
+++ b/docs/guides/managed-variables.md
@@ -1,0 +1,72 @@
+---
+title: Managed Variables
+description: Use logfire/vars and @pydantic/logfire-node/vars for local and remote managed variables.
+---
+
+# Managed Variables
+
+Managed variables let code resolve runtime configuration from local config or the Logfire Variables API.
+
+Use `@pydantic/logfire-node/vars` in Node.js projects and `logfire/vars` in runtime-agnostic code.
+
+## Local Variables
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+import { defineVar } from '@pydantic/logfire-node/vars'
+
+logfire.configure({
+  serviceName: 'checkout-api',
+  variables: {
+    config: {
+      variables: {
+        checkout_button_copy: {
+          labels: {
+            control: { serialized_value: '"Start trial"', version: 1 },
+          },
+          name: 'checkout_button_copy',
+          overrides: [],
+          rollout: { labels: { control: 1 } },
+        },
+      },
+    },
+  },
+})
+
+const checkoutButtonCopy = defineVar('checkout_button_copy', {
+  default: 'Continue',
+})
+
+const resolved = await checkoutButtonCopy.get({
+  targetingKey: 'user_123',
+})
+```
+
+## Remote Variables
+
+Remote variables require a Logfire API key:
+
+```ts
+logfire.configure({
+  apiKey: process.env.LOGFIRE_API_KEY,
+  serviceName: 'checkout-api',
+  variables: {
+    blockBeforeFirstResolve: true,
+    polling: false,
+  },
+})
+```
+
+Do not expose API keys in browser bundles. Browser apps should use local variables or resolve variables through a trusted backend.
+
+## Baggage Context
+
+Resolved variables can attach their selected label to OpenTelemetry baggage:
+
+```ts
+await resolved.withContext(async () => {
+  logfire.info('checkout copy selected')
+})
+```
+
+See `examples/node/variables.ts` for a complete local and remote example.

--- a/docs/guides/resource-attributes.md
+++ b/docs/guides/resource-attributes.md
@@ -1,0 +1,45 @@
+---
+title: Resource Attributes
+description: Add stable OpenTelemetry resource attributes to Logfire TypeScript SDK telemetry.
+---
+
+# Resource Attributes
+
+Resource attributes describe the entity producing telemetry. Use them for stable metadata such as service namespace, deployment metadata, or an application instance identifier.
+
+## Node.js
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'checkout-api',
+  resourceAttributes: {
+    'service.namespace': 'payments',
+    'service.instance.id': process.env.HOSTNAME,
+  },
+})
+```
+
+## Browser
+
+```ts
+import * as logfire from '@pydantic/logfire-browser'
+
+logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'web-app',
+  resourceAttributes: {
+    'service.namespace': 'frontend',
+    'app.installation.id': installationId,
+  },
+})
+```
+
+## Precedence
+
+First-class options such as `serviceName`, `serviceVersion`, and `environment` take precedence over conflicting resource attributes.
+
+In Node.js, values from `OTEL_RESOURCE_ATTRIBUTES` are also read by the OpenTelemetry SDK and can override code-level values depending on SDK configuration.
+
+Do not use resource attributes for per-request values, user identifiers, or secrets. Put request-specific data on spans as attributes instead.

--- a/docs/guides/sampling.md
+++ b/docs/guides/sampling.md
@@ -1,0 +1,56 @@
+---
+title: Sampling
+description: Control Logfire TypeScript SDK trace volume with head and tail sampling.
+---
+
+# Sampling
+
+Sampling controls which traces are exported. The TypeScript SDK supports head sampling and tail sampling.
+
+## Head Sampling
+
+Head sampling makes a probabilistic decision when a trace starts:
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  sampling: { head: 0.1 },
+  serviceName: 'checkout-api',
+})
+```
+
+In Node.js, `LOGFIRE_TRACE_SAMPLE_RATE=0.1` configures head sampling from the environment.
+
+## Tail Sampling
+
+Tail sampling can keep traces based on span level or duration:
+
+```ts
+logfire.configure({
+  sampling: logfire.levelOrDuration({
+    durationThreshold: 2.0,
+    levelThreshold: 'warning',
+  }),
+  serviceName: 'checkout-api',
+})
+```
+
+You can also provide a callback:
+
+```ts
+logfire.configure({
+  sampling: {
+    tail: (spanInfo) => {
+      if (spanInfo.level.gte('error')) return 1.0
+      if (spanInfo.duration > 1.5) return 1.0
+      return 0.0
+    },
+  },
+  serviceName: 'worker',
+})
+```
+
+Tail sampling buffers spans until a decision can be made. Be conservative in browsers and long-lived processes because buffering can increase memory usage.
+
+See `examples/node/sampling.ts` for a runnable example.

--- a/docs/guides/scrubbing.md
+++ b/docs/guides/scrubbing.md
@@ -1,0 +1,50 @@
+---
+title: Scrubbing
+description: Scrub sensitive data from Logfire TypeScript SDK span attributes before export.
+---
+
+# Scrubbing
+
+The TypeScript SDK scrubs sensitive-looking attribute values before export. Scrubbing applies to manual span attributes and to data processed through the Logfire API helpers.
+
+## Add Patterns
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  scrubbing: {
+    extraPatterns: ['secret_token', 'internal_customer_note'],
+  },
+  serviceName: 'checkout-api',
+})
+```
+
+## Disable Scrubbing
+
+Disable scrubbing only when you are certain telemetry cannot contain sensitive data:
+
+```ts
+logfire.configure({
+  scrubbing: false,
+  serviceName: 'local-test',
+})
+```
+
+## Custom Callback
+
+Use a callback for application-specific handling:
+
+```ts
+logfire.configure({
+  scrubbing: {
+    callback: (match) => {
+      if (match.path.includes('debug')) return match.value
+      return '[scrubbed]'
+    },
+  },
+  serviceName: 'checkout-api',
+})
+```
+
+Prefer not to attach secrets to span attributes in the first place. Scrubbing is a backstop, not a replacement for careful telemetry design.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+---
+title: TypeScript SDK
+description: TypeScript and JavaScript SDK documentation for Pydantic Logfire.
+---
+
+# TypeScript SDK
+
+The TypeScript SDK provides Logfire support for JavaScript and TypeScript applications across Node.js, browsers, Cloudflare Workers, and other OpenTelemetry-compatible runtimes.
+
+These docs cover the JavaScript packages that live in the `pydantic/logfire-js` repository. The main Logfire documentation remains focused on the Python SDK and the Logfire platform; this chapter is the package and runtime guide for JavaScript applications.
+
+## Packages
+
+- [`logfire`](packages/logfire.md) provides the runtime-agnostic manual tracing API: spans, logs, levels, error reporting, sampling helpers, evaluations, and managed variables.
+- [`@pydantic/logfire-node`](packages/node.md) configures the OpenTelemetry Node SDK, exporters, automatic instrumentation, logs, metrics, and the `logfire` manual API.
+- [`@pydantic/logfire-browser`](packages/browser.md) configures browser tracing and re-exports the `logfire` manual API for client code.
+- [`@pydantic/logfire-cf-workers`](packages/cloudflare.md) instruments Cloudflare Workers and forwards Worker spans to Logfire.
+
+## Where to Start
+
+Use [Getting Started](get-started.md) for a minimal script, then move to the package page for your runtime:
+
+- Server-side Node.js applications should start with [Node.js](packages/node.md).
+- Browser applications should start with [Browser](packages/browser.md), especially the proxy requirement.
+- Cloudflare Workers should start with [Cloudflare Workers](packages/cloudflare.md).
+- Framework users can use the [Express](frameworks/express.md), [Next.js](frameworks/nextjs.md), [Deno](frameworks/deno.md), or [Vercel AI SDK](frameworks/vercel-ai.md) guides.

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -1,0 +1,99 @@
+[
+  {
+    "label": "TypeScript SDK",
+    "items": [
+      {
+        "label": "Overview",
+        "slug": "index"
+      },
+      {
+        "label": "Getting Started",
+        "slug": "get-started"
+      },
+      {
+        "label": "Packages",
+        "items": [
+          {
+            "label": "logfire",
+            "slug": "packages/logfire"
+          },
+          {
+            "label": "Node.js",
+            "slug": "packages/node"
+          },
+          {
+            "label": "Browser",
+            "slug": "packages/browser"
+          },
+          {
+            "label": "Cloudflare Workers",
+            "slug": "packages/cloudflare"
+          }
+        ]
+      },
+      {
+        "label": "Frameworks & Runtimes",
+        "items": [
+          {
+            "label": "Express",
+            "slug": "frameworks/express"
+          },
+          {
+            "label": "Next.js",
+            "slug": "frameworks/nextjs"
+          },
+          {
+            "label": "Deno",
+            "slug": "frameworks/deno"
+          },
+          {
+            "label": "Vercel AI SDK",
+            "slug": "frameworks/vercel-ai"
+          }
+        ]
+      },
+      {
+        "label": "Guides",
+        "items": [
+          {
+            "label": "Configuration",
+            "slug": "guides/configuration"
+          },
+          {
+            "label": "Resource Attributes",
+            "slug": "guides/resource-attributes"
+          },
+          {
+            "label": "Sampling",
+            "slug": "guides/sampling"
+          },
+          {
+            "label": "Scrubbing",
+            "slug": "guides/scrubbing"
+          },
+          {
+            "label": "Evaluations",
+            "slug": "guides/evals"
+          },
+          {
+            "label": "Managed Variables",
+            "slug": "guides/managed-variables"
+          }
+        ]
+      },
+      {
+        "label": "Reference",
+        "items": [
+          {
+            "label": "Environment Variables",
+            "slug": "reference/environment-variables"
+          },
+          {
+            "label": "API Overview",
+            "slug": "reference/api"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -1,0 +1,76 @@
+---
+title: Browser Package
+description: Configure @pydantic/logfire-browser for browser tracing with an authenticated backend proxy.
+---
+
+# `@pydantic/logfire-browser`
+
+`@pydantic/logfire-browser` configures OpenTelemetry browser tracing and re-exports the manual `logfire` API for client-side spans and logs.
+
+Browser telemetry must be sent through your own backend proxy. Do not put a Logfire write token in browser code.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
+```
+
+## Configure
+
+```ts
+import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
+import * as logfire from '@pydantic/logfire-browser'
+
+logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'web-app',
+  serviceVersion: '1.0.0',
+  instrumentations: [getWebAutoInstrumentations()],
+})
+```
+
+`traceUrl` should point to a server-side endpoint that forwards OTLP trace requests to Logfire and adds the `Authorization` header on the server.
+
+## Manual Client Events
+
+```ts
+document.querySelector('button')?.addEventListener('click', () => {
+  logfire.info('checkout button clicked')
+})
+```
+
+Report caught errors with `reportError()`:
+
+```ts
+window.addEventListener('error', (event) => {
+  if (event.error instanceof Error) {
+    logfire.reportError('uncaught browser error', event.error)
+  }
+})
+```
+
+## Proxy Requirement
+
+A browser proxy should:
+
+- accept requests from your frontend only
+- add `Authorization: <write-token>` server-side
+- forward to the Logfire OTLP trace endpoint
+- apply authentication, rate limiting, or origin checks for production apps
+
+For Next.js, see [Next.js](../frameworks/nextjs.md). For a standalone browser example, see the `examples/browser` project in this repository.
+
+## Shutdown
+
+`configure()` returns an async shutdown function:
+
+```ts
+const shutdown = logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'web-app',
+})
+
+window.addEventListener('pagehide', () => {
+  void shutdown()
+})
+```

--- a/docs/packages/cloudflare.md
+++ b/docs/packages/cloudflare.md
@@ -1,0 +1,81 @@
+---
+title: Cloudflare Workers Package
+description: Instrument Cloudflare Workers with @pydantic/logfire-cf-workers.
+---
+
+# `@pydantic/logfire-cf-workers`
+
+`@pydantic/logfire-cf-workers` instruments Cloudflare Workers and exports the manual `logfire` API through the core `logfire` package.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-cf-workers logfire
+```
+
+Enable Node.js compatibility in Wrangler:
+
+```json title="wrangler.jsonc"
+{
+  "compatibility_flags": ["nodejs_compat"]
+}
+```
+
+For local development, set a write token in `.dev.vars`:
+
+```bash title=".dev.vars"
+LOGFIRE_TOKEN=your-write-token
+LOGFIRE_ENVIRONMENT=development
+```
+
+For production, store `LOGFIRE_TOKEN` as a Worker secret.
+
+## In-Process Instrumentation
+
+```ts
+import * as logfire from 'logfire'
+import { instrument } from '@pydantic/logfire-cf-workers'
+
+const handler = {
+  async fetch(): Promise<Response> {
+    logfire.info('worker request handled')
+    return new Response('hello from Logfire')
+  },
+} satisfies ExportedHandler
+
+export default instrument(handler, {
+  service: {
+    name: 'checkout-worker',
+    namespace: '',
+    version: '1.0.0',
+  },
+})
+```
+
+`instrument()` is an alias for `instrumentInProcess()`. It reads `LOGFIRE_TOKEN`, `LOGFIRE_ENVIRONMENT`, and `LOGFIRE_BASE_URL` from the Worker environment.
+
+## Tail Workers
+
+The package also supports Cloudflare Tail Worker flows:
+
+- use `instrumentTail()` in the producer Worker
+- use `exportTailEventsToLogfire()` in the Tail Worker
+
+See `examples/cf-producer-worker` and `examples/cf-tail-worker` in this repository for the full wiring.
+
+## Scrubbing
+
+Pass `scrubbing` to control sensitive data scrubbing before telemetry is sent:
+
+```ts
+export default instrument(handler, {
+  scrubbing: {
+    extraPatterns: ['secret_token'],
+  },
+  service: {
+    name: 'checkout-worker',
+    namespace: '',
+    version: '1.0.0',
+  },
+})
+```

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -1,0 +1,83 @@
+---
+title: logfire Package
+description: Manual tracing, structured logs, error reporting, evaluations, and managed variables with the runtime-agnostic logfire package.
+---
+
+# `logfire`
+
+The `logfire` package is the runtime-agnostic manual API. It does not configure a runtime SDK by itself; use it with a configured OpenTelemetry provider, or import it through a runtime package such as `@pydantic/logfire-node`, `@pydantic/logfire-browser`, or `@pydantic/logfire-cf-workers`.
+
+Install it directly when a package or framework already configures OpenTelemetry for you:
+
+```bash
+npm install logfire
+```
+
+## Spans
+
+`span()` starts an active span, runs your callback, records thrown errors, and ends the span automatically.
+
+```ts
+import * as logfire from 'logfire'
+
+await logfire.span('fetch user profile', {
+  attributes: { user_id: 'user_123' },
+  callback: async () => {
+    return fetchProfile('user_123')
+  },
+})
+```
+
+Use `startSpan()` when you need to control the span lifetime yourself:
+
+```ts
+const span = logfire.startSpan('manual operation', { job_id: 'job_123' })
+
+try {
+  await runJob()
+} finally {
+  span.end()
+}
+```
+
+## Logs
+
+Log helpers create point-in-time Logfire events:
+
+```ts
+logfire.info('payment authorized', { payment_id: 'pay_123' })
+logfire.warning('retrying payment provider', { attempt: 2 })
+logfire.error('payment provider failed', { provider: 'stripe' })
+```
+
+Message templates become structured telemetry. Attribute values are attached to the span and are available for search and SQL queries.
+
+## Errors
+
+Use `reportError()` when you catch an exception and want it to appear as an error event in Logfire:
+
+```ts
+try {
+  await syncCustomer()
+} catch (error) {
+  logfire.reportError('customer sync failed', error as Error, {
+    customer_id: 'cus_123',
+  })
+}
+```
+
+Runtime packages can enable error fingerprinting so related errors group together in Logfire.
+
+## Subpath APIs
+
+`logfire/evals` exports the JavaScript evaluation API. See [Evaluations](../guides/evals.md).
+
+`logfire/vars` exports managed variables. See [Managed Variables](../guides/managed-variables.md).
+
+## Runtime Setup
+
+Use a runtime package unless your platform already configures OpenTelemetry:
+
+- [`@pydantic/logfire-node`](node.md) for Node.js
+- [`@pydantic/logfire-browser`](browser.md) for browsers
+- [`@pydantic/logfire-cf-workers`](cloudflare.md) for Cloudflare Workers

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -1,0 +1,115 @@
+---
+title: Node.js Package
+description: Configure @pydantic/logfire-node for Node.js tracing, logging, metrics, automatic instrumentation, and manual spans.
+---
+
+# `@pydantic/logfire-node`
+
+`@pydantic/logfire-node` is the main package for Node.js applications. It configures the OpenTelemetry Node SDK, exporters, automatic instrumentation, logs, metrics, and the manual `logfire` API.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-node
+```
+
+If you want automatic instrumentation, also install the OpenTelemetry instrumentation packages used by your application. The package expects OpenTelemetry dependencies as peers.
+
+```bash
+npm install @opentelemetry/auto-instrumentations-node
+```
+
+## Configure
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'payments-api',
+  serviceVersion: '1.0.0',
+  environment: 'production',
+})
+```
+
+The write token is read from `LOGFIRE_TOKEN` unless you pass `token`.
+
+## Automatic Instrumentation
+
+Call `configure()` before importing instrumented libraries:
+
+```ts title="instrumentation.ts"
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'payments-api',
+})
+```
+
+Run the app with the instrumentation loaded first:
+
+```bash
+node --import ./instrumentation.js server.js
+```
+
+You can customize Node auto instrumentation with `nodeAutoInstrumentations`:
+
+```ts
+logfire.configure({
+  nodeAutoInstrumentations: {
+    '@opentelemetry/instrumentation-fs': { enabled: false },
+    '@opentelemetry/instrumentation-http': { enabled: true },
+  },
+  serviceName: 'payments-api',
+})
+```
+
+## Manual API
+
+The package re-exports `logfire`, so you can use the same import for setup and spans:
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+await logfire.span('charge card', {
+  attributes: { amount: 42.5, currency: 'USD' },
+  callback: async () => {
+    logfire.info('calling payment provider')
+  },
+})
+```
+
+## Logs and Metrics
+
+Logs and metrics are sent to Logfire by default when a token is present. Disable metrics when you only want traces and logs:
+
+```ts
+logfire.configure({
+  metrics: false,
+  serviceName: 'worker',
+})
+```
+
+Use `console: true` to also print spans to the console while developing:
+
+```ts
+logfire.configure({
+  console: true,
+  serviceName: 'worker',
+})
+```
+
+## Short-Lived Scripts
+
+Flush before process exit:
+
+```ts
+await logfire.forceFlush()
+await logfire.shutdown()
+```
+
+## Related Guides
+
+- [Configuration](../guides/configuration.md)
+- [Sampling](../guides/sampling.md)
+- [Scrubbing](../guides/scrubbing.md)
+- [Resource Attributes](../guides/resource-attributes.md)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,74 @@
+---
+title: API Overview
+description: Overview of the main TypeScript SDK exports and package entry points.
+---
+
+# API Overview
+
+This page is a package-level map of the public TypeScript SDK APIs. It is not a generated API reference.
+
+## `logfire`
+
+Manual tracing and logging:
+
+- `span(message, options)` and `span(message, attributes, options, callback)`
+- `startSpan(message, attributes?, options?)`
+- `log()`, `trace()`, `debug()`, `info()`, `notice()`, `warning()`, `error()`, `fatal()`
+- `reportError(message, error, extraAttributes?)`
+- `Level`
+
+Configuration helpers and utilities:
+
+- `configureLogfireApi()`
+- `logfireApiConfig`
+- `resolveBaseUrl()`
+- `resolveSendToLogfire()`
+- `serializeAttributes()`
+- `LogfireAttributeScrubber`
+- `NoopAttributeScrubber`
+- `TailSamplingProcessor`
+- `ULIDGenerator`
+- sampling helpers such as `levelOrDuration()`
+
+Subpaths:
+
+- `logfire/evals`
+- `logfire/vars`
+
+## `@pydantic/logfire-node`
+
+Node.js runtime setup:
+
+- `configure(options?)`
+- `logfireConfig`
+- `forceFlush()`
+- `shutdown()`
+- `DiagLogLevel`
+
+The package also re-exports the public API from `logfire`.
+
+## `@pydantic/logfire-browser`
+
+Browser runtime setup:
+
+- `configure(options)` returns an async shutdown function
+- `DiagLogLevel`
+
+The package also re-exports the public API from `logfire`.
+
+## `@pydantic/logfire-cf-workers`
+
+Cloudflare Worker setup:
+
+- `instrument(handler, config)`
+- `instrumentInProcess(handler, config)`
+- `instrumentTail(handler, config)`
+- `getTailConfig(config)`
+- `exportTailEventsToLogfire(events, env)`
+
+Unlike the Node and browser packages, this package does not re-export the manual `logfire` API as named exports. Import spans, logs, and `reportError` from `logfire` directly:
+
+```ts
+import * as logfire from 'logfire'
+import { instrument } from '@pydantic/logfire-cf-workers'
+```

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,50 @@
+---
+title: Environment Variables
+description: Environment variables used by the Logfire TypeScript SDK packages.
+---
+
+# Environment Variables
+
+## Node.js
+
+`@pydantic/logfire-node` reads these variables:
+
+| Variable                      | Purpose                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------ |
+| `LOGFIRE_TOKEN`               | Write token used to send traces, metrics, and logs to Logfire.           |
+| `LOGFIRE_API_KEY`             | API key for platform APIs such as remote managed variables.              |
+| `LOGFIRE_SERVICE_NAME`        | Service name resource metadata.                                          |
+| `LOGFIRE_SERVICE_VERSION`     | Service version resource metadata.                                       |
+| `LOGFIRE_ENVIRONMENT`         | Deployment environment resource metadata.                                |
+| `LOGFIRE_CONSOLE`             | Set to `true` to also print spans to the console.                        |
+| `LOGFIRE_SEND_TO_LOGFIRE`     | Set sending behavior. `if-token-present` sends only when a token exists. |
+| `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
+| `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`.                                      |
+| `LOGFIRE_BASE_URL`            | Override the Logfire API base URL.                                       |
+
+## Cloudflare Workers
+
+`@pydantic/logfire-cf-workers` reads Worker environment values:
+
+| Variable              | Purpose                                  |
+| --------------------- | ---------------------------------------- |
+| `LOGFIRE_TOKEN`       | Write token used by the Worker exporter. |
+| `LOGFIRE_ENVIRONMENT` | Deployment environment metadata.         |
+| `LOGFIRE_BASE_URL`    | Override the Logfire API base URL.       |
+
+Store production values as Worker secrets.
+
+## Browser
+
+`@pydantic/logfire-browser` does not read Logfire credentials from environment variables. Configure a `traceUrl` that points at your backend proxy.
+
+## Generic OpenTelemetry
+
+Platforms such as Deno and Vercel's OpenTelemetry integration use standard OTLP environment variables:
+
+| Variable                              | Purpose                                                                 |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`         | Base OTLP endpoint, such as `https://logfire-api.pydantic.dev`.         |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  | Trace endpoint, such as `https://logfire-api.pydantic.dev/v1/traces`.   |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metric endpoint, such as `https://logfire-api.pydantic.dev/v1/metrics`. |
+| `OTEL_EXPORTER_OTLP_HEADERS`          | Headers for OTLP export, including `Authorization=your-write-token`.    |


### PR DESCRIPTION
## Summary
- Add a package-oriented TypeScript SDK documentation chapter under docs/
- Cover the logfire, Node.js, browser, and Cloudflare Workers packages
- Add framework/runtime guides for Express, Next.js, Deno, and Vercel AI SDK
- Add guides for configuration, resource attributes, sampling, scrubbing, evaluations, managed variables, environment variables, and API overview
- Add docs/nav.json so unified-docs can publish this as a Logfire subchapter

## Validation
- pnpm run format-check
- node nav/file existence check for docs/nav.json
- USE_LOCAL_COPY=1 pnpm build in unified-docs