### PR TITLE
Rename logfire docs section to Core API

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -14,7 +14,7 @@
         "label": "Packages",
         "items": [
           {
-            "label": "logfire",
+            "label": "Core API",
             "slug": "packages/logfire"
           },
           {

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -1,9 +1,9 @@
 ---
-title: logfire Package
+title: Core API Package
 description: Manual tracing, structured logs, error reporting, evaluations, and managed variables with the runtime-agnostic logfire package.
 ---
 
-# `logfire`
+# Core API
 
 The `logfire` package is the runtime-agnostic manual API. It does not configure a runtime SDK by itself; use it with a configured OpenTelemetry provider, or import it through a runtime package such as `@pydantic/logfire-node`, `@pydantic/logfire-browser`, or `@pydantic/logfire-cf-workers`.
 


### PR DESCRIPTION
## Summary
- Rename the Packages sidebar entry for the runtime-agnostic `logfire` package to "Core API".
- Update the destination page title and H1 to match the sidebar label.

## Why
The previous `logfire` label looked inconsistent next to the runtime package labels (`Node.js`, `Browser`, and `Cloudflare Workers`). "Core API" describes the package role without colliding with the Reference API overview.

## Testing
- Commit hook: `vp check --fix` on staged docs files
- Pre-push hook: package builds and tests completed successfully