### PR TITLE
Update browser proxy docs for public forwarding API

### DIFF
--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -79,11 +79,7 @@ For Next.js, see [Next.js](../frameworks/nextjs.md). For a standalone browser ex
 
 ## Python Backend Proxy
 
-Python backends can use the public `logfire.forward_export_request_starlette` and `logfire.forward_export_request` helpers to create a telemetry ingress endpoint without exposing the write token.
-
-These helpers validate incoming OTLP export requests, admit accepted payloads to the configured Logfire forwarding pipeline, and return an OTLP export response to the browser. An HTTP 200 OTLP success response means the Python process accepted the payload for local forwarding; it does not mean Logfire has already received, processed, or stored that telemetry.
-
-Forwarded OTLP request bodies are treated as opaque payloads. The Python helper does not parse, split, merge, rewrite, or apply Python-side scrubbing to browser telemetry before forwarding it, so scrub or filter sensitive browser/client attributes before they reach this endpoint.
+Python backends can use the `logfire.forward_export_request_starlette` and `logfire.forward_export_request` helpers to create a telemetry ingress endpoint without exposing the write token.
 
 For FastAPI, mount `logfire.forward_export_request_starlette` on a path that captures the OTLP suffix:
 
@@ -106,24 +102,7 @@ async def proxy_browser_telemetry(request: Request):
     return await logfire.forward_export_request_starlette(request)
 ```
 
-The `{path:path}` route parameter is required so `/logfire-proxy/v1/traces` forwards the `/v1/traces` OTLP path. The helper rejects paths other than `/v1/traces`, `/v1/logs`, and `/v1/metrics`, strips incoming credentials, adds the configured Logfire token, and limits request bodies to 50 MB by default.
-
-For Starlette, mount the same handler as a route:
-
-```py title="main.py" skip-run="true" skip-reason="server-start"
-from starlette.applications import Starlette
-from starlette.routing import Route
-
-import logfire
-
-logfire.configure()
-
-app = Starlette(
-    routes=[
-        Route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST']),
-    ],
-)
-```
+The `{path:path}` route parameter is required. The helper rejects paths other than `/v1/traces`, `/v1/logs`, and `/v1/metrics` so that it can forward to the appropriate Logfire backend endpoint. Starlette apps can use the same helper on an equivalent `POST` route, with authentication, session, CORS, and rate-limiting controls applied through middleware or the route wrapper before the handler runs.
 
 For Django, Flask, Litestar, or a custom HTTP server, use `forward_export_request` directly:
 

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -81,9 +81,9 @@ For Next.js, see [Next.js](../frameworks/nextjs.md). For a standalone browser ex
 
 Python backends can use the `logfire.forward_export_request_starlette` and `logfire.forward_export_request` helpers to create a telemetry ingress endpoint without exposing the write token.
 
-For FastAPI, mount `logfire.forward_export_request_starlette` on a path that captures the OTLP suffix:
+For FastAPI/Starlette, use `logfire.forward_export_request_starlette` in an endpoint, for example:
 
-```py title="main.py" skip-run="true" skip-reason="server-start"
+```py title="main.py"
 from fastapi import Depends, FastAPI, Request
 
 import logfire
@@ -102,11 +102,11 @@ async def proxy_browser_telemetry(request: Request):
     return await logfire.forward_export_request_starlette(request)
 ```
 
-The `{path:path}` route parameter is required. The helper rejects paths other than `/v1/traces`, `/v1/logs`, and `/v1/metrics` so that it can forward to the appropriate Logfire backend endpoint. Starlette apps can use the same helper on an equivalent `POST` route, with authentication, session, CORS, and rate-limiting controls applied through middleware or the route wrapper before the handler runs.
+The `{path:path}` route parameter is required. `forward_export_request_starlette` rejects paths other than `/v1/traces`, `/v1/logs`, and `/v1/metrics` so that it can forward to the appropriate Logfire backend endpoint.
 
-For Django, Flask, Litestar, or a custom HTTP server, use `forward_export_request` directly:
+For Django, Flask, Litestar, or a custom HTTP server, use `forward_export_request` directly, e.g:
 
