### PR TITLE
PYD-3529 Close Logfire JS manual API parity gaps

### DIFF
--- a/.changeset/baggage-span-attributes.md
+++ b/.changeset/baggage-span-attributes.md
@@ -1,0 +1,7 @@
+---
+'logfire': minor
+'@pydantic/logfire-node': patch
+'@pydantic/logfire-browser': patch
+---
+
+Add opt-in baggage projection for Logfire JS manual span attributes.

--- a/.changeset/function-instrumentation.md
+++ b/.changeset/function-instrumentation.md
@@ -1,0 +1,8 @@
+---
+'logfire': minor
+'@pydantic/logfire-node': patch
+'@pydantic/logfire-browser': patch
+'@pydantic/logfire-cf-workers': patch
+---
+
+Add a core `instrument(fn, options?)` wrapper for manual function spans.

--- a/.changeset/json-schema-metadata.md
+++ b/.changeset/json-schema-metadata.md
@@ -1,0 +1,7 @@
+---
+'logfire': minor
+'@pydantic/logfire-node': patch
+'@pydantic/logfire-browser': patch
+---
+
+Add richer bounded JSON schema metadata for serialized object and array attributes, with `jsonSchema` modes for rich, legacy broad, or disabled schema metadata.

--- a/.changeset/min-level-filtering.md
+++ b/.changeset/min-level-filtering.md
@@ -1,0 +1,7 @@
+---
+'logfire': minor
+'@pydantic/logfire-node': patch
+'@pydantic/logfire-browser': patch
+---
+
+Add configurable minimum-level filtering for manual Logfire telemetry.

--- a/.changeset/node-console-output-options.md
+++ b/.changeset/node-console-output-options.md
@@ -1,0 +1,8 @@
+---
+'@pydantic/logfire-node': minor
+---
+
+Add Node object-style console output options for minimum level, tags, and timestamps.
+
+`console: true` and `LOGFIRE_CONSOLE=true` now use an `info` console minimum by default. Use `console: { minLevel: 'debug' }`
+or `console: { minLevel: 'trace' }` to print lower-severity output locally.

--- a/.changeset/otel-service-env.md
+++ b/.changeset/otel-service-env.md
@@ -1,0 +1,6 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Read `OTEL_SERVICE_NAME` and `OTEL_SERVICE_VERSION` as Node service metadata fallbacks when the corresponding `LOGFIRE_*`
+environment variables are unset.

--- a/.changeset/report-error-options.md
+++ b/.changeset/report-error-options.md
@@ -1,0 +1,8 @@
+---
+'logfire': minor
+'@pydantic/logfire-browser': patch
+'@pydantic/logfire-cf-workers': patch
+'@pydantic/logfire-node': patch
+---
+
+Add `reportError()` options for tags and parent spans, and allow reporting unknown caught values.

--- a/.changeset/scoped-manual-clients.md
+++ b/.changeset/scoped-manual-clients.md
@@ -1,7 +1,7 @@
 ---
 'logfire': minor
-'@pydantic/logfire-browser': patch
-'@pydantic/logfire-cf-workers': patch
+'@pydantic/logfire-browser': minor
+'@pydantic/logfire-cf-workers': minor
 '@pydantic/logfire-node': patch
 ---
 