-```py title="main.py" skip-run="true" skip-reason="server-start"
+```py title="main.py"
 import logfire
 
 logfire.configure()

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -31,7 +31,7 @@ logfire.configure({
 })
 ```
 
-`traceUrl` should point to a server-side endpoint that forwards OTLP trace requests to Logfire and adds the `Authorization` header on the server.
+`traceUrl` should point to a server-side endpoint that accepts OTLP trace requests from your browser instrumentation, forwards them to Logfire, and adds the `Authorization` header on the server.
 
 Use `diagLogLevel` while troubleshooting local browser instrumentation:
 
@@ -79,28 +79,31 @@ For Next.js, see [Next.js](../frameworks/nextjs.md). For a standalone browser ex
 
 ## Python Backend Proxy
 
-Python backends can use the experimental `logfire.experimental.forwarding` helpers to forward browser OTLP requests without exposing the write token.
+Python backends can use the public `logfire.forward_export_request_starlette` and `logfire.forward_export_request` helpers to create a telemetry ingress endpoint without exposing the write token.
 
-For FastAPI, mount `logfire_proxy` on a path that captures the OTLP suffix:
+These helpers validate incoming OTLP export requests, admit accepted payloads to the configured Logfire forwarding pipeline, and return an OTLP export response to the browser. An HTTP 200 OTLP success response means the Python process accepted the payload for local forwarding; it does not mean Logfire has already received, processed, or stored that telemetry.
+
+Forwarded OTLP request bodies are treated as opaque payloads. The Python helper does not parse, split, merge, rewrite, or apply Python-side scrubbing to browser telemetry before forwarding it, so scrub or filter sensitive browser/client attributes before they reach this endpoint.
+
+For FastAPI, mount `logfire.forward_export_request_starlette` on a path that captures the OTLP suffix:
 
 ```py title="main.py" skip-run="true" skip-reason="server-start"
 from fastapi import Depends, FastAPI, Request
 
 import logfire
-from logfire.experimental.forwarding import logfire_proxy
 
 logfire.configure()
 app = FastAPI()
 
 
 async def verify_user_session():
-    # Add authentication, rate limiting, or origin checks here.
+    # Add authentication, session, rate limiting, or origin checks here.
     pass
 
 
 @app.post('/logfire-proxy/{path:path}', dependencies=[Depends(verify_user_session)])
 async def proxy_browser_telemetry(request: Request):
-    return await logfire_proxy(request)
+    return await logfire.forward_export_request_starlette(request)
 ```
 
 The `{path:path}` route parameter is required so `/logfire-proxy/v1/traces` forwards the `/v1/traces` OTLP path. The helper rejects paths other than `/v1/traces`, `/v1/logs`, and `/v1/metrics`, strips incoming credentials, adds the configured Logfire token, and limits request bodies to 50 MB by default.
@@ -112,13 +115,12 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 
 import logfire
-from logfire.experimental.forwarding import logfire_proxy
 
 logfire.configure()
 
 app = Starlette(
     routes=[
-        Route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST']),
+        Route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST']),
     ],
 )
 ```
@@ -127,13 +129,12 @@ For Django, Flask, Litestar, or a custom HTTP server, use `forward_export_reques
 
 ```py title="main.py" skip-run="true" skip-reason="server-start"
 import logfire
-from logfire.experimental.forwarding import forward_export_request
 
 logfire.configure()
 
 
 def my_custom_proxy_route(request):
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path=request.path.removeprefix('/logfire-proxy'),
         headers=request.headers,
         body=request.read(),
@@ -146,7 +147,7 @@ def my_custom_proxy_route(request):
     )
 ```
 
-Protect this endpoint in production. Any client that can reach it can send telemetry to your Logfire project.
+Protect this endpoint in production. Treat browser telemetry ingress like any other externally reachable write endpoint: clients can be numerous, retry requests, duplicate payloads, or send malicious data. Use your normal authentication, session, CORS, and rate-limiting controls. Configure CORS for the app origin that should send telemetry; avoid `*` unless you intentionally operate a public telemetry ingestion endpoint.
 
 ## Shutdown
 


### PR DESCRIPTION
Update browser proxy docs to use `logfire.forward_export_request_starlette` and `logfire.forward_export_request` instead of experimental forwarding imports, added in https://github.com/pydantic/logfire/pull/1974.