--- a/.changeset/scoped-manual-clients.md
+++ b/.changeset/scoped-manual-clients.md
@@ -1,0 +1,8 @@
+---
+'logfire': minor
+'@pydantic/logfire-browser': patch
+'@pydantic/logfire-cf-workers': patch
+'@pydantic/logfire-node': patch
+---
+
+Add scoped manual API clients with `withTags()` and `withSettings()` for reusable tags and default levels.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "apply_patch|functions.apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/vp-check-fix-changed.sh\"",
+            "timeout": 60,
+            "statusMessage": "Running vp check --fix on changed files"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/vp-check-fix-changed.sh
+++ b/.codex/hooks/vp-check-fix-changed.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+mapfile -t files < <(
+  {
+    git diff --name-only --diff-filter=ACMR
+    git diff --cached --name-only --diff-filter=ACMR
+    git ls-files --others --exclude-standard
+  } |
+    awk '
+      /\.(js|ts|tsx|mjs|mts|json|md|ya?ml)$/ {
+        if ($0 ~ /^(packages|examples|docs|\.changeset)\// || $0 ~ /^\.codex\/hooks\.json$/ || $0 ~ /^(package\.json|pnpm-workspace\.yaml|vite\.config\.ts|README\.md|AGENTS\.md)$/) {
+          print
+        }
+      }
+    ' |
+    sort -u
+)
+
+if [ "${#files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+vp check --fix "${files[@]}"

--- a/README.md
+++ b/README.md
@@ -693,6 +693,28 @@ control the behavior of the instrumentation. Alternatively, you can
 [use environment variables](https://logfire.pydantic.dev/docs/reference/configuration/#programmatically-via-configure)
 to configure the instrumentation.
 
+In Node.js, `console: true` or `LOGFIRE_CONSOLE=true` prints spans to the
+console with a default console minimum level of `info`. Use object-style
+console options when you want to tune local console output without changing
+which telemetry is created:
+
+```ts
+logfire.configure({
+  console: {
+    minLevel: 'warning',
+    includeTags: true,
+    includeTimestamps: false,
+  },
+})
+```
+
+Browser and Cloudflare configuration currently support only boolean `console`
+values.
+
+Spans without a Logfire level, including ordinary auto-instrumentation spans,
+are treated as `info` for console filtering, so `console.minLevel` above `info`
+hides those spans from local console output.
+
 ## Trace API
 
 The `logfire` package exports several convenience wrappers around the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,28 @@ logfire.configure({
 })
 ```
 
-In Node.js, `LOGFIRE_CONSOLE=true` has the same effect.
+In Node.js, `LOGFIRE_CONSOLE=true` has the same effect and uses a console
+minimum level of `info`, matching Python's default. To tune Node console output
+without changing which telemetry is created, pass object-style console options:
+
+```ts
+logfire.configure({
+  console: {
+    minLevel: 'warning',
+    includeTags: true,
+    includeTimestamps: false,
+  },
+  serviceName: 'local-worker',
+})
+```
+
+`console.minLevel` filters console output only. SDK-level `minLevel` controls
+whether manual Logfire telemetry is created. Browser and Cloudflare
+configuration currently support only boolean `console` values.
+
+Spans without a Logfire level, including ordinary auto-instrumentation spans,
+are treated as `info` for console filtering. Setting `console.minLevel` above
+`info` hides those spans from local console output.
 
 ## Minimum Level
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,17 @@ LOGFIRE_SERVICE_VERSION=1.0.0
 LOGFIRE_ENVIRONMENT=production
 ```
 
+Node.js also accepts standard OpenTelemetry service metadata when the
+Logfire-specific variables are omitted:
+
+```bash
+OTEL_SERVICE_NAME=checkout-api
+OTEL_SERVICE_VERSION=1.0.0
+```
+
+Precedence is `configure()` options, then `LOGFIRE_*` environment variables,
+then `OTEL_*` environment variables.
+
 ## Tokens
 
 Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser code must not receive the token; use a backend proxy and configure `traceUrl` instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,33 @@ logfire.configure({
 
 In Node.js, `LOGFIRE_CONSOLE=true` has the same effect.
 
+## Minimum Level
+
+Use `minLevel` to stop low-severity manual Logfire telemetry before spans are
+created. This is not console-output filtering; console configuration is
+separate.
+
+```ts
+logfire.configure({
+  minLevel: 'warning',
+  serviceName: 'checkout-api',
+})
+```
+
+`minLevel` accepts `trace`, `debug`, `info`, `notice`, `warning`, `error`, or
+`fatal`, or numeric values from `logfire.Level`. Set `minLevel: null` to disable
+a previously configured minimum. In Node.js, `LOGFIRE_MIN_LEVEL=warning` has
+the same effect when the code configuration omits `minLevel`; invalid
+environment values are warned about and ignored.
+
+The filter applies to manual Logfire APIs. Log helpers and `reportError()` are
+filtered by their level. `span()`, `startSpan()`, `startPendingSpan()`, and
+`instrument()` are filtered only when the call or scoped client sets an
+explicit level, so ordinary duration spans without a level are preserved. If a
+filtered `span()` callback throws or rejects, the error still propagates to your
+code but Logfire does not record it. Use `reportError()` or a span level at or
+above the minimum when errors should always be reported.
+
 ## Sending Control
 
 Node.js defaults to sending telemetry when a token is present. You can override this:

--- a/docs/frameworks/express.md
+++ b/docs/frameworks/express.md
@@ -45,8 +45,8 @@ app.get('/rolldice', (_req, res) => {
   res.send(String(Math.floor(Math.random() * 6) + 1))
 })
 
-app.use((err: Error, _req: express.Request, res: express.Response, _next: () => unknown) => {
-  logfire.reportError('express request failed', err)
+app.use((err: Error, req: express.Request, res: express.Response, _next: () => unknown) => {
+  logfire.reportError('express request failed', err, { path: req.path }, { tags: ['express'] })
   res.status(500).send('internal server error')
 })
 

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -64,6 +64,31 @@ window.addEventListener('error', (event) => {
 })
 ```
 
+## Baggage Span Attributes
+
+Use `baggage.spanAttributes` to copy selected active OpenTelemetry baggage
+values onto Logfire manual spans and logs:
+
+```ts
+logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'web-app',
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+Projection is disabled by default and allowlisted. Configured key `tenant` is
+emitted as `baggage.tenant` on manual spans/logs, including `span()`,
+`startSpan()`, `startPendingSpan()`, log helpers, `reportError()`, scoped
+clients, and `instrument()` spans. Explicit attributes win on conflict, missing
+keys are ignored, and values are truncated to 1000 characters.
+
+Baggage propagates across service boundaries. Do not store secrets,
+credentials, session cookies, raw emails, or other sensitive user data in
+baggage.
+
 ## Proxy Requirement
 
 A browser proxy should:

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -60,9 +60,7 @@ Report caught errors with `reportError()`:
 
 ```ts
 window.addEventListener('error', (event) => {
-  if (event.error instanceof Error) {
-    logfire.reportError('uncaught browser error', event.error)
-  }
+  logfire.reportError('uncaught browser error', event.error, { filename: event.filename }, { tags: ['browser'] })
 })
 ```
 

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -64,6 +64,26 @@ window.addEventListener('error', (event) => {
 })
 ```
 
+## Minimum Level Filtering
+
+Use `minLevel` to suppress low-severity manual Logfire telemetry before spans
+are created:
+
+```ts
+logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'web-app',
+  minLevel: 'warning',
+})
+```
+
+Browser configuration does not read Logfire environment variables. Pass
+`minLevel` in code, or pass `minLevel: null` to clear a previous setting. The
+filter applies to manual Logfire APIs. Log helpers and `reportError()` are
+filtered by their level; `span()`, `startSpan()`, `startPendingSpan()`, and
+`instrument()` are filtered only when the call or scoped client sets an
+explicit level.
+
 ## Baggage Span Attributes
 
 Use `baggage.spanAttributes` to copy selected active OpenTelemetry baggage

--- a/docs/packages/cloudflare.md
+++ b/docs/packages/cloudflare.md
@@ -64,6 +64,15 @@ export default instrument(handler, {
 
 `instrument()` is an alias for `instrumentInProcess()`. It reads `LOGFIRE_TOKEN`, `LOGFIRE_ENVIRONMENT`, and `LOGFIRE_BASE_URL` from the Worker environment.
 
+This `instrument(handler, config)` function is the Cloudflare Worker runtime
+entrypoint. If you also want to wrap an individual business function in a
+manual span, import the core wrapper from `logfire` directly:
+
+```ts
+import { instrument as instrumentFunction } from 'logfire'
+import { instrument as instrumentWorker } from '@pydantic/logfire-cf-workers'
+```
+
 ## Tail Workers
 
 The package also supports Cloudflare Tail Worker flows:

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -172,6 +172,36 @@ logfire.error('payment provider failed', { provider: 'stripe' })
 
 Message templates become structured telemetry. Attribute values are attached to the span and are available for search and SQL queries.
 
+## Minimum Level Filtering
+
+Configure `minLevel` to suppress low-severity manual Logfire telemetry before a
+span is created. This is separate from console-output configuration.
+
+```ts
+import * as logfire from 'logfire'
+
+logfire.configureLogfireApi({
+  minLevel: 'warning',
+})
+```
+
+The accepted names are `trace`, `debug`, `info`, `notice`, `warning`, `error`,
+and `fatal`. You can also pass numeric values from `logfire.Level`, such as
+`logfire.Level.Warning`. Set `minLevel: null` to clear a previous setting.
+
+Log helpers are filtered by their level, and `log()` defaults to
+`logfire.Level.Info`. `reportError()` uses `logfire.Level.Error`. Duration-style
+APIs such as `span()`, `startSpan()`, `startPendingSpan()`, and `instrument()`
+are filtered only when the call or a scoped client sets an explicit `level`.
+This preserves ordinary unlevelled spans while still allowing opt-in debug span
+filtering.
+
+When a filtered `span()` call uses a callback, Logfire still runs the callback
+with a no-op span. If the callback throws or rejects, that error propagates to
+your code normally, but Logfire does not record it because the call was
+filtered. Use `reportError()` or a span level at or above the minimum when
+errors should always be reported.
+
 ## Errors
 
 Use `reportError()` when you catch an exception and want it to appear as an error event in Logfire:

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -119,13 +119,30 @@ Use `reportError()` when you catch an exception and want it to appear as an erro
 try {
   await syncCustomer()
 } catch (error) {
-  logfire.reportError('customer sync failed', error as Error, {
-    customer_id: 'cus_123',
-  })
+  logfire.reportError('customer sync failed', error, { customer_id: 'cus_123' }, { tags: ['customers'] })
 }
 ```
 
-Runtime packages can enable error fingerprinting so related errors group together in Logfire.
+The caught value can be `unknown`; real `Error` values keep their stack traces
+and can be fingerprinted for grouping. The third argument is always structured
+attributes. Use the optional fourth argument for report options such as `tags`
+or `parentSpan`.
+
+Scoped clients merge their tags with per-call `reportError()` tags:
+
+```ts
+const customers = logfire.withTags('customers')
+
+try {
+  await syncCustomer()
+} catch (error) {
+  customers.reportError('customer sync failed', error, { customer_id: 'cus_123' }, { tags: ['sync'] })
+}
+```
+
+Runtime packages can enable error fingerprinting so related errors group
+together in Logfire. The JavaScript API does not include a Python-style
+`exception()` helper in this first pass; use explicit catch blocks.
 
 ## Subpath APIs
 

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -205,6 +205,64 @@ Runtime packages can enable error fingerprinting so related errors group
 together in Logfire. The JavaScript API does not include a Python-style
 `exception()` helper in this first pass; use explicit catch blocks.
 
+## Baggage Projection And Propagation
+
+Use `baggage.spanAttributes` when stable OpenTelemetry baggage values should be
+copied onto Logfire manual spans and logs:
+
+```ts
+import { configureLogfireApi } from 'logfire'
+
+configureLogfireApi({
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+The Node and browser runtime packages expose the same config shape through
+`logfire.configure()`. Projection is disabled by default and uses an explicit
+allowlist. It affects manual `span()`, `startSpan()`, `startPendingSpan()`, log
+helpers, `reportError()`, scoped clients, and `instrument()` spans. Automatic
+instrumentation spans are not changed by this option.
+
+Allowlisted baggage key `tenant` is emitted as `baggage.tenant`. If a call
+already sets `baggage.tenant` in its explicit attributes, the explicit
+attribute wins. Missing baggage keys are ignored, baggage metadata is ignored,
+and baggage values remain strings truncated to 1000 characters.
+
+Baggage is propagated across service boundaries. Do not store secrets,
+credentials, session cookies, raw emails, or other sensitive user data in
+baggage. Treat incoming trace context and baggage from untrusted callers as
+untrusted input.
+
+For non-HTTP carriers such as queue messages or background-job metadata, use
+OpenTelemetry propagation APIs directly:
+
+```ts
+import { context, propagation } from '@opentelemetry/api'
+import * as logfire from 'logfire'
+
+const carrier: Record<string, string> = {}
+propagation.inject(context.active(), carrier)
+
+// Later, in a worker or queue consumer:
+const extractedContext = propagation.extract(context.active(), carrier)
+await context.with(extractedContext, async () => {
+  await logfire.span('process job', {
+    callback: async () => processJob(),
+  })
+})
+```
+
+A carrier is a serializable object such as HTTP headers, queue metadata, or job
+attributes. OpenTelemetry `Context` is runtime-local execution state and is not
+serializable. Baggage is propagated key/value metadata inside that context.
+Logfire JS intentionally does not add generic `getContext()` /
+`attachContext()` / `injectContext()` / `extractContext()` wrappers in this
+first pass; use OpenTelemetry APIs directly when moving context between
+processes or async execution boundaries.
+
 ## Subpath APIs
 
 `logfire/evals` exports the JavaScript evaluation API. See [Evaluations](../evals.md).

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -34,8 +34,8 @@ await payments.span('capture payment', {
 ```
 
 Scoped clients expose the same manual methods as the default API, including
-`span()`, `startSpan()`, `startPendingSpan()`, log helpers, `reportError()`,
-`withTags()`, and `withSettings()`.
+`instrument()`, `span()`, `startSpan()`, `startPendingSpan()`, log helpers,
+`reportError()`, `withTags()`, and `withSettings()`.
 
 `withSettings()` currently supports reusable `tags` and a default `level`:
 
@@ -53,6 +53,67 @@ state. Per-call tags are appended after scoped tags, then duplicates are
 removed while preserving first occurrence order. Per-call scalar options such
 as `level` override scoped defaults, while level-specific helpers such as
 `info()` and `error()` keep their explicit levels.
+
+## Function Instrumentation
+
+Use `instrument(fn, options?)` to wrap a sync or async function in a span while
+preserving the original call signature, `this` value, return value, and thrown
+or rejected errors:
+
+```ts
+import * as logfire from 'logfire'
+
+const fetchProfile = logfire.instrument(
+  async (userId: string) => {
+    return getProfile(userId)
+  },
+  {
+    message: 'fetch profile {user_id}',
+    extractArgs: ['user_id'],
+    tags: ['users'],
+  }
+)
+
+await fetchProfile('user_123')
+```
+
+Supported options include:
+
+- `message`: span message template. Defaults to `Calling ${fn.name || 'function'}`.
+- `spanName`: stable OpenTelemetry span name when it should differ from the message template.
+- `attributes`: static attributes added to every call span.
+- `extractArgs`: `false` by default. Pass an explicit name array for stable positional argument attributes, or `true` for best-effort parameter-name extraction.
+- `recordReturn`: records successful sync or async return values as span attributes on a best-effort basis.
+- `tags`, `level`, and `parentSpan`: forwarded to the underlying span.
+
+Prefer `extractArgs: ['user_id']` in production code. `extractArgs: true`
+parses function source text and may produce unstable names after bundling,
+minification, default parameters, or destructuring. Extracted arguments override
+static `attributes` when they use the same key.
+
+`recordReturn: true` records only successful return values. Serialization is
+best effort; Logfire falls back instead of making a successful function call
+fail because telemetry could not serialize the return value. For async
+functions, the wrapper may return an equivalent chained promise so the resolved
+or rejected value is preserved while the return value is recorded before the
+span closes.
+
+Scoped clients merge their settings with per-wrapper options:
+
+```ts
+const users = logfire.withSettings({
+  tags: ['users'],
+  level: logfire.Level.Debug,
+})
+
+const fetchProfileWithSpan = users.instrument(fetchProfileImpl, {
+  message: 'fetch profile {user_id}',
+  extractArgs: ['user_id'],
+})
+```
+
+TypeScript decorators are intentionally not part of the JavaScript API in this
+first pass.
 
 ## Spans
 

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -172,6 +172,44 @@ logfire.error('payment provider failed', { provider: 'stripe' })
 
 Message templates become structured telemetry. Attribute values are attached to the span and are available for search and SQL queries.
 
+## Attribute Serialization
+
+OpenTelemetry span attributes are scalar values or scalar arrays, so Logfire
+serializes object and array attributes as JSON strings and adds
+`logfire.json_schema` metadata to help the backend render them as structured
+values.
+
+By default, Logfire emits bounded best-effort nested schema metadata for
+ordinary JSON-like values:
+
+```ts
+logfire.info('order received', {
+  order: {
+    id: 'ord_123',
+    items: [{ sku: 'sku_123', quantity: 2 }],
+  },
+})
+```
+
+Schema inference is intentionally limited to normal JavaScript JSON-like data
+such as objects, arrays, strings, numbers, booleans, `null`, and dates. It is
+bounded by internal depth, object-property, and array-sampling limits. Exotic
+objects fall back to broad metadata, and values that cannot be serialized are
+recorded as `"[unserializable]"` instead of making application code fail.
+
+Configure `jsonSchema` when you need a cheaper or quieter mode:
+
+```ts
+logfire.configureLogfireApi({
+  jsonSchema: 'basic',
+})
+```
+
+Use `jsonSchema: 'basic'` for legacy broad top-level `object`/`array` schemas,
+or `jsonSchema: false` to omit `logfire.json_schema` entirely. This only
+controls schema metadata; object and array attributes are still serialized as
+JSON strings.
+
 ## Minimum Level Filtering
 
 Configure `minLevel` to suppress low-severity manual Logfire telemetry before a

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -13,6 +13,47 @@ Install it directly when a package or framework already configures OpenTelemetry
 npm install logfire
 ```
 
+## Scoped Clients
+
+Use `withTags()` or `withSettings()` to create a bound manual API client with
+stable defaults:
+
+```ts
+import * as logfire from 'logfire'
+
+const payments = logfire.withTags('payments')
+
+payments.info('payment authorized', { payment_id: 'pay_123' })
+
+await payments.span('capture payment', {
+  attributes: { payment_id: 'pay_123' },
+  callback: async () => {
+    return capturePayment('pay_123')
+  },
+})
+```
+
+Scoped clients expose the same manual methods as the default API, including
+`span()`, `startSpan()`, `startPendingSpan()`, log helpers, `reportError()`,
+`withTags()`, and `withSettings()`.
+
+`withSettings()` currently supports reusable `tags` and a default `level`:
+
+```ts
+const debugTools = logfire.withSettings({
+  tags: ['debug-tools'],
+  level: logfire.Level.Debug,
+})
+
+debugTools.log('raw payload', { payload })
+```
+
+Scoped clients do not mutate global defaults and do not use callback-local
+state. Per-call tags are appended after scoped tags, then duplicates are
+removed while preserving first occurrence order. Per-call scalar options such
+as `level` override scoped defaults, while level-specific helpers such as
+`info()` and `error()` keep their explicit levels.
+
 ## Spans
 
 `span()` starts an active span, runs your callback, records thrown errors, and ends the span automatically.

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -95,6 +95,30 @@ await logfire.span('charge card', {
 })
 ```
 
+## Baggage Span Attributes
+
+Use `baggage.spanAttributes` to copy selected active OpenTelemetry baggage
+values onto Logfire manual spans and logs:
+
+```ts
+logfire.configure({
+  serviceName: 'payments-api',
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+Projection is disabled by default and allowlisted. Configured key `tenant` is
+emitted as `baggage.tenant` on manual spans/logs, including `span()`,
+`startSpan()`, `startPendingSpan()`, log helpers, `reportError()`, scoped
+clients, and `instrument()` spans. Explicit attributes win on conflict, missing
+keys are ignored, and values are truncated to 1000 characters.
+
+Baggage propagates across service boundaries. Do not store secrets,
+credentials, session cookies, raw emails, or other sensitive user data in
+baggage.
+
 ## Logs and Metrics
 
 Logs and metrics are sent to Logfire by default when a token is present. Disable metrics when you only want traces and logs:

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -33,6 +33,12 @@ logfire.configure({
 
 The write token is read from `LOGFIRE_TOKEN` unless you pass `token`.
 
+Service metadata can be configured in code, with Logfire-specific environment
+variables, or with standard OpenTelemetry service variables. Precedence is
+`configure()` options, then `LOGFIRE_SERVICE_NAME` /
+`LOGFIRE_SERVICE_VERSION`, then `OTEL_SERVICE_NAME` /
+`OTEL_SERVICE_VERSION`.
+
 For rotating proxy or OAuth credentials, pass a token provider. The provider is
 resolved by the OpenTelemetry exporters when telemetry is exported, so
 `configure()` remains synchronous:

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -161,6 +161,29 @@ logfire.configure({
 })
 ```
 
+Console output defaults to a minimum level of `info`, matching Python's
+console behavior. To change console output without changing which telemetry is
+created, pass object-style console options:
+
+```ts
+logfire.configure({
+  console: {
+    minLevel: 'warning',
+    includeTags: true,
+    includeTimestamps: false,
+  },
+  serviceName: 'worker',
+})
+```
+
+Use `console: { minLevel: 'debug' }` or `console: { minLevel: 'trace' }` when
+you want lower-severity spans printed locally. `LOGFIRE_CONSOLE=true` remains a
+boolean enable switch and uses the default `info` console minimum.
+
+Spans without a Logfire level, including ordinary auto-instrumentation spans,
+are treated as `info` for console filtering. Setting `console.minLevel` above
+`info` hides those spans from local console output.
+
 ## Flush And Shutdown
 
 Logfire batches telemetry through OpenTelemetry processors. For short-lived

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -95,6 +95,28 @@ await logfire.span('charge card', {
 })
 ```
 
+## Minimum Level Filtering
+
+Use `minLevel` to suppress low-severity manual Logfire telemetry before spans
+are created:
+
+```ts
+logfire.configure({
+  serviceName: 'payments-api',
+  minLevel: 'warning',
+})
+```
+
+Node.js also reads `LOGFIRE_MIN_LEVEL` when `configure()` does not receive a
+`minLevel` option. Code configuration takes precedence over the environment,
+and `minLevel: null` clears a previous setting. Invalid environment values are
+warned about and ignored.
+
+The filter applies to manual Logfire APIs. Log helpers and `reportError()` are
+filtered by their level; `span()`, `startSpan()`, `startPendingSpan()`, and
+`instrument()` are filtered only when the call or scoped client sets an
+explicit level.
+
 ## Baggage Span Attributes
 
 Use `baggage.spanAttributes` to copy selected active OpenTelemetry baggage

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -51,6 +51,22 @@ missing keys are ignored, baggage metadata is ignored, and values are truncated
 to 1000 characters. The Node and browser runtime packages expose the same shape
 through `configure()`.
 
+`configureLogfireApi()` also accepts `minLevel` to suppress low-severity manual
+Logfire telemetry before spans are created. This is separate from console-output
+configuration:
+
+```ts
+configureLogfireApi({
+  minLevel: 'warning',
+})
+```
+
+Use lowercase level names (`trace`, `debug`, `info`, `notice`, `warning`,
+`error`, `fatal`) or numeric values from `Level`. Set `minLevel: null` to clear
+a previously configured minimum. Log helpers and `reportError()` are filtered by
+their level; span-like APIs are filtered only when the call or scoped client
+sets an explicit level.
+
 Subpaths:
 
 - `logfire/evals`
@@ -69,7 +85,8 @@ Node.js runtime setup:
 - `DiagLogLevel`
 
 The package also re-exports the public API from `logfire`.
-Node `configure()` accepts `baggage.spanAttributes` for the shared manual API.
+Node `configure()` accepts `baggage.spanAttributes` and `minLevel` for the
+shared manual API.
 
 ## `@pydantic/logfire-browser`
 
@@ -79,7 +96,8 @@ Browser runtime setup:
 - `DiagLogLevel`
 
 The package also re-exports the public API from `logfire`.
-Browser `configure()` accepts `baggage.spanAttributes` for the shared manual API.
+Browser `configure()` accepts `baggage.spanAttributes` and `minLevel` for the
+shared manual API.
 
 ## `@pydantic/logfire-cf-workers`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -11,6 +11,7 @@ This page is a package-level map of the public TypeScript SDK APIs. It is not a 
 
 Manual tracing and logging:
 
+- `instrument(fn, options?)`
 - `span(message, options)` and `span(message, attributes, options, callback)`
 - `startSpan(message, attributes?, options?)`
 - `startPendingSpan(message, attributes?, options?)`
@@ -76,4 +77,13 @@ Unlike the Node and browser packages, this package does not re-export the manual
 ```ts
 import * as logfire from 'logfire'
 import { instrument } from '@pydantic/logfire-cf-workers'
+```
+
+The Cloudflare package's `instrument(handler, config)` configures Worker
+runtime tracing. To wrap an individual function in a manual span, import the
+core wrapper from `logfire`:
+
+```ts
+import { instrument as instrumentFunction } from 'logfire'
+import { instrument as instrumentWorker } from '@pydantic/logfire-cf-workers'
 ```

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,6 +14,7 @@ Manual tracing and logging:
 - `span(message, options)` and `span(message, attributes, options, callback)`
 - `startSpan(message, attributes?, options?)`
 - `startPendingSpan(message, attributes?, options?)`
+- `withTags(...tags)` and `withSettings(settings)` for scoped manual API clients
 - `log()`, `trace()`, `debug()`, `info()`, `notice()`, `warning()`, `error()`, `fatal()`
 - `reportError(message, error, extraAttributes?)`
 - `Level`

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,7 +16,7 @@ Manual tracing and logging:
 - `startPendingSpan(message, attributes?, options?)`
 - `withTags(...tags)` and `withSettings(settings)` for scoped manual API clients
 - `log()`, `trace()`, `debug()`, `info()`, `notice()`, `warning()`, `error()`, `fatal()`
-- `reportError(message, error, extraAttributes?)`
+- `reportError(message, error, extraAttributes?, options?)`
 - `Level`
 
 Configuration helpers and utilities:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -67,6 +67,21 @@ a previously configured minimum. Log helpers and `reportError()` are filtered by
 their level; span-like APIs are filtered only when the call or scoped client
 sets an explicit level.
 
+`configureLogfireApi()` accepts `jsonSchema` to control schema metadata for
+serialized object and array attributes:
+
+```ts
+configureLogfireApi({
+  jsonSchema: 'rich',
+})
+```
+
+The default `rich` mode emits bounded best-effort nested schema metadata for
+ordinary JSON-like values. Use `basic` to keep legacy broad top-level
+`object`/`array` metadata, or `false` to omit `logfire.json_schema` entirely.
+This setting controls schema metadata only; object and array attributes are
+still serialized as JSON strings.
+
 Subpaths:
 
 - `logfire/evals`
@@ -85,8 +100,9 @@ Node.js runtime setup:
 - `DiagLogLevel`
 
 The package also re-exports the public API from `logfire`.
-Node `configure()` accepts `baggage.spanAttributes` and `minLevel` for the
-shared manual API. It also accepts Node-only object-style console options:
+Node `configure()` accepts `baggage.spanAttributes`, `minLevel`, and
+`jsonSchema` for the shared manual API. It also accepts Node-only object-style
+console options:
 
 ```ts
 logfire.configure({
@@ -110,8 +126,8 @@ Browser runtime setup:
 - `DiagLogLevel`
 
 The package also re-exports the public API from `logfire`.
-Browser `configure()` accepts `baggage.spanAttributes` and `minLevel` for the
-shared manual API.
+Browser `configure()` accepts `baggage.spanAttributes`, `minLevel`, and
+`jsonSchema` for the shared manual API.
 
 ## `@pydantic/logfire-cf-workers`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -34,6 +34,23 @@ Configuration helpers and utilities:
 - `ULIDGenerator`
 - sampling helpers such as `levelOrDuration()`
 
+`configureLogfireApi()` accepts `baggage.spanAttributes` to copy allowlisted
+active OpenTelemetry baggage keys onto Logfire manual spans/logs as
+`baggage.<key>` attributes:
+
+```ts
+configureLogfireApi({
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+Projection is disabled by default. Explicit user attributes win on conflict,
+missing keys are ignored, baggage metadata is ignored, and values are truncated
+to 1000 characters. The Node and browser runtime packages expose the same shape
+through `configure()`.
+
 Subpaths:
 
 - `logfire/evals`
@@ -52,6 +69,7 @@ Node.js runtime setup:
 - `DiagLogLevel`
 
 The package also re-exports the public API from `logfire`.
+Node `configure()` accepts `baggage.spanAttributes` for the shared manual API.
 
 ## `@pydantic/logfire-browser`
 
@@ -61,6 +79,7 @@ Browser runtime setup:
 - `DiagLogLevel`
 
 The package also re-exports the public API from `logfire`.
+Browser `configure()` accepts `baggage.spanAttributes` for the shared manual API.
 
 ## `@pydantic/logfire-cf-workers`
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -86,7 +86,21 @@ Node.js runtime setup:
 
 The package also re-exports the public API from `logfire`.
 Node `configure()` accepts `baggage.spanAttributes` and `minLevel` for the
-shared manual API.
+shared manual API. It also accepts Node-only object-style console options:
+
+```ts
+logfire.configure({
+  console: {
+    minLevel: 'warning',
+    includeTags: true,
+    includeTimestamps: true,
+  },
+})
+```
+
+`console.minLevel` filters console output only. Browser and Cloudflare
+configuration remain boolean-only for console output. Spans without a Logfire
+level are treated as `info` for console filtering.
 
 ## `@pydantic/logfire-browser`
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -16,7 +16,7 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 | `LOGFIRE_SERVICE_NAME`        | Service name resource metadata.                                          |
 | `LOGFIRE_SERVICE_VERSION`     | Service version resource metadata.                                       |
 | `LOGFIRE_ENVIRONMENT`         | Deployment environment resource metadata.                                |
-| `LOGFIRE_CONSOLE`             | Set to `true` to also print spans to the console.                        |
+| `LOGFIRE_CONSOLE`             | Set to `true` to also print spans to the console. Boolean-only.          |
 | `LOGFIRE_MIN_LEVEL`           | Minimum manual Logfire level to emit.                                    |
 | `LOGFIRE_SEND_TO_LOGFIRE`     | Set sending behavior. `if-token-present` sends only when a token exists. |
 | `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
@@ -26,6 +26,11 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 `LOGFIRE_MIN_LEVEL` accepts `trace`, `debug`, `info`, `notice`, `warning`,
 `error`, or `fatal`. Values are matched case-insensitively. Numeric strings are
 not accepted. Invalid values warn with `console.warn` and are ignored.
+
+`LOGFIRE_CONSOLE=true` enables Node console output with the default console
+minimum level of `info`. Object-style console options such as
+`console.minLevel`, `console.includeTags`, and `console.includeTimestamps` are
+available only through code configuration.
 
 ## Cloudflare Workers
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -17,10 +17,15 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 | `LOGFIRE_SERVICE_VERSION`     | Service version resource metadata.                                       |
 | `LOGFIRE_ENVIRONMENT`         | Deployment environment resource metadata.                                |
 | `LOGFIRE_CONSOLE`             | Set to `true` to also print spans to the console.                        |
+| `LOGFIRE_MIN_LEVEL`           | Minimum manual Logfire level to emit.                                    |
 | `LOGFIRE_SEND_TO_LOGFIRE`     | Set sending behavior. `if-token-present` sends only when a token exists. |
 | `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
 | `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`.                                      |
 | `LOGFIRE_BASE_URL`            | Override the Logfire API base URL.                                       |
+
+`LOGFIRE_MIN_LEVEL` accepts `trace`, `debug`, `info`, `notice`, `warning`,
+`error`, or `fatal`. Values are matched case-insensitively. Numeric strings are
+not accepted. Invalid values warn with `console.warn` and are ignored.
 
 ## Cloudflare Workers
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -22,6 +22,11 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 | `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
 | `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`.                                      |
 | `LOGFIRE_BASE_URL`            | Override the Logfire API base URL.                                       |
+| `OTEL_SERVICE_NAME`           | Service name fallback when `LOGFIRE_SERVICE_NAME` is unset.              |
+| `OTEL_SERVICE_VERSION`        | Service version fallback when `LOGFIRE_SERVICE_VERSION` is unset.        |
+
+For service metadata, precedence is code configuration, then `LOGFIRE_*`, then
+`OTEL_*`.
 
 `LOGFIRE_MIN_LEVEL` accepts `trace`, `debug`, `info`, `notice`, `warning`,
 `error`, or `fatal`. Values are matched case-insensitively. Numeric strings are

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -87,6 +87,58 @@ The third argument is always structured attributes. Use the optional fourth
 argument for report options such as `tags` or `parentSpan`. The JavaScript API
 does not include a Python-style `exception()` helper in this first pass.
 
+## Baggage span attributes
+
+Configure an explicit baggage allowlist when stable OpenTelemetry baggage values
+should be copied onto Logfire manual spans and logs:
+
+```ts
+import { configureLogfireApi } from 'logfire'
+
+configureLogfireApi({
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+The Node and browser runtime packages expose the same shape through
+`logfire.configure()`. Projection is disabled by default and affects Logfire
+manual spans/logs, including `span()`, `startSpan()`, `startPendingSpan()`, log
+helpers, `reportError()`, and `instrument()`.
+
+Configured keys are emitted with a `baggage.` prefix, such as
+`baggage.tenant`. User-provided attributes win if they already set the same
+attribute key. Missing baggage keys are ignored, baggage metadata is ignored,
+and values are kept as strings truncated to 1000 characters.
+
+Baggage propagates across service boundaries. Do not store secrets,
+credentials, session cookies, raw emails, or other sensitive user data in
+baggage.
+
+Use OpenTelemetry propagation APIs directly when you need to move context
+through queues or background-job metadata:
+
+```ts
+import { context, propagation } from '@opentelemetry/api'
+import * as logfire from 'logfire'
+
+const carrier: Record<string, string> = {}
+propagation.inject(context.active(), carrier)
+
+const extractedContext = propagation.extract(context.active(), carrier)
+await context.with(extractedContext, async () => {
+  await logfire.span('process job', {
+    callback: async () => processJob(),
+  })
+})
+```
+
+The carrier is a serializable object such as headers or queue metadata.
+OpenTelemetry `Context` is runtime-local and is not serializable. Logfire JS
+does not add generic `getContext()` / `attachContext()` wrappers in this first
+pass; use the OpenTelemetry APIs directly for those cases.
+
 ## Manual pending spans
 
 Use `startPendingSpan()` when you want to show a long-running operation as

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -29,6 +29,47 @@ scoped tags and duplicates are removed while preserving order. `withSettings()`
 currently supports reusable `tags` and a default `level` for calls such as
 `log()` and spans whose options do not set a level.
 
+## Function instrumentation
+
+Use `instrument()` to wrap a sync or async function in a Logfire span without
+changing the function body:
+
+```ts
+import * as logfire from 'logfire'
+
+const fetchCustomer = logfire.instrument(
+  async (customerId: string) => {
+    return loadCustomer(customerId)
+  },
+  {
+    message: 'Fetch customer {customer_id}',
+    extractArgs: ['customer_id'],
+    tags: ['customers'],
+  }
+)
+
+await fetchCustomer('cus_123')
+```
+
+Argument extraction is off by default. Prefer explicit names such as
+`extractArgs: ['customer_id']`; `extractArgs: true` is best effort and can be
+unreliable after bundling or minification. `recordReturn: true` records
+successful return values as telemetry on a best-effort basis, but never makes a
+successful function call fail because return serialization failed.
+
+Scoped clients expose the same wrapper:
+
+```ts
+const customers = logfire.withTags('customers')
+
+const syncCustomer = customers.instrument(syncCustomerImpl, {
+  message: 'Sync customer {customer_id}',
+  extractArgs: ['customer_id'],
+})
+```
+
+TypeScript decorators are intentionally not part of this first pass.
+
 ## Error reporting
 
 Use `reportError()` from explicit catch blocks. The caught value can be

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -29,6 +29,23 @@ scoped tags and duplicates are removed while preserving order. `withSettings()`
 currently supports reusable `tags` and a default `level` for calls such as
 `log()` and spans whose options do not set a level.
 
+## Error reporting
+
+Use `reportError()` from explicit catch blocks. The caught value can be
+`unknown`, matching modern TypeScript catch behavior:
+
+```ts
+try {
+  await syncCustomer()
+} catch (error) {
+  logfire.reportError('Customer sync failed', error, { customer_id: 'cus_123' }, { tags: ['customers'] })
+}
+```
+
+The third argument is always structured attributes. Use the optional fourth
+argument for report options such as `tags` or `parentSpan`. The JavaScript API
+does not include a Python-style `exception()` helper in this first pass.
+
 ## Manual pending spans
 
 Use `startPendingSpan()` when you want to show a long-running operation as

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -95,6 +95,30 @@ errors propagate normally, but Logfire does not record them because the call was
 filtered. Use `reportError()` or a span level at or above the minimum when
 errors should always be reported.
 
+## Attribute serialization
+
+Logfire serializes object and array attributes as JSON strings and adds
+`logfire.json_schema` metadata so the backend can render them as structured
+values. By default, schema metadata uses bounded best-effort inference for
+ordinary JSON-like values such as objects, arrays, strings, numbers, booleans,
+`null`, and dates.
+
+Configure `jsonSchema` when you need a cheaper or quieter mode:
+
+```ts
+import * as logfire from 'logfire'
+
+logfire.configureLogfireApi({
+  jsonSchema: 'basic',
+})
+```
+
+Use `jsonSchema: 'basic'` for legacy broad top-level `object`/`array` schemas,
+or `jsonSchema: false` to omit `logfire.json_schema` entirely. This only
+controls schema metadata; object and array attributes are still serialized as
+JSON strings. Values that cannot be serialized are recorded as
+`"[unserializable]"`.
+
 ## Error reporting
 
 Use `reportError()` from explicit catch blocks. The caught value can be

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -4,6 +4,31 @@ From the team behind [Pydantic Validation](https://pydantic.dev/), **Pydantic Lo
 
 Check the [Github Repository README](https://github.com/pydantic/logfire-js) for more information on how to use the SDK.
 
+## Scoped manual clients
+
+Use `withTags()` or `withSettings()` when several manual spans or logs share
+stable defaults:
+
+```ts
+import * as logfire from 'logfire'
+
+const payments = logfire.withTags('payments')
+
+payments.info('Payment authorized {payment_id}', {
+  payment_id: 'pay_123',
+})
+
+await payments.span('Capture payment {payment_id}', {
+  attributes: { payment_id: 'pay_123' },
+  callback: async () => capturePayment('pay_123'),
+})
+```
+
+Scoped clients do not mutate global defaults. Per-call tags are appended after
+scoped tags and duplicates are removed while preserving order. `withSettings()`
+currently supports reusable `tags` and a default `level` for calls such as
+`log()` and spans whose options do not set a level.
+
 ## Manual pending spans
 
 Use `startPendingSpan()` when you want to show a long-running operation as

--- a/packages/logfire-api/README.md
+++ b/packages/logfire-api/README.md
@@ -70,6 +70,31 @@ const syncCustomer = customers.instrument(syncCustomerImpl, {
 
 TypeScript decorators are intentionally not part of this first pass.
 
+## Minimum level filtering
+
+Use `configureLogfireApi({ minLevel })` to suppress low-severity manual Logfire
+telemetry before spans are created. This is separate from console-output
+configuration:
+
+```ts
+import * as logfire from 'logfire'
+
+logfire.configureLogfireApi({
+  minLevel: 'warning',
+})
+```
+
+`minLevel` accepts `trace`, `debug`, `info`, `notice`, `warning`, `error`, or
+`fatal`, or numeric values from `logfire.Level`. Set `minLevel: null` to clear a
+previous setting. Log helpers and `reportError()` are filtered by their level;
+`span()`, `startSpan()`, `startPendingSpan()`, and `instrument()` are filtered
+only when the call or scoped client sets an explicit level.
+
+Filtered `span()` callbacks still run with a no-op span. Thrown or rejected
+errors propagate normally, but Logfire does not record them because the call was
+filtered. Use `reportError()` or a span level at or above the minimum when
+errors should always be reported.
+
 ## Error reporting
 
 Use `reportError()` from explicit catch blocks. The caught value can be

--- a/packages/logfire-api/src/AttributeScrubber.ts
+++ b/packages/logfire-api/src/AttributeScrubber.ts
@@ -99,6 +99,9 @@ const SAFE_KEYS = new Set([
   'url.query',
 ])
 
+const MAX_SCRUB_DEPTH = 100
+const MAX_DEPTH_REPLACEMENT = '[Scrubbed due to max depth]'
+
 export class LogfireAttributeScrubber implements BaseScrubber {
   /**
    * List of keys that are considered safe and don't need scrubbing
@@ -124,7 +127,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
    */
   scrubValue<T>(path: JsonPath, value: T): readonly [T, ScrubbedNote[]] {
     const scrubbedNotes: ScrubbedNote[] = []
-    const scrubbedValue = this.scrub(path, value, scrubbedNotes, new WeakSet())
+    const scrubbedValue = this.scrub(path, value, scrubbedNotes, new WeakSet(), 0)
     return [scrubbedValue as T, scrubbedNotes] as const
   }
 
@@ -142,7 +145,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
     return `[Scrubbed due to '${matchedSubstring}']`
   }
 
-  private scrub(path: JsonPath, value: unknown, notes: ScrubbedNote[], seen: WeakSet<object>): unknown {
+  private scrub(path: JsonPath, value: unknown, notes: ScrubbedNote[], seen: WeakSet<object>, depth: number): unknown {
     if (typeof value === 'string') {
       // Check if the string matches the pattern
       const match = value.match(this.pattern)
@@ -153,8 +156,11 @@ export class LogfireAttributeScrubber implements BaseScrubber {
           // Try to parse as JSON
           try {
             const parsed = JSON.parse(value) as unknown
+            if (depth >= MAX_SCRUB_DEPTH) {
+              return this.redact(path, value, match, notes)
+            }
             // If parsed, scrub the parsed object
-            const newVal = this.scrub(path, parsed, notes, seen)
+            const newVal = this.scrub(path, parsed, notes, seen, depth + 1)
             return JSON.stringify(newVal)
           } catch {
             // Not JSON, redact directly
@@ -166,16 +172,22 @@ export class LogfireAttributeScrubber implements BaseScrubber {
     } else if (value instanceof Date) {
       return value
     } else if (Array.isArray(value)) {
+      if (depth >= MAX_SCRUB_DEPTH) {
+        return MAX_DEPTH_REPLACEMENT
+      }
       if (seen.has(value)) {
         return value
       }
       seen.add(value)
       try {
-        return value.map((v, i) => this.scrub([...path, i], v, notes, seen))
+        return value.map((v, i) => this.scrub([...path, i], v, notes, seen, depth + 1))
       } finally {
         seen.delete(value)
       }
     } else if (value !== null && typeof value === 'object') {
+      if (depth >= MAX_SCRUB_DEPTH) {
+        return MAX_DEPTH_REPLACEMENT
+      }
       if (seen.has(value)) {
         return value
       }
@@ -199,7 +211,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
               result[k] = redacted
             } else {
               // Scrub the value recursively
-              result[k] = this.scrub([...path, k], v, notes, seen)
+              result[k] = this.scrub([...path, k], v, notes, seen, depth + 1)
             }
           }
         }

--- a/packages/logfire-api/src/AttributeScrubber.ts
+++ b/packages/logfire-api/src/AttributeScrubber.ts
@@ -124,7 +124,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
    */
   scrubValue<T>(path: JsonPath, value: T): readonly [T, ScrubbedNote[]] {
     const scrubbedNotes: ScrubbedNote[] = []
-    const scrubbedValue = this.scrub(path, value, scrubbedNotes)
+    const scrubbedValue = this.scrub(path, value, scrubbedNotes, new WeakSet())
     return [scrubbedValue as T, scrubbedNotes] as const
   }
 
@@ -142,7 +142,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
     return `[Scrubbed due to '${matchedSubstring}']`
   }
 
-  private scrub(path: JsonPath, value: unknown, notes: ScrubbedNote[]): unknown {
+  private scrub(path: JsonPath, value: unknown, notes: ScrubbedNote[], seen: WeakSet<object>): unknown {
     if (typeof value === 'string') {
       // Check if the string matches the pattern
       const match = value.match(this.pattern)
@@ -154,7 +154,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
           try {
             const parsed = JSON.parse(value) as unknown
             // If parsed, scrub the parsed object
-            const newVal = this.scrub(path, parsed, notes)
+            const newVal = this.scrub(path, parsed, notes, seen)
             return JSON.stringify(newVal)
           } catch {
             // Not JSON, redact directly
@@ -163,32 +163,50 @@ export class LogfireAttributeScrubber implements BaseScrubber {
         }
       }
       return value
+    } else if (value instanceof Date) {
+      return value
     } else if (Array.isArray(value)) {
-      return value.map((v, i) => this.scrub([...path, i], v, notes))
+      if (seen.has(value)) {
+        return value
+      }
+      seen.add(value)
+      try {
+        return value.map((v, i) => this.scrub([...path, i], v, notes, seen))
+      } finally {
+        seen.delete(value)
+      }
     } else if (value !== null && typeof value === 'object') {
+      if (seen.has(value)) {
+        return value
+      }
+      seen.add(value)
       // Object
-      const result: Record<string, unknown> = {}
-      for (const [k, v] of Object.entries(value)) {
-        if (SAFE_KEYS.has(k) || ['boolean', 'number', 'undefined'].includes(typeof v) || v === null) {
-          // Safe key or a primitive value, no scrubbing of the key itself.
-          // (In the Python SDK we still scrub primitive values to be extra careful)
-          result[k] = v
-        } else {
-          // Check key against the pattern
-          const keyMatch = k.match(this.pattern)
-          if (keyMatch) {
-            // Key contains sensitive substring
-            const redacted = this.redact([...path, k], v, keyMatch, notes)
-            // If v is an object/array and got redacted to a string, we may want to consider if that's correct.
-            // For simplicity, we just store the redacted string.
-            result[k] = redacted
+      try {
+        const result: Record<string, unknown> = {}
+        for (const [k, v] of Object.entries(value)) {
+          if (SAFE_KEYS.has(k) || ['boolean', 'number', 'undefined'].includes(typeof v) || v === null) {
+            // Safe key or a primitive value, no scrubbing of the key itself.
+            // (In the Python SDK we still scrub primitive values to be extra careful)
+            result[k] = v
           } else {
-            // Scrub the value recursively
-            result[k] = this.scrub([...path, k], v, notes)
+            // Check key against the pattern
+            const keyMatch = k.match(this.pattern)
+            if (keyMatch) {
+              // Key contains sensitive substring
+              const redacted = this.redact([...path, k], v, keyMatch, notes)
+              // If v is an object/array and got redacted to a string, we may want to consider if that's correct.
+              // For simplicity, we just store the redacted string.
+              result[k] = redacted
+            } else {
+              // Scrub the value recursively
+              result[k] = this.scrub([...path, k], v, notes, seen)
+            }
           }
         }
+        return result
+      } finally {
+        seen.delete(value)
       }
-      return result
     }
 
     return value

--- a/packages/logfire-api/src/AttributeScrubber.ts
+++ b/packages/logfire-api/src/AttributeScrubber.ts
@@ -101,6 +101,7 @@ const SAFE_KEYS = new Set([
 
 const MAX_SCRUB_DEPTH = 100
 const MAX_DEPTH_REPLACEMENT = '[Scrubbed due to max depth]'
+const CYCLE_REPLACEMENT = '[Scrubbed due to cycle]'
 
 export class LogfireAttributeScrubber implements BaseScrubber {
   /**
@@ -176,7 +177,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
         return MAX_DEPTH_REPLACEMENT
       }
       if (seen.has(value)) {
-        return value
+        return CYCLE_REPLACEMENT
       }
       seen.add(value)
       try {
@@ -189,7 +190,7 @@ export class LogfireAttributeScrubber implements BaseScrubber {
         return MAX_DEPTH_REPLACEMENT
       }
       if (seen.has(value)) {
-        return value
+        return CYCLE_REPLACEMENT
       }
       seen.add(value)
       // Object

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -1,6 +1,6 @@
 import type { Context, Span } from '@opentelemetry/api'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
-import { ATTR_EXCEPTION_MESSAGE } from '@opentelemetry/semantic-conventions'
+import { ATTR_EXCEPTION_MESSAGE, ATTR_EXCEPTION_STACKTRACE } from '@opentelemetry/semantic-conventions'
 import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 
 import {
@@ -278,6 +278,82 @@ describe('span', () => {
   })
 })
 
+describe('reportError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.reset()
+  })
+
+  test('preserves legacy attributes argument and error behavior', () => {
+    const error = new Error('legacy')
+
+    reportError('Legacy error', error, { path: '/users' })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual([])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Error)
+    expect(attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY]).toEqual(expect.any(String))
+    expect(attributes[ATTR_EXCEPTION_MESSAGE]).toBe('legacy')
+    expect(attributes[ATTR_EXCEPTION_STACKTRACE]).toBe(error.stack)
+    expect(attributes['path']).toBe('/users')
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: legacy' })
+  })
+
+  test('applies fourth-argument tags', () => {
+    reportError('Tagged error', new Error('tagged'), { path: '/users' }, { tags: ['api', 'db'] })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['api', 'db'])
+    expect(attributes['path']).toBe('/users')
+  })
+
+  test('uses fourth-argument parentSpan', () => {
+    const parentSpan = mocks.makeSpan({ startTime: [100, 0] })
+
+    reportError('Child error', new Error('child'), {}, { parentSpan: parentSpan as unknown as Span })
+
+    expect(mocks.setSpan).toHaveBeenCalledWith(mocks.activeContext, parentSpan)
+    expect(mocks.tracerMock.startSpan.mock.calls[0]?.[2]).toBe(mocks.setSpan.mock.results[0]?.value)
+  })
+
+  test('accepts a thrown string without fingerprinting', () => {
+    reportError('String error', 'oops', { path: '/users' })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTR_EXCEPTION_MESSAGE]).toBe('oops')
+    expect(attributes).not.toHaveProperty(ATTR_EXCEPTION_STACKTRACE)
+    expect(attributes).not.toHaveProperty(ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY)
+    expect(attributes['path']).toBe('/users')
+    expect(spanMock.recordException).toHaveBeenCalledWith('oops')
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: oops' })
+  })
+
+  test('accepts null, undefined, and plain object values without throwing', () => {
+    const values = [null, undefined, { code: 'E_OBJECT' }]
+
+    for (const value of values) {
+      expect(() => {
+        reportError('Unknown error', value)
+      }).not.toThrow()
+    }
+
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledTimes(3)
+    expect(spanMock.recordException).toHaveBeenNthCalledWith(1, 'null')
+    expect(spanMock.recordException).toHaveBeenNthCalledWith(2, 'undefined')
+    expect(spanMock.recordException).toHaveBeenNthCalledWith(3, '[object Object]')
+  })
+
+  test('default export exposes the updated reportError function', () => {
+    const defaultReportError = Object.getOwnPropertyDescriptor(defaultExport, 'reportError')?.value as typeof reportError
+
+    expect(defaultReportError).toBe(reportError)
+    expect(() => {
+      defaultReportError('Default export error', 'oops')
+    }).not.toThrow()
+  })
+})
+
 describe('scoped clients', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -385,6 +461,16 @@ describe('scoped clients', () => {
     expect(spanMock.recordException).toHaveBeenCalledWith(error)
   })
 
+  test('scoped reportError tags merge with fourth-argument tags and keep error level', () => {
+    const error = new Error('boom')
+
+    withSettings({ level: Level.Warning, tags: ['scope', 'shared'] }).reportError('Caught error', error, {}, { tags: ['shared', 'call'] })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'shared', 'call'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Error)
+  })
+
   test('top-level and default exports expose scoped client helpers', () => {
     const defaultWithTags = Object.getOwnPropertyDescriptor(defaultExport, 'withTags')?.value as typeof withTags
     const defaultWithSettings = Object.getOwnPropertyDescriptor(defaultExport, 'withSettings')?.value as typeof withSettings
@@ -392,17 +478,6 @@ describe('scoped clients', () => {
     expect(defaultWithTags).toBe(withTags)
     expect(defaultWithSettings).toBe(withSettings)
     expect(typeof defaultWithTags('default').info).toBe('function')
-  })
-
-  test('existing reportError export remains source-compatible', () => {
-    const error = new Error('legacy')
-
-    reportError('Legacy error', error, { path: '/users' })
-
-    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
-    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual([])
-    expect(attributes['path']).toBe('/users')
-    expect(spanMock.recordException).toHaveBeenCalledWith(error)
   })
 })
 

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -17,13 +17,18 @@ import {
 } from './constants'
 import defaultExport, {
   configureLogfireApi,
+  debug,
+  error,
   info,
   instrument,
   Level,
+  log,
+  logfireApiConfig,
   reportError,
   span,
   startPendingSpan,
   startSpan,
+  warning,
   withSettings,
   withTags,
 } from './index'
@@ -109,6 +114,7 @@ const mocks = vi.hoisted(() => {
 
   const activeContext = makeContext()
   const spanMock = makeSpan({ startTime: [1000, 0] })
+  const noopSpan = makeSpan({ recording: false })
   const startSpanResults: MockSpan[] = []
   const getActiveBaggage = vi.fn<() => MockBaggage | undefined>(() => activeBaggage)
 
@@ -136,11 +142,18 @@ const mocks = vi.hoisted(() => {
       spanMock.setAttribute.mockClear()
       spanMock.setStatus.mockClear()
       spanMock.spanContext.mockClear()
+      noopSpan.end.mockClear()
+      noopSpan.isRecording.mockClear()
+      noopSpan.recordException.mockClear()
+      noopSpan.setAttribute.mockClear()
+      noopSpan.setStatus.mockClear()
+      noopSpan.spanContext.mockClear()
     },
     setActiveBaggage(entries: Record<string, string> | undefined) {
       activeBaggage = entries === undefined ? undefined : makeBaggage(entries)
     },
     setSpan: vi.fn<(ctx: MockContext, span: MockSpan) => MockContext>((ctx, span) => ctx.setValue(Symbol.for('otel-test-span'), span)),
+    noopSpan,
     spanMock,
     startSpanResults,
     tracerMock,
@@ -156,6 +169,11 @@ vi.mock('@opentelemetry/api', () => {
       with: mocks.contextWith,
     },
     createContextKey: (description: string) => Symbol.for(description),
+    INVALID_SPAN_CONTEXT: {
+      spanId: '0000000000000000',
+      traceFlags: 0,
+      traceId: '00000000000000000000000000000000',
+    },
     SpanStatusCode: { ERROR: 2 },
     propagation: {
       getActiveBaggage: mocks.getActiveBaggage,
@@ -163,12 +181,13 @@ vi.mock('@opentelemetry/api', () => {
     trace: {
       getTracer: vi.fn<() => typeof mocks.tracerMock>(() => mocks.tracerMock),
       setSpan: mocks.setSpan,
+      wrapSpanContext: vi.fn<(_context?: unknown) => typeof mocks.noopSpan>(() => mocks.noopSpan),
     },
   }
 })
 
 beforeEach(() => {
-  configureLogfireApi({ baggage: { spanAttributes: [] }, errorFingerprinting: true })
+  configureLogfireApi({ baggage: { spanAttributes: [] }, errorFingerprinting: true, minLevel: null })
   mocks.setActiveBaggage(undefined)
 })
 
@@ -343,6 +362,166 @@ describe('baggage span attributes', () => {
 
     expect(getStartSpanAttributes()['baggage.tenant']).toBe('acme')
     expect(getStartSpanAttributes()[ATTRIBUTES_TAGS_KEY]).toEqual(['scope'])
+  })
+})
+
+describe('minLevel filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.reset()
+  })
+
+  test('filters log helpers below minLevel and keeps logs at or above minLevel', () => {
+    configureLogfireApi({ minLevel: 'warning' })
+
+    debug('debug event')
+    log('default info event')
+    warning('warning event')
+    error('error event')
+
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledTimes(2)
+    expect(getStartSpanAttributes(0)[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+    expect(getStartSpanAttributes(1)[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Error)
+    expect(spanMock.end).toHaveBeenCalledTimes(2)
+    expect(mocks.noopSpan.end).toHaveBeenCalledTimes(2)
+  })
+
+  test('filters explicit manual spans while preserving unlevelled spans', () => {
+    configureLogfireApi({ minLevel: 'fatal' })
+
+    expect(startSpan('manual span')).toBe(spanMock)
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledOnce()
+
+    mocks.reset()
+
+    expect(startSpan('debug span', {}, { level: Level.Debug })).toBe(mocks.noopSpan)
+    expect(startPendingSpan('debug pending span', {}, { level: Level.Debug })).toBe(mocks.noopSpan)
+    expect(mocks.tracerMock.startSpan).not.toHaveBeenCalled()
+  })
+
+  test('filters explicit active spans with a no-op span and still runs sync callbacks', () => {
+    configureLogfireApi({ minLevel: 'warning' })
+    const callback = vi.fn<(activeSpan: Span) => string>(() => 'ok')
+
+    const result = span('debug active span', { level: Level.Debug, callback })
+
+    expect(result).toBe('ok')
+    expect(callback).toHaveBeenCalledWith(mocks.noopSpan)
+    expect(mocks.tracerMock.startActiveSpan).not.toHaveBeenCalled()
+    expect(spanMock.end).not.toHaveBeenCalled()
+    expect(spanMock.recordException).not.toHaveBeenCalled()
+  })
+
+  test('filters positional active spans with explicit levels', () => {
+    configureLogfireApi({ minLevel: 'warning' })
+    const callback = vi.fn<(activeSpan: Span) => string>(() => 'ok')
+
+    const result = span('debug active span', { id: 1 }, { level: Level.Debug }, callback)
+
+    expect(result).toBe('ok')
+    expect(callback).toHaveBeenCalledWith(mocks.noopSpan)
+    expect(mocks.tracerMock.startActiveSpan).not.toHaveBeenCalled()
+    expect(mocks.getActiveBaggage).not.toHaveBeenCalled()
+  })
+
+  test('does not record filtered active span callback failures', async () => {
+    configureLogfireApi({ minLevel: 'warning' })
+    const syncError = new Error('sync failure')
+    const asyncError = new Error('async failure')
+
+    expect(() =>
+      span('debug active span', {
+        level: Level.Debug,
+        callback: () => {
+          throw syncError
+        },
+      })
+    ).toThrow(syncError)
+
+    await expect(
+      span('debug async span', {
+        level: Level.Debug,
+        callback: async () => Promise.reject(asyncError),
+      })
+    ).rejects.toThrow(asyncError)
+
+    expect(mocks.tracerMock.startActiveSpan).not.toHaveBeenCalled()
+    expect(spanMock.recordException).not.toHaveBeenCalled()
+    expect(mocks.noopSpan.recordException).not.toHaveBeenCalled()
+    expect(spanMock.end).not.toHaveBeenCalled()
+    expect(mocks.noopSpan.end).not.toHaveBeenCalled()
+  })
+
+  test('filters reportError only when error level is below minLevel', () => {
+    configureLogfireApi({ minLevel: 'fatal' })
+
+    reportError('caught error', new Error('boom'))
+
+    expect(mocks.tracerMock.startSpan).not.toHaveBeenCalled()
+    expect(spanMock.recordException).not.toHaveBeenCalled()
+    expect(mocks.noopSpan.recordException).toHaveBeenCalledWith(expect.any(Error))
+
+    mocks.reset()
+    configureLogfireApi({ minLevel: 'error' })
+
+    reportError('caught error', new Error('boom'))
+
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledOnce()
+    expect(getStartSpanAttributes()[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Error)
+  })
+
+  test('filters instrumented calls before creating span attributes', () => {
+    configureLogfireApi({ minLevel: 'warning' })
+    const fn = vi.fn<(payload: { id: string }) => { id: string }>((payload) => ({ id: payload.id }))
+    const wrapped = instrument(fn, {
+      extractArgs: ['payload'],
+      level: Level.Debug,
+      recordReturn: true,
+    })
+
+    expect(wrapped({ id: '123' })).toEqual({ id: '123' })
+
+    expect(fn).toHaveBeenCalledWith({ id: '123' })
+    expect(mocks.tracerMock.startActiveSpan).not.toHaveBeenCalled()
+    expect(spanMock.setAttribute).not.toHaveBeenCalled()
+  })
+
+  test('applies scoped levels and helper overrides before filtering', () => {
+    configureLogfireApi({ minLevel: 'warning' })
+    const scoped = withSettings({ level: Level.Debug })
+
+    scoped.log('scoped debug event')
+    scoped.warning('scoped warning event')
+
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledOnce()
+    expect(getStartSpanAttributes()[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+  })
+
+  test('parses minLevel names case-insensitively and resets with null', () => {
+    configureLogfireApi({ minLevel: ' WARNING ' as 'warning' })
+
+    debug('debug event')
+    warning('warning event')
+
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledOnce()
+    expect(logfireApiConfig.minLevel).toBe(Level.Warning)
+
+    mocks.reset()
+    configureLogfireApi({ minLevel: null })
+    error('error event')
+
+    expect(logfireApiConfig.minLevel).toBeUndefined()
+    expect(mocks.tracerMock.startSpan).toHaveBeenCalledOnce()
+  })
+
+  test('rejects invalid code-configured minLevel values', () => {
+    expect(() => {
+      configureLogfireApi({ minLevel: 12 as never })
+    }).toThrow('Invalid minLevel')
+
+    expect(() => {
+      configureLogfireApi({ minLevel: 'warn' as never })
+    }).toThrow('Invalid minLevel')
   })
 })
 

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -993,13 +993,13 @@ describe('instrument', () => {
     )
   })
 
-  test('recordReturn true falls back when serialization fails', () => {
+  test('recordReturn true records circular return values with a cycle placeholder', () => {
     const circular: Record<string, unknown> = {}
     circular['self'] = circular
     const wrapped = instrument(() => circular, { recordReturn: true })
 
     expect(wrapped()).toBe(circular)
-    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '[unserializable]')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '{"self":"[Scrubbed due to cycle]"}')
   })
 
   test('recordReturn true does not record thrown or rejected values', async () => {

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -487,6 +487,32 @@ describe('minLevel filtering', () => {
     expect(spanMock.setAttribute).not.toHaveBeenCalled()
   })
 
+  test('filtered async instrumented calls still resolve their original value', async () => {
+    configureLogfireApi({ minLevel: 'warning' })
+    const wrapped = instrument(
+      async () => {
+        await sleep(0)
+        return 'ok'
+      },
+      { level: Level.Debug, recordReturn: true }
+    )
+
+    await expect(wrapped()).resolves.toBe('ok')
+
+    expect(mocks.tracerMock.startActiveSpan).not.toHaveBeenCalled()
+    expect(spanMock.setAttribute).not.toHaveBeenCalled()
+  })
+
+  test('does not filter instrumented calls without an explicit level', () => {
+    configureLogfireApi({ minLevel: 'fatal' })
+    const wrapped = instrument(() => 'ok')
+
+    expect(wrapped()).toBe('ok')
+
+    expect(mocks.tracerMock.startActiveSpan).toHaveBeenCalledOnce()
+    expect(getStartActiveSpanAttributes()[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Info)
+  })
+
   test('applies scoped levels and helper overrides before filtering', () => {
     configureLogfireApi({ minLevel: 'warning' })
     const scoped = withSettings({ level: Level.Debug })
@@ -846,6 +872,20 @@ describe('instrument', () => {
     expect(attributes['includeDetails']).toBe(true)
   })
 
+  test('extractArgs true falls back to arg names for bare-arrow functions', () => {
+    const identity = ((id: string) => id) as ((id: string) => string) & { toString: () => string }
+    identity.toString = () => 'id => id'
+
+    instrument(identity, {
+      extractArgs: true,
+      message: 'fetch user {arg0}',
+    })('user-123')
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes['arg0']).toBe('user-123')
+    expect(attributes[ATTRIBUTES_MESSAGE_KEY]).toBe('fetch user user-123')
+  })
+
   test('extracted args override static attributes', () => {
     function fetchUser(id: string) {
       return id
@@ -933,6 +973,23 @@ describe('instrument', () => {
     expect(spanMock.setAttribute).toHaveBeenCalledWith(
       'logfire.json_schema',
       '{"properties":{"return":{"items":{"type":"string"},"type":"array"}},"type":"object"}'
+    )
+  })
+
+  test('recordReturn true records resolved non-Promise thenable values', async () => {
+    const thenable: PromiseLike<{ ok: boolean }> = {
+      async then(onFulfilled, onRejected) {
+        return Promise.resolve({ ok: true }).then(onFulfilled, onRejected)
+      },
+    }
+    const wrapped = instrument(() => thenable, { recordReturn: true })
+
+    await expect(wrapped()).resolves.toEqual({ ok: true })
+
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '{"ok":true}')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith(
+      JSON_SCHEMA_KEY,
+      '{"properties":{"return":{"properties":{"ok":{"type":"boolean"}},"type":"object"}},"type":"object"}'
     )
   })
 

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -12,8 +12,10 @@ import {
   ATTRIBUTES_SPAN_TYPE_KEY,
   ATTRIBUTES_TAGS_KEY,
   INVALID_SPAN_ID,
+  JSON_NULL_FIELDS_KEY,
+  JSON_SCHEMA_KEY,
 } from './constants'
-import defaultExport, { info, Level, reportError, span, startPendingSpan, withSettings, withTags } from './index'
+import defaultExport, { info, instrument, Level, reportError, span, startPendingSpan, withSettings, withTags } from './index'
 import { isPendingSpanSuppressed } from './pendingSpanSuppression'
 
 const sleep = async (ms: number): Promise<void> =>
@@ -351,6 +353,288 @@ describe('reportError', () => {
     expect(() => {
       defaultReportError('Default export error', 'oops')
     }).not.toThrow()
+  })
+})
+
+describe('instrument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.reset()
+  })
+
+  test('sync wrapper returns the original value and emits a span', () => {
+    function fetchUser(id: string) {
+      return { id }
+    }
+
+    const wrapped = instrument(fetchUser, { extractArgs: ['id'], message: 'fetch user {id}' })
+    const result = wrapped('user-123')
+
+    expect(result).toEqual({ id: 'user-123' })
+    expect(mocks.tracerMock.startActiveSpan.mock.calls[0]?.[0]).toBe('fetch user {id}')
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]).toBe('fetch user {id}')
+    expect(attributes[ATTRIBUTES_MESSAGE_KEY]).toBe('fetch user user-123')
+    expect(attributes['id']).toBe('user-123')
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('async wrapper resolves the original value and ends the span after settlement', async () => {
+    async function fetchUser(id: string) {
+      await sleep(0)
+      return { id }
+    }
+
+    const wrapped = instrument(fetchUser, { extractArgs: ['id'], message: 'fetch user {id}' })
+    await expect(wrapped('user-123')).resolves.toEqual({ id: 'user-123' })
+
+    expect(spanMock.end).toHaveBeenCalledOnce()
+    expect(spanMock.recordException).not.toHaveBeenCalled()
+  })
+
+  test('sync thrown errors are recorded and rethrown', () => {
+    const error = new Error('boom')
+    const wrapped = instrument(() => {
+      throw error
+    })
+
+    expect(() => wrapped()).toThrow(error)
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: boom' })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('async rejected errors are recorded and rejected', async () => {
+    const error = new Error('async-boom')
+    const wrapped = instrument(async () => Promise.reject(error))
+
+    await expect(wrapped()).rejects.toThrow(error)
+    await sleep(0)
+
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: async-boom' })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('wrapper preserves this', () => {
+    const service = {
+      multiplier: 3,
+      calculate: instrument(function (this: { multiplier: number }, value: number) {
+        return this.multiplier * value
+      }),
+    }
+
+    expect(service.calculate(4)).toBe(12)
+  })
+
+  test('default message uses the function name', () => {
+    function namedFunction() {
+      return 'ok'
+    }
+
+    instrument(namedFunction)()
+
+    expect(mocks.tracerMock.startActiveSpan.mock.calls[0]?.[0]).toBe('Calling namedFunction')
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]).toBe('Calling namedFunction')
+    expect(attributes[ATTRIBUTES_MESSAGE_KEY]).toBe('Calling namedFunction')
+  })
+
+  test('custom message and spanName are used independently', () => {
+    const wrapped = instrument(() => 'ok', {
+      message: 'friendly {id}',
+      spanName: 'stable-operation',
+      attributes: { id: 1 },
+    })
+
+    wrapped()
+
+    expect(mocks.tracerMock.startActiveSpan.mock.calls[0]?.[0]).toBe('stable-operation')
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]).toBe('friendly {id}')
+    expect(attributes[ATTRIBUTES_MESSAGE_KEY]).toBe('friendly 1')
+  })
+
+  test('extractArgs defaults to no argument attributes', () => {
+    function fetchUser(id: string) {
+      return id
+    }
+
+    instrument(fetchUser, { message: 'fetch user' })('user-123')
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes).not.toHaveProperty('id')
+    expect(attributes).not.toHaveProperty('arg0')
+  })
+
+  test('extractArgs with names records positional arguments', () => {
+    function fetchUser(id: string, includeDetails: boolean) {
+      return { id, includeDetails }
+    }
+
+    instrument(fetchUser, {
+      extractArgs: ['id', 'include_details'],
+      message: 'fetch user {id}',
+    })('user-123', true)
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes['id']).toBe('user-123')
+    expect(attributes['include_details']).toBe(true)
+  })
+
+  test('extractArgs true records best-effort parameter names', () => {
+    function fetchUser(id: string, includeDetails: boolean) {
+      return { id, includeDetails }
+    }
+
+    instrument(fetchUser, {
+      extractArgs: true,
+      message: 'fetch user {id}',
+    })('user-123', true)
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes['id']).toBe('user-123')
+    expect(attributes['includeDetails']).toBe(true)
+  })
+
+  test('extracted args override static attributes', () => {
+    function fetchUser(id: string) {
+      return id
+    }
+
+    instrument(fetchUser, {
+      attributes: { id: 'static' },
+      extractArgs: ['id'],
+      message: 'fetch user {id}',
+    })('actual')
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes['id']).toBe('actual')
+    expect(attributes[ATTRIBUTES_MESSAGE_KEY]).toBe('fetch user actual')
+  })
+
+  test('recordReturn true records sync return values', () => {
+    const wrapped = instrument(
+      () => ({
+        ok: true,
+      }),
+      { recordReturn: true }
+    )
+
+    expect(wrapped()).toEqual({ ok: true })
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '{"ok":true}')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('logfire.json_schema', '{"properties":{"return":{"type":"object"}},"type":"object"}')
+  })
+
+  test('recordReturn true preserves complex input schema when recording complex return values', () => {
+    function processPayload(_payload: { value: string }) {
+      return { status: 'ok' }
+    }
+
+    const wrapped = instrument(processPayload, {
+      extractArgs: ['payload'],
+      recordReturn: true,
+    })
+
+    expect(wrapped({ value: 'input' })).toEqual({ status: 'ok' })
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[JSON_SCHEMA_KEY]).toBe('{"properties":{"payload":{"type":"object"}},"type":"object"}')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '{"status":"ok"}')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith(
+      JSON_SCHEMA_KEY,
+      '{"properties":{"payload":{"type":"object"},"return":{"type":"object"}},"type":"object"}'
+    )
+  })
+
+  test('recordReturn true preserves null input metadata when recording null return values', () => {
+    function processPayload(payload: null) {
+      return payload
+    }
+
+    const wrapped = instrument(processPayload, {
+      extractArgs: ['payload'],
+      recordReturn: true,
+    })
+
+    expect(wrapped(null)).toBeNull()
+
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[JSON_NULL_FIELDS_KEY]).toEqual(['payload'])
+    expect(spanMock.setAttribute).toHaveBeenCalledWith(JSON_NULL_FIELDS_KEY, ['payload', 'return'])
+  })
+
+  test('recordReturn true records async resolved values', async () => {
+    const wrapped = instrument(
+      async () => {
+        await sleep(0)
+        return ['ok']
+      },
+      { recordReturn: true }
+    )
+
+    await expect(wrapped()).resolves.toEqual(['ok'])
+
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '["ok"]')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('logfire.json_schema', '{"properties":{"return":{"type":"array"}},"type":"object"}')
+  })
+
+  test('recordReturn true falls back when serialization fails', () => {
+    const circular: Record<string, unknown> = {}
+    circular['self'] = circular
+    const wrapped = instrument(() => circular, { recordReturn: true })
+
+    expect(wrapped()).toBe(circular)
+    expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '[unserializable]')
+  })
+
+  test('recordReturn true does not record thrown or rejected values', async () => {
+    const syncWrapped = instrument(
+      () => {
+        throw new Error('sync')
+      },
+      { recordReturn: true }
+    )
+    const asyncWrapped = instrument(async () => Promise.reject(new Error('async')), { recordReturn: true })
+
+    expect(() => syncWrapped()).toThrow('sync')
+    await expect(asyncWrapped()).rejects.toThrow('async')
+    await sleep(0)
+
+    expect(spanMock.setAttribute).not.toHaveBeenCalledWith('return', expect.anything())
+  })
+
+  test('tags, parentSpan, and level are passed to the span', () => {
+    const parentSpan = mocks.makeSpan({ startTime: [100, 0] })
+
+    instrument(() => 'ok', {
+      level: Level.Warning,
+      parentSpan: parentSpan as unknown as Span,
+      tags: ['instrumented'],
+    })()
+
+    expect(mocks.setSpan).toHaveBeenCalledWith(mocks.activeContext, parentSpan)
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['instrumented'])
+  })
+
+  test('scoped client instrument merges scoped settings', () => {
+    const wrapped = withSettings({ level: Level.Warning, tags: ['scope', 'shared'] }).instrument(() => 'ok', {
+      tags: ['shared', 'call'],
+    })
+
+    expect(wrapped()).toBe('ok')
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'shared', 'call'])
+  })
+
+  test('default export exposes instrument', () => {
+    const defaultInstrument = Object.getOwnPropertyDescriptor(defaultExport, 'instrument')?.value as typeof instrument
+
+    expect(defaultInstrument).toBe(instrument)
+    expect(defaultInstrument(() => 'ok')()).toBe('ok')
   })
 })
 

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -187,7 +187,7 @@ vi.mock('@opentelemetry/api', () => {
 })
 
 beforeEach(() => {
-  configureLogfireApi({ baggage: { spanAttributes: [] }, errorFingerprinting: true, minLevel: null })
+  configureLogfireApi({ baggage: { spanAttributes: [] }, errorFingerprinting: true, jsonSchema: 'rich', minLevel: null })
   mocks.setActiveBaggage(undefined)
 })
 
@@ -240,7 +240,8 @@ describe('info', () => {
           [ATTRIBUTES_SPAN_TYPE_KEY]: 'log',
           [ATTRIBUTES_TAGS_KEY]: [],
           i: 1,
-          'logfire.json_schema': '{"properties":{"logfire.scrubbed":{"type":"array"}},"type":"object"}',
+          'logfire.json_schema':
+            '{"properties":{"logfire.scrubbed":{"items":{"properties":{"matched_substring":{"type":"string"},"path":{"items":{"type":"string"},"type":"array"}},"type":"object"},"type":"array"}},"type":"object"}',
           'logfire.scrubbed': '[{"matched_substring":"password","path":["password"]}]',
           password: "[Scrubbed due to 'password']",
         },
@@ -871,7 +872,10 @@ describe('instrument', () => {
 
     expect(wrapped()).toEqual({ ok: true })
     expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '{"ok":true}')
-    expect(spanMock.setAttribute).toHaveBeenCalledWith('logfire.json_schema', '{"properties":{"return":{"type":"object"}},"type":"object"}')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith(
+      'logfire.json_schema',
+      '{"properties":{"return":{"properties":{"ok":{"type":"boolean"}},"type":"object"}},"type":"object"}'
+    )
   })
 
   test('recordReturn true preserves complex input schema when recording complex return values', () => {
@@ -887,11 +891,13 @@ describe('instrument', () => {
     expect(wrapped({ value: 'input' })).toEqual({ status: 'ok' })
 
     const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
-    expect(attributes[JSON_SCHEMA_KEY]).toBe('{"properties":{"payload":{"type":"object"}},"type":"object"}')
+    expect(attributes[JSON_SCHEMA_KEY]).toBe(
+      '{"properties":{"payload":{"properties":{"value":{"type":"string"}},"type":"object"}},"type":"object"}'
+    )
     expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '{"status":"ok"}')
     expect(spanMock.setAttribute).toHaveBeenCalledWith(
       JSON_SCHEMA_KEY,
-      '{"properties":{"payload":{"type":"object"},"return":{"type":"object"}},"type":"object"}'
+      '{"properties":{"payload":{"properties":{"value":{"type":"string"}},"type":"object"},"return":{"properties":{"status":{"type":"string"}},"type":"object"}},"type":"object"}'
     )
   })
 
@@ -924,7 +930,10 @@ describe('instrument', () => {
     await expect(wrapped()).resolves.toEqual(['ok'])
 
     expect(spanMock.setAttribute).toHaveBeenCalledWith('return', '["ok"]')
-    expect(spanMock.setAttribute).toHaveBeenCalledWith('logfire.json_schema', '{"properties":{"return":{"type":"array"}},"type":"object"}')
+    expect(spanMock.setAttribute).toHaveBeenCalledWith(
+      'logfire.json_schema',
+      '{"properties":{"return":{"items":{"type":"string"},"type":"array"}},"type":"object"}'
+    )
   })
 
   test('recordReturn true falls back when serialization fails', () => {

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -1,5 +1,6 @@
 import type { Context, Span } from '@opentelemetry/api'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
+import { ATTR_EXCEPTION_MESSAGE } from '@opentelemetry/semantic-conventions'
 import { beforeEach, describe, expect, test, vi } from 'vite-plus/test'
 
 import {
@@ -12,7 +13,7 @@ import {
   ATTRIBUTES_TAGS_KEY,
   INVALID_SPAN_ID,
 } from './constants'
-import defaultExport, { info, span, startPendingSpan } from './index'
+import defaultExport, { info, Level, reportError, span, startPendingSpan, withSettings, withTags } from './index'
 import { isPendingSpanSuppressed } from './pendingSpanSuppression'
 
 const sleep = async (ms: number): Promise<void> =>
@@ -274,6 +275,134 @@ describe('span', () => {
     expect(result).toBe(lazyThenable)
     expect(then).not.toHaveBeenCalled()
     expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+})
+
+describe('scoped clients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.reset()
+  })
+
+  test('withTags applies tags to log helpers', () => {
+    withTags('user', 'db').info('Loaded user {id}', { id: 1 })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['user', 'db'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Info)
+    expect(attributes[ATTRIBUTES_SPAN_TYPE_KEY]).toBe('log')
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('scoped and per-call tags merge with stable deduplication', () => {
+    withTags('a', 'b').info('Tagged event', {}, { tags: ['b', 'c', 'a'] })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['a', 'b', 'c'])
+  })
+
+  test('nested clients accumulate tags and scoped level applies to log()', () => {
+    const scoped = withTags('a', 'b')
+      .withSettings({ level: Level.Warning, tags: ['b', 'c'] })
+      .withTags('c', 'd')
+
+    scoped.log('Nested event', {}, { tags: ['a', 'e'] })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['a', 'b', 'c', 'd', 'e'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+  })
+
+  test('level-specific helpers override scoped level', () => {
+    withSettings({ level: Level.Warning }).info('Info event')
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Info)
+  })
+
+  test('per-call level overrides scoped level for startSpan()', () => {
+    withSettings({ level: Level.Warning, tags: ['scope'] }).startSpan('Manual span', {}, { level: Level.Error, tags: ['call'] })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'call'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Error)
+    expect(attributes[ATTRIBUTES_SPAN_TYPE_KEY]).toBe('span')
+  })
+
+  test('scoped settings apply to startPendingSpan() real and pending spans', () => {
+    const startTime: [number, number] = [123, 456]
+    const realSpan = mocks.makeSpan({ startTime })
+    const pendingSpan = mocks.makeSpan({ startTime })
+    mocks.startSpanResults.push(realSpan, pendingSpan)
+
+    withSettings({ level: Level.Warning, tags: ['scope'] }).startPendingSpan('Pending span', {}, { tags: ['call'] })
+
+    const realAttributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    const pendingAttributes = (mocks.tracerMock.startSpan.mock.calls[1]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(realAttributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'call'])
+    expect(realAttributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+    expect(pendingAttributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'call'])
+    expect(pendingAttributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+    expect(pendingAttributes[ATTRIBUTES_SPAN_TYPE_KEY]).toBe('pending_span')
+    expect(pendingSpan.end).toHaveBeenCalledWith(startTime)
+  })
+
+  test('scoped settings apply to object-style span()', () => {
+    const result = withSettings({ level: Level.Warning, tags: ['scope'] }).span('Scoped active span {id}', {
+      attributes: { id: 1 },
+      callback: () => 'ok',
+      tags: ['call'],
+    })
+
+    expect(result).toBe('ok')
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'call'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Warning)
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('scoped settings apply to positional span()', () => {
+    const result = withTags('scope').span('Positional active span {id}', { id: 1 }, { tags: ['call'] }, () => 'ok')
+
+    expect(result).toBe('ok')
+    const attributes = (mocks.tracerMock.startActiveSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope', 'call'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Info)
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('scoped tags apply to reportError without changing its public arguments', () => {
+    const error = new Error('boom')
+
+    withTags('scope').reportError('Caught error', error, { job: 'sync' })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual(['scope'])
+    expect(attributes[ATTRIBUTES_LEVEL_KEY]).toBe(Level.Error)
+    expect(attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY]).toEqual(expect.any(String))
+    expect(attributes[ATTR_EXCEPTION_MESSAGE]).toBe('boom')
+    expect(attributes['job']).toBe('sync')
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+  })
+
+  test('top-level and default exports expose scoped client helpers', () => {
+    const defaultWithTags = Object.getOwnPropertyDescriptor(defaultExport, 'withTags')?.value as typeof withTags
+    const defaultWithSettings = Object.getOwnPropertyDescriptor(defaultExport, 'withSettings')?.value as typeof withSettings
+
+    expect(defaultWithTags).toBe(withTags)
+    expect(defaultWithSettings).toBe(withSettings)
+    expect(typeof defaultWithTags('default').info).toBe('function')
+  })
+
+  test('existing reportError export remains source-compatible', () => {
+    const error = new Error('legacy')
+
+    reportError('Legacy error', error, { path: '/users' })
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTRIBUTES_TAGS_KEY]).toEqual([])
+    expect(attributes['path']).toBe('/users')
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
   })
 })
 

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -15,7 +15,18 @@ import {
   JSON_NULL_FIELDS_KEY,
   JSON_SCHEMA_KEY,
 } from './constants'
-import defaultExport, { info, instrument, Level, reportError, span, startPendingSpan, withSettings, withTags } from './index'
+import defaultExport, {
+  configureLogfireApi,
+  info,
+  instrument,
+  Level,
+  reportError,
+  span,
+  startPendingSpan,
+  startSpan,
+  withSettings,
+  withTags,
+} from './index'
 import { isPendingSpanSuppressed } from './pendingSpanSuppression'
 
 const sleep = async (ms: number): Promise<void> =>
@@ -43,7 +54,17 @@ const mocks = vi.hoisted(() => {
     startTime?: [number, number]
   }
 
+  interface MockBaggageEntry {
+    value: string
+  }
+
+  interface MockBaggage {
+    getAllEntries(): [string, MockBaggageEntry][]
+    getEntry(key: string): MockBaggageEntry | undefined
+  }
+
   let contextId = 0
+  let activeBaggage: MockBaggage | undefined
 
   function makeContext(values = new Map<symbol, unknown>()): MockContext {
     contextId++
@@ -76,9 +97,20 @@ const mocks = vi.hoisted(() => {
     }
   }
 
+  function makeBaggage(entries: Record<string, string>): MockBaggage {
+    return {
+      getAllEntries: () => Object.entries(entries).map(([key, value]) => [key, { value }] as [string, MockBaggageEntry]),
+      getEntry: (key: string) => {
+        const value = entries[key]
+        return value === undefined ? undefined : { value }
+      },
+    }
+  }
+
   const activeContext = makeContext()
   const spanMock = makeSpan({ startTime: [1000, 0] })
   const startSpanResults: MockSpan[] = []
+  const getActiveBaggage = vi.fn<() => MockBaggage | undefined>(() => activeBaggage)
 
   const tracerMock = {
     startActiveSpan: vi.fn<(_name: string, _options: unknown, _context: unknown, fn: (s: MockSpan) => unknown) => unknown>(
@@ -90,8 +122,11 @@ const mocks = vi.hoisted(() => {
   return {
     activeContext,
     contextWith: vi.fn<() => unknown>(),
+    getActiveBaggage,
     makeSpan,
     reset() {
+      activeBaggage = undefined
+      getActiveBaggage.mockClear()
       startSpanResults.length = 0
       tracerMock.startActiveSpan.mockClear()
       tracerMock.startSpan.mockClear()
@@ -101,6 +136,9 @@ const mocks = vi.hoisted(() => {
       spanMock.setAttribute.mockClear()
       spanMock.setStatus.mockClear()
       spanMock.spanContext.mockClear()
+    },
+    setActiveBaggage(entries: Record<string, string> | undefined) {
+      activeBaggage = entries === undefined ? undefined : makeBaggage(entries)
     },
     setSpan: vi.fn<(ctx: MockContext, span: MockSpan) => MockContext>((ctx, span) => ctx.setValue(Symbol.for('otel-test-span'), span)),
     spanMock,
@@ -119,12 +157,28 @@ vi.mock('@opentelemetry/api', () => {
     },
     createContextKey: (description: string) => Symbol.for(description),
     SpanStatusCode: { ERROR: 2 },
+    propagation: {
+      getActiveBaggage: mocks.getActiveBaggage,
+    },
     trace: {
       getTracer: vi.fn<() => typeof mocks.tracerMock>(() => mocks.tracerMock),
       setSpan: mocks.setSpan,
     },
   }
 })
+
+beforeEach(() => {
+  configureLogfireApi({ baggage: { spanAttributes: [] }, errorFingerprinting: true })
+  mocks.setActiveBaggage(undefined)
+})
+
+function getStartSpanAttributes(callIndex = 0): Record<string, unknown> {
+  return (mocks.tracerMock.startSpan.mock.calls[callIndex]?.[1] as { attributes: Record<string, unknown> }).attributes
+}
+
+function getStartActiveSpanAttributes(callIndex = 0): Record<string, unknown> {
+  return (mocks.tracerMock.startActiveSpan.mock.calls[callIndex]?.[1] as { attributes: Record<string, unknown> }).attributes
+}
 
 describe('info', () => {
   beforeEach(() => {
@@ -174,6 +228,121 @@ describe('info', () => {
       },
       mocks.activeContext
     )
+  })
+})
+
+describe('baggage span attributes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.reset()
+  })
+
+  test('is disabled by default', () => {
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    info('event')
+
+    expect(getStartSpanAttributes()).not.toHaveProperty('baggage.tenant')
+    expect(mocks.getActiveBaggage).not.toHaveBeenCalled()
+  })
+
+  test('copies only configured active baggage keys and skips missing keys', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant', 'missing'] } })
+    mocks.setActiveBaggage({ region: 'eu', tenant: 'acme' })
+
+    info('event')
+
+    const attributes = getStartSpanAttributes()
+    expect(attributes['baggage.tenant']).toBe('acme')
+    expect(attributes).not.toHaveProperty('baggage.region')
+    expect(attributes).not.toHaveProperty('baggage.missing')
+  })
+
+  test('lets explicit user attributes win over baggage projection', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'from-baggage' })
+
+    info('event', { 'baggage.tenant': 'from-user' })
+
+    expect(getStartSpanAttributes()['baggage.tenant']).toBe('from-user')
+  })
+
+  test('truncates projected baggage values to 1000 characters', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'x'.repeat(1005) })
+
+    info('event')
+
+    expect(getStartSpanAttributes()['baggage.tenant']).toBe(`${'x'.repeat(997)}...`)
+  })
+
+  test('copies baggage for startSpan', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    startSpan('manual span')
+
+    expect(getStartSpanAttributes()['baggage.tenant']).toBe('acme')
+  })
+
+  test('copies baggage for object-style active span', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    span('active span', { callback: () => 'ok' })
+
+    expect(getStartActiveSpanAttributes()['baggage.tenant']).toBe('acme')
+  })
+
+  test('copies baggage for positional active span', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    span('active span', {}, {}, () => 'ok')
+
+    expect(getStartActiveSpanAttributes()['baggage.tenant']).toBe('acme')
+  })
+
+  test('copies baggage for real and pending placeholder spans', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+    const startTime: [number, number] = [123, 456]
+    const realSpan = mocks.makeSpan({ startTime })
+    const pendingSpan = mocks.makeSpan({ startTime })
+    mocks.startSpanResults.push(realSpan, pendingSpan)
+
+    startPendingSpan('pending span')
+
+    expect(getStartSpanAttributes(0)['baggage.tenant']).toBe('acme')
+    expect(getStartSpanAttributes(1)['baggage.tenant']).toBe('acme')
+  })
+
+  test('copies baggage for reportError', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    reportError('caught error', new Error('boom'))
+
+    expect(getStartSpanAttributes()['baggage.tenant']).toBe('acme')
+  })
+
+  test('copies baggage for instrumented functions', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    instrument(() => 'ok')()
+
+    expect(getStartActiveSpanAttributes()['baggage.tenant']).toBe('acme')
+  })
+
+  test('scoped clients inherit baggage projection', () => {
+    configureLogfireApi({ baggage: { spanAttributes: ['tenant'] } })
+    mocks.setActiveBaggage({ tenant: 'acme' })
+
+    withTags('scope').info('scoped event')
+
+    expect(getStartSpanAttributes()['baggage.tenant']).toBe('acme')
+    expect(getStartSpanAttributes()[ATTRIBUTES_TAGS_KEY]).toEqual(['scope'])
   })
 })
 

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -1,5 +1,5 @@
 import type { Attributes, Context, HrTime, Span } from '@opentelemetry/api'
-import { SpanStatusCode, context as TheContextAPI, trace as TheTraceAPI } from '@opentelemetry/api'
+import { SpanStatusCode, context as TheContextAPI, propagation as ThePropagationAPI, trace as TheTraceAPI } from '@opentelemetry/api'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 import { ATTR_EXCEPTION_MESSAGE, ATTR_EXCEPTION_STACKTRACE } from '@opentelemetry/semantic-conventions'
 
@@ -18,7 +18,7 @@ import {
   JSON_SCHEMA_KEY,
 } from './constants'
 import { canonicalizeError, computeFingerprint } from './fingerprint'
-import { logfireFormatWithExtras } from './formatter'
+import { logfireFormatWithExtras, truncateString } from './formatter'
 import { configureLogfireApi, logfireApiConfig, resolveBaseUrl, resolveSendToLogfire, serializeAttributes } from './logfireApiConfig'
 import { PendingSpanProcessor } from './PendingSpanProcessor'
 import { setPendingSpanSuppressed } from './pendingSpanSuppression'
@@ -29,7 +29,7 @@ import { ULIDGenerator } from './ULIDGenerator'
 export * from './AttributeScrubber'
 export { canonicalizeError, computeFingerprint } from './fingerprint'
 export { configureLogfireApi, logfireApiConfig, resolveBaseUrl, resolveSendToLogfire } from './logfireApiConfig'
-export type { LogfireApiConfig, LogfireApiConfigOptions, ScrubbingOptions } from './logfireApiConfig'
+export type { BaggageOptions, LogfireApiConfig, LogfireApiConfigOptions, ScrubbingOptions } from './logfireApiConfig'
 export { ATTRIBUTES_PENDING_SPAN_REAL_PARENT_KEY } from './constants'
 export { PendingSpanProcessor } from './PendingSpanProcessor'
 export * from './sampling'
@@ -149,6 +149,8 @@ type InstrumentableFunction = (...args: never[]) => unknown
 type SerializedAttributeValue = ReturnType<typeof serializeAttributes>[string]
 
 const ROOT_CLIENT_SETTINGS: ResolvedLogfireClientSettings = { tags: [] }
+const BAGGAGE_ATTRIBUTE_PREFIX = 'baggage.' as const
+const MAX_BAGGAGE_VALUE_LENGTH = 1000 as const
 
 function mergeTags(...tagGroups: (readonly string[] | undefined)[]): string[] {
   return Array.from(new Set(tagGroups.flatMap((tags) => tags ?? [])).values())
@@ -177,20 +179,69 @@ function mergeLogOptions(settings: ResolvedLogfireClientSettings, options: LogOp
   return merged
 }
 
+function getBaggageSpanAttributes(existingAttributes: Record<string, unknown>): Record<string, string> {
+  const allowedKeys = logfireApiConfig.baggage.spanAttributes
+  if (allowedKeys.length === 0) {
+    return {}
+  }
+
+  const baggage = ThePropagationAPI.getActiveBaggage()
+  if (baggage === undefined) {
+    return {}
+  }
+
+  const attributes: Record<string, string> = {}
+  for (const key of allowedKeys) {
+    const attributeKey = `${BAGGAGE_ATTRIBUTE_PREFIX}${key}`
+    if (attributeKey in existingAttributes) {
+      continue
+    }
+
+    const entry = baggage.getEntry(key)
+    if (entry === undefined) {
+      continue
+    }
+
+    attributes[attributeKey] = truncateString(entry.value, MAX_BAGGAGE_VALUE_LENGTH)
+  }
+  return attributes
+}
+
+function buildSerializedLogfireAttributes(
+  msgTemplate: string,
+  attributes: Record<string, unknown>,
+  { tags = [], level = Level.Info }: Pick<LogOptions, 'level' | 'tags'>
+): {
+  formattedMessage: string
+  newTemplate: string
+  serializedAttributes: Attributes
+} {
+  const { formattedMessage, extraAttributes, newTemplate } = logfireFormatWithExtras(msgTemplate, attributes, logfireApiConfig.scrubber)
+  const userAttributes = { ...attributes, ...extraAttributes }
+
+  return {
+    formattedMessage,
+    newTemplate,
+    serializedAttributes: {
+      ...serializeAttributes({ ...getBaggageSpanAttributes(userAttributes), ...userAttributes }),
+      [ATTRIBUTES_MESSAGE_TEMPLATE_KEY]: newTemplate,
+      [ATTRIBUTES_MESSAGE_KEY]: formattedMessage,
+      [ATTRIBUTES_LEVEL_KEY]: level,
+      [ATTRIBUTES_TAGS_KEY]: Array.from(new Set(tags).values()),
+    },
+  }
+}
+
 function buildLogfireSpanStart(
   msgTemplate: string,
   attributes: Record<string, unknown>,
   { log, tags = [], level = Level.Info, _spanName }: Pick<LogOptions, '_spanName' | 'level' | 'log' | 'tags'>
 ): LogfireSpanStart {
-  const { formattedMessage, extraAttributes, newTemplate } = logfireFormatWithExtras(msgTemplate, attributes, logfireApiConfig.scrubber)
+  const { serializedAttributes } = buildSerializedLogfireAttributes(msgTemplate, attributes, { tags, level })
 
   return {
     attributes: {
-      ...serializeAttributes({ ...attributes, ...extraAttributes }),
-      [ATTRIBUTES_MESSAGE_TEMPLATE_KEY]: newTemplate,
-      [ATTRIBUTES_MESSAGE_KEY]: formattedMessage,
-      [ATTRIBUTES_LEVEL_KEY]: level,
-      [ATTRIBUTES_TAGS_KEY]: Array.from(new Set(tags).values()),
+      ...serializedAttributes,
       [ATTRIBUTES_SPAN_TYPE_KEY]: log ? 'log' : 'span',
     },
     name: _spanName ?? msgTemplate,
@@ -251,7 +302,8 @@ function buildInstrumentedCallAttributes(
 
 function buildInstrumentedCallSerializationAttributes(msgTemplate: string, attributes: Record<string, unknown>): Record<string, unknown> {
   const { extraAttributes } = logfireFormatWithExtras(msgTemplate, attributes, logfireApiConfig.scrubber)
-  return { ...attributes, ...extraAttributes }
+  const userAttributes = { ...attributes, ...extraAttributes }
+  return { ...getBaggageSpanAttributes(userAttributes), ...userAttributes }
 }
 
 function safeSetSpanAttribute(span: Span, key: string, value: SerializedAttributeValue): void {
@@ -411,19 +463,13 @@ function spanWithSettings<R>(
     callback = args[2]
   }
 
-  const { formattedMessage, extraAttributes, newTemplate } = logfireFormatWithExtras(msgTemplate, attributes, logfireApiConfig.scrubber)
+  const { serializedAttributes } = buildSerializedLogfireAttributes(msgTemplate, attributes, { tags, level })
 
   const context = parentSpan ? TheTraceAPI.setSpan(TheContextAPI.active(), parentSpan) : TheContextAPI.active()
   return logfireApiConfig.tracer.startActiveSpan(
     spanName ?? msgTemplate,
     {
-      attributes: {
-        ...serializeAttributes({ ...attributes, ...extraAttributes }),
-        [ATTRIBUTES_MESSAGE_TEMPLATE_KEY]: newTemplate,
-        [ATTRIBUTES_MESSAGE_KEY]: formattedMessage,
-        [ATTRIBUTES_LEVEL_KEY]: level,
-        [ATTRIBUTES_TAGS_KEY]: Array.from(new Set(tags).values()),
-      },
+      attributes: serializedAttributes,
     },
     context,
     (span: Span) => {

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -82,6 +82,17 @@ export interface LogfireClientSettings {
   tags?: string[]
 }
 
+export interface ReportErrorOptions {
+  /**
+   * Set a span started with `startSpan` as parentSpan to create a child error span.
+   */
+  parentSpan?: Span
+  /**
+   * Tags to add to the error span.
+   */
+  tags?: string[]
+}
+
 interface LogfireSpanStart {
   attributes: Attributes
   name: string
@@ -395,6 +406,55 @@ function recordSpanException(span: Span, thrown: unknown): void {
   }
 }
 
+interface NormalizedReportError {
+  attributes: Record<string, unknown>
+  fingerprintSource?: Error
+  recordExceptionValue: Error | string
+  statusMessage: string
+}
+
+function stringifyThrownValue(thrown: unknown): string {
+  try {
+    return String(thrown)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+function normalizeReportError(error: unknown): NormalizedReportError {
+  if (error instanceof Error) {
+    return {
+      attributes: {
+        [ATTR_EXCEPTION_MESSAGE]: error.message,
+        [ATTR_EXCEPTION_STACKTRACE]: error.stack,
+      },
+      fingerprintSource: error,
+      recordExceptionValue: error,
+      statusMessage: `${error.name}: ${error.message}`,
+    }
+  }
+
+  const errorMessage = stringifyThrownValue(error)
+  return {
+    attributes: {
+      [ATTR_EXCEPTION_MESSAGE]: errorMessage,
+    },
+    recordExceptionValue: errorMessage,
+    statusMessage: `Error: ${errorMessage}`,
+  }
+}
+
+function reportErrorOptionsToLogOptions(options: ReportErrorOptions | undefined): LogOptions {
+  const logOptions: LogOptions = { level: Level.Error }
+  if (options?.parentSpan !== undefined) {
+    logOptions.parentSpan = options.parentSpan
+  }
+  if (options?.tags !== undefined) {
+    logOptions.tags = options.tags
+  }
+  return logOptions
+}
+
 /**
  * Use this method to report an error to Logfire.
  * Captures the error stack trace and message in the respective semantic attributes and sets the correct level and status.
@@ -403,28 +463,34 @@ function recordSpanException(span: Span, thrown: unknown): void {
 function reportErrorWithSettings(
   settings: ResolvedLogfireClientSettings,
   message: string,
-  error: Error,
-  extraAttributes: Record<string, unknown> = {}
+  error: unknown,
+  extraAttributes: Record<string, unknown> = {},
+  options?: ReportErrorOptions
 ): void {
+  const normalized = normalizeReportError(error)
   const attributes: Record<string, unknown> = {
-    [ATTR_EXCEPTION_MESSAGE]: error.message,
-    [ATTR_EXCEPTION_STACKTRACE]: error.stack,
+    ...normalized.attributes,
     ...extraAttributes,
   }
 
-  if (logfireApiConfig.enableErrorFingerprinting) {
-    attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY] = computeFingerprint(error)
+  if (logfireApiConfig.enableErrorFingerprinting && normalized.fingerprintSource !== undefined) {
+    attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY] = computeFingerprint(normalized.fingerprintSource)
   }
 
-  const span = startSpanWithSettings(settings, message, attributes, { level: Level.Error })
+  const span = startSpanWithSettings(settings, message, attributes, reportErrorOptionsToLogOptions(options))
 
-  span.recordException(error)
-  span.setStatus({ code: SpanStatusCode.ERROR, message: `${error.name}: ${error.message}` })
+  span.recordException(normalized.recordExceptionValue)
+  span.setStatus({ code: SpanStatusCode.ERROR, message: normalized.statusMessage })
   span.end()
 }
 
-export function reportError(message: string, error: Error, extraAttributes: Record<string, unknown> = {}): void {
-  reportErrorWithSettings(ROOT_CLIENT_SETTINGS, message, error, extraAttributes)
+export function reportError(
+  message: string,
+  error: unknown,
+  extraAttributes: Record<string, unknown> = {},
+  options?: ReportErrorOptions
+): void {
+  reportErrorWithSettings(ROOT_CLIENT_SETTINGS, message, error, extraAttributes, options)
 }
 
 export interface LogfireClient {
@@ -434,7 +500,7 @@ export interface LogfireClient {
   info(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   log(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   notice(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
-  reportError(message: string, error: Error, extraAttributes?: Record<string, unknown>): void
+  reportError(message: string, error: unknown, extraAttributes?: Record<string, unknown>, options?: ReportErrorOptions): void
   span: typeof span
   startPendingSpan(message: string, attributes?: Record<string, unknown>, options?: StartPendingSpanOptions): Span
   startSpan(message: string, attributes?: Record<string, unknown>, options?: LogOptions): Span
@@ -467,8 +533,8 @@ function createLogfireClient(settings: ResolvedLogfireClientSettings): LogfireCl
     notice: (message, attributes, options) => {
       logWithSettings(settings, message, attributes, { ...options, level: Level.Notice })
     },
-    reportError: (message, error, extraAttributes) => {
-      reportErrorWithSettings(settings, message, error, extraAttributes)
+    reportError: (message, error, extraAttributes, options) => {
+      reportErrorWithSettings(settings, message, error, extraAttributes, options)
     },
     span: scopedSpan,
     startPendingSpan: (message, attributes, options) => startPendingSpanWithSettings(settings, message, attributes, options),

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -10,9 +10,12 @@ import {
   ATTRIBUTES_MESSAGE_KEY,
   ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
   ATTRIBUTES_PENDING_SPAN_REAL_PARENT_KEY,
+  ATTRIBUTES_SCRUBBED_KEY,
   ATTRIBUTES_SPAN_TYPE_KEY,
   ATTRIBUTES_TAGS_KEY,
   INVALID_SPAN_ID,
+  JSON_NULL_FIELDS_KEY,
+  JSON_SCHEMA_KEY,
 } from './constants'
 import { canonicalizeError, computeFingerprint } from './fingerprint'
 import { logfireFormatWithExtras } from './formatter'
@@ -93,6 +96,44 @@ export interface ReportErrorOptions {
   tags?: string[]
 }
 
+export interface InstrumentOptions {
+  /**
+   * Static attributes to add to each instrumented call span.
+   */
+  attributes?: Record<string, unknown>
+  /**
+   * Extract positional arguments into span attributes.
+   *
+   * Defaults to false. Pass a string array for stable names, or true for
+   * best-effort parameter-name extraction from function source.
+   */
+  extractArgs?: boolean | readonly string[]
+  /**
+   * The log level for the instrumented call span.
+   */
+  level?: LogFireLevel
+  /**
+   * The message template for the instrumented call span.
+   */
+  message?: string
+  /**
+   * Set a span started with `startSpan` as parentSpan to create a child span.
+   */
+  parentSpan?: Span
+  /**
+   * Record successful return values as span attributes.
+   */
+  recordReturn?: boolean
+  /**
+   * Override the OTel span name without changing the message template.
+   */
+  spanName?: string
+  /**
+   * Tags to add to the instrumented call span.
+   */
+  tags?: string[]
+}
+
 interface LogfireSpanStart {
   attributes: Attributes
   name: string
@@ -104,6 +145,8 @@ interface ResolvedLogfireClientSettings {
 }
 
 type ReadableSpanFields = Pick<ReadableSpan, 'parentSpanContext' | 'startTime'>
+type InstrumentableFunction = (...args: never[]) => unknown
+type SerializedAttributeValue = ReturnType<typeof serializeAttributes>[string]
 
 const ROOT_CLIENT_SETTINGS: ResolvedLogfireClientSettings = { tags: [] }
 
@@ -165,6 +208,72 @@ function getReadableSpanFields(span: Span): Partial<ReadableSpanFields> {
 
 function isHrTime(value: unknown): value is HrTime {
   return Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number'
+}
+
+function getFunctionName(fn: InstrumentableFunction): string {
+  return fn.name || 'function'
+}
+
+function extractParamNames(fn: InstrumentableFunction): string[] {
+  const src = fn.toString()
+  // Crude by design: this is opt-in and exists for readable development builds.
+  const match = /^(?:async\s+)?(?:function[^(]*)?\(([^)]*)\)/u.exec(src)
+  if (match === null) {
+    return []
+  }
+  const inside = match[1]?.trim() ?? ''
+  if (inside === '') {
+    return []
+  }
+  return inside.split(',').map((param) => {
+    const trimmed = param.trim()
+    return trimmed.replace(/[=:].*$/u, '').trim()
+  })
+}
+
+function buildInstrumentedCallAttributes(
+  fn: InstrumentableFunction,
+  args: readonly unknown[],
+  options: InstrumentOptions
+): Record<string, unknown> {
+  const attributes: Record<string, unknown> = { ...(options.attributes ?? {}) }
+  if (options.extractArgs === undefined || options.extractArgs === false) {
+    return attributes
+  }
+
+  const argNames: readonly string[] = Array.isArray(options.extractArgs) ? options.extractArgs : extractParamNames(fn)
+  for (let i = 0; i < args.length; i++) {
+    const argName = argNames[i] ?? `arg${i.toString()}`
+    attributes[argName] = args[i]
+  }
+  return attributes
+}
+
+function buildInstrumentedCallSerializationAttributes(msgTemplate: string, attributes: Record<string, unknown>): Record<string, unknown> {
+  const { extraAttributes } = logfireFormatWithExtras(msgTemplate, attributes, logfireApiConfig.scrubber)
+  return { ...attributes, ...extraAttributes }
+}
+
+function safeSetSpanAttribute(span: Span, key: string, value: SerializedAttributeValue): void {
+  try {
+    span.setAttribute(key, value)
+  } catch {
+    // Return recording is best-effort and must never change function outcome.
+  }
+}
+
+function recordReturnAttributes(span: Span, spanSerializationAttributes: Record<string, unknown>, value: unknown): void {
+  try {
+    const serializedAttributes = serializeAttributes({ ...spanSerializationAttributes, return: value })
+    for (const key of ['return', JSON_SCHEMA_KEY, JSON_NULL_FIELDS_KEY, ATTRIBUTES_SCRUBBED_KEY]) {
+      const serializedValue = serializedAttributes[key]
+      if (serializedValue !== undefined) {
+        safeSetSpanAttribute(span, key, serializedValue)
+      }
+    }
+  } catch {
+    safeSetSpanAttribute(span, 'return', '[unserializable]')
+  }
 }
 
 /**
@@ -392,6 +501,55 @@ export function warning(message: string, attributes: Record<string, unknown> = {
   logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Warning })
 }
 
+function instrumentWithSettings<F extends InstrumentableFunction>(
+  settings: ResolvedLogfireClientSettings,
+  fn: F,
+  options: InstrumentOptions = {}
+): F {
+  const wrapped = function (this: ThisParameterType<F>, ...args: Parameters<F>): ReturnType<F> {
+    const message = options.message ?? `Calling ${getFunctionName(fn)}`
+    const attributes = buildInstrumentedCallAttributes(fn, args, options)
+    const spanSerializationAttributes =
+      options.recordReturn === true ? buildInstrumentedCallSerializationAttributes(message, attributes) : undefined
+    const spanOptions: SpanArgsVariant2<ReturnType<F>>[0] = {
+      attributes,
+      callback: (activeSpan) => {
+        const result = fn.apply(this, args) as ReturnType<F>
+        if (options.recordReturn !== true) {
+          return result
+        }
+        if (result instanceof Promise) {
+          return result.then((value: Awaited<ReturnType<F>>) => {
+            recordReturnAttributes(activeSpan, spanSerializationAttributes ?? {}, value)
+            return value
+          }) as ReturnType<F>
+        }
+        recordReturnAttributes(activeSpan, spanSerializationAttributes ?? {}, result)
+        return result
+      },
+    }
+    if (options.level !== undefined) {
+      spanOptions.level = options.level
+    }
+    if (options.parentSpan !== undefined) {
+      spanOptions.parentSpan = options.parentSpan
+    }
+    if (options.spanName !== undefined) {
+      spanOptions._spanName = options.spanName
+    }
+    if (options.tags !== undefined) {
+      spanOptions.tags = options.tags
+    }
+    return spanWithSettings(settings, message, spanOptions)
+  }
+
+  return wrapped as F
+}
+
+export function instrument<F extends InstrumentableFunction>(fn: F, options: InstrumentOptions = {}): F {
+  return instrumentWithSettings(ROOT_CLIENT_SETTINGS, fn, options)
+}
+
 function recordSpanException(span: Span, thrown: unknown): void {
   const isError = thrown instanceof Error
   const errorMessage = isError ? thrown.message : String(thrown)
@@ -498,6 +656,7 @@ export interface LogfireClient {
   error(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   fatal(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   info(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  instrument<F extends InstrumentableFunction>(fn: F, options?: InstrumentOptions): F
   log(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   notice(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   reportError(message: string, error: unknown, extraAttributes?: Record<string, unknown>, options?: ReportErrorOptions): void
@@ -527,6 +686,7 @@ function createLogfireClient(settings: ResolvedLogfireClientSettings): LogfireCl
     info: (message, attributes, options) => {
       logWithSettings(settings, message, attributes, { ...options, level: Level.Info })
     },
+    instrument: (fn, options) => instrumentWithSettings(settings, fn, options),
     log: (message, attributes, options) => {
       logWithSettings(settings, message, attributes, options)
     },
@@ -576,6 +736,7 @@ const defaultExport: {
   error: typeof error
   fatal: typeof fatal
   info: typeof info
+  instrument: typeof instrument
   levelOrDuration: typeof levelOrDuration
   log: typeof log
   logfireApiConfig: typeof logfireApiConfig
@@ -608,6 +769,7 @@ const defaultExport: {
   error,
   fatal,
   info,
+  instrument,
   levelOrDuration,
   log,
   get logfireApiConfig() {

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -316,6 +316,12 @@ function isHrTime(value: unknown): value is HrTime {
   return Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number'
 }
 
+function isThenable<T>(value: T): value is T & PromiseLike<Awaited<T>> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') && value !== null && typeof (value as { then?: unknown }).then === 'function'
+  )
+}
+
 function getFunctionName(fn: InstrumentableFunction): string {
   return fn.name || 'function'
 }
@@ -637,7 +643,7 @@ function instrumentWithSettings<F extends InstrumentableFunction>(
         if (options.recordReturn !== true) {
           return result
         }
-        if (result instanceof Promise) {
+        if (isThenable(result)) {
           return result.then((value: Awaited<ReturnType<F>>) => {
             recordReturnAttributes(activeSpan, spanSerializationAttributes ?? {}, value)
             return value

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -39,6 +39,7 @@ export { canonicalizeError, computeFingerprint } from './fingerprint'
 export { configureLogfireApi, logfireApiConfig, resolveBaseUrl, resolveSendToLogfire } from './logfireApiConfig'
 export type {
   BaggageOptions,
+  JsonSchemaMode,
   LevelName,
   LogFireLevel,
   LogfireApiConfig,

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -1,5 +1,11 @@
 import type { Attributes, Context, HrTime, Span } from '@opentelemetry/api'
-import { SpanStatusCode, context as TheContextAPI, propagation as ThePropagationAPI, trace as TheTraceAPI } from '@opentelemetry/api'
+import {
+  INVALID_SPAN_CONTEXT,
+  SpanStatusCode,
+  context as TheContextAPI,
+  propagation as ThePropagationAPI,
+  trace as TheTraceAPI,
+} from '@opentelemetry/api'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 import { ATTR_EXCEPTION_MESSAGE, ATTR_EXCEPTION_STACKTRACE } from '@opentelemetry/semantic-conventions'
 
@@ -19,6 +25,8 @@ import {
 } from './constants'
 import { canonicalizeError, computeFingerprint } from './fingerprint'
 import { logfireFormatWithExtras, truncateString } from './formatter'
+import { Level } from './levels'
+import type { LogFireLevel } from './levels'
 import { configureLogfireApi, logfireApiConfig, resolveBaseUrl, resolveSendToLogfire, serializeAttributes } from './logfireApiConfig'
 import { PendingSpanProcessor } from './PendingSpanProcessor'
 import { setPendingSpanSuppressed } from './pendingSpanSuppression'
@@ -29,25 +37,22 @@ import { ULIDGenerator } from './ULIDGenerator'
 export * from './AttributeScrubber'
 export { canonicalizeError, computeFingerprint } from './fingerprint'
 export { configureLogfireApi, logfireApiConfig, resolveBaseUrl, resolveSendToLogfire } from './logfireApiConfig'
-export type { BaggageOptions, LogfireApiConfig, LogfireApiConfigOptions, ScrubbingOptions } from './logfireApiConfig'
+export type {
+  BaggageOptions,
+  LevelName,
+  LogFireLevel,
+  LogfireApiConfig,
+  LogfireApiConfigOptions,
+  MinLevel,
+  ScrubbingOptions,
+} from './logfireApiConfig'
 export { ATTRIBUTES_PENDING_SPAN_REAL_PARENT_KEY } from './constants'
+export { Level } from './levels'
 export { PendingSpanProcessor } from './PendingSpanProcessor'
 export * from './sampling'
 export { serializeAttributes } from './serializeAttributes'
 export { TailSamplingProcessor, type TailSamplingProcessorOptions } from './TailSamplingProcessor'
 export * from './ULIDGenerator'
-
-export const Level = {
-  Trace: 1 as const,
-  Debug: 5 as const,
-  Info: 9 as const,
-  Notice: 10 as const,
-  Warning: 13 as const,
-  Error: 17 as const,
-  Fatal: 21 as const,
-}
-
-export type LogFireLevel = (typeof Level)[keyof typeof Level]
 
 export interface LogOptions {
   /**
@@ -139,6 +144,14 @@ interface LogfireSpanStart {
   name: string
 }
 
+type LevelSource = 'default' | 'explicit'
+
+interface ResolvedLogOptions extends Omit<LogOptions, 'level' | 'tags'> {
+  level: LogFireLevel
+  levelSource: LevelSource
+  tags: string[]
+}
+
 interface ResolvedLogfireClientSettings {
   level?: LogFireLevel
   tags: string[]
@@ -151,6 +164,7 @@ type SerializedAttributeValue = ReturnType<typeof serializeAttributes>[string]
 const ROOT_CLIENT_SETTINGS: ResolvedLogfireClientSettings = { tags: [] }
 const BAGGAGE_ATTRIBUTE_PREFIX = 'baggage.' as const
 const MAX_BAGGAGE_VALUE_LENGTH = 1000 as const
+const NOOP_SPAN = TheTraceAPI.wrapSpanContext(INVALID_SPAN_CONTEXT)
 
 function mergeTags(...tagGroups: (readonly string[] | undefined)[]): string[] {
   return Array.from(new Set(tagGroups.flatMap((tags) => tags ?? [])).values())
@@ -167,16 +181,56 @@ function mergeClientSettings(parent: ResolvedLogfireClientSettings, child: Logfi
   return merged
 }
 
-function mergeLogOptions(settings: ResolvedLogfireClientSettings, options: LogOptions | undefined, forcedLevel?: LogFireLevel): LogOptions {
-  const merged: LogOptions = {
+function resolveLogOptions(settings: ResolvedLogfireClientSettings, options: LogOptions | undefined): ResolvedLogOptions {
+  const merged: ResolvedLogOptions = {
     ...options,
+    level: Level.Info,
+    levelSource: 'default',
     tags: mergeTags(settings.tags, options?.tags),
   }
-  const level = forcedLevel ?? options?.level ?? settings.level
-  if (level !== undefined) {
-    merged.level = level
+  if (options?.level !== undefined) {
+    merged.level = options.level
+    merged.levelSource = 'explicit'
+  } else if (settings.level !== undefined) {
+    merged.level = settings.level
+    merged.levelSource = 'explicit'
   }
   return merged
+}
+
+function resolveLogLevel(
+  settings: ResolvedLogfireClientSettings,
+  options: { level?: LogFireLevel } | undefined
+): {
+  level: LogFireLevel
+  source: LevelSource
+} {
+  if (options?.level !== undefined) {
+    return { level: options.level, source: 'explicit' }
+  }
+  if (settings.level !== undefined) {
+    return { level: settings.level, source: 'explicit' }
+  }
+  return { level: Level.Info, source: 'default' }
+}
+
+function shouldFilterLevel(level: LogFireLevel, source: LevelSource, alwaysFilter: boolean): boolean {
+  const minLevel = logfireApiConfig.minLevel
+  if (minLevel === undefined) {
+    return false
+  }
+  if (!alwaysFilter && source !== 'explicit') {
+    return false
+  }
+  return level < minLevel
+}
+
+function getNoopSpan(): Span {
+  return NOOP_SPAN
+}
+
+function withNoopSpan<R>(callback: SpanCallback<R>): R {
+  return callback(getNoopSpan())
 }
 
 function getBaggageSpanAttributes(existingAttributes: Record<string, unknown>): Record<string, string> {
@@ -339,13 +393,16 @@ function startSpanWithSettings(
   attributes: Record<string, unknown> = {},
   options: LogOptions = {}
 ): Span {
-  options = mergeLogOptions(settings, options)
-  const spanStart = buildLogfireSpanStart(msgTemplate, attributes, options)
+  const resolvedOptions = resolveLogOptions(settings, options)
+  if (shouldFilterLevel(resolvedOptions.level, resolvedOptions.levelSource, resolvedOptions.log === true)) {
+    return getNoopSpan()
+  }
+  const spanStart = buildLogfireSpanStart(msgTemplate, attributes, resolvedOptions)
 
   const span = logfireApiConfig.tracer.startSpan(
     spanStart.name,
     { attributes: spanStart.attributes },
-    getSpanStartContext(options.parentSpan)
+    getSpanStartContext(resolvedOptions.parentSpan)
   )
 
   return span
@@ -365,9 +422,12 @@ function startPendingSpanWithSettings(
   attributes: Record<string, unknown> = {},
   options: StartPendingSpanOptions = {}
 ): Span {
-  options = mergeLogOptions(settings, options)
-  const spanStart = buildLogfireSpanStart(msgTemplate, attributes, options)
-  const parentContext = getSpanStartContext(options.parentSpan)
+  const resolvedOptions = resolveLogOptions(settings, options)
+  if (shouldFilterLevel(resolvedOptions.level, resolvedOptions.levelSource, false)) {
+    return getNoopSpan()
+  }
+  const spanStart = buildLogfireSpanStart(msgTemplate, attributes, resolvedOptions)
+  const parentContext = getSpanStartContext(resolvedOptions.parentSpan)
   const realSpan = logfireApiConfig.tracer.startSpan(
     spanStart.name,
     { attributes: spanStart.attributes },
@@ -441,26 +501,34 @@ function spanWithSettings<R>(
 ): R {
   let attributes: Record<string, unknown>
   let level: LogFireLevel
+  let levelSource: LevelSource
   let tags: string[]
   let callback!: SpanCallback<R>
   let parentSpan: Span | undefined
   let spanName: string | undefined
   if (args.length === 1) {
     const options = args[0]
+    const resolvedLevel = resolveLogLevel(settings, options)
     attributes = args[0].attributes ?? {}
-    level = options.level ?? settings.level ?? Level.Info
+    level = resolvedLevel.level
+    levelSource = resolvedLevel.source
     tags = mergeTags(settings.tags, options.tags)
     callback = options.callback
     parentSpan = options.parentSpan
     spanName = options._spanName
   } else {
-    const options = mergeLogOptions(settings, args[1])
+    const options = resolveLogOptions(settings, args[1])
     attributes = args[0]
-    level = options.level ?? Level.Info
-    tags = options.tags ?? []
+    level = options.level
+    levelSource = options.levelSource
+    tags = options.tags
     parentSpan = options.parentSpan
     spanName = options._spanName
     callback = args[2]
+  }
+
+  if (shouldFilterLevel(level, levelSource, false)) {
+    return withNoopSpan(callback)
   }
 
   const { serializedAttributes } = buildSerializedLogfireAttributes(msgTemplate, attributes, { tags, level })
@@ -554,6 +622,10 @@ function instrumentWithSettings<F extends InstrumentableFunction>(
 ): F {
   const wrapped = function (this: ThisParameterType<F>, ...args: Parameters<F>): ReturnType<F> {
     const message = options.message ?? `Calling ${getFunctionName(fn)}`
+    const resolvedLevel = resolveLogLevel(settings, options)
+    if (shouldFilterLevel(resolvedLevel.level, resolvedLevel.source, false)) {
+      return fn.apply(this, args) as ReturnType<F>
+    }
     const attributes = buildInstrumentedCallAttributes(fn, args, options)
     const spanSerializationAttributes =
       options.recordReturn === true ? buildInstrumentedCallSerializationAttributes(message, attributes) : undefined

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -77,12 +77,51 @@ export interface LogOptions {
 
 export type StartPendingSpanOptions = Omit<LogOptions, 'log'>
 
+export interface LogfireClientSettings {
+  level?: LogFireLevel
+  tags?: string[]
+}
+
 interface LogfireSpanStart {
   attributes: Attributes
   name: string
 }
 
+interface ResolvedLogfireClientSettings {
+  level?: LogFireLevel
+  tags: string[]
+}
+
 type ReadableSpanFields = Pick<ReadableSpan, 'parentSpanContext' | 'startTime'>
+
+const ROOT_CLIENT_SETTINGS: ResolvedLogfireClientSettings = { tags: [] }
+
+function mergeTags(...tagGroups: (readonly string[] | undefined)[]): string[] {
+  return Array.from(new Set(tagGroups.flatMap((tags) => tags ?? [])).values())
+}
+
+function mergeClientSettings(parent: ResolvedLogfireClientSettings, child: LogfireClientSettings): ResolvedLogfireClientSettings {
+  const merged: ResolvedLogfireClientSettings = {
+    tags: mergeTags(parent.tags, child.tags),
+  }
+  const level = child.level ?? parent.level
+  if (level !== undefined) {
+    merged.level = level
+  }
+  return merged
+}
+
+function mergeLogOptions(settings: ResolvedLogfireClientSettings, options: LogOptions | undefined, forcedLevel?: LogFireLevel): LogOptions {
+  const merged: LogOptions = {
+    ...options,
+    tags: mergeTags(settings.tags, options?.tags),
+  }
+  const level = forcedLevel ?? options?.level ?? settings.level
+  if (level !== undefined) {
+    merged.level = level
+  }
+  return merged
+}
 
 function buildLogfireSpanStart(
   msgTemplate: string,
@@ -122,7 +161,13 @@ function isHrTime(value: unknown): value is HrTime {
  * This method does NOT modify the current Context.
  * You need to manually call `span.end()` to finish the span.
  */
-export function startSpan(msgTemplate: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): Span {
+function startSpanWithSettings(
+  settings: ResolvedLogfireClientSettings,
+  msgTemplate: string,
+  attributes: Record<string, unknown> = {},
+  options: LogOptions = {}
+): Span {
+  options = mergeLogOptions(settings, options)
   const spanStart = buildLogfireSpanStart(msgTemplate, attributes, options)
 
   const span = logfireApiConfig.tracer.startSpan(
@@ -134,15 +179,21 @@ export function startSpan(msgTemplate: string, attributes: Record<string, unknow
   return span
 }
 
+export function startSpan(msgTemplate: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): Span {
+  return startSpanWithSettings(ROOT_CLIENT_SETTINGS, msgTemplate, attributes, options)
+}
+
 /**
  * Starts a real span and immediately emits a manual pending-span placeholder
  * for it. The returned real span must still be ended by the caller.
  */
-export function startPendingSpan(
+function startPendingSpanWithSettings(
+  settings: ResolvedLogfireClientSettings,
   msgTemplate: string,
   attributes: Record<string, unknown> = {},
   options: StartPendingSpanOptions = {}
 ): Span {
+  options = mergeLogOptions(settings, options)
   const spanStart = buildLogfireSpanStart(msgTemplate, attributes, options)
   const parentContext = getSpanStartContext(options.parentSpan)
   const realSpan = logfireApiConfig.tracer.startSpan(
@@ -178,6 +229,14 @@ export function startPendingSpan(
   return realSpan
 }
 
+export function startPendingSpan(
+  msgTemplate: string,
+  attributes: Record<string, unknown> = {},
+  options: StartPendingSpanOptions = {}
+): Span {
+  return startPendingSpanWithSettings(ROOT_CLIENT_SETTINGS, msgTemplate, attributes, options)
+}
+
 type SpanCallback<R> = (activeSpan: Span) => R
 type SpanArgsVariant1<R> = [Record<string, unknown>, LogOptions, SpanCallback<R>]
 type SpanArgsVariant2<R> = [
@@ -200,6 +259,14 @@ type SpanArgsVariant2<R> = [
 export function span<R>(msgTemplate: string, options: SpanArgsVariant2<R>[0]): R
 export function span<R>(msgTemplate: string, attributes: Record<string, unknown>, options: LogOptions, callback: (span: Span) => R): R
 export function span<R>(msgTemplate: string, ...args: SpanArgsVariant1<R> | SpanArgsVariant2<R>): R {
+  return spanWithSettings(ROOT_CLIENT_SETTINGS, msgTemplate, ...args)
+}
+
+function spanWithSettings<R>(
+  settings: ResolvedLogfireClientSettings,
+  msgTemplate: string,
+  ...args: SpanArgsVariant1<R> | SpanArgsVariant2<R>
+): R {
   let attributes: Record<string, unknown>
   let level: LogFireLevel
   let tags: string[]
@@ -207,18 +274,20 @@ export function span<R>(msgTemplate: string, ...args: SpanArgsVariant1<R> | Span
   let parentSpan: Span | undefined
   let spanName: string | undefined
   if (args.length === 1) {
+    const options = args[0]
     attributes = args[0].attributes ?? {}
-    level = args[0].level ?? Level.Info
-    tags = args[0].tags ?? []
-    callback = args[0].callback
-    parentSpan = args[0].parentSpan
-    spanName = args[0]._spanName
+    level = options.level ?? settings.level ?? Level.Info
+    tags = mergeTags(settings.tags, options.tags)
+    callback = options.callback
+    parentSpan = options.parentSpan
+    spanName = options._spanName
   } else {
+    const options = mergeLogOptions(settings, args[1])
     attributes = args[0]
-    level = args[1].level ?? Level.Info
-    tags = args[1].tags ?? []
-    parentSpan = args[1].parentSpan
-    spanName = args[1]._spanName
+    level = options.level ?? Level.Info
+    tags = options.tags ?? []
+    parentSpan = options.parentSpan
+    spanName = options._spanName
     callback = args[2]
   }
 
@@ -271,36 +340,45 @@ export function span<R>(msgTemplate: string, ...args: SpanArgsVariant1<R> | Span
   )
 }
 
+function logWithSettings(
+  settings: ResolvedLogfireClientSettings,
+  message: string,
+  attributes: Record<string, unknown> = {},
+  options: LogOptions = {}
+): void {
+  startSpanWithSettings(settings, message, attributes, { ...options, log: true }).end()
+}
+
 export function log(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  startSpan(message, attributes, { ...options, log: true }).end()
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, options)
 }
 
 export function debug(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Debug })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Debug })
 }
 
 export function info(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Info })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Info })
 }
 
 export function trace(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Trace })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Trace })
 }
 
 export function error(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Error })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Error })
 }
 
 export function fatal(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Fatal })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Fatal })
 }
 
 export function notice(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Notice })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Notice })
 }
 
 export function warning(message: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): void {
-  log(message, attributes, { ...options, level: Level.Warning })
+  logWithSettings(ROOT_CLIENT_SETTINGS, message, attributes, { ...options, level: Level.Warning })
 }
 
 function recordSpanException(span: Span, thrown: unknown): void {
@@ -322,7 +400,12 @@ function recordSpanException(span: Span, thrown: unknown): void {
  * Captures the error stack trace and message in the respective semantic attributes and sets the correct level and status.
  * Computes a fingerprint for the error to enable issue grouping in the Logfire backend (if errorFingerprinting is enabled).
  */
-export function reportError(message: string, error: Error, extraAttributes: Record<string, unknown> = {}): void {
+function reportErrorWithSettings(
+  settings: ResolvedLogfireClientSettings,
+  message: string,
+  error: Error,
+  extraAttributes: Record<string, unknown> = {}
+): void {
   const attributes: Record<string, unknown> = {
     [ATTR_EXCEPTION_MESSAGE]: error.message,
     [ATTR_EXCEPTION_STACKTRACE]: error.stack,
@@ -333,11 +416,82 @@ export function reportError(message: string, error: Error, extraAttributes: Reco
     attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY] = computeFingerprint(error)
   }
 
-  const span = startSpan(message, attributes, { level: Level.Error })
+  const span = startSpanWithSettings(settings, message, attributes, { level: Level.Error })
 
   span.recordException(error)
   span.setStatus({ code: SpanStatusCode.ERROR, message: `${error.name}: ${error.message}` })
   span.end()
+}
+
+export function reportError(message: string, error: Error, extraAttributes: Record<string, unknown> = {}): void {
+  reportErrorWithSettings(ROOT_CLIENT_SETTINGS, message, error, extraAttributes)
+}
+
+export interface LogfireClient {
+  debug(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  error(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  fatal(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  info(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  log(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  notice(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  reportError(message: string, error: Error, extraAttributes?: Record<string, unknown>): void
+  span: typeof span
+  startPendingSpan(message: string, attributes?: Record<string, unknown>, options?: StartPendingSpanOptions): Span
+  startSpan(message: string, attributes?: Record<string, unknown>, options?: LogOptions): Span
+  trace(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  warning(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
+  withSettings(settings: LogfireClientSettings): LogfireClient
+  withTags(...tags: string[]): LogfireClient
+}
+
+function createLogfireClient(settings: ResolvedLogfireClientSettings): LogfireClient {
+  const scopedSpan = (<R>(msgTemplate: string, ...args: SpanArgsVariant1<R> | SpanArgsVariant2<R>) =>
+    spanWithSettings(settings, msgTemplate, ...args)) as typeof span
+
+  return {
+    debug: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Debug })
+    },
+    error: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Error })
+    },
+    fatal: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Fatal })
+    },
+    info: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Info })
+    },
+    log: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, options)
+    },
+    notice: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Notice })
+    },
+    reportError: (message, error, extraAttributes) => {
+      reportErrorWithSettings(settings, message, error, extraAttributes)
+    },
+    span: scopedSpan,
+    startPendingSpan: (message, attributes, options) => startPendingSpanWithSettings(settings, message, attributes, options),
+    startSpan: (message, attributes, options) => startSpanWithSettings(settings, message, attributes, options),
+    trace: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Trace })
+    },
+    warning: (message, attributes, options) => {
+      logWithSettings(settings, message, attributes, { ...options, level: Level.Warning })
+    },
+    withSettings: (childSettings) => createLogfireClient(mergeClientSettings(settings, childSettings)),
+    withTags: (...tags) => createLogfireClient(mergeClientSettings(settings, { tags })),
+  }
+}
+
+const defaultClient = createLogfireClient(ROOT_CLIENT_SETTINGS)
+
+export function withSettings(settings: LogfireClientSettings): LogfireClient {
+  return defaultClient.withSettings(settings)
+}
+
+export function withTags(...tags: string[]): LogfireClient {
+  return defaultClient.withTags(...tags)
 }
 
 const defaultExport: {
@@ -369,6 +523,8 @@ const defaultExport: {
   startSpan: typeof startSpan
   trace: typeof trace
   warning: typeof warning
+  withSettings: typeof withSettings
+  withTags: typeof withTags
   Level: typeof Level
 } = {
   LogfireAttributeScrubber,
@@ -401,6 +557,8 @@ const defaultExport: {
   startSpan,
   trace,
   warning,
+  withSettings,
+  withTags,
   Level,
 }
 

--- a/packages/logfire-api/src/levels.ts
+++ b/packages/logfire-api/src/levels.ts
@@ -1,0 +1,50 @@
+export const Level = {
+  Trace: 1 as const,
+  Debug: 5 as const,
+  Info: 9 as const,
+  Notice: 10 as const,
+  Warning: 13 as const,
+  Error: 17 as const,
+  Fatal: 21 as const,
+}
+
+export type LogFireLevel = (typeof Level)[keyof typeof Level]
+const LEVEL_NAMES = ['trace', 'debug', 'info', 'notice', 'warning', 'error', 'fatal'] as const
+export type LevelName = (typeof LEVEL_NAMES)[number]
+export type MinLevel = LogFireLevel | LevelName
+
+export const LEVEL_NUMBERS: Record<LevelName, LogFireLevel> = {
+  trace: Level.Trace,
+  debug: Level.Debug,
+  info: Level.Info,
+  notice: Level.Notice,
+  warning: Level.Warning,
+  error: Level.Error,
+  fatal: Level.Fatal,
+}
+
+const LEVEL_NUMBER_VALUES = new Set<LogFireLevel>(Object.values(Level))
+
+export function isLogFireLevel(value: number): value is LogFireLevel {
+  return LEVEL_NUMBER_VALUES.has(value as LogFireLevel)
+}
+
+export function parseLevelName(value: string): LevelName | undefined {
+  const normalized = value.trim().toLowerCase()
+  return Object.hasOwn(LEVEL_NUMBERS, normalized) ? (normalized as LevelName) : undefined
+}
+
+export function resolveMinLevel(value: MinLevel): LogFireLevel {
+  if (typeof value === 'number') {
+    if (isLogFireLevel(value)) {
+      return value
+    }
+  } else {
+    const levelName = parseLevelName(value)
+    if (levelName !== undefined) {
+      return LEVEL_NUMBERS[levelName]
+    }
+  }
+
+  throw new Error(`Invalid minLevel: ${value}. Expected one of ${LEVEL_NAMES.join(', ')} or a numeric value from logfire.Level.`)
+}

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -27,6 +27,8 @@ export interface BaggageOptions {
   spanAttributes?: readonly string[]
 }
 
+export type JsonSchemaMode = 'rich' | 'basic' | false
+
 export interface LogfireApiConfigOptions {
   baggage?: BaggageOptions
   /**
@@ -35,6 +37,17 @@ export interface LogfireApiConfigOptions {
    * Defaults to true for Node.js, false for browser (minified code produces unstable fingerprints).
    */
   errorFingerprinting?: boolean
+  /**
+   * Controls JSON schema metadata for serialized object/array attributes.
+   *
+   * - 'rich' infers bounded nested schema metadata.
+   * - 'basic' preserves the legacy broad top-level object/array schema metadata.
+   * - false omits logfire.json_schema metadata.
+   *
+   * This does not change how attribute values are serialized.
+   * Defaults to 'rich'.
+   */
+  jsonSchema?: JsonSchemaMode
   minLevel?: MinLevel | null
   otelScope?: string
   /**
@@ -61,6 +74,7 @@ export interface LogfireApiConfig {
   baggage: ResolvedBaggageOptions
   context: Context
   enableErrorFingerprinting: boolean
+  jsonSchema: JsonSchemaMode
   minLevel: LogFireLevel | undefined
   otelScope: string
   scrubber: BaseScrubber
@@ -80,6 +94,7 @@ const DEFAULT_LOGFIRE_API_CONFIG: LogfireApiConfig = {
     return ContextAPI.active()
   },
   enableErrorFingerprinting: true,
+  jsonSchema: 'rich',
   minLevel: undefined,
   otelScope: DEFAULT_OTEL_SCOPE,
   scrubber: new LogfireAttributeScrubber(),
@@ -97,6 +112,10 @@ export function configureLogfireApi(config: LogfireApiConfigOptions): void {
 
   if (config.errorFingerprinting !== undefined) {
     logfireApiConfig.enableErrorFingerprinting = config.errorFingerprinting
+  }
+
+  if (config.jsonSchema !== undefined) {
+    logfireApiConfig.jsonSchema = config.jsonSchema
   }
 
   if (config.minLevel !== undefined) {

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -2,10 +2,14 @@ import type { Context, Tracer } from '@opentelemetry/api'
 import { context as ContextAPI, trace as TraceAPI } from '@opentelemetry/api'
 
 import type { BaseScrubber, ScrubCallback } from './AttributeScrubber'
+import type { LogFireLevel, MinLevel } from './levels'
 import { LogfireAttributeScrubber, NoopAttributeScrubber } from './AttributeScrubber'
 import { DEFAULT_OTEL_SCOPE } from './constants'
+import { Level, resolveMinLevel } from './levels'
 
 export * from './AttributeScrubber'
+export { Level }
+export type { LevelName, LogFireLevel, MinLevel } from './levels'
 export { serializeAttributes } from './serializeAttributes'
 
 export interface ScrubbingOptions {
@@ -31,6 +35,7 @@ export interface LogfireApiConfigOptions {
    * Defaults to true for Node.js, false for browser (minified code produces unstable fingerprints).
    */
   errorFingerprinting?: boolean
+  minLevel?: MinLevel | null
   otelScope?: string
   /**
    * Options for scrubbing sensitive data. Set to False to disable.
@@ -44,19 +49,7 @@ export interface ResolvedBaggageOptions {
 
 export type SendToLogfire = 'if-token-present' | boolean | undefined
 
-export const Level = {
-  Trace: 1 as const,
-  Debug: 5 as const,
-  Info: 9 as const,
-  Notice: 10 as const,
-  Warning: 13 as const,
-  Error: 17 as const,
-  Fatal: 21 as const,
-}
-
 export type Env = Record<string, string | undefined>
-
-export type LogFireLevel = (typeof Level)[keyof typeof Level]
 
 export interface LogOptions {
   level?: LogFireLevel
@@ -68,6 +61,7 @@ export interface LogfireApiConfig {
   baggage: ResolvedBaggageOptions
   context: Context
   enableErrorFingerprinting: boolean
+  minLevel: LogFireLevel | undefined
   otelScope: string
   scrubber: BaseScrubber
   tracer: Tracer
@@ -86,6 +80,7 @@ const DEFAULT_LOGFIRE_API_CONFIG: LogfireApiConfig = {
     return ContextAPI.active()
   },
   enableErrorFingerprinting: true,
+  minLevel: undefined,
   otelScope: DEFAULT_OTEL_SCOPE,
   scrubber: new LogfireAttributeScrubber(),
   tracer: TraceAPI.getTracer(DEFAULT_OTEL_SCOPE),
@@ -102,6 +97,10 @@ export function configureLogfireApi(config: LogfireApiConfigOptions): void {
 
   if (config.errorFingerprinting !== undefined) {
     logfireApiConfig.enableErrorFingerprinting = config.errorFingerprinting
+  }
+
+  if (config.minLevel !== undefined) {
+    logfireApiConfig.minLevel = config.minLevel === null ? undefined : resolveMinLevel(config.minLevel)
   }
 
   if (config.scrubbing !== undefined) {

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -13,7 +13,18 @@ export interface ScrubbingOptions {
   extraPatterns?: string[]
 }
 
+export interface BaggageOptions {
+  /**
+   * Active OpenTelemetry baggage keys to copy to Logfire spans/logs.
+   *
+   * Keys are emitted as attributes prefixed with `baggage.`.
+   * Defaults to [].
+   */
+  spanAttributes?: readonly string[]
+}
+
 export interface LogfireApiConfigOptions {
+  baggage?: BaggageOptions
   /**
    * Whether to compute fingerprints for errors reported via reportError().
    * Fingerprints enable error grouping in the Logfire backend.
@@ -25,6 +36,10 @@ export interface LogfireApiConfigOptions {
    * Options for scrubbing sensitive data. Set to False to disable.
    */
   scrubbing?: false | ScrubbingOptions
+}
+
+export interface ResolvedBaggageOptions {
+  spanAttributes: readonly string[]
 }
 
 export type SendToLogfire = 'if-token-present' | boolean | undefined
@@ -50,6 +65,7 @@ export interface LogOptions {
 }
 
 export interface LogfireApiConfig {
+  baggage: ResolvedBaggageOptions
   context: Context
   enableErrorFingerprinting: boolean
   otelScope: string
@@ -63,6 +79,9 @@ export interface RegionData {
 }
 
 const DEFAULT_LOGFIRE_API_CONFIG: LogfireApiConfig = {
+  baggage: {
+    spanAttributes: [],
+  },
   get context() {
     return ContextAPI.active()
   },
@@ -75,6 +94,12 @@ const DEFAULT_LOGFIRE_API_CONFIG: LogfireApiConfig = {
 export const logfireApiConfig: LogfireApiConfig = DEFAULT_LOGFIRE_API_CONFIG
 
 export function configureLogfireApi(config: LogfireApiConfigOptions): void {
+  if (config.baggage !== undefined) {
+    logfireApiConfig.baggage = {
+      spanAttributes: [...(config.baggage.spanAttributes ?? [])],
+    }
+  }
+
   if (config.errorFingerprinting !== undefined) {
     logfireApiConfig.enableErrorFingerprinting = config.errorFingerprinting
   }

--- a/packages/logfire-api/src/sampling.ts
+++ b/packages/logfire-api/src/sampling.ts
@@ -2,18 +2,8 @@ import type { Context } from '@opentelemetry/api'
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
 import { ATTRIBUTES_LEVEL_KEY } from './constants'
-
-type LevelName = 'debug' | 'error' | 'fatal' | 'info' | 'notice' | 'trace' | 'warning'
-
-const LEVEL_NUMBERS: Record<LevelName, number> = {
-  debug: 5,
-  error: 17,
-  fatal: 21,
-  info: 9,
-  notice: 10,
-  trace: 1,
-  warning: 13,
-}
+import { LEVEL_NUMBERS } from './levels'
+import type { LevelName } from './levels'
 
 const DEFAULT_LEVEL_NUM = LEVEL_NUMBERS.info
 

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, test } from 'vite-plus/test'
+
+import { JSON_NULL_FIELDS_KEY, JSON_SCHEMA_KEY } from './constants'
+import { configureLogfireApi } from './logfireApiConfig'
+import { serializeAttributes } from './serializeAttributes'
+
+function parseSchema(result: Record<string, unknown>): unknown {
+  const schema = result[JSON_SCHEMA_KEY]
+  expect(typeof schema).toBe('string')
+  return JSON.parse(schema as string) as unknown
+}
+
+describe('serializeAttributes', () => {
+  beforeEach(() => {
+    configureLogfireApi({
+      jsonSchema: 'rich',
+      minLevel: null,
+      scrubbing: {},
+    })
+  })
+
+  test('keeps top-level primitives and nullish metadata behavior unchanged', () => {
+    expect(serializeAttributes({ active: true, count: 2, missing: undefined, name: 'Ada', nothing: null })).toEqual({
+      active: true,
+      count: 2,
+      [JSON_NULL_FIELDS_KEY]: ['missing', 'nothing'],
+      name: 'Ada',
+    })
+  })
+
+  test('emits deterministic nested object schema for ordinary JSON-like values', () => {
+    const result = serializeAttributes({
+      payload: {
+        count: 2,
+        meta: { active: true },
+        name: 'Ada',
+      },
+    })
+
+    expect(result['payload']).toBe('{"count":2,"meta":{"active":true},"name":"Ada"}')
+    expect(result[JSON_SCHEMA_KEY]).toBe(
+      '{"properties":{"payload":{"properties":{"count":{"type":"number"},"meta":{"properties":{"active":{"type":"boolean"}},"type":"object"},"name":{"type":"string"}},"type":"object"}},"type":"object"}'
+    )
+  })
+
+  test('supports rich, basic, and disabled schema modes', () => {
+    expect(parseSchema(serializeAttributes({ payload: { id: '123' } }))).toEqual({
+      properties: {
+        payload: {
+          properties: {
+            id: { type: 'string' },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+
+    configureLogfireApi({ jsonSchema: 'basic' })
+    expect(parseSchema(serializeAttributes({ payload: { id: '123' } }))).toEqual({
+      properties: {
+        payload: { type: 'object' },
+      },
+      type: 'object',
+    })
+
+    configureLogfireApi({ jsonSchema: false })
+    expect(serializeAttributes({ payload: { id: '123' } })).not.toHaveProperty(JSON_SCHEMA_KEY)
+  })
+
+  test('emits Date schema for top-level and nested dates', () => {
+    const createdAt = new Date('2026-01-02T03:04:05.000Z')
+    const result = serializeAttributes({
+      createdAt,
+      payload: {
+        createdAt,
+      },
+    })
+
+    expect(result['createdAt']).toBe('2026-01-02T03:04:05.000Z')
+    expect(result['payload']).toBe('{"createdAt":"2026-01-02T03:04:05.000Z"}')
+    expect(parseSchema(result)).toEqual({
+      properties: {
+        createdAt: { format: 'date-time', type: 'string' },
+        payload: {
+          properties: {
+            createdAt: { format: 'date-time', type: 'string' },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+  })
+
+  test('follows JSON.stringify visibility for nested undefined, function, and symbol values', () => {
+    const result = serializeAttributes({
+      array: [undefined, () => undefined, Symbol('hidden')],
+      payload: {
+        dropFunction: () => undefined,
+        dropSymbol: Symbol('hidden'),
+        dropUndefined: undefined,
+        keep: true,
+      },
+    })
+
+    expect(result['payload']).toBe('{"keep":true}')
+    expect(result['array']).toBe('[null,null,null]')
+    expect(parseSchema(result)).toEqual({
+      properties: {
+        array: {
+          items: { type: 'null' },
+          type: 'array',
+        },
+        payload: {
+          properties: {
+            keep: { type: 'boolean' },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+  })
+
+  test('covers homogeneous arrays and falls back for heterogeneous arrays', () => {
+    const result = serializeAttributes({
+      heterogeneous: [1, 'two'],
+      objects: [{ id: 'a' }, { id: 'b' }],
+      strings: ['a', 'b'],
+    })
+
+    expect(parseSchema(result)).toEqual({
+      properties: {
+        heterogeneous: { type: 'array' },
+        objects: {
+          items: {
+            properties: {
+              id: { type: 'string' },
+            },
+            type: 'object',
+          },
+          type: 'array',
+        },
+        strings: {
+          items: { type: 'string' },
+          type: 'array',
+        },
+      },
+      type: 'object',
+    })
+  })
+
+  test('keeps schema inference bounded by depth, object properties, and array samples', () => {
+    const manyProperties: Record<string, number> = {}
+    for (let index = 0; index < 25; index++) {
+      manyProperties[`k${index.toString().padStart(2, '0')}`] = index
+    }
+
+    const result = serializeAttributes({
+      array: [...Array.from({ length: 20 }, () => 'sampled'), 123],
+      deep: { a: { b: { c: { d: { e: 'too deep' } } } } },
+      manyProperties,
+    })
+    const schema = parseSchema(result) as {
+      properties: {
+        array: unknown
+        deep: unknown
+        manyProperties: { properties: Record<string, unknown> }
+      }
+    }
+
+    expect(schema.properties.array).toEqual({
+      items: { type: 'string' },
+      type: 'array',
+    })
+    expect(schema.properties.deep).toEqual({
+      properties: {
+        a: {
+          properties: {
+            b: {
+              properties: {
+                c: {
+                  properties: {
+                    d: { type: 'object' },
+                  },
+                  type: 'object',
+                },
+              },
+              type: 'object',
+            },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+    expect(Object.keys(schema.properties.manyProperties.properties)).toHaveLength(20)
+    expect(schema.properties.manyProperties.properties).toHaveProperty('k00')
+    expect(schema.properties.manyProperties.properties).toHaveProperty('k19')
+    expect(schema.properties.manyProperties.properties).not.toHaveProperty('k20')
+  })
+
+  test('uses broad schemas for unsupported object-like values', () => {
+    class CustomValue {
+      value = 'custom'
+    }
+
+    const result = serializeAttributes({
+      custom: new CustomValue(),
+      map: new Map([['key', 'value']]),
+      set: new Set(['value']),
+    })
+
+    expect(result['custom']).toBe('{"value":"custom"}')
+    expect(result['map']).toBe('{}')
+    expect(result['set']).toBe('{}')
+    expect(parseSchema(result)).toEqual({
+      properties: {
+        custom: { type: 'object' },
+        map: { type: 'object' },
+        set: { type: 'object' },
+      },
+      type: 'object',
+    })
+  })
+
+  test('does not throw when object or array serialization fails', () => {
+    const circular: Record<string, unknown> = {}
+    circular['self'] = circular
+
+    const result = serializeAttributes({
+      bigintPayload: { value: 1n },
+      circular,
+      handler: () => undefined,
+      symbol: Symbol('top-level'),
+    })
+
+    expect(result).toEqual({
+      bigintPayload: '[unserializable]',
+      circular: '[unserializable]',
+      handler: '[unserializable]',
+      symbol: '[unserializable]',
+    })
+  })
+
+  test('uses scrubbed values for schema inference', () => {
+    const result = serializeAttributes({
+      payload: {
+        password: 'secret-value',
+      },
+    })
+
+    expect(result['payload']).toBe('{"password":"[Scrubbed due to \'password\']"}')
+    expect(parseSchema(result)).toMatchObject({
+      properties: {
+        payload: {
+          properties: {
+            password: { type: 'string' },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+  })
+})

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -226,22 +226,24 @@ describe('serializeAttributes', () => {
   })
 
   test('does not throw when object or array serialization fails', () => {
-    const circular: Record<string, unknown> = {}
+    const circular: Record<string, unknown> = { password: 'secret-value' }
     circular['self'] = circular
+    const circularArray: unknown[] = []
+    circularArray.push(circularArray)
 
     const result = serializeAttributes({
       bigintPayload: { value: 1n },
       circular,
+      circularArray,
       handler: () => undefined,
       symbol: Symbol('top-level'),
     })
 
-    expect(result).toEqual({
-      bigintPayload: '[unserializable]',
-      circular: '[unserializable]',
-      handler: '[unserializable]',
-      symbol: '[unserializable]',
-    })
+    expect(result['bigintPayload']).toBe('[unserializable]')
+    expect(result['circular']).toBe('{"password":"[Scrubbed due to \'password\']","self":"[Scrubbed due to cycle]"}')
+    expect(result['circularArray']).toBe('["[Scrubbed due to cycle]"]')
+    expect(result['handler']).toBe('[unserializable]')
+    expect(result['symbol']).toBe('[unserializable]')
   })
 
   test('does not throw for deeply nested attributes before JSON serialization', () => {

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -244,6 +244,18 @@ describe('serializeAttributes', () => {
     })
   })
 
+  test('does not throw for deeply nested attributes before JSON serialization', () => {
+    let deep: Record<string, unknown> = { value: 'ok' }
+    for (let index = 0; index < 10_000; index++) {
+      deep = { child: deep }
+    }
+
+    const result = serializeAttributes({ deep })
+
+    expect(result).toHaveProperty('deep')
+    expect(result['deep']).toContain('[Scrubbed due to max depth]')
+  })
+
   test('uses scrubbed values for schema inference', () => {
     const result = serializeAttributes({
       payload: {

--- a/packages/logfire-api/src/serializeAttributes.ts
+++ b/packages/logfire-api/src/serializeAttributes.ts
@@ -6,17 +6,26 @@ export type AttributeValue = boolean | number | string | string[]
 
 export type RawAttributes = Record<string, unknown>
 
-interface JSONSchema {
-  properties: Record<
-    string,
-    {
-      type: 'array' | 'object'
-    }
-  >
+type JSONSchema =
+  | { items?: JSONSchema; type: 'array' }
+  | { properties?: Record<string, JSONSchema>; type: 'object' }
+  | { format?: 'date-time'; type: 'string' }
+  | { type: 'boolean' }
+  | { type: 'null' }
+  | { type: 'number' }
+
+interface AttributesJSONSchema {
+  properties: Record<string, JSONSchema>
   type: 'object'
 }
 
 type SerializedAttributes = Record<string, AttributeValue>
+type ContainerKind = 'array' | 'object' | 'top-level'
+
+const MAX_SCHEMA_DEPTH = 4
+const MAX_OBJECT_PROPERTIES = 20
+const MAX_ARRAY_ITEMS = 20
+const UNSERIALIZABLE_VALUE = '[unserializable]'
 
 export function serializeAttributes(attributes: RawAttributes): SerializedAttributes {
   const scrubber = logfireApiConfig.scrubber
@@ -25,7 +34,7 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
 
   const result: SerializedAttributes = {}
   const nullArgs: string[] = []
-  const schema: JSONSchema = { properties: {}, type: 'object' }
+  const schema: AttributesJSONSchema = { properties: {}, type: 'object' }
 
   if (scrubNotes.length > 0) {
     if (ATTRIBUTES_SCRUBBED_KEY in scrubbedAttributes) {
@@ -35,6 +44,7 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
     }
   }
   for (const [key, value] of Object.entries(scrubbedAttributes)) {
+    const rawValue = Object.hasOwn(attributes, key) ? attributes[key] : value
     // we don't want to serialize the tags
     if (key === ATTRIBUTES_TAGS_KEY) {
       result[key] = value as string[]
@@ -46,18 +56,18 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
     } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       result[key] = value
     } else if (value instanceof Date) {
-      result[key] = value.toISOString()
+      try {
+        result[key] = value.toISOString()
+        if (logfireApiConfig.jsonSchema === 'rich') {
+          schema.properties[key] = { format: 'date-time', type: 'string' }
+        }
+      } catch {
+        result[key] = UNSERIALIZABLE_VALUE
+      }
     } else if (Array.isArray(value)) {
-      schema.properties[key] = {
-        type: 'array',
-      }
-      result[key] = JSON.stringify(value)
+      serializeJsonAttribute(key, value, rawValue, 'array', result, schema)
     } else {
-      schema.properties[key] = {
-        type: 'object',
-      }
-
-      result[key] = JSON.stringify(value)
+      serializeJsonAttribute(key, value, rawValue, 'object', result, schema)
     }
   }
   if (nullArgs.length > 0) {
@@ -67,4 +77,218 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
     result[JSON_SCHEMA_KEY] = JSON.stringify(schema)
   }
   return result
+}
+
+function serializeJsonAttribute(
+  key: string,
+  value: unknown,
+  rawValue: unknown,
+  basicType: 'array' | 'object',
+  result: SerializedAttributes,
+  schema: AttributesJSONSchema
+): void {
+  const serializedValue = stringifyJsonAttribute(value)
+  if (serializedValue === undefined) {
+    result[key] = UNSERIALIZABLE_VALUE
+    return
+  }
+
+  result[key] = serializedValue
+
+  if (logfireApiConfig.jsonSchema === false) {
+    return
+  }
+
+  if (logfireApiConfig.jsonSchema === 'basic') {
+    schema.properties[key] = { type: basicType }
+    return
+  }
+
+  const inferredSchema = inferJsonSchema(value, {
+    container: 'top-level',
+    depth: 0,
+    rawValue,
+    seen: new WeakSet(),
+  })
+  if (inferredSchema !== undefined) {
+    schema.properties[key] = inferredSchema
+  }
+}
+
+function stringifyJsonAttribute(value: unknown): string | undefined {
+  try {
+    const serialized = JSON.stringify(value)
+    return typeof serialized === 'string' ? serialized : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function inferJsonSchema(
+  value: unknown,
+  state: {
+    container: ContainerKind
+    depth: number
+    rawValue: unknown
+    seen: WeakSet<object>
+  }
+): JSONSchema | undefined {
+  const rawValue = state.rawValue
+
+  if (value === null) {
+    return { type: 'null' }
+  }
+  if (value === undefined) {
+    return state.container === 'array' ? { type: 'null' } : undefined
+  }
+
+  switch (typeof value) {
+    case 'boolean':
+      return { type: 'boolean' }
+    case 'number':
+      return Number.isFinite(value) ? { type: 'number' } : { type: 'null' }
+    case 'string':
+      return { type: 'string' }
+    case 'bigint':
+      return undefined
+    case 'function':
+    case 'symbol':
+      return state.container === 'array' ? { type: 'null' } : undefined
+    case 'object':
+      break
+    case 'undefined':
+      return state.container === 'array' ? { type: 'null' } : undefined
+    default:
+      return undefined
+  }
+
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? { format: 'date-time', type: 'string' } : { type: 'null' }
+  }
+
+  if (Array.isArray(value)) {
+    return inferArraySchema(value, Array.isArray(rawValue) ? rawValue : value, state)
+  }
+
+  if (
+    rawValue !== null &&
+    typeof rawValue === 'object' &&
+    !Array.isArray(rawValue) &&
+    !(rawValue instanceof Date) &&
+    !isPlainObject(rawValue)
+  ) {
+    return { type: 'object' }
+  }
+
+  if (!isPlainObject(value)) {
+    return { type: 'object' }
+  }
+
+  const rawObjectValue = rawValue !== null && typeof rawValue === 'object' && isPlainObject(rawValue) ? rawValue : value
+  return inferObjectSchema(value, rawObjectValue, state)
+}
+
+function inferArraySchema(
+  value: unknown[],
+  rawValue: unknown[],
+  state: {
+    depth: number
+    seen: WeakSet<object>
+  }
+): JSONSchema {
+  if (state.depth >= MAX_SCHEMA_DEPTH || state.seen.has(value)) {
+    return { type: 'array' }
+  }
+
+  state.seen.add(value)
+  try {
+    if (value.length === 0) {
+      return { type: 'array' }
+    }
+
+    const itemSchemas: JSONSchema[] = []
+    for (let index = 0; index < Math.min(value.length, MAX_ARRAY_ITEMS); index++) {
+      const itemSchema = inferJsonSchema(value[index], {
+        container: 'array',
+        depth: state.depth + 1,
+        rawValue: rawValue[index],
+        seen: state.seen,
+      })
+      if (itemSchema !== undefined) {
+        itemSchemas.push(itemSchema)
+      }
+    }
+
+    if (itemSchemas.length === 0 || !schemasAreHomogeneous(itemSchemas)) {
+      return { type: 'array' }
+    }
+
+    const itemSchema = itemSchemas[0]
+    if (itemSchema === undefined || isBroadContainerSchema(itemSchema)) {
+      return { type: 'array' }
+    }
+
+    return { items: itemSchema, type: 'array' }
+  } finally {
+    state.seen.delete(value)
+  }
+}
+
+function inferObjectSchema(
+  value: Record<string, unknown>,
+  rawValue: Record<string, unknown>,
+  state: {
+    depth: number
+    seen: WeakSet<object>
+  }
+): JSONSchema {
+  if (state.depth >= MAX_SCHEMA_DEPTH || state.seen.has(value)) {
+    return { type: 'object' }
+  }
+
+  state.seen.add(value)
+  try {
+    const properties: Record<string, JSONSchema> = {}
+    const keys = Object.keys(value).sort().slice(0, MAX_OBJECT_PROPERTIES)
+
+    for (const key of keys) {
+      const propertySchema = inferJsonSchema(value[key], {
+        container: 'object',
+        depth: state.depth + 1,
+        rawValue: rawValue[key],
+        seen: state.seen,
+      })
+      if (propertySchema !== undefined) {
+        properties[key] = propertySchema
+      }
+    }
+
+    return Object.keys(properties).length > 0 ? { properties, type: 'object' } : { type: 'object' }
+  } finally {
+    state.seen.delete(value)
+  }
+}
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value) as unknown
+  return prototype === Object.prototype || prototype === null
+}
+
+function schemasAreHomogeneous(schemas: JSONSchema[]): boolean {
+  const firstSchema = stringifyStableSchema(schemas[0])
+  return schemas.every((schema) => stringifyStableSchema(schema) === firstSchema)
+}
+
+function stringifyStableSchema(schema: JSONSchema | undefined): string {
+  return JSON.stringify(schema)
+}
+
+function isBroadContainerSchema(schema: JSONSchema): boolean {
+  if (schema.type === 'object') {
+    return schema.properties === undefined
+  }
+  if (schema.type === 'array') {
+    return schema.items === undefined
+  }
+  return false
 }

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -73,6 +73,27 @@ characters. Do not store secrets, credentials, session cookies, raw emails, or
 other sensitive user data in baggage because baggage propagates across service
 boundaries.
 
+## Minimum level filtering
+
+Use `minLevel` to suppress low-severity manual Logfire telemetry before spans
+are created:
+
+```js
+import * as logfire from '@pydantic/logfire-browser'
+
+logfire.configure({
+  traceUrl: '/client-traces',
+  serviceName: 'browser-app',
+  minLevel: 'warning',
+})
+```
+
+Browser configuration does not read Logfire environment variables. Pass
+`minLevel` in code, or pass `minLevel: null` to clear a previous setting. Log
+helpers and `reportError()` are filtered by their level. Duration-style APIs
+such as `span()`, `startSpan()`, `startPendingSpan()`, and `instrument()` are
+filtered only when the call or scoped client sets an explicit level.
+
 ## Runtime lifecycle
 
 `configure()` returns an async cleanup function. Call it when your application is

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -49,6 +49,30 @@ Do not use resource attributes for per-request values or sensitive user data.
 First-class options such as `serviceName`, `serviceVersion`, and `environment`
 take precedence over conflicting `resourceAttributes` keys.
 
+## Baggage span attributes
+
+Use `baggage.spanAttributes` to copy selected active OpenTelemetry baggage
+values onto Logfire manual spans and logs:
+
+```js
+import * as logfire from '@pydantic/logfire-browser'
+
+logfire.configure({
+  traceUrl: '/client-traces',
+  serviceName: 'browser-app',
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+Projection is disabled by default and allowlisted. Configured baggage key
+`tenant` is emitted as `baggage.tenant`. Explicit span attributes win on
+conflict, missing keys are ignored, and values are truncated to 1000
+characters. Do not store secrets, credentials, session cookies, raw emails, or
+other sensitive user data in baggage because baggage propagates across service
+boundaries.
+
 ## Runtime lifecycle
 
 `configure()` returns an async cleanup function. Call it when your application is

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -184,7 +184,7 @@ describe('browser configure resource attributes', () => {
 
   afterEach(async () => {
     await cleanup?.()
-    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,
@@ -249,6 +249,15 @@ describe('browser configure resource attributes', () => {
 
     expect(logfireApiConfig.minLevel).toBe(Level.Warning)
   })
+
+  it('passes jsonSchema config to the shared API', () => {
+    cleanup = configure({
+      jsonSchema: 'basic',
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(logfireApiConfig.jsonSchema).toBe('basic')
+  })
 })
 
 describe('browser pending spans', () => {
@@ -267,7 +276,7 @@ describe('browser pending spans', () => {
 
   afterEach(async () => {
     await cleanup?.()
-    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,
@@ -337,7 +346,7 @@ describe('browser cleanup', () => {
 
   afterEach(async () => {
     await cleanup?.()
-    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -113,7 +113,7 @@ vi.mock('@opentelemetry/sdk-trace-web', () => ({
   WebTracerProvider: mocks.MockWebTracerProvider,
 }))
 
-import { configureLogfireApi, logfireApiConfig, PendingSpanProcessor, TailSamplingProcessor } from 'logfire'
+import { configureLogfireApi, Level, logfireApiConfig, PendingSpanProcessor, TailSamplingProcessor } from 'logfire'
 
 import logfireBrowser, { configure, instrument, startPendingSpan, withSettings, withTags } from './index'
 
@@ -184,7 +184,7 @@ describe('browser configure resource attributes', () => {
 
   afterEach(async () => {
     await cleanup?.()
-    configureLogfireApi({ baggage: { spanAttributes: [] } })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,
@@ -240,6 +240,15 @@ describe('browser configure resource attributes', () => {
 
     expect(logfireApiConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
   })
+
+  it('passes minLevel config to the shared API', () => {
+    cleanup = configure({
+      minLevel: 'warning',
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(logfireApiConfig.minLevel).toBe(Level.Warning)
+  })
 })
 
 describe('browser pending spans', () => {
@@ -258,7 +267,7 @@ describe('browser pending spans', () => {
 
   afterEach(async () => {
     await cleanup?.()
-    configureLogfireApi({ baggage: { spanAttributes: [] } })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,
@@ -328,7 +337,7 @@ describe('browser cleanup', () => {
 
   afterEach(async () => {
     await cleanup?.()
-    configureLogfireApi({ baggage: { spanAttributes: [] } })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -115,7 +115,7 @@ vi.mock('@opentelemetry/sdk-trace-web', () => ({
 
 import { PendingSpanProcessor, TailSamplingProcessor } from 'logfire'
 
-import logfireBrowser, { configure, startPendingSpan, withSettings, withTags } from './index'
+import logfireBrowser, { configure, instrument, startPendingSpan, withSettings, withTags } from './index'
 
 const originalNavigator = globalThis.navigator
 let cleanup: (() => Promise<void>) | undefined
@@ -287,6 +287,10 @@ describe('browser pending spans', () => {
   it('re-exports startPendingSpan from the shared API', () => {
     expect(typeof startPendingSpan).toBe('function')
     expect(logfireBrowser.startPendingSpan).toBe(startPendingSpan)
+  })
+
+  it('re-exports instrument from the shared API', () => {
+    expect(logfireBrowser.instrument).toBe(instrument)
   })
 
   it('re-exports scoped client helpers from the shared API', () => {

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -113,7 +113,7 @@ vi.mock('@opentelemetry/sdk-trace-web', () => ({
   WebTracerProvider: mocks.MockWebTracerProvider,
 }))
 
-import { PendingSpanProcessor, TailSamplingProcessor } from 'logfire'
+import { configureLogfireApi, logfireApiConfig, PendingSpanProcessor, TailSamplingProcessor } from 'logfire'
 
 import logfireBrowser, { configure, instrument, startPendingSpan, withSettings, withTags } from './index'
 
@@ -184,6 +184,7 @@ describe('browser configure resource attributes', () => {
 
   afterEach(async () => {
     await cleanup?.()
+    configureLogfireApi({ baggage: { spanAttributes: [] } })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,
@@ -228,6 +229,17 @@ describe('browser configure resource attributes', () => {
       'telemetry.sdk.name': 'logfire-browser',
     })
   })
+
+  it('passes baggage span attributes config to the shared API', () => {
+    cleanup = configure({
+      baggage: {
+        spanAttributes: ['tenant'],
+      },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(logfireApiConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
+  })
 })
 
 describe('browser pending spans', () => {
@@ -246,6 +258,7 @@ describe('browser pending spans', () => {
 
   afterEach(async () => {
     await cleanup?.()
+    configureLogfireApi({ baggage: { spanAttributes: [] } })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,
@@ -315,6 +328,7 @@ describe('browser cleanup', () => {
 
   afterEach(async () => {
     await cleanup?.()
+    configureLogfireApi({ baggage: { spanAttributes: [] } })
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
       value: originalNavigator,

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -115,7 +115,7 @@ vi.mock('@opentelemetry/sdk-trace-web', () => ({
 
 import { PendingSpanProcessor, TailSamplingProcessor } from 'logfire'
 
-import logfireBrowser, { configure, startPendingSpan } from './index'
+import logfireBrowser, { configure, startPendingSpan, withSettings, withTags } from './index'
 
 const originalNavigator = globalThis.navigator
 let cleanup: (() => Promise<void>) | undefined
@@ -287,6 +287,11 @@ describe('browser pending spans', () => {
   it('re-exports startPendingSpan from the shared API', () => {
     expect(typeof startPendingSpan).toBe('function')
     expect(logfireBrowser.startPendingSpan).toBe(startPendingSpan)
+  })
+
+  it('re-exports scoped client helpers from the shared API', () => {
+    expect(logfireBrowser.withSettings).toBe(withSettings)
+    expect(logfireBrowser.withTags).toBe(withTags)
   })
 })
 

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -28,7 +28,7 @@ import {
   ATTR_BROWSER_PLATFORM,
   ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
 } from '@opentelemetry/semantic-conventions/incubating'
-import type { SamplingOptions, ScrubbingOptions } from 'logfire'
+import type { BaggageOptions, LogfireApiConfigOptions, SamplingOptions, ScrubbingOptions } from 'logfire'
 import {
   configureLogfireApi,
   debug,
@@ -68,6 +68,10 @@ export interface LogfireConfigOptions {
    * The configuration of the batch span processor.
    */
   batchSpanProcessorConfig?: BufferConfig
+  /**
+   * Active OpenTelemetry baggage keys to copy to Logfire manual spans/logs as span attributes.
+   */
+  baggage?: BaggageOptions
   /**
    * Whether to log the spans to the console in addition to sending them to the Logfire API.
    */
@@ -163,11 +167,11 @@ export function configure(options: LogfireConfigOptions): () => Promise<void> {
     diag.setLogger(new DiagConsoleLogger(), options.diagLogLevel)
   }
 
-  const apiConfig: {
-    errorFingerprinting: boolean
-    scrubbing?: false | ScrubbingOptions
-  } = {
+  const apiConfig: LogfireApiConfigOptions = {
     errorFingerprinting: options.errorFingerprinting ?? false,
+  }
+  if (options.baggage !== undefined) {
+    apiConfig.baggage = options.baggage
   }
   if (options.scrubbing !== undefined) {
     apiConfig.scrubbing = options.scrubbing

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -52,6 +52,8 @@ import {
   trace,
   ULIDGenerator,
   warning,
+  withSettings,
+  withTags,
 } from 'logfire'
 
 import { LogfireSpanProcessor } from './LogfireSpanProcessor'
@@ -296,6 +298,8 @@ const defaultExport: {
   startSpan: typeof startSpan
   trace: typeof trace
   warning: typeof warning
+  withSettings: typeof withSettings
+  withTags: typeof withTags
 } = {
   configure,
   configureLogfireApi,
@@ -321,6 +325,8 @@ const defaultExport: {
   trace,
   ULIDGenerator,
   warning,
+  withSettings,
+  withTags,
 }
 
 export default defaultExport

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -28,7 +28,7 @@ import {
   ATTR_BROWSER_PLATFORM,
   ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
 } from '@opentelemetry/semantic-conventions/incubating'
-import type { BaggageOptions, LogfireApiConfigOptions, SamplingOptions, ScrubbingOptions } from 'logfire'
+import type { BaggageOptions, LogfireApiConfigOptions, MinLevel, SamplingOptions, ScrubbingOptions } from 'logfire'
 import {
   configureLogfireApi,
   debug,
@@ -101,6 +101,13 @@ export interface LogfireConfigOptions {
    */
   instrumentations?: (Instrumentation | Instrumentation[])[]
   /**
+   * Minimum Logfire level to emit for manual log-like spans.
+   *
+   * Accepts lowercase level names (trace, debug, info, notice, warning, error, fatal)
+   * or numeric values from `logfire.Level`. Set to null to disable a previously configured minimum.
+   */
+  minLevel?: MinLevel | null
+  /**
    * Sampling options for controlling which traces are exported.
    * `head` sets a probabilistic sample rate (0.0-1.0) at trace creation time.
    * `tail` provides a callback evaluated on every span to decide whether to keep the trace.
@@ -172,6 +179,9 @@ export function configure(options: LogfireConfigOptions): () => Promise<void> {
   }
   if (options.baggage !== undefined) {
     apiConfig.baggage = options.baggage
+  }
+  if (options.minLevel !== undefined) {
+    apiConfig.minLevel = options.minLevel
   }
   if (options.scrubbing !== undefined) {
     apiConfig.scrubbing = options.scrubbing

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -35,6 +35,7 @@ import {
   error,
   fatal,
   info,
+  instrument,
   Level,
   log,
   logfireApiConfig,
@@ -286,6 +287,7 @@ const defaultExport: {
   error: typeof error
   fatal: typeof fatal
   info: typeof info
+  instrument: typeof instrument
   log: typeof log
   logfireApiConfig: typeof logfireApiConfig
   notice: typeof notice
@@ -308,6 +310,7 @@ const defaultExport: {
   error,
   fatal,
   info,
+  instrument,
   // Re-export all from logfire
   Level,
   log,

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -28,7 +28,7 @@ import {
   ATTR_BROWSER_PLATFORM,
   ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
 } from '@opentelemetry/semantic-conventions/incubating'
-import type { BaggageOptions, LogfireApiConfigOptions, MinLevel, SamplingOptions, ScrubbingOptions } from 'logfire'
+import type { BaggageOptions, JsonSchemaMode, LogfireApiConfigOptions, MinLevel, SamplingOptions, ScrubbingOptions } from 'logfire'
 import {
   configureLogfireApi,
   debug,
@@ -96,6 +96,12 @@ export interface LogfireConfigOptions {
    * Defaults to false for browser since minified code produces unstable fingerprints.
    */
   errorFingerprinting?: boolean
+  /**
+   * Controls JSON schema metadata for serialized object/array attributes.
+   *
+   * Defaults to 'rich'. Use 'basic' for legacy broad schemas, or false to omit schema metadata.
+   */
+  jsonSchema?: JsonSchemaMode
   /**
    * The instrumentations to register - a common one [is the fetch instrumentation](https://www.npmjs.com/package/@opentelemetry/instrumentation-fetch).
    */
@@ -179,6 +185,9 @@ export function configure(options: LogfireConfigOptions): () => Promise<void> {
   }
   if (options.baggage !== undefined) {
     apiConfig.baggage = options.baggage
+  }
+  if (options.jsonSchema !== undefined) {
+    apiConfig.jsonSchema = options.jsonSchema
   }
   if (options.minLevel !== undefined) {
     apiConfig.minLevel = options.minLevel

--- a/packages/logfire-cf-workers/README.md
+++ b/packages/logfire-cf-workers/README.md
@@ -21,6 +21,15 @@ If you need to instrument your browser application, see the [Logfire Browser pac
 
 See the [cf-worker example](https://github.com/pydantic/logfire-js/tree/main/examples/cf-worker) for a primer.
 
+The Cloudflare package's `instrument(handler, config)` function configures the
+Worker runtime. To wrap an individual function in a manual Logfire span, import
+the core wrapper from `logfire`:
+
+```ts
+import { instrument as instrumentFunction } from 'logfire'
+import { instrument as instrumentWorker } from '@pydantic/logfire-cf-workers'
+```
+
 ## Runtime lifecycle
 
 Cloudflare Workers do not have a process-style shutdown hook. Logfire relies on

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { startPendingSpan, withSettings, withTags } from 'logfire'
+import { instrument as instrumentFunction, startPendingSpan, withSettings, withTags } from 'logfire'
 
-import logfireCfWorkers from './index'
+import logfireCfWorkers, { instrument as instrumentWorker } from './index'
 
 describe('cf-workers default export', () => {
+  it('keeps instrument as the Cloudflare runtime helper', () => {
+    const defaultInstrument = Object.getOwnPropertyDescriptor(logfireCfWorkers, 'instrument')?.value as typeof instrumentWorker
+
+    expect(defaultInstrument).toBe(instrumentWorker)
+    expect(defaultInstrument).not.toBe(instrumentFunction)
+  })
+
   it('re-exports startPendingSpan from the shared API', () => {
     expect(logfireCfWorkers.startPendingSpan).toBe(startPendingSpan)
   })

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { startPendingSpan } from 'logfire'
+import { startPendingSpan, withSettings, withTags } from 'logfire'
 
 import logfireCfWorkers from './index'
 
 describe('cf-workers default export', () => {
   it('re-exports startPendingSpan from the shared API', () => {
     expect(logfireCfWorkers.startPendingSpan).toBe(startPendingSpan)
+  })
+
+  it('mirrors scoped client helpers on the default export', () => {
+    expect(logfireCfWorkers.withSettings).toBe(withSettings)
+    expect(logfireCfWorkers.withTags).toBe(withTags)
   })
 })

--- a/packages/logfire-cf-workers/src/index.ts
+++ b/packages/logfire-cf-workers/src/index.ts
@@ -25,6 +25,8 @@ import {
   trace,
   ULIDGenerator,
   warning,
+  withSettings,
+  withTags,
 } from 'logfire'
 
 import { exportTailEventsToLogfire } from './exportTailEventsToLogfire'
@@ -152,6 +154,8 @@ const defaultExport: {
   startSpan: typeof startSpan
   trace: typeof trace
   warning: typeof warning
+  withSettings: typeof withSettings
+  withTags: typeof withTags
 } = {
   exportTailEventsToLogfire,
   configureLogfireApi,
@@ -180,6 +184,8 @@ const defaultExport: {
   trace,
   ULIDGenerator,
   warning,
+  withSettings,
+  withTags,
 }
 
 export default defaultExport

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -77,6 +77,9 @@ logfire.configure({
 First-class options such as `serviceName`, `serviceVersion`, and `environment`
 take precedence over conflicting `resourceAttributes` keys. Values from
 `OTEL_RESOURCE_ATTRIBUTES` still take precedence over code configuration.
+When `serviceName` or `serviceVersion` is omitted, Node reads
+`LOGFIRE_SERVICE_NAME` / `LOGFIRE_SERVICE_VERSION` first, then falls back to
+`OTEL_SERVICE_NAME` / `OTEL_SERVICE_VERSION`.
 
 ## Baggage span attributes
 

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -123,6 +123,43 @@ Log helpers and `reportError()` are filtered by their level. Duration-style APIs
 such as `span()`, `startSpan()`, `startPendingSpan()`, and `instrument()` are
 filtered only when the call or scoped client sets an explicit level.
 
+## Console output
+
+Use `console: true` to print spans to the console while developing. Console
+output defaults to a minimum level of `info`, matching Python's console
+behavior:
+
+```js
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'example-node-script',
+  console: true,
+})
+```
+
+To change console output without changing which telemetry is created, pass
+object-style console options:
+
+```js
+logfire.configure({
+  serviceName: 'example-node-script',
+  console: {
+    minLevel: 'warning',
+    includeTags: true,
+    includeTimestamps: false,
+  },
+})
+```
+
+Use `console: { minLevel: 'debug' }` or `console: { minLevel: 'trace' }` when
+you want lower-severity spans printed locally. `LOGFIRE_CONSOLE=true` remains a
+boolean enable switch and uses the default `info` console minimum.
+
+Spans without a Logfire level, including ordinary auto-instrumentation spans,
+are treated as `info` for console filtering. Setting `console.minLevel` above
+`info` hides those spans from local console output.
+
 ## Flush and shutdown
 
 Logfire batches telemetry through OpenTelemetry processors. For short-lived

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -101,6 +101,28 @@ characters. Do not store secrets, credentials, session cookies, raw emails, or
 other sensitive user data in baggage because baggage propagates across service
 boundaries.
 
+## Minimum level filtering
+
+Use `minLevel` to suppress low-severity manual Logfire telemetry before spans
+are created:
+
+```js
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'example-node-script',
+  minLevel: 'warning',
+})
+```
+
+Node.js also reads `LOGFIRE_MIN_LEVEL` when code configuration omits
+`minLevel`. Code configuration takes precedence, and `minLevel: null` clears a
+previous setting. Invalid environment values are warned about and ignored.
+
+Log helpers and `reportError()` are filtered by their level. Duration-style APIs
+such as `span()`, `startSpan()`, `startPendingSpan()`, and `instrument()` are
+filtered only when the call or scoped client sets an explicit level.
+
 ## Flush and shutdown
 
 Logfire batches telemetry through OpenTelemetry processors. For short-lived

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -78,6 +78,29 @@ First-class options such as `serviceName`, `serviceVersion`, and `environment`
 take precedence over conflicting `resourceAttributes` keys. Values from
 `OTEL_RESOURCE_ATTRIBUTES` still take precedence over code configuration.
 
+## Baggage span attributes
+
+Use `baggage.spanAttributes` to copy selected active OpenTelemetry baggage
+values onto Logfire manual spans and logs:
+
+```js
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  serviceName: 'example-node-script',
+  baggage: {
+    spanAttributes: ['tenant', 'region'],
+  },
+})
+```
+
+Projection is disabled by default and allowlisted. Configured baggage key
+`tenant` is emitted as `baggage.tenant`. Explicit span attributes win on
+conflict, missing keys are ignored, and values are truncated to 1000
+characters. Do not store secrets, credentials, session cookies, raw emails, or
+other sensitive user data in baggage because baggage propagates across service
+boundaries.
+
 ## Flush and shutdown
 
 Logfire batches telemetry through OpenTelemetry processors. For short-lived

--- a/packages/logfire-node/src/LogfireConsoleSpanExporter.ts
+++ b/packages/logfire-node/src/LogfireConsoleSpanExporter.ts
@@ -1,7 +1,13 @@
 import type { ExportResult } from '@opentelemetry/core'
 import { ExportResultCode, hrTimeToMicroseconds } from '@opentelemetry/core'
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base'
+import { Level } from 'logfire'
 import pc from 'picocolors'
+
+import type { ResolvedConsoleOptions } from './consoleOptions'
+
+const ATTRIBUTES_LEVEL_KEY = 'logfire.level_num'
+const ATTRIBUTES_TAGS_KEY = 'logfire.tags'
 
 const LevelLabels = {
   1: 'trace',
@@ -23,7 +29,20 @@ const ColorMap = {
   warning: pc.yellow,
 }
 
+const DEFAULT_OPTIONS = {
+  enabled: true,
+  includeTags: true,
+  includeTimestamps: true,
+  minLevel: Level.Info,
+} satisfies ResolvedConsoleOptions
+
 export class LogfireConsoleSpanExporter implements SpanExporter {
+  private readonly options: ResolvedConsoleOptions
+
+  constructor(options: ResolvedConsoleOptions = DEFAULT_OPTIONS) {
+    this.options = options
+  }
+
   export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
     this.sendSpans(spans, resultCallback)
   }
@@ -63,16 +82,53 @@ export class LogfireConsoleSpanExporter implements SpanExporter {
 
   private sendSpans(spans: ReadableSpan[], done?: (result: ExportResult) => void): void {
     for (const span of spans) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      const type = LevelLabels[span.attributes['logfire.level_num'] as keyof typeof LevelLabels] ?? 'info'
+      const { level, type } = this.getSpanLevel(span)
+      if (level < this.options.minLevel) {
+        continue
+      }
 
       const { attributes, name, ...rest } = this.exportInfo(span)
       console.log(`${pc.bgMagentaBright('Logfire')} ${ColorMap[type](type)} ${name}`)
-      console.dir(attributes)
-      console.dir(rest)
+      console.dir(this.printedAttributes(attributes))
+      console.dir(this.printedMetadata(rest))
     }
     if (done) {
       done({ code: ExportResultCode.SUCCESS })
     }
+  }
+
+  private getSpanLevel(span: ReadableSpan): {
+    level: (typeof Level)[keyof typeof Level]
+    type: (typeof LevelLabels)[keyof typeof LevelLabels]
+  } {
+    const level = span.attributes[ATTRIBUTES_LEVEL_KEY]
+    if (typeof level === 'number' && Object.hasOwn(LevelLabels, level)) {
+      return {
+        level: level as (typeof Level)[keyof typeof Level],
+        type: LevelLabels[level as keyof typeof LevelLabels],
+      }
+    }
+    return {
+      level: Level.Info,
+      type: 'info',
+    }
+  }
+
+  private printedAttributes(attributes: ReadableSpan['attributes']): ReadableSpan['attributes'] {
+    if (this.options.includeTags) {
+      return attributes
+    }
+
+    const { [ATTRIBUTES_TAGS_KEY]: _tags, ...rest } = attributes
+    return rest
+  }
+
+  private printedMetadata<T extends { timestamp: number }>(metadata: T): Omit<T, 'timestamp'> | T {
+    if (this.options.includeTimestamps) {
+      return metadata
+    }
+
+    const { timestamp: _timestamp, ...rest } = metadata
+    return rest
   }
 }

--- a/packages/logfire-node/src/__test__/LogfireConsoleSpanExporter.test.ts
+++ b/packages/logfire-node/src/__test__/LogfireConsoleSpanExporter.test.ts
@@ -1,0 +1,196 @@
+import type { HrTime } from '@opentelemetry/api'
+import { SpanKind, SpanStatusCode, TraceFlags } from '@opentelemetry/api'
+import { ExportResultCode } from '@opentelemetry/core'
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import type { MockInstance } from 'vite-plus/test'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { Level } from 'logfire'
+
+import type { ResolvedConsoleOptions } from '../consoleOptions'
+import { LogfireConsoleSpanExporter } from '../LogfireConsoleSpanExporter'
+import { logfireSpanProcessor } from '../traceExporter'
+
+const BASE_OPTIONS: ResolvedConsoleOptions = {
+  enabled: true,
+  includeTags: true,
+  includeTimestamps: true,
+  minLevel: Level.Info,
+}
+
+function makeSpan(attributes: ReadableSpan['attributes'] = {}): ReadableSpan {
+  return {
+    attributes,
+    duration: [0, 123_000] as HrTime,
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    endTime: [1000, 123_579_789] as HrTime,
+    ended: true,
+    events: [],
+    instrumentationScope: { name: 'test-scope' },
+    kind: SpanKind.INTERNAL,
+    links: [],
+    name: 'test span',
+    parentSpanContext: undefined,
+    resource: { attributes: { 'service.name': 'test-service' } },
+    spanContext: () => ({
+      isRemote: false,
+      spanId: '2222222222222222',
+      traceFlags: TraceFlags.SAMPLED,
+      traceId: '11111111111111111111111111111111',
+    }),
+    startTime: [1000, 123_456_789] as HrTime,
+    status: { code: SpanStatusCode.UNSET },
+  } as unknown as ReadableSpan
+}
+
+function exportOne(exporter: LogfireConsoleSpanExporter, span: ReadableSpan): void {
+  let resultCode: ExportResultCode | undefined
+  exporter.export([span], (result) => {
+    resultCode = result.code
+  })
+  expect(resultCode).toBe(ExportResultCode.SUCCESS)
+}
+
+describe('LogfireConsoleSpanExporter', () => {
+  let logSpy: MockInstance<typeof console.log>
+  let dirSpy: MockInstance<typeof console.dir>
+
+  function getDirObject(callIndex: number): Record<string, unknown> {
+    const value: unknown = dirSpy.mock.calls[callIndex]?.[0]
+    expect(value).toBeDefined()
+    expect(typeof value).toBe('object')
+    return value as Record<string, unknown>
+  }
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    dirSpy = vi.spyOn(console, 'dir').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('prints the existing three-part output shape at info by default', () => {
+    const span = makeSpan({
+      'logfire.level_num': Level.Info,
+      'logfire.tags': ['local'],
+      item: 'checkout',
+    })
+
+    exportOne(new LogfireConsoleSpanExporter(), span)
+
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    expect(String(logSpy.mock.calls[0]?.[0])).toContain('info')
+    expect(String(logSpy.mock.calls[0]?.[0])).toContain('test span')
+    expect(dirSpy).toHaveBeenCalledTimes(2)
+    expect(getDirObject(0)).toEqual({
+      'logfire.level_num': Level.Info,
+      'logfire.tags': ['local'],
+      item: 'checkout',
+    })
+    const metadata = getDirObject(1)
+    expect(metadata['traceId']).toBe('11111111111111111111111111111111')
+    expect(typeof metadata['duration']).toBe('number')
+    expect(typeof metadata['timestamp']).toBe('number')
+  })
+
+  it('uses info as the default console minimum', () => {
+    exportOne(
+      new LogfireConsoleSpanExporter(),
+      makeSpan({
+        'logfire.level_num': Level.Debug,
+      })
+    )
+
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(dirSpy).not.toHaveBeenCalled()
+  })
+
+  it('filters below the configured console min level and still reports success', () => {
+    const exporter = new LogfireConsoleSpanExporter({
+      ...BASE_OPTIONS,
+      minLevel: Level.Warning,
+    })
+
+    exportOne(
+      exporter,
+      makeSpan({
+        'logfire.level_num': Level.Info,
+      })
+    )
+
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(dirSpy).not.toHaveBeenCalled()
+  })
+
+  it('prints spans at or above the configured console min level', () => {
+    const exporter = new LogfireConsoleSpanExporter({
+      ...BASE_OPTIONS,
+      minLevel: Level.Warning,
+    })
+
+    exportOne(
+      exporter,
+      makeSpan({
+        'logfire.level_num': Level.Warning,
+      })
+    )
+    exportOne(
+      exporter,
+      makeSpan({
+        'logfire.level_num': Level.Error,
+      })
+    )
+
+    expect(logSpy).toHaveBeenCalledTimes(2)
+    expect(dirSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('removes tags from printed attributes without mutating the span', () => {
+    const attributes = {
+      'logfire.level_num': Level.Info,
+      'logfire.tags': ['local'],
+      item: 'checkout',
+    }
+
+    exportOne(new LogfireConsoleSpanExporter({ ...BASE_OPTIONS, includeTags: false }), makeSpan(attributes))
+
+    expect(getDirObject(0)).toEqual({
+      'logfire.level_num': Level.Info,
+      item: 'checkout',
+    })
+    expect(attributes).toEqual({
+      'logfire.level_num': Level.Info,
+      'logfire.tags': ['local'],
+      item: 'checkout',
+    })
+  })
+
+  it('removes timestamps from printed metadata', () => {
+    exportOne(new LogfireConsoleSpanExporter({ ...BASE_OPTIONS, includeTimestamps: false }), makeSpan({ 'logfire.level_num': Level.Info }))
+
+    const metadata = getDirObject(1)
+    expect(metadata).not.toHaveProperty('timestamp')
+    expect(metadata['traceId']).toBe('11111111111111111111111111111111')
+    expect(typeof metadata['duration']).toBe('number')
+  })
+
+  it('keeps the wrapped span processor path when console filtering suppresses output', () => {
+    const wrappedOnEndSpy = vi.spyOn(BatchSpanProcessor.prototype, 'onEnd')
+    const processor = logfireSpanProcessor({ minLevel: 'warning' })
+    const span = makeSpan({ 'logfire.level_num': Level.Debug })
+
+    processor.onEnd(span)
+
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(wrappedOnEndSpy).toHaveBeenCalledWith(span)
+  })
+
+  it('rejects invalid console min levels before creating the processor', () => {
+    expect(() => logfireSpanProcessor({ minLevel: 'warn' as never })).toThrow('Invalid console.minLevel')
+  })
+})

--- a/packages/logfire-node/src/__test__/consoleOptions.test.ts
+++ b/packages/logfire-node/src/__test__/consoleOptions.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { Level } from 'logfire'
+
+import { resolveConsoleOptions } from '../consoleOptions'
+
+describe('resolveConsoleOptions', () => {
+  it('disables console output when omitted or false', () => {
+    expect(resolveConsoleOptions(undefined)).toEqual({
+      enabled: false,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Info,
+    })
+    expect(resolveConsoleOptions(false)).toEqual({
+      enabled: false,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Info,
+    })
+  })
+
+  it('uses Python-like defaults when enabled with a boolean or object', () => {
+    expect(resolveConsoleOptions(true)).toEqual({
+      enabled: true,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Info,
+    })
+    expect(resolveConsoleOptions({})).toEqual({
+      enabled: true,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Info,
+    })
+  })
+
+  it('lets object config disable console output', () => {
+    expect(resolveConsoleOptions({ enabled: false, minLevel: 'error' })).toEqual({
+      enabled: false,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Error,
+    })
+  })
+
+  it('resolves explicit options', () => {
+    expect(
+      resolveConsoleOptions({
+        includeTags: false,
+        includeTimestamps: false,
+        minLevel: ' WARNING ' as 'warning',
+      })
+    ).toEqual({
+      enabled: true,
+      includeTags: false,
+      includeTimestamps: false,
+      minLevel: Level.Warning,
+    })
+
+    expect(resolveConsoleOptions({ minLevel: Level.Debug }).minLevel).toBe(Level.Debug)
+  })
+
+  it('rejects invalid console min levels', () => {
+    expect(() => resolveConsoleOptions({ minLevel: 'warn' as never })).toThrow('Invalid console.minLevel')
+    expect(() => resolveConsoleOptions({ minLevel: 12 as never })).toThrow('Invalid console.minLevel')
+  })
+
+  it('validates minLevel even when object config disables output', () => {
+    expect(() => resolveConsoleOptions({ enabled: false, minLevel: 'warn' as never })).toThrow('Invalid console.minLevel')
+  })
+})

--- a/packages/logfire-node/src/__test__/index.test.ts
+++ b/packages/logfire-node/src/__test__/index.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import logfireNode, { startPendingSpan } from '../index'
+import logfireNode, { startPendingSpan, withSettings, withTags } from '../index'
 
 describe('node default export', () => {
   it('re-exports startPendingSpan from the shared API', () => {
     expect(logfireNode.startPendingSpan).toBe(startPendingSpan)
+  })
+
+  it('re-exports scoped client helpers from the shared API', () => {
+    expect(logfireNode.withSettings).toBe(withSettings)
+    expect(logfireNode.withTags).toBe(withTags)
   })
 })

--- a/packages/logfire-node/src/__test__/index.test.ts
+++ b/packages/logfire-node/src/__test__/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import logfireNode, { startPendingSpan, withSettings, withTags } from '../index'
+import logfireNode, { instrument, startPendingSpan, withSettings, withTags } from '../index'
 
 describe('node default export', () => {
+  it('re-exports instrument from the shared API', () => {
+    expect(logfireNode.instrument).toBe(instrument)
+  })
+
   it('re-exports startPendingSpan from the shared API', () => {
     expect(logfireNode.startPendingSpan).toBe(startPendingSpan)
   })

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
+import { configureLogfireApi, logfireApiConfig } from 'logfire'
 import { shutdownVariables } from 'logfire/vars'
 
 import { configure, logfireConfig } from '../logfireConfig'
@@ -19,6 +20,7 @@ describe('logfire config', () => {
     delete process.env['LOGFIRE_BASE_URL']
     delete process.env['LOGFIRE_SEND_TO_LOGFIRE']
     delete process.env['LOGFIRE_TOKEN']
+    configureLogfireApi({ baggage: { spanAttributes: [] } })
     await shutdownVariables()
   })
 
@@ -45,6 +47,9 @@ describe('logfire config', () => {
     }
     Object.assign(logfireConfig, {
       authorizationHeaders: {},
+      baggage: {
+        spanAttributes: [],
+      },
       baseUrl: '',
       logsExporterUrl: '',
       metricExporterUrl: '',
@@ -53,6 +58,7 @@ describe('logfire config', () => {
       token: '',
       traceExporterUrl: '',
     })
+    configureLogfireApi({ baggage: { spanAttributes: [] } })
     await shutdownVariables()
   })
 
@@ -111,6 +117,17 @@ describe('logfire config', () => {
     configure({ resourceAttributes })
 
     expect(logfireConfig.resourceAttributes).toBe(resourceAttributes)
+  })
+
+  it('passes baggage span attributes config to the shared API', () => {
+    configure({
+      baggage: {
+        spanAttributes: ['tenant'],
+      },
+    })
+
+    expect(logfireConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
+    expect(logfireApiConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
   })
 
   it('supports a token provider without resolving it during configure', async () => {

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
-import { configureLogfireApi, logfireApiConfig } from 'logfire'
+import { configureLogfireApi, Level, logfireApiConfig } from 'logfire'
 import { shutdownVariables } from 'logfire/vars'
 
 import { configure, logfireConfig } from '../logfireConfig'
@@ -12,15 +12,17 @@ vi.mock('../sdk', () => ({
 describe('logfire config', () => {
   const originalApiKey = process.env['LOGFIRE_API_KEY']
   const originalBaseUrl = process.env['LOGFIRE_BASE_URL']
+  const originalMinLevel = process.env['LOGFIRE_MIN_LEVEL']
   const originalSendToLogfire = process.env['LOGFIRE_SEND_TO_LOGFIRE']
   const originalToken = process.env['LOGFIRE_TOKEN']
 
   beforeEach(async () => {
     process.env['LOGFIRE_API_KEY'] = ''
     delete process.env['LOGFIRE_BASE_URL']
+    delete process.env['LOGFIRE_MIN_LEVEL']
     delete process.env['LOGFIRE_SEND_TO_LOGFIRE']
     delete process.env['LOGFIRE_TOKEN']
-    configureLogfireApi({ baggage: { spanAttributes: [] } })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
     await shutdownVariables()
   })
 
@@ -34,6 +36,11 @@ describe('logfire config', () => {
       delete process.env['LOGFIRE_BASE_URL']
     } else {
       process.env['LOGFIRE_BASE_URL'] = originalBaseUrl
+    }
+    if (originalMinLevel === undefined) {
+      delete process.env['LOGFIRE_MIN_LEVEL']
+    } else {
+      process.env['LOGFIRE_MIN_LEVEL'] = originalMinLevel
     }
     if (originalSendToLogfire === undefined) {
       delete process.env['LOGFIRE_SEND_TO_LOGFIRE']
@@ -53,12 +60,13 @@ describe('logfire config', () => {
       baseUrl: '',
       logsExporterUrl: '',
       metricExporterUrl: '',
+      minLevel: undefined,
       resourceAttributes: {},
       sendToLogfire: false,
       token: '',
       traceExporterUrl: '',
     })
-    configureLogfireApi({ baggage: { spanAttributes: [] } })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
     await shutdownVariables()
   })
 
@@ -128,6 +136,55 @@ describe('logfire config', () => {
 
     expect(logfireConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
     expect(logfireApiConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
+  })
+
+  it('passes code minLevel config to the shared API', () => {
+    configure({
+      minLevel: 'warning',
+    })
+
+    expect(logfireApiConfig.minLevel).toBe(Level.Warning)
+    expect(logfireConfig.minLevel).toBe(Level.Warning)
+  })
+
+  it('reads LOGFIRE_MIN_LEVEL when code config omits minLevel', () => {
+    process.env['LOGFIRE_MIN_LEVEL'] = 'ERROR'
+
+    configure()
+
+    expect(logfireApiConfig.minLevel).toBe(Level.Error)
+    expect(logfireConfig.minLevel).toBe(Level.Error)
+  })
+
+  it('lets code minLevel override LOGFIRE_MIN_LEVEL, including null reset', () => {
+    process.env['LOGFIRE_MIN_LEVEL'] = 'error'
+
+    configure({
+      minLevel: null,
+    })
+
+    expect(logfireApiConfig.minLevel).toBeUndefined()
+    expect(logfireConfig.minLevel).toBeUndefined()
+  })
+
+  it('warns and ignores invalid LOGFIRE_MIN_LEVEL values without dropping other shared API config', () => {
+    process.env['LOGFIRE_MIN_LEVEL'] = 'verbose'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    try {
+      configure({
+        baggage: {
+          spanAttributes: ['tenant'],
+        },
+      })
+
+      expect(warnSpy).toHaveBeenCalledWith('Invalid LOGFIRE_MIN_LEVEL value "verbose" ignored.')
+      expect(logfireApiConfig.minLevel).toBeUndefined()
+      expect(logfireConfig.minLevel).toBeUndefined()
+      expect(logfireApiConfig.baggage).toEqual({ spanAttributes: ['tenant'] })
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('supports a token provider without resolving it during configure', async () => {

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -12,6 +12,7 @@ vi.mock('../sdk', () => ({
 describe('logfire config', () => {
   const originalApiKey = process.env['LOGFIRE_API_KEY']
   const originalBaseUrl = process.env['LOGFIRE_BASE_URL']
+  const originalConsole = process.env['LOGFIRE_CONSOLE']
   const originalMinLevel = process.env['LOGFIRE_MIN_LEVEL']
   const originalSendToLogfire = process.env['LOGFIRE_SEND_TO_LOGFIRE']
   const originalToken = process.env['LOGFIRE_TOKEN']
@@ -19,6 +20,7 @@ describe('logfire config', () => {
   beforeEach(async () => {
     process.env['LOGFIRE_API_KEY'] = ''
     delete process.env['LOGFIRE_BASE_URL']
+    delete process.env['LOGFIRE_CONSOLE']
     delete process.env['LOGFIRE_MIN_LEVEL']
     delete process.env['LOGFIRE_SEND_TO_LOGFIRE']
     delete process.env['LOGFIRE_TOKEN']
@@ -36,6 +38,11 @@ describe('logfire config', () => {
       delete process.env['LOGFIRE_BASE_URL']
     } else {
       process.env['LOGFIRE_BASE_URL'] = originalBaseUrl
+    }
+    if (originalConsole === undefined) {
+      delete process.env['LOGFIRE_CONSOLE']
+    } else {
+      process.env['LOGFIRE_CONSOLE'] = originalConsole
     }
     if (originalMinLevel === undefined) {
       delete process.env['LOGFIRE_MIN_LEVEL']
@@ -58,6 +65,7 @@ describe('logfire config', () => {
         spanAttributes: [],
       },
       baseUrl: '',
+      console: false,
       logsExporterUrl: '',
       metricExporterUrl: '',
       minLevel: undefined,
@@ -125,6 +133,54 @@ describe('logfire config', () => {
     configure({ resourceAttributes })
 
     expect(logfireConfig.resourceAttributes).toBe(resourceAttributes)
+  })
+
+  it('preserves boolean console configuration compatibility', () => {
+    configure({ console: true })
+    expect(logfireConfig.console).toBe(true)
+
+    configure({ console: false })
+    expect(logfireConfig.console).toBe(false)
+  })
+
+  it('stores object-style console configuration', () => {
+    const consoleConfig = {
+      includeTags: false,
+      includeTimestamps: false,
+      minLevel: 'warning' as const,
+    }
+
+    configure({ console: consoleConfig })
+
+    expect(logfireConfig.console).toBe(consoleConfig)
+  })
+
+  it('rejects invalid object-style console min levels during configure', () => {
+    expect(() => {
+      configure({
+        console: {
+          minLevel: 'warn' as never,
+        },
+      })
+    }).toThrow('Invalid console.minLevel')
+
+    expect(logfireConfig.console).toBe(false)
+  })
+
+  it('reads LOGFIRE_CONSOLE as boolean true when code config omits console', () => {
+    process.env['LOGFIRE_CONSOLE'] = 'true'
+
+    configure()
+
+    expect(logfireConfig.console).toBe(true)
+  })
+
+  it('does not parse LOGFIRE_CONSOLE as object-style console config', () => {
+    process.env['LOGFIRE_CONSOLE'] = '{"enabled":true}'
+
+    configure()
+
+    expect(logfireConfig.console).toBe(false)
   })
 
   it('passes baggage span attributes config to the shared API', () => {

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -15,6 +15,10 @@ describe('logfire config', () => {
   const originalConsole = process.env['LOGFIRE_CONSOLE']
   const originalMinLevel = process.env['LOGFIRE_MIN_LEVEL']
   const originalSendToLogfire = process.env['LOGFIRE_SEND_TO_LOGFIRE']
+  const originalLogfireServiceName = process.env['LOGFIRE_SERVICE_NAME']
+  const originalLogfireServiceVersion = process.env['LOGFIRE_SERVICE_VERSION']
+  const originalOtelServiceName = process.env['OTEL_SERVICE_NAME']
+  const originalOtelServiceVersion = process.env['OTEL_SERVICE_VERSION']
   const originalToken = process.env['LOGFIRE_TOKEN']
 
   beforeEach(async () => {
@@ -23,6 +27,10 @@ describe('logfire config', () => {
     delete process.env['LOGFIRE_CONSOLE']
     delete process.env['LOGFIRE_MIN_LEVEL']
     delete process.env['LOGFIRE_SEND_TO_LOGFIRE']
+    delete process.env['LOGFIRE_SERVICE_NAME']
+    delete process.env['LOGFIRE_SERVICE_VERSION']
+    delete process.env['OTEL_SERVICE_NAME']
+    delete process.env['OTEL_SERVICE_VERSION']
     delete process.env['LOGFIRE_TOKEN']
     configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
     await shutdownVariables()
@@ -54,6 +62,26 @@ describe('logfire config', () => {
     } else {
       process.env['LOGFIRE_SEND_TO_LOGFIRE'] = originalSendToLogfire
     }
+    if (originalLogfireServiceName === undefined) {
+      delete process.env['LOGFIRE_SERVICE_NAME']
+    } else {
+      process.env['LOGFIRE_SERVICE_NAME'] = originalLogfireServiceName
+    }
+    if (originalLogfireServiceVersion === undefined) {
+      delete process.env['LOGFIRE_SERVICE_VERSION']
+    } else {
+      process.env['LOGFIRE_SERVICE_VERSION'] = originalLogfireServiceVersion
+    }
+    if (originalOtelServiceName === undefined) {
+      delete process.env['OTEL_SERVICE_NAME']
+    } else {
+      process.env['OTEL_SERVICE_NAME'] = originalOtelServiceName
+    }
+    if (originalOtelServiceVersion === undefined) {
+      delete process.env['OTEL_SERVICE_VERSION']
+    } else {
+      process.env['OTEL_SERVICE_VERSION'] = originalOtelServiceVersion
+    }
     if (originalToken === undefined) {
       delete process.env['LOGFIRE_TOKEN']
     } else {
@@ -71,6 +99,8 @@ describe('logfire config', () => {
       minLevel: undefined,
       resourceAttributes: {},
       sendToLogfire: false,
+      serviceName: undefined,
+      serviceVersion: undefined,
       token: '',
       traceExporterUrl: '',
     })
@@ -133,6 +163,43 @@ describe('logfire config', () => {
     configure({ resourceAttributes })
 
     expect(logfireConfig.resourceAttributes).toBe(resourceAttributes)
+  })
+
+  it('reads OTEL service metadata when Logfire-specific environment variables are omitted', () => {
+    process.env['OTEL_SERVICE_NAME'] = 'otel-service'
+    process.env['OTEL_SERVICE_VERSION'] = '1.2.3'
+
+    configure()
+
+    expect(logfireConfig.serviceName).toBe('otel-service')
+    expect(logfireConfig.serviceVersion).toBe('1.2.3')
+  })
+
+  it('lets LOGFIRE service metadata override OTEL service metadata', () => {
+    process.env['LOGFIRE_SERVICE_NAME'] = 'logfire-service'
+    process.env['LOGFIRE_SERVICE_VERSION'] = '2.0.0'
+    process.env['OTEL_SERVICE_NAME'] = 'otel-service'
+    process.env['OTEL_SERVICE_VERSION'] = '1.2.3'
+
+    configure()
+
+    expect(logfireConfig.serviceName).toBe('logfire-service')
+    expect(logfireConfig.serviceVersion).toBe('2.0.0')
+  })
+
+  it('lets code service metadata override LOGFIRE and OTEL environment variables', () => {
+    process.env['LOGFIRE_SERVICE_NAME'] = 'logfire-service'
+    process.env['LOGFIRE_SERVICE_VERSION'] = '2.0.0'
+    process.env['OTEL_SERVICE_NAME'] = 'otel-service'
+    process.env['OTEL_SERVICE_VERSION'] = '1.2.3'
+
+    configure({
+      serviceName: 'code-service',
+      serviceVersion: '3.0.0',
+    })
+
+    expect(logfireConfig.serviceName).toBe('code-service')
+    expect(logfireConfig.serviceVersion).toBe('3.0.0')
   })
 
   it('preserves boolean console configuration compatibility', () => {

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -183,6 +183,28 @@ describe('logfire config', () => {
     expect(logfireConfig.serviceVersion).toBe('1.2.3')
   })
 
+  it('ignores empty service metadata environment variables', () => {
+    process.env['LOGFIRE_SERVICE_NAME'] = ' '
+    process.env['LOGFIRE_SERVICE_VERSION'] = ''
+    process.env['OTEL_SERVICE_NAME'] = 'otel-service'
+    process.env['OTEL_SERVICE_VERSION'] = '1.2.3'
+
+    configure()
+
+    expect(logfireConfig.serviceName).toBe('otel-service')
+    expect(logfireConfig.serviceVersion).toBe('1.2.3')
+
+    process.env['LOGFIRE_SERVICE_NAME'] = ''
+    process.env['LOGFIRE_SERVICE_VERSION'] = ' '
+    process.env['OTEL_SERVICE_NAME'] = ''
+    process.env['OTEL_SERVICE_VERSION'] = ' '
+
+    configure()
+
+    expect(logfireConfig.serviceName).toBeUndefined()
+    expect(logfireConfig.serviceVersion).toBeUndefined()
+  })
+
   it('lets LOGFIRE service metadata override OTEL service metadata', () => {
     process.env['LOGFIRE_SERVICE_NAME'] = 'logfire-service'
     process.env['LOGFIRE_SERVICE_VERSION'] = '2.0.0'

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -32,7 +32,7 @@ describe('logfire config', () => {
     delete process.env['OTEL_SERVICE_NAME']
     delete process.env['OTEL_SERVICE_VERSION']
     delete process.env['LOGFIRE_TOKEN']
-    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     await shutdownVariables()
   })
 
@@ -94,6 +94,7 @@ describe('logfire config', () => {
       },
       baseUrl: '',
       console: false,
+      jsonSchema: 'rich',
       logsExporterUrl: '',
       metricExporterUrl: '',
       minLevel: undefined,
@@ -104,7 +105,7 @@ describe('logfire config', () => {
       token: '',
       traceExporterUrl: '',
     })
-    configureLogfireApi({ baggage: { spanAttributes: [] }, minLevel: null })
+    configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     await shutdownVariables()
   })
 
@@ -163,6 +164,13 @@ describe('logfire config', () => {
     configure({ resourceAttributes })
 
     expect(logfireConfig.resourceAttributes).toBe(resourceAttributes)
+  })
+
+  it('passes jsonSchema config to the shared API', () => {
+    configure({ jsonSchema: 'basic' })
+
+    expect(logfireApiConfig.jsonSchema).toBe('basic')
+    expect(logfireConfig.jsonSchema).toBe('basic')
   })
 
   it('reads OTEL service metadata when Logfire-specific environment variables are omitted', () => {

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -246,12 +246,14 @@ vi.mock('@opentelemetry/sdk-node', () => ({
 }))
 
 vi.mock('logfire', async () => {
-  const [{ PendingSpanProcessor }, { TailSamplingProcessor }, { ULIDGenerator }] = await Promise.all([
+  const [{ Level }, { PendingSpanProcessor }, { TailSamplingProcessor }, { ULIDGenerator }] = await Promise.all([
+    import('../../../logfire-api/src/levels'),
     import('../../../logfire-api/src/PendingSpanProcessor'),
     import('../../../logfire-api/src/TailSamplingProcessor'),
     import('../../../logfire-api/src/ULIDGenerator'),
   ])
   return {
+    Level,
     PendingSpanProcessor,
     reportError: (...args: unknown[]) => {
       mocks.reportErrorCalls.push(args)

--- a/packages/logfire-node/src/consoleOptions.ts
+++ b/packages/logfire-node/src/consoleOptions.ts
@@ -1,0 +1,88 @@
+import type { LogFireLevel, MinLevel } from 'logfire'
+import { Level } from 'logfire'
+
+export interface ConsoleOptions {
+  /**
+   * Whether to print spans to the console. Defaults to true when console is an object.
+   */
+  enabled?: boolean
+  /**
+   * Minimum Logfire level to print to the console. Defaults to info.
+   *
+   * This filters console output only and does not control telemetry creation.
+   */
+  minLevel?: MinLevel
+  /**
+   * Whether to include logfire.tags in printed attributes. Defaults to true.
+   */
+  includeTags?: boolean
+  /**
+   * Whether to include span timestamps in printed metadata. Defaults to true.
+   */
+  includeTimestamps?: boolean
+}
+
+export type ConsoleConfig = boolean | ConsoleOptions
+
+export interface ResolvedConsoleOptions {
+  enabled: boolean
+  includeTags: boolean
+  includeTimestamps: boolean
+  minLevel: LogFireLevel
+}
+
+const LEVEL_NAMES = ['trace', 'debug', 'info', 'notice', 'warning', 'error', 'fatal'] as const
+const LEVEL_NUMBERS: Record<(typeof LEVEL_NAMES)[number], LogFireLevel> = {
+  debug: Level.Debug,
+  error: Level.Error,
+  fatal: Level.Fatal,
+  info: Level.Info,
+  notice: Level.Notice,
+  trace: Level.Trace,
+  warning: Level.Warning,
+}
+const LEVEL_NUMBER_VALUES = new Set<LogFireLevel>(Object.values(Level))
+
+export function resolveConsoleOptions(config: ConsoleConfig | undefined): ResolvedConsoleOptions {
+  if (config === undefined || config === false) {
+    return {
+      enabled: false,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Info,
+    }
+  }
+
+  if (config === true) {
+    return {
+      enabled: true,
+      includeTags: true,
+      includeTimestamps: true,
+      minLevel: Level.Info,
+    }
+  }
+
+  return {
+    enabled: config.enabled ?? true,
+    includeTags: config.includeTags ?? true,
+    includeTimestamps: config.includeTimestamps ?? true,
+    minLevel: config.minLevel === undefined ? Level.Info : resolveConsoleMinLevel(config.minLevel),
+  }
+}
+
+function resolveConsoleMinLevel(value: MinLevel): LogFireLevel {
+  if (typeof value === 'number') {
+    if (LEVEL_NUMBER_VALUES.has(value)) {
+      return value
+    }
+  } else {
+    const normalized = value.trim().toLowerCase()
+    if (Object.hasOwn(LEVEL_NUMBERS, normalized)) {
+      return LEVEL_NUMBERS[normalized as keyof typeof LEVEL_NUMBERS]
+    }
+  }
+
+  throw new Error(
+    `Invalid console.minLevel: ${String(value)}. Expected one of ${LEVEL_NAMES.join(', ')} or a numeric value from logfire.Level.`
+  )
+}

--- a/packages/logfire-node/src/index.ts
+++ b/packages/logfire-node/src/index.ts
@@ -21,6 +21,8 @@ import {
   trace,
   ULIDGenerator,
   warning,
+  withSettings,
+  withTags,
 } from 'logfire'
 
 import { configure, logfireConfig } from './logfireConfig'
@@ -59,6 +61,8 @@ const defaultExport: {
   startSpan: typeof startSpan
   trace: typeof trace
   warning: typeof warning
+  withSettings: typeof withSettings
+  withTags: typeof withTags
 } = {
   configure,
   configureLogfireApi,
@@ -87,6 +91,8 @@ const defaultExport: {
   trace,
   ULIDGenerator,
   warning,
+  withSettings,
+  withTags,
 }
 
 export default defaultExport

--- a/packages/logfire-node/src/index.ts
+++ b/packages/logfire-node/src/index.ts
@@ -5,6 +5,7 @@ import {
   error,
   fatal,
   info,
+  instrument,
   Level,
   log,
   logfireApiConfig,
@@ -48,6 +49,7 @@ const defaultExport: {
   fatal: typeof fatal
   forceFlush: typeof forceFlush
   info: typeof info
+  instrument: typeof instrument
   log: typeof log
   logfireApiConfig: typeof logfireApiConfig
   notice: typeof notice
@@ -72,6 +74,7 @@ const defaultExport: {
   fatal,
   forceFlush,
   info,
+  instrument,
   // Re-export all from logfire
   Level,
   log,

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -1,4 +1,4 @@
-import type { SamplingOptions } from 'logfire'
+import type { BaggageOptions, SamplingOptions } from 'logfire'
 import type { VariablesConfigOptions } from 'logfire/vars'
 
 import type { Attributes, DiagLogLevel } from '@opentelemetry/api'
@@ -59,6 +59,10 @@ export interface LogfireConfigOptions {
    * Advanced configuration options
    */
   advanced?: AdvancedLogfireConfigOptions
+  /**
+   * Active OpenTelemetry baggage keys to copy to Logfire manual spans/logs as span attributes.
+   */
+  baggage?: BaggageOptions
   /**
    * Settings for the source code of the project.
    */
@@ -163,6 +167,7 @@ export interface LogfireConfig {
   additionalSpanProcessors: SpanProcessor[]
   apiKey: string | undefined
   authorizationHeaders: AuthorizationHeaders
+  baggage: BaggageOptions
   baseUrl: string
   codeSource: CodeSource | undefined
   console: boolean | undefined
@@ -191,6 +196,9 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   additionalSpanProcessors: [],
   apiKey: undefined,
   authorizationHeaders: {},
+  baggage: {
+    spanAttributes: [],
+  },
   baseUrl: '',
   codeSource: undefined,
   console: false,
@@ -217,12 +225,15 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
 export const logfireConfig: LogfireConfig = DEFAULT_LOGFIRE_CONFIG
 
 export function configure(config: LogfireConfigOptions = {}): void {
-  const { errorFingerprinting, otelScope, sampling, scrubbing, ...cnf } = config
+  const { baggage, errorFingerprinting, otelScope, sampling, scrubbing, ...cnf } = config
 
   const env = process.env
 
-  if (errorFingerprinting !== undefined || otelScope !== undefined || scrubbing !== undefined) {
+  if (baggage !== undefined || errorFingerprinting !== undefined || otelScope !== undefined || scrubbing !== undefined) {
     const apiConfig: logfireApi.LogfireApiConfigOptions = {}
+    if (baggage !== undefined) {
+      apiConfig.baggage = baggage
+    }
     if (errorFingerprinting !== undefined) {
       apiConfig.errorFingerprinting = errorFingerprinting
     }
@@ -253,6 +264,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
     additionalSpanProcessors: cnf.additionalSpanProcessors ?? [],
     apiKey,
     authorizationHeaders: resolveAuthorizationHeaders(token),
+    baggage: baggage !== undefined ? { spanAttributes: [...(baggage.spanAttributes ?? [])] } : logfireConfig.baggage,
     baseUrl,
     codeSource: cnf.codeSource,
     console,

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -1,4 +1,4 @@
-import type { BaggageOptions, SamplingOptions } from 'logfire'
+import type { BaggageOptions, LogFireLevel, MinLevel, SamplingOptions } from 'logfire'
 import type { VariablesConfigOptions } from 'logfire/vars'
 
 import type { Attributes, DiagLogLevel } from '@opentelemetry/api'
@@ -95,6 +95,14 @@ export interface LogfireConfigOptions {
    */
   instrumentations?: Instrumentation[]
   /**
+   * Minimum Logfire level to emit for manual log-like spans.
+   *
+   * Accepts lowercase level names (trace, debug, info, notice, warning, error, fatal)
+   * or numeric values from `logfire.Level`. Set to null to disable a previously configured minimum.
+   * Defaults to the `LOGFIRE_MIN_LEVEL` environment variable when omitted.
+   */
+  minLevel?: MinLevel | null
+  /**
    * Set to False to disable sending all metrics, or provide a MetricsOptions object to configure metrics, e.g. additional metric readers.
    */
   metrics?: false | MetricsOptions
@@ -179,6 +187,7 @@ export interface LogfireConfig {
   logsExporterUrl: string
   metricExporterUrl: string
   metrics: false | MetricsOptions | undefined
+  minLevel: LogFireLevel | undefined
   nodeAutoInstrumentations: InstrumentationConfigMap
   otelScope: string
   resourceAttributes: Attributes
@@ -209,6 +218,7 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   logsExporterUrl: '',
   metricExporterUrl: '',
   metrics: undefined,
+  minLevel: undefined,
   nodeAutoInstrumentations: DEFAULT_AUTO_INSTRUMENTATION_CONFIG,
   otelScope: DEFAULT_OTEL_SCOPE,
   resourceAttributes: {},
@@ -225,12 +235,21 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
 export const logfireConfig: LogfireConfig = DEFAULT_LOGFIRE_CONFIG
 
 export function configure(config: LogfireConfigOptions = {}): void {
-  const { baggage, errorFingerprinting, otelScope, sampling, scrubbing, ...cnf } = config
+  const { baggage, errorFingerprinting, minLevel, otelScope, sampling, scrubbing, ...cnf } = config
 
   const env = process.env
+  const envMinLevel = env['LOGFIRE_MIN_LEVEL']
 
-  if (baggage !== undefined || errorFingerprinting !== undefined || otelScope !== undefined || scrubbing !== undefined) {
+  if (
+    baggage !== undefined ||
+    errorFingerprinting !== undefined ||
+    minLevel !== undefined ||
+    envMinLevel !== undefined ||
+    otelScope !== undefined ||
+    scrubbing !== undefined
+  ) {
     const apiConfig: logfireApi.LogfireApiConfigOptions = {}
+    let minLevelSource: 'code' | 'env' | undefined
     if (baggage !== undefined) {
       apiConfig.baggage = baggage
     }
@@ -240,10 +259,20 @@ export function configure(config: LogfireConfigOptions = {}): void {
     if (otelScope !== undefined) {
       apiConfig.otelScope = otelScope
     }
+    if (minLevel !== undefined) {
+      apiConfig.minLevel = minLevel
+      minLevelSource = 'code'
+    } else if (envMinLevel !== undefined) {
+      apiConfig.minLevel = envMinLevel as MinLevel
+      minLevelSource = 'env'
+    }
     if (scrubbing !== undefined) {
       apiConfig.scrubbing = scrubbing
     }
-    logfireApi.configureLogfireApi(apiConfig)
+    const minLevelUpdated = configureSharedApi(apiConfig, minLevelSource)
+    if (minLevelUpdated) {
+      logfireConfig.minLevel = logfireApi.logfireApiConfig.minLevel
+    }
   }
 
   const token = cnf.token ?? env['LOGFIRE_TOKEN']
@@ -276,6 +305,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
     logsExporterUrl: `${baseUrl}/${LOGS_ENDPOINT_PATH}`,
     metricExporterUrl: `${baseUrl}/${METRIC_ENDPOINT_PATH}`,
     metrics: cnf.metrics,
+    minLevel: logfireConfig.minLevel,
     nodeAutoInstrumentations: cnf.nodeAutoInstrumentations ?? DEFAULT_AUTO_INSTRUMENTATION_CONFIG,
     resourceAttributes: cnf.resourceAttributes ?? {},
     sampling: resolveSampling(sampling),
@@ -289,6 +319,25 @@ export function configure(config: LogfireConfigOptions = {}): void {
   })
 
   start()
+}
+
+function configureSharedApi(apiConfig: logfireApi.LogfireApiConfigOptions, minLevelSource: 'code' | 'env' | undefined): boolean {
+  try {
+    logfireApi.configureLogfireApi(apiConfig)
+    return minLevelSource !== undefined
+  } catch (error) {
+    if (minLevelSource !== 'env') {
+      throw error
+    }
+
+    console.warn(`Invalid LOGFIRE_MIN_LEVEL value "${String(apiConfig.minLevel)}" ignored.`)
+    const fallbackApiConfig = { ...apiConfig }
+    delete fallbackApiConfig.minLevel
+    if (Object.keys(fallbackApiConfig).length > 0) {
+      logfireApi.configureLogfireApi(fallbackApiConfig)
+    }
+    return false
+  }
 }
 
 function resolveSampling(option: SamplingOptions | undefined): SamplingOptions | undefined {

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -8,7 +8,11 @@ import type { MetricReader } from '@opentelemetry/sdk-metrics'
 import type { IdGenerator, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 import * as logfireApi from 'logfire'
 
+import type { ConsoleConfig } from './consoleOptions'
+import { resolveConsoleOptions } from './consoleOptions'
 import { start } from './sdk'
+
+export type { ConsoleConfig, ConsoleOptions } from './consoleOptions'
 
 export interface AdvancedLogfireConfigOptions {
   /**
@@ -70,7 +74,7 @@ export interface LogfireConfigOptions {
   /**
    * Whether to log the spans to the console in addition to sending them to the Logfire API.
    */
-  console?: boolean
+  console?: ConsoleConfig
   /**
    * Defines the available internal logging levels for the diagnostic logger.
    */
@@ -178,7 +182,7 @@ export interface LogfireConfig {
   baggage: BaggageOptions
   baseUrl: string
   codeSource: CodeSource | undefined
-  console: boolean | undefined
+  console: ConsoleConfig | undefined
   deploymentEnvironment: string | undefined
   diagLogLevel?: DiagLogLevel
   distributedTracing: boolean
@@ -239,6 +243,9 @@ export function configure(config: LogfireConfigOptions = {}): void {
 
   const env = process.env
   const envMinLevel = env['LOGFIRE_MIN_LEVEL']
+  const console = 'console' in cnf ? cnf.console : env['LOGFIRE_CONSOLE'] === 'true'
+
+  resolveConsoleOptions(console)
 
   if (
     baggage !== undefined ||
@@ -279,7 +286,6 @@ export function configure(config: LogfireConfigOptions = {}): void {
   const apiKey = cnf.apiKey ?? env['LOGFIRE_API_KEY']
   const sendToLogfire = resolveSendToLogfire(cnf.sendToLogfire, token)
   const baseUrl = resolveBaseUrl(env, cnf.advanced?.baseUrl, token, sendToLogfire)
-  const console = 'console' in cnf ? cnf.console : env['LOGFIRE_CONSOLE'] === 'true'
   const deploymentEnvironment = cnf.environment ?? env['LOGFIRE_ENVIRONMENT']
   const serviceName = cnf.serviceName ?? env['LOGFIRE_SERVICE_NAME']
   const serviceVersion = cnf.serviceVersion ?? env['LOGFIRE_SERVICE_VERSION']

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -1,4 +1,4 @@
-import type { BaggageOptions, LogFireLevel, MinLevel, SamplingOptions } from 'logfire'
+import type { BaggageOptions, JsonSchemaMode, LogFireLevel, MinLevel, SamplingOptions } from 'logfire'
 import type { VariablesConfigOptions } from 'logfire/vars'
 
 import type { Attributes, DiagLogLevel } from '@opentelemetry/api'
@@ -95,6 +95,12 @@ export interface LogfireConfigOptions {
    */
   errorFingerprinting?: boolean
   /**
+   * Controls JSON schema metadata for serialized object/array attributes.
+   *
+   * Defaults to 'rich'. Use 'basic' for legacy broad schemas, or false to omit schema metadata.
+   */
+  jsonSchema?: JsonSchemaMode
+  /**
    * Additional third-party instrumentations to use.
    */
   instrumentations?: Instrumentation[]
@@ -188,6 +194,7 @@ export interface LogfireConfig {
   distributedTracing: boolean
   idGenerator: IdGenerator
   instrumentations: Instrumentation[]
+  jsonSchema: JsonSchemaMode
   logsExporterUrl: string
   metricExporterUrl: string
   metrics: false | MetricsOptions | undefined
@@ -219,6 +226,7 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   distributedTracing: true,
   idGenerator: new logfireApi.ULIDGenerator(),
   instrumentations: [],
+  jsonSchema: 'rich',
   logsExporterUrl: '',
   metricExporterUrl: '',
   metrics: undefined,
@@ -239,7 +247,7 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
 export const logfireConfig: LogfireConfig = DEFAULT_LOGFIRE_CONFIG
 
 export function configure(config: LogfireConfigOptions = {}): void {
-  const { baggage, errorFingerprinting, minLevel, otelScope, sampling, scrubbing, ...cnf } = config
+  const { baggage, errorFingerprinting, jsonSchema, minLevel, otelScope, sampling, scrubbing, ...cnf } = config
 
   const env = process.env
   const envMinLevel = env['LOGFIRE_MIN_LEVEL']
@@ -250,6 +258,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
   if (
     baggage !== undefined ||
     errorFingerprinting !== undefined ||
+    jsonSchema !== undefined ||
     minLevel !== undefined ||
     envMinLevel !== undefined ||
     otelScope !== undefined ||
@@ -262,6 +271,9 @@ export function configure(config: LogfireConfigOptions = {}): void {
     }
     if (errorFingerprinting !== undefined) {
       apiConfig.errorFingerprinting = errorFingerprinting
+    }
+    if (jsonSchema !== undefined) {
+      apiConfig.jsonSchema = jsonSchema
     }
     if (otelScope !== undefined) {
       apiConfig.otelScope = otelScope
@@ -308,6 +320,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
     distributedTracing: resolveDistributedTracing(cnf.distributedTracing),
     idGenerator: cnf.advanced?.idGenerator ?? new logfireApi.ULIDGenerator(),
     instrumentations: cnf.instrumentations ?? [],
+    jsonSchema: jsonSchema ?? logfireConfig.jsonSchema,
     logsExporterUrl: `${baseUrl}/${LOGS_ENDPOINT_PATH}`,
     metricExporterUrl: `${baseUrl}/${METRIC_ENDPOINT_PATH}`,
     metrics: cnf.metrics,

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -181,6 +181,19 @@ const DEFAULT_AUTO_INSTRUMENTATION_CONFIG: InstrumentationConfigMap = {
   },
 }
 
+function readNonEmptyEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key]
+  return value === undefined || value.trim() === '' ? undefined : value
+}
+
+function readServiceNameEnv(env: NodeJS.ProcessEnv): string | undefined {
+  return readNonEmptyEnv(env, 'LOGFIRE_SERVICE_NAME') ?? readNonEmptyEnv(env, 'OTEL_SERVICE_NAME')
+}
+
+function readServiceVersionEnv(env: NodeJS.ProcessEnv): string | undefined {
+  return readNonEmptyEnv(env, 'LOGFIRE_SERVICE_VERSION') ?? readNonEmptyEnv(env, 'OTEL_SERVICE_VERSION')
+}
+
 export interface LogfireConfig {
   additionalSpanProcessors: SpanProcessor[]
   apiKey: string | undefined
@@ -236,8 +249,8 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   resourceAttributes: {},
   sampling: undefined,
   sendToLogfire: false,
-  serviceName: process.env['LOGFIRE_SERVICE_NAME'] ?? process.env['OTEL_SERVICE_NAME'],
-  serviceVersion: process.env['LOGFIRE_SERVICE_VERSION'] ?? process.env['OTEL_SERVICE_VERSION'],
+  serviceName: readServiceNameEnv(process.env),
+  serviceVersion: readServiceVersionEnv(process.env),
   token: '',
   traceExporterUrl: '',
   variables: undefined,
@@ -299,8 +312,8 @@ export function configure(config: LogfireConfigOptions = {}): void {
   const sendToLogfire = resolveSendToLogfire(cnf.sendToLogfire, token)
   const baseUrl = resolveBaseUrl(env, cnf.advanced?.baseUrl, token, sendToLogfire)
   const deploymentEnvironment = cnf.environment ?? env['LOGFIRE_ENVIRONMENT']
-  const serviceName = cnf.serviceName ?? env['LOGFIRE_SERVICE_NAME'] ?? env['OTEL_SERVICE_NAME']
-  const serviceVersion = cnf.serviceVersion ?? env['LOGFIRE_SERVICE_VERSION'] ?? env['OTEL_SERVICE_VERSION']
+  const serviceName = cnf.serviceName ?? readServiceNameEnv(env)
+  const serviceVersion = cnf.serviceVersion ?? readServiceVersionEnv(env)
   const variablesBaseUrl =
     apiKey !== undefined && apiKey !== '' ? logfireApi.resolveBaseUrl(process.env, cnf.advanced?.baseUrl, apiKey) : cnf.advanced?.baseUrl
   if (requiresRemoteVariables(cnf.variables) && (apiKey === undefined || apiKey === '')) {

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -140,12 +140,12 @@ export interface LogfireConfigOptions {
   sendToLogfire?: 'if-token-present' | boolean
   /**
    * Name of this service.
-   * Defaults to the `LOGFIRE_SERVICE_NAME` environment variable.
+   * Defaults to the `LOGFIRE_SERVICE_NAME` environment variable, then `OTEL_SERVICE_NAME`.
    */
   serviceName?: string
   /**
    * Version of this service.
-   * Defaults to the `LOGFIRE_SERVICE_VERSION` environment variable.
+   * Defaults to the `LOGFIRE_SERVICE_VERSION` environment variable, then `OTEL_SERVICE_VERSION`.
    */
   serviceVersion?: string
   /**
@@ -228,8 +228,8 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   resourceAttributes: {},
   sampling: undefined,
   sendToLogfire: false,
-  serviceName: process.env['LOGFIRE_SERVICE_NAME'],
-  serviceVersion: process.env['LOGFIRE_SERVICE_VERSION'],
+  serviceName: process.env['LOGFIRE_SERVICE_NAME'] ?? process.env['OTEL_SERVICE_NAME'],
+  serviceVersion: process.env['LOGFIRE_SERVICE_VERSION'] ?? process.env['OTEL_SERVICE_VERSION'],
   token: '',
   traceExporterUrl: '',
   variables: undefined,
@@ -287,8 +287,8 @@ export function configure(config: LogfireConfigOptions = {}): void {
   const sendToLogfire = resolveSendToLogfire(cnf.sendToLogfire, token)
   const baseUrl = resolveBaseUrl(env, cnf.advanced?.baseUrl, token, sendToLogfire)
   const deploymentEnvironment = cnf.environment ?? env['LOGFIRE_ENVIRONMENT']
-  const serviceName = cnf.serviceName ?? env['LOGFIRE_SERVICE_NAME']
-  const serviceVersion = cnf.serviceVersion ?? env['LOGFIRE_SERVICE_VERSION']
+  const serviceName = cnf.serviceName ?? env['LOGFIRE_SERVICE_NAME'] ?? env['OTEL_SERVICE_NAME']
+  const serviceVersion = cnf.serviceVersion ?? env['LOGFIRE_SERVICE_VERSION'] ?? env['OTEL_SERVICE_VERSION']
   const variablesBaseUrl =
     apiKey !== undefined && apiKey !== '' ? logfireApi.resolveBaseUrl(process.env, cnf.advanced?.baseUrl, apiKey) : cnf.advanced?.baseUrl
   if (requiresRemoteVariables(cnf.variables) && (apiKey === undefined || apiKey === '')) {

--- a/packages/logfire-node/src/traceExporter.ts
+++ b/packages/logfire-node/src/traceExporter.ts
@@ -5,10 +5,12 @@ import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trac
 
 import { logfireConfig } from './logfireConfig'
 import { LogfireConsoleSpanExporter } from './LogfireConsoleSpanExporter'
+import type { ConsoleConfig } from './consoleOptions'
+import { resolveConsoleOptions } from './consoleOptions'
 import { VoidTraceExporter } from './VoidTraceExporter'
 
-export function logfireSpanProcessor(enableConsole: boolean | undefined): SpanProcessor {
-  return new LogfireSpanProcessor(new BatchSpanProcessor(traceExporter()), Boolean(enableConsole))
+export function logfireSpanProcessor(consoleConfig: ConsoleConfig | undefined): SpanProcessor {
+  return new LogfireSpanProcessor(new BatchSpanProcessor(traceExporter()), consoleConfig)
 }
 
 /**
@@ -35,9 +37,10 @@ class LogfireSpanProcessor implements SpanProcessor {
   private readonly console?: SpanProcessor
   private readonly wrapped: SpanProcessor
 
-  constructor(wrapped: SpanProcessor, enableConsole: boolean) {
-    if (enableConsole) {
-      this.console = new SimpleSpanProcessor(new LogfireConsoleSpanExporter())
+  constructor(wrapped: SpanProcessor, consoleConfig: ConsoleConfig | undefined) {
+    const consoleOptions = resolveConsoleOptions(consoleConfig)
+    if (consoleOptions.enabled) {
+      this.console = new SimpleSpanProcessor(new LogfireConsoleSpanExporter(consoleOptions))
     }
     this.wrapped = wrapped
   }


### PR DESCRIPTION
## Summary

Closes PYD-3529.

This PR closes the remaining Logfire JS manual API and configuration parity work as a set of topical commits. The branch keeps the JS API shape idiomatic while matching the useful Python parity semantics where they map cleanly.

Referenced child issues:
- Refs PYD-3885 - parity decision matrix
- Refs PYD-3886 - scoped manual API helpers
- Refs PYD-3887 - reportError() options
- Refs PYD-3888 - function instrumentation wrapper
- Refs PYD-3889 - baggage-to-span attributes and propagation docs
- Refs PYD-3890 - minimum-level filtering
- Refs PYD-3891 - Node console output options
- Refs PYD-3892 - Node OTel service env fallbacks
- Refs PYD-3893 - richer JSON schema metadata

## What Changed

- Added scoped manual API clients via withTags() and withSettings().
- Modernized reportError() options while preserving the legacy attributes argument.
- Added a JS-native instrument() wrapper with explicit argument extraction and best-effort return recording.
- Added opt-in baggage projection for manual spans and logs.
- Added minLevel filtering for manual telemetry and Node LOGFIRE_MIN_LEVEL.
- Added Node-only object-style console options.
- Added Node fallbacks for OTEL_SERVICE_NAME and OTEL_SERVICE_VERSION.
- Added bounded logfire.json_schema inference with jsonSchema: rich | basic | false.

## Validation

- pnpm exec vp run logfire#test
- pnpm exec vp run logfire#typecheck
- pnpm exec vp run logfire#lint
- pnpm exec vp run @pydantic/logfire-node#test
- pnpm exec vp run @pydantic/logfire-node#typecheck
- pnpm exec vp run @pydantic/logfire-browser#test
- pnpm exec vp run @pydantic/logfire-browser#typecheck
- pnpm run format-check
- pnpm run build
- git diff --check
