### PR TITLE
Add npx logfire CLI for auth and project management

### DIFF
--- a/.changeset/fresh-logfire-cli.md
+++ b/.changeset/fresh-logfire-cli.md
@@ -1,0 +1,8 @@
+---
+"@pydantic/logfire-node": minor
+"logfire": minor
+---
+
+Add a Node-only `npx logfire` CLI for authentication, project selection/creation, read-token creation, local credential cleanup, `whoami`, and runtime info. The CLI writes Python-compatible global auth tokens and local `.logfire/logfire_credentials.json` project credentials.
+
+`@pydantic/logfire-node` now reads local project credentials when no explicit token and no `LOGFIRE_TOKEN` are configured, while browser and worker packages remain credential-file free.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,21 @@ then `OTEL_*` environment variables.
 
 Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser code must not receive the token; use a backend proxy and configure `traceUrl` instead.
 
+For local Node.js development, you can also let the CLI write project credentials:
+
+```bash
+npx logfire auth
+npx logfire projects use my-project
+```
+
+`@pydantic/logfire-node` reads `.logfire/logfire_credentials.json` when no explicit `token` and no `LOGFIRE_TOKEN` are set. Token precedence in Node.js is:
+
+1. `configure({ token })`
+2. `LOGFIRE_TOKEN`
+3. Local project credentials from `dataDir`, `LOGFIRE_CREDENTIALS_DIR`, or `.logfire`
+
+If local credentials supply the token, their `logfire_api_url` is also used as the base URL unless `advanced.baseUrl` or `LOGFIRE_BASE_URL` overrides it. Browser and Cloudflare packages do not read local credential files.
+
 In Node.js, `token` can also be a function when credentials rotate:
 
 ```ts

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -22,6 +22,15 @@ Set your Logfire write token in the environment:
 export LOGFIRE_TOKEN="your-write-token"
 ```
 
+For local development, you can also authenticate and select a project with the CLI:
+
+```bash
+npx logfire auth
+npx logfire projects use my-project
+```
+
+The CLI writes `.logfire/logfire_credentials.json`, which `@pydantic/logfire-node` reads when `LOGFIRE_TOKEN` is unset.
+
 ## Send a Span
 
 Create `hello.mjs`:

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -80,6 +80,10 @@
         "label": "Reference",
         "items": [
           {
+            "label": "CLI",
+            "slug": "reference/cli"
+          },
+          {
             "label": "Environment Variables",
             "slug": "reference/environment-variables"
           },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,99 @@
+---
+title: CLI
+description: Use npx logfire to authenticate, select projects, and manage read tokens.
+---
+
+# CLI
+
+The `logfire` package exposes a Node-only CLI:
+
+```bash
+npx logfire --help
+```
+
+Supported commands:
+
+- `auth`: authenticate with Logfire and write user credentials to `~/.logfire/default.toml`.
+- `auth logout`: remove user credentials.
+- `projects list`: list projects where the current user can create write tokens.
+- `projects new [project-name]`: create a project and write local project credentials.
+- `projects use [project-name]`: create a write token for an existing project and write local project credentials.
+- `read-tokens --project <org>/<project> create`: create a read token and print it to stdout.
+- `whoami`: show configured user and project information.
+- `clean`: remove local project credentials.
+- `info`: print SDK and runtime information.
+
+The JavaScript CLI does not implement Python SDK commands such as `run`, `inspect`, `gateway`, or `prompt`.
+
+## Global options
+
+- `--version`: print the CLI, Node.js, and platform versions, then exit.
+- `--region <region>`: select a Logfire data region (`us` or `eu`).
+- `--base-url <url>`: target a self-hosted or custom Logfire API. Mutually exclusive with `--region`.
+
+## Auth
+
+Authenticate once per machine:
+
+```bash
+npx logfire auth
+```
+
+Use `--region` or `--base-url` to select a specific Logfire API:
+
+```bash
+npx logfire --region us auth
+npx logfire --base-url https://logfire-us.pydantic.dev auth
+```
+
+User auth tokens are stored in `~/.logfire/default.toml`, using the same token section shape as the Python SDK.
+
+Log out to remove stored user tokens:
+
+```bash
+npx logfire auth logout
+```
+
+By default this removes every stored user token. Pass `--region` or `--base-url` to log out from only one Logfire API:
+
+```bash
+npx logfire --region eu auth logout
+```
+
+## Projects
+
+Configure the current Node.js project to use an existing Logfire project:
+
+```bash
+npx logfire projects use my-project
+```
+
+Or create a new project:
+
+```bash
+npx logfire projects new my-project
+```
+
+Both commands write `.logfire/logfire_credentials.json` and `.logfire/.gitignore`. The Node.js runtime package reads those local credentials when no explicit `token` and no `LOGFIRE_TOKEN` are set.
+
+Pass `--data-dir <dir>` to write credentials somewhere other than `.logfire`.
+
+## Whoami and clean
+
+Show the configured user and project for the current directory:
+
+```bash
+npx logfire whoami
+```
+
+Remove the local project credentials written by `projects use/new`:
+
+```bash
+npx logfire clean
+```
+
+Both commands accept `--data-dir <dir>` to read or remove credentials from a directory other than `.logfire`. `whoami` resolves project information from `LOGFIRE_TOKEN`, then global user auth, then local credentials, matching the Node.js runtime precedence.
+
+## Browser Safety
+
+Local credential files are Node-only. Browser code must not receive a Logfire write token; configure `@pydantic/logfire-browser` with a backend `traceUrl` proxy instead.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -22,6 +22,7 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 | `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
 | `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`.                                      |
 | `LOGFIRE_BASE_URL`            | Override the Logfire API base URL.                                       |
+| `LOGFIRE_CREDENTIALS_DIR`     | Directory containing `logfire_credentials.json` for local Node projects. |
 | `OTEL_SERVICE_NAME`           | Service name fallback when `LOGFIRE_SERVICE_NAME` is unset.              |
 | `OTEL_SERVICE_VERSION`        | Service version fallback when `LOGFIRE_SERVICE_VERSION` is unset.        |
 
@@ -36,6 +37,11 @@ not accepted. Invalid values warn with `console.warn` and are ignored.
 minimum level of `info`. Object-style console options such as
 `console.minLevel`, `console.includeTags`, and `console.includeTimestamps` are
 available only through code configuration.
+
+When `LOGFIRE_TOKEN` is unset and no code token is passed, Node.js also checks
+for `.logfire/logfire_credentials.json` in the current working directory.
+`LOGFIRE_CREDENTIALS_DIR` changes that directory. These local credentials are
+written by `npx logfire projects use/new` and are not read by browser code.
 
 ## Cloudflare Workers
 

--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -31,6 +31,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "logfire": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "import": {

--- a/packages/logfire-api/src/cli/authClient.ts
+++ b/packages/logfire-api/src/cli/authClient.ts
@@ -1,0 +1,9 @@
+import { LogfireApiClient } from './client'
+import type { CliContext, GlobalOptions } from './context'
+import { defaultAuthFilePath, UserTokenCollection } from './credentials'
+
+export async function createAuthenticatedClient(globalOptions: GlobalOptions, context: CliContext): Promise<LogfireApiClient> {
+  const authFile = globalOptions.authFile ?? defaultAuthFilePath(context.homeDir)
+  const token = await new UserTokenCollection(authFile).getToken(globalOptions.baseUrl, context.prompt)
+  return new LogfireApiClient({ fetch: context.fetch, userToken: token })
+}

--- a/packages/logfire-api/src/cli/client.test.ts
+++ b/packages/logfire-api/src/cli/client.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import { LogfireApiClient, InvalidProjectNameError, ProjectAlreadyExistsError, pollForToken, requestDeviceCode, urlFor } from './client'
+
+describe('CLI client', () => {
+  it('uses Python-compatible device auth endpoints', async () => {
+    const calls: CapturedRequest[] = []
+    const fetchImpl = fetchSequence(calls, [
+      jsonResponse({ device_code: 'DC', frontend_auth_url: 'https://example.com/auth' }),
+      jsonResponse({ expiration: '2099-12-31T23:59:59Z', token: 'user-token' }),
+    ])
+
+    await expect(
+      requestDeviceCode({ baseUrl: 'https://logfire-us.pydantic.dev', fetch: fetchImpl, machineName: 'machine' })
+    ).resolves.toEqual({
+      device_code: 'DC',
+      frontend_auth_url: 'https://example.com/auth',
+    })
+    await expect(pollForToken({ baseUrl: 'https://logfire-us.pydantic.dev', deviceCode: 'DC', fetch: fetchImpl })).resolves.toEqual({
+      expiration: '2099-12-31T23:59:59Z',
+      token: 'user-token',
+    })
+
+    expect(calls.map((call) => [call.method, call.url])).toEqual([
+      ['POST', 'https://logfire-us.pydantic.dev/v1/device-auth/new/?machine_name=machine'],
+      ['GET', 'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC'],
+    ])
+  })
+
+  it('uses project endpoints and auth headers', async () => {
+    const calls: CapturedRequest[] = []
+    const client = new LogfireApiClient({
+      fetch: fetchSequence(calls, [
+        jsonResponse([{ organization_name: 'org', project_name: 'project' }]),
+        jsonResponse([{ organization_name: 'org' }]),
+        jsonResponse({ default_organization: { organization_name: 'org' }, name: 'User' }),
+        jsonResponse({ project_name: 'project', project_url: 'url', token: 'write-token' }),
+        jsonResponse({ token: 'read-token' }),
+      ]),
+      userToken: {
+        baseUrl: 'https://logfire-us.pydantic.dev',
+        expiration: '2099-12-31T23:59:59Z',
+        token: 'user-token',
+      },
+    })
+
+    await client.getUserProjects()
+    await client.getUserOrganizations()
+    await client.getUserInformation()
+    await client.createWriteToken('org', 'project')
+    await client.createReadToken('org', 'project')
+
+    expect(calls.map((call) => [call.method, call.url, call.authorization])).toEqual([
+      ['GET', 'https://logfire-us.pydantic.dev/v1/writable-projects/', 'user-token'],
+      ['GET', 'https://logfire-us.pydantic.dev/v1/organizations/available-for-projects/', 'user-token'],
+      ['GET', 'https://logfire-us.pydantic.dev/v1/account/me', 'user-token'],
+      ['POST', 'https://logfire-us.pydantic.dev/v1/organizations/org/projects/project/write-tokens/', 'user-token'],
+      ['POST', 'https://logfire-us.pydantic.dev/v1/organizations/org/projects/project/read-tokens', 'user-token'],
+    ])
+    expect(calls[4]?.body).toBe('{"description":"Created by Logfire CLI"}')
+  })
+
+  it('maps project creation errors', async () => {
+    const duplicateClient = makeClient(jsonResponse({ detail: 'exists' }, 409))
+    await expect(duplicateClient.createNewProject('org', 'project')).rejects.toBeInstanceOf(ProjectAlreadyExistsError)
+
+    const invalidClient = makeClient(jsonResponse({ detail: [{ loc: ['body', 'project_name'], msg: 'bad name' }] }, 422))
+    await expect(invalidClient.createNewProject('org', 'project')).rejects.toEqual(new InvalidProjectNameError('bad name'))
+  })
+
+  it('joins endpoint URLs against base URLs with or without trailing slashes', () => {
+    expect(urlFor('https://example.com', '/v1/info')).toBe('https://example.com/v1/info')
+    expect(urlFor('https://example.com/', '/v1/info')).toBe('https://example.com/v1/info')
+  })
+})
+
+interface CapturedRequest {
+  authorization: string | undefined
+  body: string | undefined
+  method: string
+  url: string
+}
+
+function makeClient(response: Response): LogfireApiClient {
+  return new LogfireApiClient({
+    fetch: fetchSequence([], [response]),
+    userToken: {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiration: '2099-12-31T23:59:59Z',
+      token: 'user-token',
+    },
+  })
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return input instanceof Request ? input.url : input.toString()
+}
+
+function fetchSequence(calls: CapturedRequest[], responses: Response[]): typeof fetch {
+  return vi.fn<typeof fetch>(async (input, init) => {
+    await Promise.resolve()
+    const headers = new Headers(init?.headers)
+    calls.push({
+      authorization: headers.get('authorization') ?? undefined,
+      body: typeof init?.body === 'string' ? init.body : undefined,
+      method: init?.method ?? 'GET',
+      url: requestUrl(input),
+    })
+    const response = responses.shift()
+    if (response === undefined) {
+      throw new Error(`Unexpected fetch call to ${requestUrl(input)}`)
+    }
+    return response
+  })
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'content-type': 'application/json' },
+    status,
+  })
+}

--- a/packages/logfire-api/src/cli/client.test.ts
+++ b/packages/logfire-api/src/cli/client.test.ts
@@ -60,6 +60,33 @@ describe('CLI client', () => {
     expect(calls[4]?.body).toBe('{"description":"Created by Logfire CLI"}')
   })
 
+  it('creates a new project with the Python-compatible endpoint and body', async () => {
+    const calls: CapturedRequest[] = []
+    const client = new LogfireApiClient({
+      fetch: fetchSequence(calls, [jsonResponse({ project_name: 'project', project_url: 'url', token: 'write-token' })]),
+      userToken: {
+        baseUrl: 'https://logfire-us.pydantic.dev',
+        expiration: '2099-12-31T23:59:59Z',
+        token: 'user-token',
+      },
+    })
+
+    await expect(client.createNewProject('org', 'project')).resolves.toEqual({
+      project_name: 'project',
+      project_url: 'url',
+      token: 'write-token',
+    })
+
+    expect(calls).toEqual([
+      {
+        authorization: 'user-token',
+        body: '{"project_name":"project"}',
+        method: 'POST',
+        url: 'https://logfire-us.pydantic.dev/v1/organizations/org/projects',
+      },
+    ])
+  })
+
   it('maps project creation errors', async () => {
     const duplicateClient = makeClient(jsonResponse({ detail: 'exists' }, 409))
     await expect(duplicateClient.createNewProject('org', 'project')).rejects.toBeInstanceOf(ProjectAlreadyExistsError)

--- a/packages/logfire-api/src/cli/client.ts
+++ b/packages/logfire-api/src/cli/client.ts
@@ -1,0 +1,256 @@
+import { hostname } from 'node:os'
+
+import type { UserToken, UserTokenData } from './credentials'
+import { LogfireCliError } from './errors'
+
+export const USER_AGENT: string = `logfire-js/${PACKAGE_VERSION}`
+
+export interface WritableProject {
+  organization_name: string
+  project_name: string
+}
+
+export interface Organization {
+  organization_name: string
+}
+
+export interface ProjectTokenResponse {
+  project_name: string
+  project_url: string
+  token: string
+}
+
+export interface UserInformation {
+  name?: string
+  default_organization?: {
+    organization_name?: string
+  }
+}
+
+export interface DeviceCodeResponse {
+  device_code: string
+  frontend_auth_url: string
+}
+
+export interface TokenInfoResponse {
+  project_name: string
+  project_url: string
+}
+
+export class ProjectAlreadyExistsError extends Error {
+  constructor() {
+    super('Project already exists')
+    this.name = 'ProjectAlreadyExistsError'
+  }
+}
+
+export class InvalidProjectNameError extends Error {
+  readonly reason: string
+
+  constructor(reason: string) {
+    super(reason)
+    this.name = 'InvalidProjectNameError'
+    this.reason = reason
+  }
+}
+
+export interface LogfireApiClientOptions {
+  fetch?: typeof fetch
+  userAgent?: string
+  userToken: UserToken
+}
+
+export class LogfireApiClient {
+  readonly baseUrl: string
+  private readonly fetchImpl: typeof fetch
+  private readonly headers: Record<string, string>
+
+  constructor(options: LogfireApiClientOptions) {
+    this.baseUrl = options.userToken.baseUrl
+    this.fetchImpl = options.fetch ?? fetch
+    this.headers = {
+      Authorization: options.userToken.token,
+      'User-Agent': options.userAgent ?? USER_AGENT,
+    }
+  }
+
+  async getUserInformation(): Promise<UserInformation> {
+    return await this.getJson<UserInformation>('/v1/account/me', 'Error retrieving user information')
+  }
+
+  async getUserOrganizations(): Promise<Organization[]> {
+    return await this.getJson<Organization[]>('/v1/organizations/available-for-projects/', 'Error retrieving list of organizations')
+  }
+
+  async getUserProjects(): Promise<WritableProject[]> {
+    return await this.getJson<WritableProject[]>('/v1/writable-projects/', 'Error retrieving list of projects')
+  }
+
+  async createNewProject(organization: string, projectName: string): Promise<ProjectTokenResponse> {
+    const response = await this.request('/v1/organizations/' + encodeURIComponent(organization) + '/projects', {
+      body: JSON.stringify({ project_name: projectName }),
+      headers: { ...this.headers, 'Content-Type': 'application/json' },
+      method: 'POST',
+    })
+    if (response.status === 409) {
+      throw new ProjectAlreadyExistsError()
+    }
+    if (response.status === 422) {
+      throw new InvalidProjectNameError(await readInvalidProjectNameReason(response))
+    }
+    if (!response.ok) {
+      throw new LogfireCliError('Error creating new project')
+    }
+    return (await response.json()) as ProjectTokenResponse
+  }
+
+  async createWriteToken(organization: string, projectName: string): Promise<ProjectTokenResponse> {
+    return await this.postJson<ProjectTokenResponse>(
+      `/v1/organizations/${encodeURIComponent(organization)}/projects/${encodeURIComponent(projectName)}/write-tokens/`,
+      undefined,
+      'Error creating project write token'
+    )
+  }
+
+  async createReadToken(organization: string, projectName: string): Promise<{ token: string }> {
+    return await this.postJson<{ token: string }>(
+      `/v1/organizations/${encodeURIComponent(organization)}/projects/${encodeURIComponent(projectName)}/read-tokens`,
+      { description: 'Created by Logfire CLI' },
+      'Error creating project read token'
+    )
+  }
+
+  private async getJson<T>(endpoint: string, errorMessage: string): Promise<T> {
+    const response = await this.request(endpoint, { headers: this.headers, method: 'GET' })
+    if (!response.ok) {
+      throw new LogfireCliError(errorMessage)
+    }
+    return (await response.json()) as T
+  }
+
+  private async postJson<T>(endpoint: string, body: unknown, errorMessage: string): Promise<T> {
+    const init: RequestInit = {
+      headers: { ...this.headers, 'Content-Type': 'application/json' },
+      method: 'POST',
+    }
+    if (body !== undefined) {
+      init.body = JSON.stringify(body)
+    }
+    const response = await this.request(endpoint, init)
+    if (!response.ok) {
+      throw new LogfireCliError(errorMessage)
+    }
+    return (await response.json()) as T
+  }
+
+  private async request(endpoint: string, init: RequestInit): Promise<Response> {
+    return await this.fetchImpl(urlFor(this.baseUrl, endpoint), init)
+  }
+}
+
+export interface DeviceAuthOptions {
+  baseUrl: string
+  fetch?: typeof fetch
+  machineName?: string
+  userAgent?: string
+}
+
+export async function requestDeviceCode(options: DeviceAuthOptions): Promise<DeviceCodeResponse> {
+  const fetchImpl = options.fetch ?? fetch
+  const url = new URL(urlFor(options.baseUrl, '/v1/device-auth/new/'))
+  url.searchParams.set('machine_name', options.machineName ?? hostname())
+  const response = await fetchImpl(url, {
+    headers: {
+      'User-Agent': options.userAgent ?? USER_AGENT,
+    },
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw new LogfireCliError('Failed to request a device code.')
+  }
+  return (await response.json()) as DeviceCodeResponse
+}
+
+export interface PollForTokenOptions {
+  baseUrl: string
+  deviceCode: string
+  fetch?: typeof fetch
+  maxAttempts?: number
+  userAgent?: string
+}
+
+export async function pollForToken(options: PollForTokenOptions): Promise<UserTokenData> {
+  const fetchImpl = options.fetch ?? fetch
+  const maxAttempts = options.maxAttempts ?? 120
+  let errors = 0
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // eslint-disable-next-line no-await-in-loop -- polling waits for each device-auth response before the next attempt.
+    const response = await fetchImpl(urlFor(options.baseUrl, `/v1/device-auth/wait/${encodeURIComponent(options.deviceCode)}`), {
+      headers: {
+        'User-Agent': options.userAgent ?? USER_AGENT,
+      },
+      method: 'GET',
+    }).catch(() => undefined)
+
+    if (response === undefined || !response.ok) {
+      errors += 1
+      if (errors >= 4) {
+        throw new LogfireCliError('Failed to poll for token.')
+      }
+      continue
+    }
+
+    // eslint-disable-next-line no-await-in-loop -- the response body must be read before deciding to poll again.
+    const token = (await response.json()) as UserTokenData | null
+    if (token !== null) {
+      return token
+    }
+  }
+
+  throw new LogfireCliError('Failed to poll for token.')
+}
+
+export async function getTokenInfo(
+  writeToken: string,
+  baseUrl: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<TokenInfoResponse | undefined> {
+  const response = await fetchImpl(urlFor(baseUrl, '/v1/info'), {
+    headers: {
+      Authorization: writeToken,
+      'User-Agent': USER_AGENT,
+    },
+    method: 'GET',
+  }).catch(() => undefined)
+  if (response === undefined || !response.ok) {
+    return undefined
+  }
+  return (await response.json()) as TokenInfoResponse
+}
+
+export function urlFor(baseUrl: string, endpoint: string): string {
+  return new URL(endpoint, baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`).toString()
+}
+
+async function readInvalidProjectNameReason(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as unknown
+    if (isRecord(data)) {
+      const detail = data['detail']
+      if (Array.isArray(detail)) {
+        const first: unknown = detail[0]
+        if (isRecord(first) && typeof first['msg'] === 'string') {
+          return first['msg']
+        }
+      }
+    }
+  } catch {
+    // Fall through to the generic message below.
+  }
+  return 'Invalid project name'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/logfire-api/src/cli/commands/auth.ts
+++ b/packages/logfire-api/src/cli/commands/auth.ts
@@ -1,0 +1,53 @@
+import { requestDeviceCode, pollForToken } from '../client'
+import type { CliContext, GlobalOptions } from '../context'
+import { defaultAuthFilePath, UserTokenCollection } from '../credentials'
+import { promptForRegion } from '../regions'
+import { writeLine } from '../output'
+
+export async function runAuthCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
+  if (args[0] === 'logout') {
+    runLogout(globalOptions, context)
+    return
+  }
+
+  const authFile = globalOptions.authFile ?? defaultAuthFilePath(context.homeDir)
+  const tokens = new UserTokenCollection(authFile)
+  let baseUrl = globalOptions.baseUrl
+  if (tokens.isLoggedIn(baseUrl)) {
+    writeLine(context.stderr, `You are already logged in. (Your credentials are stored in ${authFile})`)
+    writeLine(context.stderr, 'If you would like to log in using a different account, use the --region argument:')
+    writeLine(context.stderr, 'logfire --region <region> auth')
+    return
+  }
+
+  writeLine(context.stderr)
+  writeLine(context.stderr, 'Welcome to Logfire!')
+  writeLine(context.stderr, 'Before you can send data to Logfire, we need to authenticate you.')
+  writeLine(context.stderr)
+
+  baseUrl = baseUrl ?? (await promptForRegion(context.prompt))
+
+  const deviceCode = await requestDeviceCode({ baseUrl, fetch: context.fetch })
+  const frontendHost = new URL(deviceCode.frontend_auth_url).host
+  await context.prompt.waitForEnter(`Press Enter to open ${frontendHost} in your browser...`)
+
+  await context.openBrowser(deviceCode.frontend_auth_url)
+  writeLine(context.stderr, `Please open ${deviceCode.frontend_auth_url} in your browser to authenticate if it hasn't already.`)
+  writeLine(context.stderr, 'Waiting for you to authenticate with Logfire...')
+
+  tokens.addToken(baseUrl, await pollForToken({ baseUrl, deviceCode: deviceCode.device_code, fetch: context.fetch }))
+  writeLine(context.stderr, 'Successfully authenticated!')
+  writeLine(context.stderr)
+  writeLine(context.stderr, `Your Logfire credentials are stored in ${authFile}`)
+}
+
+function runLogout(globalOptions: GlobalOptions, context: CliContext): void {
+  const authFile = globalOptions.authFile ?? defaultAuthFilePath(context.homeDir)
+  const tokens = new UserTokenCollection(authFile)
+  const removed = tokens.logout(globalOptions.baseUrl)
+  for (const url of removed) {
+    writeLine(context.stderr, `Successfully logged out from ${url}`)
+  }
+  writeLine(context.stderr)
+  writeLine(context.stderr, `Your Logfire credentials have been removed from ${authFile}`)
+}

--- a/packages/logfire-api/src/cli/commands/auth.ts
+++ b/packages/logfire-api/src/cli/commands/auth.ts
@@ -1,13 +1,20 @@
 import { requestDeviceCode, pollForToken } from '../client'
 import type { CliContext, GlobalOptions } from '../context'
 import { defaultAuthFilePath, UserTokenCollection } from '../credentials'
+import { LogfireCliError } from '../errors'
 import { promptForRegion } from '../regions'
 import { writeLine } from '../output'
 
 export async function runAuthCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
   if (args[0] === 'logout') {
+    if (args.length > 1) {
+      throw new LogfireCliError(`Unexpected argument ${args[1] ?? ''}`)
+    }
     runLogout(globalOptions, context)
     return
+  }
+  if (args.length > 0) {
+    throw new LogfireCliError(`Unexpected argument ${args[0] ?? ''}`)
   }
 
   const authFile = globalOptions.authFile ?? defaultAuthFilePath(context.homeDir)

--- a/packages/logfire-api/src/cli/commands/clean.ts
+++ b/packages/logfire-api/src/cli/commands/clean.ts
@@ -1,0 +1,59 @@
+import { existsSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import type { CliContext } from '../context'
+import { defaultDataDir, projectCredentialsPath, removeProjectCredentials } from '../credentials'
+import { LogfireCliError } from '../errors'
+import { writeLine } from '../output'
+
+export async function runCleanCommand(args: string[], context: CliContext): Promise<void> {
+  const options = parseCleanArgs(args)
+  const dataDir = options.dataDir ?? defaultDataDir(context.cwd)
+
+  if (options.logs) {
+    writeLine(context.stderr, 'No JavaScript Logfire CLI log files are created; --logs has nothing to remove.')
+  }
+
+  if (!existsSync(dataDir) || !statSync(dataDir).isDirectory()) {
+    throw new LogfireCliError(`No Logfire data found in ${dataDir}`)
+  }
+
+  const files = [join(dataDir, '.gitignore'), projectCredentialsPath(dataDir)].filter((path) => existsSync(path))
+  const confirmed = await context.prompt.confirm(`The following files will be deleted:\n${files.join('\n')}\nAre you sure?`, false)
+  if (confirmed) {
+    removeProjectCredentials(dataDir)
+    writeLine(context.stderr, 'Cleaned Logfire data.')
+  } else {
+    writeLine(context.stderr, 'Clean aborted.')
+  }
+}
+
+interface CleanOptions {
+  dataDir?: string
+  logs: boolean
+}
+
+function parseCleanArgs(args: string[]): CleanOptions {
+  const options: CleanOptions = { logs: false }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index] ?? ''
+    if (arg === '--data-dir') {
+      options.dataDir = readRequiredValue(args, ++index, '--data-dir')
+    } else if (arg.startsWith('--data-dir=')) {
+      options.dataDir = arg.slice('--data-dir='.length)
+    } else if (arg === '--logs') {
+      options.logs = true
+    } else {
+      throw new LogfireCliError(`Unexpected argument ${arg}`)
+    }
+  }
+  return options
+}
+
+function readRequiredValue(args: string[], index: number, option: string): string {
+  const value = args[index]
+  if (value === undefined) {
+    throw new LogfireCliError(`Missing value for ${option}`)
+  }
+  return value
+}

--- a/packages/logfire-api/src/cli/commands/info.ts
+++ b/packages/logfire-api/src/cli/commands/info.ts
@@ -1,0 +1,10 @@
+import type { CliContext } from '../context'
+import { writeLine } from '../output'
+
+export function runInfoCommand(context: CliContext): void {
+  writeLine(context.stderr, `logfire="${PACKAGE_VERSION}"`)
+  writeLine(context.stderr, `platform="${context.platform}"`)
+  writeLine(context.stderr, `node="${process.version}"`)
+  writeLine(context.stderr, '[related_packages]')
+  writeLine(context.stderr, 'logfire="' + PACKAGE_VERSION + '"')
+}

--- a/packages/logfire-api/src/cli/commands/projects.test.ts
+++ b/packages/logfire-api/src/cli/commands/projects.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { sanitizeProjectName } from './projects'
+
+describe('sanitizeProjectName', () => {
+  // Ported from Python `tests/test_configure.py::test_sanitize_project_name` to keep
+  // the default project name suggested by the JS and Python CLIs identical.
+  it('matches the Python sanitizer behavior', () => {
+    expect(sanitizeProjectName('foo')).toBe('foo')
+    expect(sanitizeProjectName('FOO')).toBe('foo')
+    expect(sanitizeProjectName('  foo - bar!!')).toBe('foobar')
+    expect(sanitizeProjectName('  Foo - BAR!!')).toBe('foobar')
+    expect(sanitizeProjectName('')).toBe('untitled')
+    expect(sanitizeProjectName('-')).toBe('untitled')
+    expect(sanitizeProjectName('...')).toBe('untitled')
+    const longName = 'abcdefg'.repeat(20)
+    expect(sanitizeProjectName(longName)).toBe(longName.slice(0, 41))
+  })
+})

--- a/packages/logfire-api/src/cli/commands/projects.ts
+++ b/packages/logfire-api/src/cli/commands/projects.ts
@@ -1,0 +1,282 @@
+import { basename } from 'node:path'
+
+import { createAuthenticatedClient } from '../authClient'
+import type { LogfireApiClient, ProjectTokenResponse, WritableProject } from '../client'
+import { InvalidProjectNameError, ProjectAlreadyExistsError } from '../client'
+import type { CliContext, GlobalOptions } from '../context'
+import { defaultDataDir, writeProjectCredentials } from '../credentials'
+import { LogfireCliError } from '../errors'
+import { prettyTable, writeLine } from '../output'
+
+const PROJECT_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u
+
+interface ProjectCommandOptions {
+  dataDir?: string
+  defaultOrg: boolean
+  org?: string
+  projectName?: string
+}
+
+export async function runProjectsCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
+  const subcommand = args[0]
+  if (subcommand === undefined || subcommand === '--help' || subcommand === '-h') {
+    printProjectsHelp(context)
+    return
+  }
+
+  const client = await createAuthenticatedClient(globalOptions, context)
+  if (subcommand === 'list') {
+    await listProjects(client, context)
+    return
+  }
+  if (subcommand === 'new') {
+    await newProject(client, parseProjectOptions(args.slice(1)), context)
+    return
+  }
+  if (subcommand === 'use') {
+    await useProject(client, parseProjectOptions(args.slice(1)), context)
+    return
+  }
+  throw new LogfireCliError(`Unknown projects command "${subcommand}".`)
+}
+
+export function sanitizeProjectName(name: string): string {
+  // Match Python's `sanitize_project_name`: strip every non-alphanumeric character (no
+  // hyphens are introduced) so JS and Python suggest identical default project names. The
+  // backend may append 9 characters on name collisions, so cap the base name at 41.
+  const sanitized = name
+    .replace(/[^a-zA-Z0-9]/gu, '')
+    .toLowerCase()
+    .slice(0, 41)
+  return sanitized || 'untitled'
+}
+
+function printProjectsHelp(context: CliContext): void {
+  writeLine(context.stdout, 'usage: logfire projects <command>')
+  writeLine(context.stdout)
+  writeLine(context.stdout, 'Commands:')
+  writeLine(context.stdout, '  list   List projects')
+  writeLine(context.stdout, '  new    Create a new project')
+  writeLine(context.stdout, '  use    Use an existing project')
+}
+
+async function listProjects(client: LogfireApiClient, context: CliContext): Promise<void> {
+  const projects = await client.getUserProjects()
+  if (projects.length === 0) {
+    writeLine(context.stderr, 'No projects found for the current user. You can create a new project with `logfire projects new`')
+    return
+  }
+
+  writeLine(context.stderr, "List of the projects you have write access to (requires the 'write_token' permission):")
+  writeLine(context.stderr)
+  context.stderr.write(
+    prettyTable(
+      ['Organization', 'Project'],
+      [...projects]
+        .sort((a: WritableProject, b: WritableProject) =>
+          `${a.organization_name}/${a.project_name}`.localeCompare(`${b.organization_name}/${b.project_name}`)
+        )
+        .map((project) => [project.organization_name, project.project_name])
+    )
+  )
+}
+
+async function newProject(client: LogfireApiClient, options: ProjectCommandOptions, context: CliContext): Promise<void> {
+  const dataDir = options.dataDir ?? defaultDataDir(context.cwd)
+  const organization = await selectOrganization(client, options, context)
+  const project = await createProjectWithPrompt(client, organization, options.projectName, context)
+  writeProjectCredentials(dataDir, { ...project, logfire_api_url: client.baseUrl })
+  writeLine(context.stderr, `Project created successfully. You will be able to view it at: ${project.project_url}`)
+}
+
+async function useProject(client: LogfireApiClient, options: ProjectCommandOptions, context: CliContext): Promise<void> {
+  const dataDir = options.dataDir ?? defaultDataDir(context.cwd)
+  const project = await selectProject(client, options, context)
+  if (project === undefined) {
+    return
+  }
+  const credentials = await client.createWriteToken(project.organization_name, project.project_name)
+  writeProjectCredentials(dataDir, { ...credentials, logfire_api_url: client.baseUrl })
+  writeLine(context.stderr, `Project configured successfully. You will be able to view it at: ${credentials.project_url}`)
+}
+
+async function selectOrganization(client: LogfireApiClient, options: ProjectCommandOptions, context: CliContext): Promise<string> {
+  const organizations = (await client.getUserOrganizations()).map((organization) => organization.organization_name)
+  if (organizations.length === 0) {
+    throw new LogfireCliError('No organizations found for the current user.')
+  }
+  if (options.org !== undefined && organizations.includes(options.org)) {
+    return options.org
+  }
+
+  if (organizations.length === 1) {
+    const organization = organizations[0]
+    if (organization === undefined) {
+      throw new LogfireCliError('No organizations found for the current user.')
+    }
+    if (!options.defaultOrg) {
+      const confirmed = await context.prompt.confirm(`The project will be created in the organization "${organization}". Continue?`, true)
+      if (!confirmed) {
+        throw new LogfireCliError('Project creation aborted.')
+      }
+    }
+    return organization
+  }
+
+  const user = await client.getUserInformation()
+  const defaultOrganization = user.default_organization?.organization_name
+  if (options.defaultOrg && defaultOrganization !== undefined && organizations.includes(defaultOrganization)) {
+    return defaultOrganization
+  }
+  return await context.prompt.choice(
+    '\nTo create and use a new project, please provide the following information:\nSelect the organization to create the project in',
+    organizations,
+    defaultOrganization ?? organizations[0]
+  )
+}
+
+async function createProjectWithPrompt(
+  client: LogfireApiClient,
+  organization: string,
+  projectName: string | undefined,
+  context: CliContext
+): Promise<ProjectTokenResponse> {
+  const defaultName = sanitizeProjectName(basename(context.cwd))
+  let promptMessage = 'Enter the project name'
+  let currentProjectName = projectName
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- loops until a name is accepted by the backend.
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop -- the name prompt must resolve before attempting creation.
+    currentProjectName = currentProjectName ?? (await context.prompt.text(promptMessage, defaultName))
+    while (!PROJECT_NAME_PATTERN.test(currentProjectName)) {
+      // eslint-disable-next-line no-await-in-loop -- reprompt sequentially until the name is valid.
+      currentProjectName = await context.prompt.text(
+        "\nThe project name you've entered is invalid. Valid project names:\n" +
+          '  * may contain lowercase alphanumeric characters\n' +
+          '  * may contain single hyphens\n' +
+          '  * may not start or end with a hyphen\n\n' +
+          'Enter the project name you want to use:',
+        defaultName
+      )
+    }
+
+    try {
+      // eslint-disable-next-line no-await-in-loop -- each creation attempt must complete before retrying with a new name.
+      return await client.createNewProject(organization, currentProjectName)
+    } catch (error) {
+      if (error instanceof ProjectAlreadyExistsError) {
+        promptMessage = `\nA project with the name '${currentProjectName}' already exists. Please enter a different project name`
+        currentProjectName = undefined
+        continue
+      }
+      if (error instanceof InvalidProjectNameError) {
+        promptMessage = `\nThe project name you entered is invalid:\n${error.reason}\nPlease enter a different project name`
+        currentProjectName = undefined
+        continue
+      }
+      throw error
+    }
+  }
+}
+
+async function selectProject(
+  client: LogfireApiClient,
+  options: Pick<ProjectCommandOptions, 'org' | 'projectName'>,
+  context: CliContext
+): Promise<WritableProject | undefined> {
+  const projects = await client.getUserProjects()
+  let filteredProjects = projects
+  let organization = options.org
+  let projectName = options.projectName
+  let orgMessage = ''
+  let orgFlag = ''
+  let projectMessage = 'projects'
+
+  if (organization !== undefined) {
+    filteredProjects = filteredProjects.filter((project) => project.organization_name === organization)
+    orgMessage = ` in organization \`${organization}\``
+    orgFlag = ` --org ${organization}`
+  }
+  if (projectName !== undefined) {
+    projectMessage = `projects with name \`${projectName}\``
+    filteredProjects = filteredProjects.filter((project) => project.project_name === projectName)
+  }
+
+  if (projectName !== undefined && filteredProjects.length === 1) {
+    const project = filteredProjects[0]
+    if (project !== undefined) {
+      return project
+    }
+  } else if (filteredProjects.length === 0) {
+    if (projects.length === 0) {
+      writeLine(context.stderr, 'No projects found for the current user. You can create a new project with `logfire projects new`')
+      return undefined
+    }
+    const chooseAll = await context.prompt.confirm(
+      `No ${projectMessage} found for the current user${orgMessage}. Choose from all projects?`,
+      true
+    )
+    if (!chooseAll) {
+      writeLine(context.stderr, `You can create a new project${orgMessage} with \`logfire projects new${orgFlag}\``)
+      return undefined
+    }
+    filteredProjects = projects
+    organization = undefined
+    projectName = undefined
+  } else {
+    if (projectName !== undefined && organization === undefined) {
+      writeLine(context.stderr, `Found multiple ${projectMessage}.`)
+    }
+    organization = undefined
+    projectName = undefined
+  }
+
+  if (organization !== undefined && projectName !== undefined) {
+    return { organization_name: organization, project_name: projectName }
+  }
+
+  const choices = filteredProjects.map((_, index) => String(index + 1))
+  const choicesText = filteredProjects
+    .map((project, index) => `${String(index + 1)}. ${project.organization_name}/${project.project_name}`)
+    .join('\n')
+  const selected = await context.prompt.choice(
+    `Please select one of the following projects by number (requires the 'write_token' permission):\n${choicesText}\n`,
+    choices,
+    '1'
+  )
+  return filteredProjects[Number(selected) - 1]
+}
+
+function parseProjectOptions(args: string[]): ProjectCommandOptions {
+  const options: ProjectCommandOptions = { defaultOrg: false }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index] ?? ''
+    if (arg === '--data-dir') {
+      options.dataDir = readRequiredValue(args, ++index, '--data-dir')
+    } else if (arg.startsWith('--data-dir=')) {
+      options.dataDir = arg.slice('--data-dir='.length)
+    } else if (arg === '--org') {
+      options.org = readRequiredValue(args, ++index, '--org')
+    } else if (arg.startsWith('--org=')) {
+      options.org = arg.slice('--org='.length)
+    } else if (arg === '--default-org') {
+      options.defaultOrg = true
+    } else if (arg.startsWith('-')) {
+      throw new LogfireCliError(`Unknown option ${arg}`)
+    } else if (options.projectName === undefined) {
+      options.projectName = arg
+    } else {
+      throw new LogfireCliError(`Unexpected argument ${arg}`)
+    }
+  }
+  return options
+}
+
+function readRequiredValue(args: string[], index: number, option: string): string {
+  const value = args[index]
+  if (value === undefined) {
+    throw new LogfireCliError(`Missing value for ${option}`)
+  }
+  return value
+}

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -1,0 +1,72 @@
+import { createAuthenticatedClient } from '../authClient'
+import type { CliContext, GlobalOptions } from '../context'
+import { LogfireCliError } from '../errors'
+import { writeLine } from '../output'
+
+export async function runReadTokensCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
+  const parsed = parseReadTokensArgs(args)
+  if (parsed.command === undefined) {
+    printReadTokensHelp(context)
+    return
+  }
+  if (parsed.command !== 'create') {
+    throw new LogfireCliError(`Unknown read-tokens command "${parsed.command}".`)
+  }
+  const client = await createAuthenticatedClient(globalOptions, context)
+  const response = await client.createReadToken(parsed.organization, parsed.project)
+  writeLine(context.stdout, response.token)
+}
+
+interface ReadTokensArgs {
+  command: string | undefined
+  organization: string
+  project: string
+}
+
+function parseReadTokensArgs(args: string[]): ReadTokensArgs {
+  let organization: string | undefined
+  let project: string | undefined
+  let command: string | undefined
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index] ?? ''
+    if (arg === '--project') {
+      ;[organization, project] = parseOrgProject(readRequiredValue(args, ++index, '--project'))
+    } else if (arg.startsWith('--project=')) {
+      ;[organization, project] = parseOrgProject(arg.slice('--project='.length))
+    } else if (arg.startsWith('-')) {
+      throw new LogfireCliError(`Unknown option ${arg}`)
+    } else if (command === undefined) {
+      command = arg
+    } else {
+      throw new LogfireCliError(`Unexpected argument ${arg}`)
+    }
+  }
+
+  if (organization === undefined || project === undefined) {
+    throw new LogfireCliError('Missing --project. Expected <org>/<project>.')
+  }
+  return { command, organization, project }
+}
+
+function parseOrgProject(value: string): [string, string] {
+  const parts = value.split('/')
+  const organization = parts[0]
+  const project = parts[1]
+  if (parts.length !== 2 || organization === undefined || organization === '' || project === undefined || project === '') {
+    throw new LogfireCliError(`Invalid format: ${value}. Expected <org>/<project>`)
+  }
+  return [organization, project]
+}
+
+function readRequiredValue(args: string[], index: number, option: string): string {
+  const value = args[index]
+  if (value === undefined) {
+    throw new LogfireCliError(`Missing value for ${option}`)
+  }
+  return value
+}
+
+function printReadTokensHelp(context: CliContext): void {
+  writeLine(context.stdout, 'usage: logfire read-tokens --project <org>/<project> create')
+}

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -4,6 +4,10 @@ import { LogfireCliError } from '../errors'
 import { writeLine } from '../output'
 
 export async function runReadTokensCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printReadTokensHelp(context)
+    return
+  }
   const parsed = parseReadTokensArgs(args)
   if (parsed.command === undefined) {
     printReadTokensHelp(context)
@@ -12,6 +16,9 @@ export async function runReadTokensCommand(args: string[], globalOptions: Global
   if (parsed.command !== 'create') {
     throw new LogfireCliError(`Unknown read-tokens command "${parsed.command}".`)
   }
+  if (parsed.organization === undefined || parsed.project === undefined) {
+    throw new LogfireCliError('Missing --project. Expected <org>/<project>.')
+  }
   const client = await createAuthenticatedClient(globalOptions, context)
   const response = await client.createReadToken(parsed.organization, parsed.project)
   writeLine(context.stdout, response.token)
@@ -19,8 +26,8 @@ export async function runReadTokensCommand(args: string[], globalOptions: Global
 
 interface ReadTokensArgs {
   command: string | undefined
-  organization: string
-  project: string
+  organization: string | undefined
+  project: string | undefined
 }
 
 function parseReadTokensArgs(args: string[]): ReadTokensArgs {
@@ -43,9 +50,6 @@ function parseReadTokensArgs(args: string[]): ReadTokensArgs {
     }
   }
 
-  if (organization === undefined || project === undefined) {
-    throw new LogfireCliError('Missing --project. Expected <org>/<project>.')
-  }
   return { command, organization, project }
 }
 

--- a/packages/logfire-api/src/cli/commands/whoami.ts
+++ b/packages/logfire-api/src/cli/commands/whoami.ts
@@ -1,0 +1,87 @@
+import { createAuthenticatedClient } from '../authClient'
+import { getTokenInfo } from '../client'
+import type { CliContext, GlobalOptions } from '../context'
+import { defaultDataDir, readProjectCredentials } from '../credentials'
+import { LogfireCliError } from '../errors'
+import { writeLine } from '../output'
+import { getBaseUrlFromToken } from '../../tokenBaseUrl'
+
+export async function runWhoamiCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
+  const dataDir = parseDataDir(args) ?? defaultDataDir(context.cwd)
+  const envTokens = parseTokenList(context.env['LOGFIRE_TOKEN'])
+
+  if (envTokens.length > 0) {
+    let anySucceeded = false
+    for (const [index, token] of envTokens.entries()) {
+      if (envTokens.length > 1) {
+        if (index > 0) {
+          writeLine(context.stderr)
+        }
+        writeLine(context.stderr, `Token ${String(index + 1)} of ${String(envTokens.length)}:`)
+      }
+      const baseUrl = globalOptions.baseUrl ?? getBaseUrlFromToken(token)
+      // eslint-disable-next-line no-await-in-loop -- each env token is validated against the backend in order.
+      const credentials = await getTokenInfo(token, baseUrl, context.fetch)
+      if (credentials !== undefined) {
+        writeProjectSummary(context, credentials.project_url)
+        anySucceeded = true
+      }
+    }
+    if (anySucceeded) {
+      return
+    }
+  }
+
+  try {
+    const client = await createAuthenticatedClient(globalOptions, context)
+    const currentUser = await client.getUserInformation()
+    writeLine(context.stderr, `Logged in as: ${currentUser.name ?? 'unknown'}`)
+  } catch {
+    writeLine(context.stderr, 'Not logged in. Run `logfire auth` to log in.')
+  }
+
+  const credentials = readProjectCredentials(dataDir)
+  if (credentials === undefined) {
+    throw new LogfireCliError(`No Logfire credentials found in ${dataDir}`)
+  }
+  writeLine(context.stderr, `Credentials loaded from data dir: ${dataDir}`)
+  writeLine(context.stderr)
+  writeProjectSummary(context, credentials.project_url)
+}
+
+function writeProjectSummary(context: CliContext, projectUrl: string): void {
+  writeLine(context.stderr, `Logfire project URL: ${projectUrl}`)
+}
+
+function parseTokenList(value: string | undefined): string[] {
+  if (value === undefined || value.trim() === '') {
+    return []
+  }
+  return value
+    .split(',')
+    .map((token) => token.trim())
+    .filter((token) => token !== '')
+}
+
+function parseDataDir(args: string[]): string | undefined {
+  let dataDir: string | undefined
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index] ?? ''
+    if (arg === '--data-dir') {
+      dataDir = readRequiredValue(args, ++index, '--data-dir')
+    } else if (arg.startsWith('--data-dir=')) {
+      dataDir = arg.slice('--data-dir='.length)
+    } else {
+      throw new LogfireCliError(`Unexpected argument ${arg}`)
+    }
+  }
+  return dataDir
+}
+
+function readRequiredValue(args: string[], index: number, option: string): string {
+  const value = args[index]
+  if (value === undefined) {
+    throw new LogfireCliError(`Missing value for ${option}`)
+  }
+  return value
+}

--- a/packages/logfire-api/src/cli/context.ts
+++ b/packages/logfire-api/src/cli/context.ts
@@ -1,0 +1,23 @@
+import type { Readable, Writable } from 'node:stream'
+
+import type { CliOutput } from './output'
+import type { Prompt } from './interactivePrompt'
+
+export interface CliContext extends CliOutput {
+  cwd: string
+  env: Record<string, string | undefined>
+  fetch: typeof fetch
+  homeDir: string
+  openBrowser(url: string): Promise<void> | void
+  platform: NodeJS.Platform
+  prompt: Prompt
+  stdin: Readable
+  stderr: Writable
+  stdout: Writable
+}
+
+export interface GlobalOptions {
+  authFile?: string
+  baseUrl?: string
+  region?: string
+}

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vite-plus/test'
+
+import {
+  UserTokenCollection,
+  formatUserToken,
+  parseUserTokensToml,
+  projectCredentialsPath,
+  readProjectCredentials,
+  stringifyUserTokensToml,
+  writeProjectCredentials,
+} from './credentials'
+
+describe('CLI credentials', () => {
+  const tmpDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('parses and writes Python-compatible user token TOML', () => {
+    const tokens = parseUserTokensToml(`
+# global credentials
+[tokens."https://logfire-us.pydantic.dev"]
+token = "abc\\\\def\\"quoted"
+expiration = "2099-12-31T23:59:59Z"
+
+[other]
+token = "ignored"
+`)
+
+    expect(tokens.get('https://logfire-us.pydantic.dev')).toEqual({
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiration: '2099-12-31T23:59:59Z',
+      token: 'abc\\def"quoted',
+    })
+    expect(parseUserTokensToml(stringifyUserTokensToml(tokens))).toEqual(tokens)
+  })
+
+  it('selects, formats, and logs out user tokens', async () => {
+    const dir = makeTmpDir()
+    const path = join(dir, 'default.toml')
+    const collection = new UserTokenCollection(path)
+
+    const token = collection.addToken('https://logfire-us.pydantic.dev', {
+      expiration: '2099-12-31T23:59:59Z',
+      token: 'pylf_v1_us_1234567890',
+    })
+
+    expect(await collection.getToken('https://logfire-us.pydantic.dev')).toEqual(token)
+    expect(formatUserToken(token)).toBe('US (https://logfire-us.pydantic.dev) - pylf_v1_us_12345****')
+    expect(collection.logout('https://logfire-us.pydantic.dev')).toEqual(['https://logfire-us.pydantic.dev'])
+    expect(readFileSync(path, 'utf8')).toBe('')
+  })
+
+  it('writes and reads local project credentials', () => {
+    const dir = makeTmpDir()
+    const credentials = {
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'myproject',
+      project_url: 'https://logfire.pydantic.dev/org/myproject',
+      token: 'write-token',
+    }
+
+    writeProjectCredentials(dir, credentials)
+
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('*')
+    expect(JSON.parse(readFileSync(projectCredentialsPath(dir), 'utf8'))).toEqual(credentials)
+    expect(readProjectCredentials(dir)).toEqual(credentials)
+  })
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'logfire-cli-credentials-'))
+    tmpDirs.push(dir)
+    return dir
+  }
+})

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vite-plus/test'
 import {
   UserTokenCollection,
   formatUserToken,
+  isExpired,
   parseUserTokensToml,
   projectCredentialsPath,
   readProjectCredentials,
@@ -42,6 +43,15 @@ token = "ignored"
     expect(parseUserTokensToml(stringifyUserTokensToml(tokens))).toEqual(tokens)
   })
 
+  it('treats naive expirations as UTC and honors explicit offsets', () => {
+    expect(isExpired('2099-12-31T23:59:59')).toBe(false)
+    expect(isExpired('2099-12-31T23:59:59Z')).toBe(false)
+    expect(isExpired('2099-12-31T23:59:59+00:00')).toBe(false)
+    expect(isExpired('2000-01-01T00:00:00Z')).toBe(true)
+    expect(isExpired('2000-01-01T00:00:00+00:00')).toBe(true)
+    expect(isExpired('not-a-date')).toBe(true)
+  })
+
   it('selects, formats, and logs out user tokens', async () => {
     const dir = makeTmpDir()
     const path = join(dir, 'default.toml')
@@ -58,8 +68,8 @@ token = "ignored"
     expect(readFileSync(path, 'utf8')).toBe('')
   })
 
-  it('writes and reads local project credentials', () => {
-    const dir = makeTmpDir()
+  it('writes and reads local project credentials, seeding .gitignore on creation', () => {
+    const dir = join(makeTmpDir(), 'nested', '.logfire')
     const credentials = {
       logfire_api_url: 'https://logfire-us.pydantic.dev',
       project_name: 'myproject',
@@ -72,6 +82,20 @@ token = "ignored"
     expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('*')
     expect(JSON.parse(readFileSync(projectCredentialsPath(dir), 'utf8'))).toEqual(credentials)
     expect(readProjectCredentials(dir)).toEqual(credentials)
+  })
+
+  it('does not clobber an existing .gitignore in the data dir', () => {
+    const dir = makeTmpDir()
+    writeFileSync(join(dir, '.gitignore'), 'node_modules\n')
+
+    writeProjectCredentials(dir, {
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'myproject',
+      project_url: 'https://logfire.pydantic.dev/org/myproject',
+      token: 'write-token',
+    })
+
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('node_modules\n')
   })
 
   function makeTmpDir(): string {

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -52,7 +52,7 @@ export function formatUserToken(userToken: UserToken): string {
   const match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.exec(userToken.token)
   if (match) {
     const matchedRegion = match.groups?.['region']
-    if (matchedRegion !== undefined && matchedRegion in LOGFIRE_REGIONS) {
+    if (matchedRegion !== undefined && Object.hasOwn(LOGFIRE_REGIONS, matchedRegion)) {
       region = matchedRegion
     }
   }

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -39,7 +39,10 @@ export function projectCredentialsPath(dataDir: string): string {
 }
 
 export function isExpired(expiration: string): boolean {
-  const normalizedExpiration = expiration.endsWith('Z') ? expiration : `${expiration}Z`
+  // Match Python, which parses naive timestamps as UTC but honors explicit offsets:
+  // only assume UTC when the string carries no timezone designator of its own.
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/u.test(expiration)
+  const normalizedExpiration = hasTimezone ? expiration : `${expiration}Z`
   const expiresAt = new Date(normalizedExpiration).getTime()
   return Number.isNaN(expiresAt) || Date.now() >= expiresAt
 }
@@ -242,6 +245,14 @@ function writeUserTokensFile(path: string, tokens: ReadonlyMap<string, UserToken
 }
 
 function ensureDataDir(dataDir: string): void {
+  // Match Python's `ensure_data_dir_exists`: only seed `.gitignore` when creating the
+  // directory, so an existing dir's ignore rules are never clobbered.
+  if (existsSync(dataDir)) {
+    if (!statSync(dataDir).isDirectory()) {
+      throw new LogfireCliError(`Data directory ${dataDir} exists but is not a directory`)
+    }
+    return
+  }
   mkdirSync(dataDir, { recursive: true })
   writeFileSync(join(dataDir, '.gitignore'), '*')
 }

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -1,0 +1,264 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { LOGFIRE_REGIONS, PYDANTIC_LOGFIRE_TOKEN_PATTERN } from '../tokenBaseUrl'
+import type { Prompt } from './interactivePrompt'
+import { LogfireCliError } from './errors'
+
+export const DEFAULT_LOGFIRE_HOME = '.logfire'
+export const USER_TOKEN_FILENAME = 'default.toml'
+export const PROJECT_CREDENTIALS_FILENAME = 'logfire_credentials.json'
+
+export interface UserTokenData {
+  token: string
+  expiration: string
+}
+
+export interface UserToken extends UserTokenData {
+  baseUrl: string
+}
+
+export interface ProjectCredentials {
+  token: string
+  project_name: string
+  project_url: string
+  logfire_api_url: string
+}
+
+export function defaultAuthFilePath(homeDir: string = homedir()): string {
+  return join(homeDir, DEFAULT_LOGFIRE_HOME, USER_TOKEN_FILENAME)
+}
+
+export function defaultDataDir(cwd: string = process.cwd()): string {
+  return join(cwd, DEFAULT_LOGFIRE_HOME)
+}
+
+export function projectCredentialsPath(dataDir: string): string {
+  return join(dataDir, PROJECT_CREDENTIALS_FILENAME)
+}
+
+export function isExpired(expiration: string): boolean {
+  const normalizedExpiration = expiration.endsWith('Z') ? expiration : `${expiration}Z`
+  const expiresAt = new Date(normalizedExpiration).getTime()
+  return Number.isNaN(expiresAt) || Date.now() >= expiresAt
+}
+
+export function formatUserToken(userToken: UserToken): string {
+  let region = 'us'
+  const match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.exec(userToken.token)
+  if (match) {
+    const matchedRegion = match.groups?.['region']
+    if (matchedRegion !== undefined && matchedRegion in LOGFIRE_REGIONS) {
+      region = matchedRegion
+    }
+  }
+
+  const safePrefix = match?.groups?.['safePart'] ?? ''
+  const tokenPrefix = match?.groups?.['token']?.slice(0, 5) ?? userToken.token.slice(0, 5)
+  return `${region.toUpperCase()} (${userToken.baseUrl}) - ${safePrefix}${tokenPrefix}****`
+}
+
+export class UserTokenCollection {
+  readonly path: string
+  readonly userTokens: Map<string, UserToken>
+
+  constructor(path: string = defaultAuthFilePath()) {
+    this.path = path
+    this.userTokens = readUserTokensFile(path)
+  }
+
+  isLoggedIn(baseUrl?: string): boolean {
+    const tokens =
+      baseUrl === undefined ? [...this.userTokens.values()] : [...this.userTokens.values()].filter((token) => token.baseUrl === baseUrl)
+    return tokens.some((token) => !isExpired(token.expiration))
+  }
+
+  async getToken(baseUrl: string | undefined, prompt?: Prompt): Promise<UserToken> {
+    let token: UserToken | undefined
+    const tokens = [...this.userTokens.values()]
+
+    if (baseUrl !== undefined) {
+      token = this.userTokens.get(baseUrl)
+      if (token === undefined) {
+        throw new LogfireCliError(
+          `No user token was found matching the ${baseUrl} Logfire URL. Please run \`logfire auth\` to authenticate.`
+        )
+      }
+    } else if (tokens.length === 1) {
+      token = tokens[0]
+    } else if (tokens.length >= 2) {
+      if (prompt === undefined) {
+        throw new LogfireCliError('Multiple user tokens found. Pass --region or --base-url to select one.')
+      }
+      const choices = tokens.map((_, index) => String(index + 1))
+      const choicesText = tokens
+        .map(
+          (candidate, index) =>
+            `${String(index + 1)}. ${formatUserToken(candidate)} (${isExpired(candidate.expiration) ? 'expired' : 'valid'})`
+        )
+        .join('\n')
+      const selected = await prompt.choice(`Multiple user tokens found. Please select one:\n${choicesText}\n`, choices)
+      token = tokens[Number(selected) - 1]
+    } else {
+      throw new LogfireCliError('You are not logged into Logfire. Please run `logfire auth` to authenticate.')
+    }
+
+    if (token === undefined) {
+      throw new LogfireCliError('You are not logged into Logfire. Please run `logfire auth` to authenticate.')
+    }
+    if (isExpired(token.expiration)) {
+      throw new LogfireCliError(`User token ${formatUserToken(token)} is expired. Please run \`logfire auth\` to authenticate.`)
+    }
+    return token
+  }
+
+  addToken(baseUrl: string, tokenData: UserTokenData): UserToken {
+    const userToken: UserToken = { ...tokenData, baseUrl }
+    this.userTokens.set(baseUrl, userToken)
+    writeUserTokensFile(this.path, this.userTokens)
+    return userToken
+  }
+
+  logout(baseUrl?: string): string[] {
+    if (this.userTokens.size === 0) {
+      throw new LogfireCliError('You are not logged into Logfire. Please run `logfire auth` to authenticate.')
+    }
+    if (baseUrl !== undefined && !this.userTokens.has(baseUrl)) {
+      throw new LogfireCliError(`No user token was found matching the ${baseUrl} Logfire URL. Please run \`logfire auth\` to authenticate.`)
+    }
+    const removed = baseUrl === undefined ? [...this.userTokens.keys()] : [baseUrl]
+    for (const url of removed) {
+      this.userTokens.delete(url)
+    }
+    writeUserTokensFile(this.path, this.userTokens)
+    return removed
+  }
+}
+
+export function parseUserTokensToml(text: string): Map<string, UserToken> {
+  const tokens = new Map<string, UserToken>()
+  let currentBaseUrl: string | undefined
+
+  for (const rawLine of text.split(/\r?\n/u)) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#')) {
+      continue
+    }
+
+    const section = line.match(/^\[tokens\."((?:[^"\\]|\\.)*)"\]$/u)
+    if (section) {
+      currentBaseUrl = unquoteTomlString(section[1] ?? '')
+      tokens.set(currentBaseUrl, { baseUrl: currentBaseUrl, expiration: '', token: '' })
+      continue
+    }
+
+    if (line.startsWith('[')) {
+      currentBaseUrl = undefined
+      continue
+    }
+
+    if (currentBaseUrl === undefined) {
+      continue
+    }
+    const assignment = line.match(/^(token|expiration)\s*=\s*"((?:[^"\\]|\\.)*)"$/u)
+    if (assignment) {
+      const token = tokens.get(currentBaseUrl)
+      if (token !== undefined) {
+        token[assignment[1] as 'token' | 'expiration'] = unquoteTomlString(assignment[2] ?? '')
+      }
+    }
+  }
+
+  for (const [baseUrl, token] of tokens) {
+    if (token.token === '' || token.expiration === '') {
+      tokens.delete(baseUrl)
+    }
+  }
+  return tokens
+}
+
+export function stringifyUserTokensToml(tokens: ReadonlyMap<string, UserToken>): string {
+  let output = ''
+  for (const [baseUrl, token] of tokens) {
+    output += `[tokens."${quoteTomlString(baseUrl)}"]\n`
+    output += `token = "${quoteTomlString(token.token)}"\n`
+    output += `expiration = "${quoteTomlString(token.expiration)}"\n`
+  }
+  return output
+}
+
+export function readProjectCredentials(dataDir: string): ProjectCredentials | undefined {
+  const path = projectCredentialsPath(dataDir)
+  if (!existsSync(path)) {
+    return undefined
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8')) as unknown
+  } catch {
+    throw new LogfireCliError(`Invalid credentials file: ${path}`)
+  }
+
+  if (!isRecord(raw)) {
+    throw new LogfireCliError(`Invalid credentials file: ${path}`)
+  }
+  const projectUrl = readString(raw, 'project_url') ?? readString(raw, 'dashboard_url')
+  const token = readString(raw, 'token')
+  const projectName = readString(raw, 'project_name')
+  const logfireApiUrl = readString(raw, 'logfire_api_url')
+  if (token === undefined || projectName === undefined || projectUrl === undefined || logfireApiUrl === undefined) {
+    throw new LogfireCliError(`Invalid credentials file: ${path}`)
+  }
+  return {
+    logfire_api_url: logfireApiUrl,
+    project_name: projectName,
+    project_url: projectUrl,
+    token,
+  }
+}
+
+export function writeProjectCredentials(dataDir: string, credentials: ProjectCredentials): void {
+  ensureDataDir(dataDir)
+  writeFileSync(projectCredentialsPath(dataDir), `${JSON.stringify(credentials, null, 2)}\n`)
+}
+
+export function removeProjectCredentials(dataDir: string): void {
+  rmSync(projectCredentialsPath(dataDir), { force: true })
+  rmSync(join(dataDir, '.gitignore'), { force: true })
+}
+
+function readUserTokensFile(path: string): Map<string, UserToken> {
+  if (!existsSync(path)) {
+    return new Map()
+  }
+  return parseUserTokensToml(readFileSync(path, 'utf8'))
+}
+
+function writeUserTokensFile(path: string, tokens: ReadonlyMap<string, UserToken>): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, stringifyUserTokensToml(tokens))
+}
+
+function ensureDataDir(dataDir: string): void {
+  mkdirSync(dataDir, { recursive: true })
+  writeFileSync(join(dataDir, '.gitignore'), '*')
+}
+
+function quoteTomlString(value: string): string {
+  return value.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"')
+}
+
+function unquoteTomlString(value: string): string {
+  return value.replace(/\\(["\\])/gu, '$1')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}

--- a/packages/logfire-api/src/cli/errors.ts
+++ b/packages/logfire-api/src/cli/errors.ts
@@ -1,0 +1,13 @@
+export class LogfireCliError extends Error {
+  readonly exitCode: number
+
+  constructor(message: string, exitCode = 1) {
+    super(message)
+    this.name = 'LogfireCliError'
+    this.exitCode = exitCode
+  }
+}
+
+export function isLogfireCliError(error: unknown): error is LogfireCliError {
+  return error instanceof LogfireCliError
+}

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/require-await -- test stubs satisfy async signatures without awaiting. */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Writable } from 'node:stream'
+
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import type { Prompt } from './interactivePrompt'
+import { runCli } from './index'
+
+describe('CLI entrypoint', () => {
+  const tmpDirs: string[] = []
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true })
+    }
+  })
+
+  it('prints help without excluded Python commands', async () => {
+    const stdout = new MemoryOutput()
+
+    await expect(runCli(['--help'], { stdout })).resolves.toBe(0)
+
+    expect(stdout.text()).toContain('auth')
+    expect(stdout.text()).toContain('projects')
+    expect(stdout.text()).not.toMatch(/^  run\s/mu)
+    expect(stdout.text()).not.toMatch(/^  inspect\s/mu)
+    expect(stdout.text()).not.toMatch(/^  gateway\s/mu)
+  })
+
+  it('authenticates and writes global user credentials', async () => {
+    const homeDir = makeTmpDir()
+    const stderr = new MemoryOutput()
+    const openBrowser = vi.fn<(_url: string) => void>()
+    const fetchImpl = fetchSequence([
+      jsonResponse({ device_code: 'DC', frontend_auth_url: 'https://example.com/auth' }),
+      jsonResponse({ expiration: '2099-12-31T23:59:59Z', token: 'user-token' }),
+    ])
+
+    await expect(
+      runCli(['--region', 'us', 'auth'], {
+        fetch: fetchImpl,
+        homeDir,
+        openBrowser,
+        prompt: promptWithDefaults(),
+        stderr,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    expect(openBrowser).toHaveBeenCalledWith('https://example.com/auth')
+    expect(readFileSync(join(homeDir, '.logfire/default.toml'), 'utf8')).toBe(
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    expect(stderr.text()).toContain('Successfully authenticated!')
+  })
+
+  it('configures an existing project and writes local credentials', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+
+    await expect(
+      runCli(['--region', 'us', 'projects', 'use', 'myproject'], {
+        cwd,
+        fetch: fetchSequence([
+          jsonResponse([
+            { organization_name: 'fake_org', project_name: 'myproject' },
+            { organization_name: 'fake_org', project_name: 'otherproject' },
+          ]),
+          jsonResponse({ project_name: 'myproject', project_url: 'fake_project_url', token: 'fake_token' }),
+        ]),
+        homeDir,
+        prompt: promptWithDefaults(),
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    expect(JSON.parse(readFileSync(join(cwd, '.logfire/logfire_credentials.json'), 'utf8'))).toEqual({
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'myproject',
+      project_url: 'fake_project_url',
+      token: 'fake_token',
+    })
+  })
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'logfire-cli-entry-'))
+    tmpDirs.push(dir)
+    return dir
+  }
+})
+
+class MemoryOutput extends Writable {
+  private readonly chunks: string[] = []
+
+  override _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    this.chunks.push(String(chunk))
+    callback()
+  }
+
+  text(): string {
+    return this.chunks.join('')
+  }
+}
+
+function promptWithDefaults(): Prompt {
+  return {
+    choice: async (_message: string, _choices: readonly string[], defaultChoice?: string) => defaultChoice ?? '1',
+    confirm: async () => true,
+    text: async (_message: string, defaultValue?: string) => defaultValue ?? 'myproject',
+    waitForEnter: async () => undefined,
+  }
+}
+
+function fetchSequence(responses: Response[]): typeof fetch {
+  return vi.fn<typeof fetch>(async () => {
+    const response = responses.shift()
+    if (response === undefined) {
+      throw new Error('Unexpected fetch call')
+    }
+    return response
+  })
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'content-type': 'application/json' },
+    status,
+  })
+}

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -30,6 +30,16 @@ describe('CLI entrypoint', () => {
     expect(stdout.text()).not.toMatch(/^  gateway\s/mu)
   })
 
+  it('rejects unexpected auth arguments instead of starting the flow', async () => {
+    const stderr = new MemoryOutput()
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(runCli(['auth', 'bogus'], { fetch: fetchImpl, homeDir: makeTmpDir(), stderr })).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(stderr.text()).toContain('Unexpected argument bogus')
+  })
+
   it('authenticates and writes global user credentials', async () => {
     const homeDir = makeTmpDir()
     const stderr = new MemoryOutput()

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -30,6 +30,16 @@ describe('CLI entrypoint', () => {
     expect(stdout.text()).not.toMatch(/^  gateway\s/mu)
   })
 
+  it('rejects a blank --base-url value', async () => {
+    const stderr = new MemoryOutput()
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(runCli(['--base-url=', 'whoami'], { fetch: fetchImpl, homeDir: makeTmpDir(), stderr })).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(stderr.text()).toContain('The --base-url value cannot be empty.')
+  })
+
   it('prints read-tokens help for no args without requiring --project', async () => {
     const stdout = new MemoryOutput()
     const fetchImpl = vi.fn<typeof fetch>()

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -30,6 +30,16 @@ describe('CLI entrypoint', () => {
     expect(stdout.text()).not.toMatch(/^  gateway\s/mu)
   })
 
+  it('prints read-tokens help for no args without requiring --project', async () => {
+    const stdout = new MemoryOutput()
+    const fetchImpl = vi.fn<typeof fetch>()
+
+    await expect(runCli(['read-tokens'], { fetch: fetchImpl, homeDir: makeTmpDir(), stdout })).resolves.toBe(0)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(stdout.text()).toContain('read-tokens --project')
+  })
+
   it('rejects unexpected auth arguments instead of starting the flow', async () => {
     const stderr = new MemoryOutput()
     const fetchImpl = vi.fn<typeof fetch>()

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -69,13 +69,18 @@ function createCliContext(options: CliContextOptions): CliContext {
   const stdin = options.stdin ?? process.stdin
   const stderr = options.stderr ?? process.stderr
   const stdout = options.stdout ?? process.stdout
+  const platform = options.platform ?? process.platform
   return {
     cwd: options.cwd ?? process.cwd(),
     env: options.env ?? process.env,
     fetch: options.fetch ?? fetch,
     homeDir: options.homeDir ?? homedir(),
-    openBrowser: options.openBrowser ?? openBrowser,
-    platform: options.platform ?? process.platform,
+    openBrowser:
+      options.openBrowser ??
+      ((url: string) => {
+        openBrowser(url, platform)
+      }),
+    platform,
     prompt: options.prompt ?? createPrompt({ input: stdin, output: stderr }),
     stderr,
     stdin,
@@ -206,9 +211,9 @@ function printVersion(context: CliContext): void {
   writeLine(context.stdout, `Running Logfire ${PACKAGE_VERSION} with Node ${process.version} on ${context.platform}.`)
 }
 
-function openBrowser(url: string): void {
-  const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open'
-  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url]
+function openBrowser(url: string, platform: NodeJS.Platform): void {
+  const command = platform === 'darwin' ? 'open' : platform === 'win32' ? 'cmd' : 'xdg-open'
+  const args = platform === 'win32' ? ['/c', 'start', '', url] : [url]
   try {
     const child = spawn(command, args, { detached: true, stdio: 'ignore' })
     child.on('error', () => undefined)

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { homedir } from 'node:os'
+import type { Readable, Writable } from 'node:stream'
+import { pathToFileURL } from 'node:url'
+
+import { runAuthCommand } from './commands/auth'
+import { runCleanCommand } from './commands/clean'
+import { runInfoCommand } from './commands/info'
+import { runProjectsCommand } from './commands/projects'
+import { runReadTokensCommand } from './commands/readTokens'
+import { runWhoamiCommand } from './commands/whoami'
+import type { CliContext, GlobalOptions } from './context'
+import { LogfireCliError, isLogfireCliError } from './errors'
+import { createPrompt } from './interactivePrompt'
+import type { Prompt } from './interactivePrompt'
+import { writeLine } from './output'
+import { resolveSelectedBaseUrl } from './regions'
+
+export interface CliContextOptions {
+  cwd?: string
+  env?: Record<string, string | undefined>
+  fetch?: typeof fetch
+  homeDir?: string
+  openBrowser?: (url: string) => Promise<void> | void
+  platform?: NodeJS.Platform
+  prompt?: Prompt
+  stderr?: Writable
+  stdin?: Readable
+  stdout?: Writable
+}
+
+interface ParsedArgs {
+  command: string | undefined
+  commandArgs: string[]
+  globalOptions: GlobalOptions
+  help: boolean
+  version: boolean
+}
+
+export async function runCli(argv: string[] = process.argv.slice(2), options: CliContextOptions = {}): Promise<number> {
+  const context = createCliContext(options)
+  try {
+    const parsed = parseArgs(argv)
+    if (parsed.version) {
+      printVersion(context)
+      return 0
+    }
+    if (parsed.help || parsed.command === undefined) {
+      printHelp(context)
+      return 0
+    }
+
+    await dispatch(parsed.command, parsed.commandArgs, parsed.globalOptions, context)
+    return 0
+  } catch (error) {
+    if (isLogfireCliError(error)) {
+      if (error.message !== '') {
+        writeLine(context.stderr, error.message)
+      }
+      return error.exitCode
+    }
+    throw error
+  }
+}
+
+function createCliContext(options: CliContextOptions): CliContext {
+  const stdin = options.stdin ?? process.stdin
+  const stderr = options.stderr ?? process.stderr
+  const stdout = options.stdout ?? process.stdout
+  return {
+    cwd: options.cwd ?? process.cwd(),
+    env: options.env ?? process.env,
+    fetch: options.fetch ?? fetch,
+    homeDir: options.homeDir ?? homedir(),
+    openBrowser: options.openBrowser ?? openBrowser,
+    platform: options.platform ?? process.platform,
+    prompt: options.prompt ?? createPrompt({ input: stdin, output: stderr }),
+    stderr,
+    stdin,
+    stdout,
+  }
+}
+
+async function dispatch(command: string, args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
+  if (command === 'auth') {
+    await runAuthCommand(args, globalOptions, context)
+    return
+  }
+  if (command === 'clean') {
+    await runCleanCommand(args, context)
+    return
+  }
+  if (command === 'info') {
+    runInfoCommand(context)
+    return
+  }
+  if (command === 'projects') {
+    await runProjectsCommand(args, globalOptions, context)
+    return
+  }
+  if (command === 'read-tokens') {
+    await runReadTokensCommand(args, globalOptions, context)
+    return
+  }
+  if (command === 'whoami') {
+    await runWhoamiCommand(args, globalOptions, context)
+    return
+  }
+  throw new LogfireCliError(`Unknown command "${command}".`)
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let command: string | undefined
+  let baseUrl: string | undefined
+  let region: string | undefined
+  let help = false
+  let version = false
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index] ?? ''
+    if (arg === '--help' || arg === '-h') {
+      help = true
+    } else if (arg === '--version') {
+      version = true
+    } else if (arg === '--base-url' || arg === '--logfire-url') {
+      assertNoRegionConflict(baseUrl, region, arg)
+      baseUrl = readRequiredValue(argv, ++index, arg)
+    } else if (arg.startsWith('--base-url=')) {
+      assertNoRegionConflict(baseUrl, region, '--base-url')
+      baseUrl = arg.slice('--base-url='.length)
+    } else if (arg.startsWith('--logfire-url=')) {
+      assertNoRegionConflict(baseUrl, region, '--logfire-url')
+      baseUrl = arg.slice('--logfire-url='.length)
+    } else if (arg === '--region') {
+      assertNoRegionConflict(baseUrl, region, '--region')
+      region = readRequiredValue(argv, ++index, '--region')
+    } else if (arg.startsWith('--region=')) {
+      assertNoRegionConflict(baseUrl, region, '--region')
+      region = arg.slice('--region='.length)
+    } else if (arg.startsWith('-')) {
+      throw new LogfireCliError(`Unknown option ${arg}`)
+    } else {
+      command = arg
+      return {
+        command,
+        commandArgs: argv.slice(index + 1),
+        globalOptions: buildGlobalOptions(baseUrl, region),
+        help,
+        version,
+      }
+    }
+  }
+
+  return {
+    command,
+    commandArgs: [],
+    globalOptions: buildGlobalOptions(baseUrl, region),
+    help,
+    version,
+  }
+}
+
+function buildGlobalOptions(baseUrl: string | undefined, region: string | undefined): GlobalOptions {
+  const resolvedBaseUrl = resolveSelectedBaseUrl(baseUrl, region)
+  const options: GlobalOptions = {}
+  if (resolvedBaseUrl !== undefined) {
+    options.baseUrl = resolvedBaseUrl
+  }
+  if (region !== undefined) {
+    options.region = region
+  }
+  return options
+}
+
+function assertNoRegionConflict(baseUrl: string | undefined, region: string | undefined, option: string): void {
+  if ((option === '--region' && baseUrl !== undefined) || (option !== '--region' && region !== undefined)) {
+    throw new LogfireCliError('Only one of --base-url and --region can be used.')
+  }
+}
+
+function readRequiredValue(args: string[], index: number, option: string): string {
+  const value = args[index]
+  if (value === undefined) {
+    throw new LogfireCliError(`Missing value for ${option}`)
+  }
+  return value
+}
+
+function printHelp(context: CliContext): void {
+  writeLine(context.stdout, 'The CLI for Pydantic Logfire.')
+  writeLine(context.stdout)
+  writeLine(context.stdout, 'Usage: logfire [--version] [--base-url <url> | --region <region>] <command>')
+  writeLine(context.stdout)
+  writeLine(context.stdout, 'Commands:')
+  writeLine(context.stdout, '  auth         Authenticate with Logfire')
+  writeLine(context.stdout, '  clean        Remove local Logfire project credentials')
+  writeLine(context.stdout, '  info         Show SDK and runtime information')
+  writeLine(context.stdout, '  projects     Project management for Logfire')
+  writeLine(context.stdout, '  read-tokens  Manage read tokens for a project')
+  writeLine(context.stdout, '  whoami       Show authenticated user and project information')
+}
+
+function printVersion(context: CliContext): void {
+  writeLine(context.stdout, `Running Logfire ${PACKAGE_VERSION} with Node ${process.version} on ${context.platform}.`)
+}
+
+function openBrowser(url: string): void {
+  const command = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'cmd' : 'xdg-open'
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url]
+  try {
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' })
+    child.on('error', () => undefined)
+    child.unref()
+  } catch {
+    // The auth command prints the URL after this attempt, so opening failure is non-fatal.
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli()
+    .then((exitCode) => {
+      process.exitCode = exitCode
+    })
+    .catch((error: unknown) => {
+      writeLine(process.stderr, String(error instanceof Error ? error.message : error))
+      process.exitCode = 1
+    })
+}

--- a/packages/logfire-api/src/cli/interactivePrompt.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.ts
@@ -1,0 +1,64 @@
+import { createInterface } from 'node:readline/promises'
+
+import type { Readable, Writable } from 'node:stream'
+
+export interface Prompt {
+  choice(message: string, choices: readonly string[], defaultChoice?: string): Promise<string>
+  confirm(message: string, defaultYes?: boolean): Promise<boolean>
+  text(message: string, defaultValue?: string): Promise<string>
+  waitForEnter(message: string): Promise<void>
+}
+
+export interface PromptStreams {
+  input: Readable
+  output: Writable
+}
+
+export function createPrompt({ input, output }: PromptStreams): Prompt {
+  async function ask(question: string): Promise<string> {
+    const rl = createInterface({ input, output, terminal: false })
+    try {
+      return await rl.question(question)
+    } finally {
+      rl.close()
+    }
+  }
+
+  return {
+    async choice(message, choices, defaultChoice) {
+      const suffix = defaultChoice !== undefined ? ` [${defaultChoice}]` : ''
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- reprompt until a valid choice is entered.
+      while (true) {
+        // eslint-disable-next-line no-await-in-loop -- prompts are inherently sequential.
+        const value = (await ask(`${message}${suffix}: `)).trim() || defaultChoice
+        if (value !== undefined && choices.includes(value)) {
+          return value
+        }
+      }
+    },
+    async confirm(message, defaultYes = true) {
+      const suffix = defaultYes ? ' [Y/n]' : ' [N/y]'
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- reprompt until a yes/no answer is entered.
+      while (true) {
+        // eslint-disable-next-line no-await-in-loop -- prompts are inherently sequential.
+        const value = (await ask(`${message}${suffix}`)).trim().toLowerCase()
+        if (value === '') {
+          return defaultYes
+        }
+        if (value === 'y' || value === 'yes') {
+          return true
+        }
+        if (value === 'n' || value === 'no') {
+          return false
+        }
+      }
+    },
+    async text(message, defaultValue) {
+      const suffix = defaultValue !== undefined ? ` [${defaultValue}]` : ''
+      return ((await ask(`${message}${suffix}: `)).trim() || defaultValue) ?? ''
+    },
+    async waitForEnter(message) {
+      await ask(`${message}\n`)
+    },
+  }
+}

--- a/packages/logfire-api/src/cli/output.ts
+++ b/packages/logfire-api/src/cli/output.ts
@@ -1,0 +1,21 @@
+export interface WritableOutput {
+  write(chunk: string): unknown
+}
+
+export interface CliOutput {
+  stderr: WritableOutput
+  stdout: WritableOutput
+}
+
+export function writeLine(output: WritableOutput, message = ''): void {
+  output.write(`${message}\n`)
+}
+
+export function prettyTable(header: string[], rows: string[][]): string {
+  const indent = (cells: string[]): string[] => [` ${cells[0] ?? ''}`, ...cells.slice(1)]
+  const tableRows = [indent(header), ...rows.map(indent)]
+  const widths = header.map((_, index) => Math.max(...tableRows.map((row) => row[index]?.length ?? 0)))
+  const lines = tableRows.map((row) => row.map((cell, index) => cell.padEnd(widths[index] ?? 0)).join('   | '))
+  lines.splice(1, 0, widths.map((width) => '-'.repeat(width)).join('---|-'))
+  return `${lines.join('\n')}\n`
+}

--- a/packages/logfire-api/src/cli/regions.test.ts
+++ b/packages/logfire-api/src/cli/regions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { getBaseUrlFromToken } from '../tokenBaseUrl'
+import { isCliRegion, resolveSelectedBaseUrl } from './regions'
+
+describe('CLI regions', () => {
+  it('accepts public regions and rejects inherited object properties', () => {
+    expect(isCliRegion('us')).toBe(true)
+    expect(isCliRegion('eu')).toBe(true)
+    expect(isCliRegion('toString')).toBe(false)
+    expect(isCliRegion('constructor')).toBe(false)
+    expect(isCliRegion('mars')).toBe(false)
+  })
+
+  it('resolves base URLs from region ids and explicit URLs', () => {
+    expect(resolveSelectedBaseUrl(undefined, 'us')).toBe('https://logfire-us.pydantic.dev')
+    expect(resolveSelectedBaseUrl(undefined, 'eu')).toBe('https://logfire-eu.pydantic.dev')
+    expect(resolveSelectedBaseUrl('https://self-hosted.example.com/', undefined)).toBe('https://self-hosted.example.com')
+    expect(resolveSelectedBaseUrl(undefined, undefined)).toBeUndefined()
+    expect(() => resolveSelectedBaseUrl(undefined, 'constructor')).toThrow('Unknown Logfire region')
+  })
+
+  it('falls back to US for tokens whose region matches an inherited property', () => {
+    // `constructor` is lowercase letters, so it matches the token regex's region group;
+    // an own-property check keeps it from resolving to Object.prototype.constructor.
+    expect(getBaseUrlFromToken('pylf_v1_constructor_abc123')).toBe('https://logfire-us.pydantic.dev')
+    expect(getBaseUrlFromToken('pylf_v1_eu_abc123')).toBe('https://logfire-eu.pydantic.dev')
+    expect(getBaseUrlFromToken(undefined)).toBe('https://logfire-us.pydantic.dev')
+  })
+})

--- a/packages/logfire-api/src/cli/regions.ts
+++ b/packages/logfire-api/src/cli/regions.ts
@@ -1,0 +1,39 @@
+import { LOGFIRE_PUBLIC_REGIONS, removeTrailingSlash } from '../tokenBaseUrl'
+import { LogfireCliError } from './errors'
+import type { Prompt } from './interactivePrompt'
+
+export type CliRegion = keyof typeof LOGFIRE_PUBLIC_REGIONS
+
+export function resolveSelectedBaseUrl(baseUrl: string | undefined, region: string | undefined): string | undefined {
+  if (baseUrl !== undefined) {
+    return removeTrailingSlash(baseUrl)
+  }
+  if (region === undefined) {
+    return undefined
+  }
+  if (!isCliRegion(region)) {
+    throw new LogfireCliError(`Unknown Logfire region "${region}". Valid regions are: ${Object.keys(LOGFIRE_PUBLIC_REGIONS).join(', ')}`)
+  }
+  return LOGFIRE_PUBLIC_REGIONS[region].baseUrl
+}
+
+export async function promptForRegion(prompt: Prompt): Promise<string> {
+  const entries = Object.entries(LOGFIRE_PUBLIC_REGIONS)
+  const choices = entries.map((_, index) => String(index + 1))
+  const choicesText = entries
+    .map(([region, data], index) => `${String(index + 1)}. ${region.toUpperCase()} (GCP region: ${data.gcpRegion})`)
+    .join('\n')
+  const selected = await prompt.choice(
+    `Logfire is available in multiple data regions. Please select one:\n${choicesText}\nSelected region`,
+    choices
+  )
+  const selectedRegion = entries[Number(selected) - 1]?.[1]
+  if (selectedRegion === undefined) {
+    throw new LogfireCliError('Invalid Logfire region selection.')
+  }
+  return selectedRegion.baseUrl
+}
+
+export function isCliRegion(region: string): region is CliRegion {
+  return region in LOGFIRE_PUBLIC_REGIONS
+}

--- a/packages/logfire-api/src/cli/regions.ts
+++ b/packages/logfire-api/src/cli/regions.ts
@@ -35,5 +35,5 @@ export async function promptForRegion(prompt: Prompt): Promise<string> {
 }
 
 export function isCliRegion(region: string): region is CliRegion {
-  return region in LOGFIRE_PUBLIC_REGIONS
+  return Object.hasOwn(LOGFIRE_PUBLIC_REGIONS, region)
 }

--- a/packages/logfire-api/src/cli/regions.ts
+++ b/packages/logfire-api/src/cli/regions.ts
@@ -6,6 +6,9 @@ export type CliRegion = keyof typeof LOGFIRE_PUBLIC_REGIONS
 
 export function resolveSelectedBaseUrl(baseUrl: string | undefined, region: string | undefined): string | undefined {
   if (baseUrl !== undefined) {
+    if (baseUrl.trim() === '') {
+      throw new LogfireCliError('The --base-url value cannot be empty.')
+    }
     return removeTrailingSlash(baseUrl)
   }
   if (region === undefined) {

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -6,11 +6,13 @@ import type { LogFireLevel, MinLevel } from './levels'
 import { LogfireAttributeScrubber, NoopAttributeScrubber } from './AttributeScrubber'
 import { DEFAULT_OTEL_SCOPE } from './constants'
 import { Level, resolveMinLevel } from './levels'
+import { resolveLogfireBaseUrl } from './tokenBaseUrl'
 
 export * from './AttributeScrubber'
 export { Level }
 export type { LevelName, LogFireLevel, MinLevel } from './levels'
 export { serializeAttributes } from './serializeAttributes'
+export type { RegionData } from './tokenBaseUrl'
 
 export interface ScrubbingOptions {
   callback?: ScrubCallback
@@ -79,11 +81,6 @@ export interface LogfireApiConfig {
   otelScope: string
   scrubber: BaseScrubber
   tracer: Tracer
-}
-
-export interface RegionData {
-  baseUrl: string
-  gcpRegion: string
 }
 
 const DEFAULT_LOGFIRE_API_CONFIG: LogfireApiConfig = {
@@ -159,49 +156,5 @@ export function resolveSendToLogfire(env: Env, option: SendToLogfire, token: str
 }
 
 export function resolveBaseUrl(env: Env, passedUrl: string | undefined, token: string): string {
-  let url = passedUrl ?? env['LOGFIRE_BASE_URL'] ?? getBaseUrlFromToken(token)
-  if (url.endsWith('/')) {
-    url = url.slice(0, -1)
-  }
-  return url
-}
-
-const PYDANTIC_LOGFIRE_TOKEN_PATTERN =
-  /^(?<safe_part>pylf_v(?<version>[0-9]+)_(?<region>[a-z]+)_(?:(?<organization_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})_)?)(?<token>[a-zA-Z0-9]+)$/u
-
-const REGIONS: Record<string, RegionData> = {
-  eu: {
-    baseUrl: 'https://logfire-eu.pydantic.dev',
-    gcpRegion: 'europe-west4',
-  },
-  stagingeu: {
-    baseUrl: 'https://logfire-eu.pydantic.info',
-    gcpRegion: 'europe-west4',
-  },
-  stagingus: {
-    baseUrl: 'https://logfire-us.pydantic.info',
-    gcpRegion: 'us-east4',
-  },
-  us: {
-    baseUrl: 'https://logfire-us.pydantic.dev',
-    gcpRegion: 'us-east4',
-  },
-}
-
-function getBaseUrlFromToken(token: string | undefined): string {
-  let regionKey = 'us'
-  if (token !== undefined && token !== '') {
-    const match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.exec(token)
-    if (match) {
-      const region = match.groups?.['region']
-      if (region !== undefined && region in REGIONS) {
-        regionKey = region
-      }
-    }
-  }
-  const regionData = REGIONS[regionKey]
-  if (!regionData) {
-    throw new Error(`Unknown region in token: ${regionKey}. Valid regions are: ${Object.keys(REGIONS).join(', ')}`)
-  }
-  return regionData.baseUrl
+  return resolveLogfireBaseUrl(env, passedUrl, token)
 }

--- a/packages/logfire-api/src/tokenBaseUrl.ts
+++ b/packages/logfire-api/src/tokenBaseUrl.ts
@@ -44,7 +44,7 @@ export function getBaseUrlFromToken(token: string | undefined): string {
     const match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.exec(token)
     if (match) {
       const region = match.groups?.['region']
-      if (region !== undefined && region in LOGFIRE_REGIONS) {
+      if (region !== undefined && Object.hasOwn(LOGFIRE_REGIONS, region)) {
         regionKey = region
       }
     }

--- a/packages/logfire-api/src/tokenBaseUrl.ts
+++ b/packages/logfire-api/src/tokenBaseUrl.ts
@@ -1,0 +1,61 @@
+export interface RegionData {
+  baseUrl: string
+  gcpRegion: string
+}
+
+const US_REGION: RegionData = {
+  baseUrl: 'https://logfire-us.pydantic.dev',
+  gcpRegion: 'us-east4',
+}
+
+const EU_REGION: RegionData = {
+  baseUrl: 'https://logfire-eu.pydantic.dev',
+  gcpRegion: 'europe-west4',
+}
+
+export const LOGFIRE_REGIONS: Record<string, RegionData> = {
+  eu: EU_REGION,
+  stagingeu: {
+    baseUrl: 'https://logfire-eu.pydantic.info',
+    gcpRegion: 'europe-west4',
+  },
+  stagingus: {
+    baseUrl: 'https://logfire-us.pydantic.info',
+    gcpRegion: 'us-east4',
+  },
+  us: US_REGION,
+}
+
+export const LOGFIRE_PUBLIC_REGIONS: Record<'us' | 'eu', RegionData> = {
+  us: US_REGION,
+  eu: EU_REGION,
+}
+
+export const PYDANTIC_LOGFIRE_TOKEN_PATTERN: RegExp =
+  /^(?<safePart>pylf_v(?<version>[0-9]+)_(?<region>[a-z]+)_(?:(?<organizationId>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})_)?)(?<token>[a-zA-Z0-9]+)$/u
+
+export function removeTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url
+}
+
+export function getBaseUrlFromToken(token: string | undefined): string {
+  let regionKey = 'us'
+  if (token !== undefined && token !== '') {
+    const match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.exec(token)
+    if (match) {
+      const region = match.groups?.['region']
+      if (region !== undefined && region in LOGFIRE_REGIONS) {
+        regionKey = region
+      }
+    }
+  }
+  const regionData = LOGFIRE_REGIONS[regionKey]
+  if (!regionData) {
+    throw new Error(`Unknown region in token: ${regionKey}. Valid regions are: ${Object.keys(LOGFIRE_REGIONS).join(', ')}`)
+  }
+  return regionData.baseUrl
+}
+
+export function resolveLogfireBaseUrl(env: Record<string, string | undefined>, passedUrl: string | undefined, token: string): string {
+  return removeTrailingSlash(passedUrl ?? env['LOGFIRE_BASE_URL'] ?? getBaseUrlFromToken(token))
+}

--- a/packages/logfire-api/src/vite-env.d.ts
+++ b/packages/logfire-api/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const PACKAGE_VERSION: string

--- a/packages/logfire-api/vite.config.ts
+++ b/packages/logfire-api/vite.config.ts
@@ -26,6 +26,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
       neverBundle: [/^@opentelemetry/u, /^node:/u, 'js-yaml', 'p-retry', 'zod'],
     },
     entry: {
+      cli: 'src/cli/index.ts',
       datasets: 'src/datasets/index.ts',
       evals: 'src/evals/index.ts',
       index: 'src/index.ts',
@@ -34,7 +35,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     format: ['esm', 'cjs'],
     hooks: {
       'build:done': () => {
-        copyCjsDeclarations(['datasets', 'evals', 'index', 'vars'])
+        copyCjsDeclarations(['cli', 'datasets', 'evals', 'index', 'vars'])
       },
     },
     minify: true,

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 import { configureLogfireApi, Level, logfireApiConfig } from 'logfire'
@@ -20,6 +24,8 @@ describe('logfire config', () => {
   const originalOtelServiceName = process.env['OTEL_SERVICE_NAME']
   const originalOtelServiceVersion = process.env['OTEL_SERVICE_VERSION']
   const originalToken = process.env['LOGFIRE_TOKEN']
+  const originalCredentialsDir = process.env['LOGFIRE_CREDENTIALS_DIR']
+  const tmpDirs: string[] = []
 
   beforeEach(async () => {
     process.env['LOGFIRE_API_KEY'] = ''
@@ -32,6 +38,7 @@ describe('logfire config', () => {
     delete process.env['OTEL_SERVICE_NAME']
     delete process.env['OTEL_SERVICE_VERSION']
     delete process.env['LOGFIRE_TOKEN']
+    delete process.env['LOGFIRE_CREDENTIALS_DIR']
     configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     await shutdownVariables()
   })
@@ -87,6 +94,14 @@ describe('logfire config', () => {
     } else {
       process.env['LOGFIRE_TOKEN'] = originalToken
     }
+    if (originalCredentialsDir === undefined) {
+      delete process.env['LOGFIRE_CREDENTIALS_DIR']
+    } else {
+      process.env['LOGFIRE_CREDENTIALS_DIR'] = originalCredentialsDir
+    }
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true })
+    }
     Object.assign(logfireConfig, {
       authorizationHeaders: {},
       baggage: {
@@ -94,6 +109,7 @@ describe('logfire config', () => {
       },
       baseUrl: '',
       console: false,
+      dataDir: '.logfire',
       jsonSchema: 'rich',
       logsExporterUrl: '',
       metricExporterUrl: '',
@@ -391,6 +407,84 @@ describe('logfire config', () => {
     expect(logfireConfig.baseUrl).toBe('')
   })
 
+  it('uses local project credentials when no explicit or environment token is set', () => {
+    const dataDir = makeCredentialsDir({
+      logfire_api_url: 'https://local.example.com/',
+      project_name: 'local-project',
+      project_url: 'https://example.com/project',
+      token: 'local-token',
+    })
+
+    configure({ dataDir })
+
+    expect(logfireConfig.dataDir).toBe(dataDir)
+    expect(logfireConfig.token).toBe('local-token')
+    expect(logfireConfig.baseUrl).toBe('https://local.example.com')
+    expect(logfireConfig.sendToLogfire).toBe(true)
+    expect(logfireConfig.authorizationHeaders).toEqual({ Authorization: 'local-token' })
+  })
+
+  it('lets explicit and environment tokens override local credentials', () => {
+    const dataDir = makeCredentialsDir({
+      logfire_api_url: 'https://local.example.com',
+      project_name: 'local-project',
+      project_url: 'https://example.com/project',
+      token: 'local-token',
+    })
+
+    configure({ advanced: { baseUrl: 'https://explicit.example.com' }, dataDir, token: 'explicit-token' })
+
+    expect(logfireConfig.token).toBe('explicit-token')
+    expect(logfireConfig.baseUrl).toBe('https://explicit.example.com')
+
+    process.env['LOGFIRE_TOKEN'] = 'env-token'
+    process.env['LOGFIRE_BASE_URL'] = 'https://env.example.com'
+    configure({ dataDir })
+
+    expect(logfireConfig.token).toBe('env-token')
+    expect(logfireConfig.baseUrl).toBe('https://env.example.com')
+  })
+
+  it('uses LOGFIRE_CREDENTIALS_DIR for local credentials', () => {
+    const dataDir = makeCredentialsDir({
+      logfire_api_url: 'https://env-dir.example.com',
+      project_name: 'local-project',
+      project_url: 'https://example.com/project',
+      token: 'env-dir-token',
+    })
+    process.env['LOGFIRE_CREDENTIALS_DIR'] = dataDir
+
+    configure()
+
+    expect(logfireConfig.dataDir).toBe(dataDir)
+    expect(logfireConfig.token).toBe('env-dir-token')
+    expect(logfireConfig.baseUrl).toBe('https://env-dir.example.com')
+  })
+
+  it('throws for invalid local credentials only when no higher-precedence token exists', () => {
+    const dataDir = makeTmpDir()
+    writeFileSync(join(dataDir, 'logfire_credentials.json'), '{"token": 123}')
+
+    expect(() => {
+      configure({ dataDir })
+    }).toThrow('Invalid credentials file')
+
+    configure({ advanced: { baseUrl: 'https://explicit.example.com' }, dataDir, token: 'explicit-token' })
+
+    expect(logfireConfig.token).toBe('explicit-token')
+  })
+
+  it('does not read invalid local credentials when sending is disabled', () => {
+    const dataDir = makeTmpDir()
+    writeFileSync(join(dataDir, 'logfire_credentials.json'), '{"token": 123}')
+
+    configure({ dataDir, sendToLogfire: false })
+
+    expect(logfireConfig.sendToLogfire).toBe(false)
+    expect(logfireConfig.token).toBeUndefined()
+    expect(logfireConfig.baseUrl).toBe('')
+  })
+
   it('throws when explicit remote variables have no api key', () => {
     expect(() => {
       configure({
@@ -401,4 +495,17 @@ describe('logfire config', () => {
       })
     }).toThrow('Remote variables require an API key')
   })
+
+  function makeCredentialsDir(credentials: { logfire_api_url: string; project_name: string; project_url: string; token: string }): string {
+    const dataDir = makeTmpDir()
+    writeFileSync(join(dataDir, 'logfire_credentials.json'), `${JSON.stringify(credentials)}\n`)
+    return dataDir
+  }
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'logfire-node-config-'))
+    mkdirSync(dir, { recursive: true })
+    tmpDirs.push(dir)
+    return dir
+  }
 })

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 import { configureLogfireApi, Level, logfireApiConfig } from 'logfire'
 import { shutdownVariables } from 'logfire/vars'
 
+import { resolveCredentialsDir } from '../credentials'
 import { configure, logfireConfig } from '../logfireConfig'
 
 vi.mock('../sdk', () => ({
@@ -459,6 +460,12 @@ describe('logfire config', () => {
     expect(logfireConfig.dataDir).toBe(dataDir)
     expect(logfireConfig.token).toBe('env-dir-token')
     expect(logfireConfig.baseUrl).toBe('https://env-dir.example.com')
+  })
+
+  it('treats blank data dir options and env vars as unset', () => {
+    expect(resolveCredentialsDir('  ', {}, '/work')).toBe(join('/work', '.logfire'))
+    expect(resolveCredentialsDir(undefined, { LOGFIRE_CREDENTIALS_DIR: '' }, '/work')).toBe(join('/work', '.logfire'))
+    expect(resolveCredentialsDir('/custom', {}, '/work')).toBe('/custom')
   })
 
   it('throws for invalid local credentials only when no higher-precedence token exists', () => {

--- a/packages/logfire-node/src/credentials.ts
+++ b/packages/logfire-node/src/credentials.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const PROJECT_CREDENTIALS_FILENAME = 'logfire_credentials.json'
+
+export interface ProjectCredentials {
+  token: string
+  project_name: string
+  project_url: string
+  logfire_api_url: string
+}
+
+export function readLocalProjectCredentials(dataDir: string): ProjectCredentials | undefined {
+  const path = join(dataDir, PROJECT_CREDENTIALS_FILENAME)
+  if (!existsSync(path)) {
+    return undefined
+  }
+
+  let data: unknown
+  try {
+    data = JSON.parse(readFileSync(path, 'utf8')) as unknown
+  } catch {
+    throw new Error(`Invalid credentials file: ${path}`)
+  }
+
+  if (!isRecord(data)) {
+    throw new Error(`Invalid credentials file: ${path}`)
+  }
+
+  const projectUrl = readString(data, 'project_url') ?? readString(data, 'dashboard_url')
+  const token = readString(data, 'token')
+  const projectName = readString(data, 'project_name')
+  const logfireApiUrl = readString(data, 'logfire_api_url')
+  if (token === undefined || projectName === undefined || projectUrl === undefined || logfireApiUrl === undefined) {
+    throw new Error(`Invalid credentials file: ${path}`)
+  }
+
+  return {
+    logfire_api_url: logfireApiUrl,
+    project_name: projectName,
+    project_url: projectUrl,
+    token,
+  }
+}
+
+export function resolveCredentialsDir(option: string | undefined, env: NodeJS.ProcessEnv, cwd: string = process.cwd()): string {
+  return option ?? env['LOGFIRE_CREDENTIALS_DIR'] ?? join(cwd, '.logfire')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}

--- a/packages/logfire-node/src/credentials.ts
+++ b/packages/logfire-node/src/credentials.ts
@@ -44,7 +44,11 @@ export function readLocalProjectCredentials(dataDir: string): ProjectCredentials
 }
 
 export function resolveCredentialsDir(option: string | undefined, env: NodeJS.ProcessEnv, cwd: string = process.cwd()): string {
-  return option ?? env['LOGFIRE_CREDENTIALS_DIR'] ?? join(cwd, '.logfire')
+  return nonBlank(option) ?? nonBlank(env['LOGFIRE_CREDENTIALS_DIR']) ?? join(cwd, '.logfire')
+}
+
+function nonBlank(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim() !== '' ? value : undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -10,6 +10,7 @@ import * as logfireApi from 'logfire'
 
 import type { ConsoleConfig } from './consoleOptions'
 import { resolveConsoleOptions } from './consoleOptions'
+import { readLocalProjectCredentials, resolveCredentialsDir } from './credentials'
 import { start } from './sdk'
 
 export type { ConsoleConfig, ConsoleOptions } from './consoleOptions'
@@ -83,6 +84,11 @@ export interface LogfireConfigOptions {
    * Set to False to suppress extraction of incoming trace context. See [Unintentional Distributed Tracing](https://logfire.pydantic.dev/docs/how-to-guides/distributed-tracing/#unintentional-distributed-tracing) for more information.
    */
   distributedTracing?: boolean
+  /**
+   * Directory containing `.logfire` project credentials written by `npx logfire projects use/new`.
+   * Defaults to `LOGFIRE_CREDENTIALS_DIR`, then `.logfire` in the current working directory.
+   */
+  dataDir?: string
   /**
    * The environment this service is running in, e.g. `staging` or `prod`. Sets the deployment.environment.name resource attribute. Useful for filtering within projects in the Logfire UI.
    * Defaults to the `LOGFIRE_ENVIRONMENT` environment variable.
@@ -205,6 +211,7 @@ export interface LogfireConfig {
   deploymentEnvironment: string | undefined
   diagLogLevel?: DiagLogLevel
   distributedTracing: boolean
+  dataDir: string
   idGenerator: IdGenerator
   instrumentations: Instrumentation[]
   jsonSchema: JsonSchemaMode
@@ -237,6 +244,7 @@ const DEFAULT_LOGFIRE_CONFIG: LogfireConfig = {
   console: false,
   deploymentEnvironment: undefined,
   distributedTracing: true,
+  dataDir: '.logfire',
   idGenerator: new logfireApi.ULIDGenerator(),
   instrumentations: [],
   jsonSchema: 'rich',
@@ -265,6 +273,8 @@ export function configure(config: LogfireConfigOptions = {}): void {
   const env = process.env
   const envMinLevel = env['LOGFIRE_MIN_LEVEL']
   const console = 'console' in cnf ? cnf.console : env['LOGFIRE_CONSOLE'] === 'true'
+  const shouldReadLocalCredentials =
+    cnf.token === undefined && readNonEmptyEnv(env, 'LOGFIRE_TOKEN') === undefined && cnf.sendToLogfire !== false
 
   resolveConsoleOptions(console)
 
@@ -307,10 +317,13 @@ export function configure(config: LogfireConfigOptions = {}): void {
     }
   }
 
-  const token = cnf.token ?? env['LOGFIRE_TOKEN']
+  const envToken = readNonEmptyEnv(env, 'LOGFIRE_TOKEN')
+  const dataDir = resolveCredentialsDir(cnf.dataDir, env)
+  const localCredentials = shouldReadLocalCredentials ? readLocalProjectCredentials(dataDir) : undefined
+  const token = cnf.token ?? envToken ?? localCredentials?.token
   const apiKey = cnf.apiKey ?? env['LOGFIRE_API_KEY']
   const sendToLogfire = resolveSendToLogfire(cnf.sendToLogfire, token)
-  const baseUrl = resolveBaseUrl(env, cnf.advanced?.baseUrl, token, sendToLogfire)
+  const baseUrl = resolveBaseUrl(env, cnf.advanced?.baseUrl, token, sendToLogfire, localCredentials?.logfire_api_url)
   const deploymentEnvironment = cnf.environment ?? env['LOGFIRE_ENVIRONMENT']
   const serviceName = cnf.serviceName ?? readServiceNameEnv(env)
   const serviceVersion = cnf.serviceVersion ?? readServiceVersionEnv(env)
@@ -328,6 +341,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
     baseUrl,
     codeSource: cnf.codeSource,
     console,
+    dataDir,
     deploymentEnvironment,
     diagLogLevel: cnf.diagLogLevel,
     distributedTracing: resolveDistributedTracing(cnf.distributedTracing),
@@ -397,7 +411,8 @@ function resolveBaseUrl(
   env: NodeJS.ProcessEnv,
   passedUrl: string | undefined,
   token: LogfireToken | undefined,
-  sendToLogfire: boolean
+  sendToLogfire: boolean,
+  localCredentialsBaseUrl: string | undefined
 ): string {
   if (!sendToLogfire) {
     return ''
@@ -412,7 +427,11 @@ function resolveBaseUrl(
   if (token === undefined || token === '') {
     return ''
   }
-  return logfireApi.resolveBaseUrl(env, passedUrl, token)
+  const configuredBaseUrl = passedUrl ?? env['LOGFIRE_BASE_URL'] ?? localCredentialsBaseUrl
+  if (configuredBaseUrl !== undefined && configuredBaseUrl !== '') {
+    return removeTrailingSlash(configuredBaseUrl)
+  }
+  return logfireApi.resolveBaseUrl(env, undefined, token)
 }
 
 function removeTrailingSlash(url: string): string {

--- a/plans/018-js-cli-auth-projects.md
+++ b/plans/018-js-cli-auth-projects.md
@@ -1,0 +1,358 @@
+## Goal
+
+Add Python-SDK-style Logfire auth and project-management CLI support to the TypeScript SDK, exposed as `npx logfire`, while explicitly excluding `run`, `inspect`, and `gateway`.
+
+The implementation should:
+
+- Add a Node-only CLI entrypoint to the existing `logfire` npm package.
+- Implement `auth`, `auth logout`, `whoami`, `clean`, `projects list`, `projects new`, `projects use`, `read-tokens --project <org>/<project> create`, `info`, `--version`, `--base-url`, and `--region`.
+- Preserve browser safety by keeping all filesystem, environment, credential, and auth logic out of `@pydantic/logfire-browser` and out of browser-imported shared runtime modules.
+- Let `@pydantic/logfire-node` read local project credentials from `.logfire/logfire_credentials.json` when no explicit token or `LOGFIRE_TOKEN` is present.
+- Maintain wire/API compatibility with the Python SDK credential files and backend endpoints where practical.
+
+## Why
+
+- `npx logfire auth` and `npx logfire projects use/new` give JavaScript users the same onboarding flow Python users have.
+- Local project credentials let Node examples and local apps work without copying write tokens into `.env`.
+- Reusing Python credential file formats allows a developer authenticated by the Python SDK to use the JS SDK and vice versa.
+- Keeping credential loading Node-only avoids accidental browser token exposure.
+
+## Success Criteria
+
+- [ ] Running `npx logfire --help` shows the supported commands and explicitly omits `run`, `inspect`, and `gateway`.
+- [ ] `npx logfire auth` stores user tokens in `~/.logfire/default.toml` using a format compatible with the Python SDK.
+- [ ] `npx logfire auth logout` removes all user tokens, or only the selected URL's token when `--region` or `--base-url` is provided.
+- [ ] `npx logfire projects new/use` writes `.logfire/logfire_credentials.json` with `token`, `project_name`, `project_url`, and `logfire_api_url`.
+- [ ] `@pydantic/logfire-node.configure()` uses local credentials only when no explicit `token` and no `LOGFIRE_TOKEN` are present.
+- [ ] `@pydantic/logfire-browser` behavior and public API remain unchanged; it still requires `traceUrl` and never reads local credentials or env tokens.
+- [ ] CLI command tests cover the auth/project happy paths, user-token edge cases, invalid project inputs, and file outputs.
+- [ ] Docs explain `npx logfire auth`, `npx logfire projects use`, local credential precedence, and the browser exclusion.
+
+## Clarifications
+
+### Session 2026-06-04
+
+- Q: Should `npx logfire` live in the existing `logfire` package or a separate CLI package? -> A: Use the existing `logfire` package and keep the CLI implementation isolated from browser-imported runtime exports.
+- Q: Should Python's agent-oriented `prompt` command behavior be included? -> A: Do not implement `prompt` in this PRP.
+- Q: Should the JS implementation add a TOML dependency for `~/.logfire/default.toml`? -> A: Use a narrow Python-compatible parser/writer for the current auth file shape; do not add a TOML dependency.
+- Q: Should JS add configurable local credential directories? -> A: Add `dataDir?: string` and `LOGFIRE_CREDENTIALS_DIR` support.
+- Q: Should local credential lookup search parent directories? -> A: No. Use the configured data dir or exact cwd `.logfire`, matching Python's default behavior.
+- Q: Should `whoami` preserve Python-style fallback behavior? -> A: Yes. If env token validation cannot produce project info, continue to global user auth and local project credentials with warnings.
+- Q: Should the CLI use a built `dist/cli.js` with a preserved shebang? -> A: Yes.
+- Q: Should release notes be split? -> A: Use one changeset covering both `logfire` and `@pydantic/logfire-node`.
+
+### POC Findings 2026-06-04
+
+- Vite+ preserves `#!/usr/bin/env node` and executable bits for a CLI entry when using the repo's config shape: `pack.entry`, `pack.format`, and `outExtensions`. A temp package produced executable `dist/cli.js` and `dist/cli.cjs`; `node dist/cli.js` worked. Risk is mainly config typo: plural `entries`/`formats` was silently ignored and only package exports were built.
+- Adding the CLI as a separate package entry kept normal `dist/index.js` free of CLI-only `node:fs` imports. This supports keeping the CLI inside the existing `logfire` package as long as `src/index.ts` does not import CLI modules.
+- A narrow TOML reader/writer is feasible for Python's auth file shape. The POC handled comments, blank lines, unrelated sections, `[tokens."<base_url>"]`, escaped quotes/backslashes, and round-tripped token/expiration fields.
+- Importing `resolveBaseUrl` from the existing `packages/logfire-api/src/logfireApiConfig.ts` into a CLI entry bundled `@opentelemetry/api` and runtime config initialization into the CLI. Do not use runtime config modules from CLI auth code. Use a small side-effect-free region/token helper instead, and optionally have runtime config import that helper later.
+
+### Final Decisions 2026-06-04
+
+- `clean` should manage local JS project credentials only. Do not invent JS CLI log cleanup; accept `--logs` as a no-op with a clear message if compatibility is useful.
+- Create a small side-effect-free region/token/base-url helper and keep CLI auth/project code off runtime config modules.
+- Match Python behavior and output shape where useful, but do not overfit exact Python text/table formatting unless tests or docs need it.
+- Use one changeset with minor bumps for `logfire` and `@pydantic/logfire-node`.
+- Do one manual authenticated smoke test against a live backend environment before release, in addition to mocked unit tests.
+
+## Context
+
+### Key Files
+
+- `packages/logfire-api/package.json` - existing `logfire` npm package; add a `bin` entry here for `npx logfire`.
+- `packages/logfire-api/vite.config.ts` - package build entries; add a CLI entry and ensure output keeps a Node shebang.
+- `packages/logfire-api/src/index.ts` - public browser-safe runtime surface; do not import CLI/auth/fs modules here.
+- `packages/logfire-node/src/logfireConfig.ts` - current Node config precedence; integrate local credential loading here.
+- `packages/logfire-node/src/__test__/logfireConfig.test.ts` - existing config tests; add local credential precedence coverage.
+- `packages/logfire-browser/src/index.ts` - browser runtime requires `traceUrl`; should remain credential-free.
+- `docs/configuration.md` - token and credential precedence documentation.
+- `docs/reference/environment-variables.md` - document Node local credentials and browser exclusion.
+- `../logfire/logfire/_internal/cli/__init__.py` - Python CLI command shape and option behavior.
+- `../logfire/logfire/_internal/cli/auth.py` - Python auth and logout behavior.
+- `../logfire/logfire/_internal/auth.py` - Python global user-token TOML format and token selection.
+- `../logfire/logfire/_internal/config.py` - Python local project credential format and project selection logic.
+- `../logfire/logfire/_internal/client.py` - Python backend endpoints for user/org/project/read-token operations.
+- `../logfire/tests/test_cli.py` and `../logfire/tests/test_auth.py` - behavior-oriented test cases to port.
+
+### External References
+
+- Node.js built-ins available in the repo's required Node 24 runtime:
+  - `node:fs`, `node:path`, `node:os` for credential files.
+  - `node:readline/promises` for interactive prompts.
+  - global `fetch` for backend API calls.
+  - `node:child_process` only for browser opening where needed.
+- NPM package `bin` semantics: a package named `logfire` with `"bin": {"logfire": "./dist/cli.js"}` is what makes `npx logfire` invoke the CLI.
+
+### Gotchas
+
+- Do not import Node-only modules from `packages/logfire-api/src/index.ts` or other browser-consumed exports. Keep CLI code reachable only through the package `bin` file.
+- Do not import runtime config modules such as `logfireApiConfig.ts` from CLI auth/project code. Those modules initialize OpenTelemetry-facing runtime defaults and were proven to bundle `@opentelemetry/api` into the CLI. Put region/token/base-url helpers in a small side-effect-free module.
+- The existing shared `logfire` package is browser-usable. Adding a CLI must not make bundlers resolve `node:fs` from normal imports.
+- `@pydantic/logfire-node.configure()` is synchronous today. Local credential loading should be synchronous JSON file reading to preserve that API.
+- Browser and Cloudflare Worker runtimes should not auto-read `.logfire/logfire_credentials.json`. Node local applications should.
+- Python writes global auth tokens as TOML but local project credentials as JSON. The JS CLI must support both.
+- Python's `LOGFIRE_TOKEN` can contain comma-separated tokens. Local credentials contain exactly one write token.
+- Python supports a configurable local credentials directory (`data_dir` / `LOGFIRE_CREDENTIALS_DIR`). JS should add matching `dataDir` / `LOGFIRE_CREDENTIALS_DIR` support for Node.
+- Python currently defaults `send_to_logfire` differently than JS. Keep JS default semantics unless explicitly changed: current JS default is `if-token-present`.
+- Interactive prompts must be testable without a real terminal.
+- The API endpoints are backend contracts; tests should mock HTTP rather than require network access.
+
+## Implementation Blueprint
+
+### Data Models
+
+```ts
+type RegionId = 'us' | 'eu'
+
+interface RegionData {
+  baseUrl: string
+  gcpRegion: string
+}
+
+interface UserTokenData {
+  token: string
+  expiration: string
+}
+
+interface UserToken {
+  baseUrl: string
+  token: string
+  expiration: string
+}
+
+interface ProjectCredentials {
+  token: string
+  project_name: string
+  project_url: string
+  logfire_api_url: string
+}
+
+interface WritableProject {
+  organization_name: string
+  project_name: string
+}
+
+interface Organization {
+  organization_name: string
+}
+```
+
+### Tasks
+
+```yaml
+Task 1: CLI packaging
+  MODIFY packages/logfire-api/package.json:
+    - Add "bin": {"logfire": "./dist/cli.js"}.
+    - Ensure "files" includes the built CLI output via "dist".
+  MODIFY packages/logfire-api/vite.config.ts:
+    - Add a cli build entry, e.g. cli: "src/cli/index.ts".
+    - Add a banner/shebang for the cli entry only, or otherwise preserve "#!/usr/bin/env node".
+    - Ensure Node built-ins stay external.
+  CREATE packages/logfire-api/src/cli/index.ts:
+    - Parse args and dispatch commands.
+    - Do not export this from package runtime exports.
+
+Task 2: Shared CLI constants and helpers
+  CREATE packages/logfire-api/src/cli/regions.ts:
+    - Define us/eu region metadata matching Python.
+    - Implement token-region/base-url parsing without importing `logfireApiConfig.ts`.
+    - Prefer a small side-effect-free helper that runtime config can later reuse, rather than importing runtime config into CLI code.
+  CREATE packages/logfire-api/src/cli/errors.ts:
+    - Define LogfireCliError with exitCode.
+    - Centralize user-facing errors.
+  CREATE packages/logfire-api/src/cli/output.ts:
+    - Stderr/stdout helpers.
+    - Pretty table helper for projects.
+  CREATE packages/logfire-api/src/cli/interactivePrompt.ts:
+    - Testable readline-based prompt helpers.
+    - askChoice, askConfirm, askText.
+
+Task 3: Credential file compatibility
+  CREATE packages/logfire-api/src/cli/credentials.ts:
+    - Read/write global user tokens at ~/.logfire/default.toml.
+    - Preserve Python-compatible TOML sections: [tokens."<base_url>"].
+    - Detect expired tokens using ISO timestamps.
+    - Select matching token by base URL; prompt when multiple tokens exist and no base URL is selected.
+    - Read/write local project credentials at <dataDir>/logfire_credentials.json.
+    - Create data dir and write <dataDir>/.gitignore containing "*".
+  CREATE packages/logfire-api/src/cli/credentials.test.ts:
+    - Cover Python-compatible TOML read/write.
+    - Cover missing, expired, multiple, and selected-token cases.
+    - Cover local project credentials read/write and invalid JSON.
+
+Task 4: Backend API client
+  CREATE packages/logfire-api/src/cli/client.ts:
+    - Implement authenticated user-token API client with global fetch.
+    - Methods:
+      - requestDeviceCode(baseUrl, machineName)
+      - pollForToken(baseUrl, deviceCode)
+      - getUserInformation()
+      - getUserOrganizations()
+      - getUserProjects()
+      - createNewProject(org, projectName)
+      - createWriteToken(org, projectName)
+      - createReadToken(org, projectName)
+      - getTokenInfo(writeToken, baseUrl)
+    - Map known error cases to user-facing CLI errors:
+      - 409 project exists
+      - 422 invalid project name
+      - generic retrieval/create failures
+  CREATE packages/logfire-api/src/cli/client.test.ts:
+    - Mock fetch for endpoint paths, headers, request bodies, and errors.
+
+Task 5: Auth commands
+  CREATE packages/logfire-api/src/cli/commands/auth.ts:
+    - Implement auth region selection when no global URL/region is supplied.
+    - Use device auth flow and browser open.
+    - Store token in ~/.logfire/default.toml.
+    - Implement logout.
+  TEST:
+    - Already logged in returns without mutating file.
+    - Region prompt handles invalid selection then valid selection.
+    - Poll retries temporary failures and fails after repeated errors.
+    - Logout all, logout region-specific, not logged in, wrong region.
+
+Task 6: Project commands
+  CREATE packages/logfire-api/src/cli/commands/projects.ts:
+    - Implement list/new/use.
+    - Project names must match Python: /^[a-z0-9]+(?:-[a-z0-9]+)*$/.
+    - Default project name should be sanitized cwd basename, max 41 chars, fallback "untitled".
+    - Implement org selection:
+      - Valid --org: use it.
+      - One organization and no --default-org: ask confirmation.
+      - Multiple organizations: use default org when --default-org and available, otherwise prompt.
+    - Implement use selection:
+      - Exact org/project match creates write token directly.
+      - Multiple matches prompts.
+      - No matches prompts whether to choose from all projects.
+      - No projects prints create hint and exits success.
+    - Write local credentials and print project URL.
+  TEST:
+    - Port Python tests for list/no projects/new/use ambiguity/invalid names/errors.
+
+Task 7: Other supported commands
+  CREATE packages/logfire-api/src/cli/commands/whoami.ts:
+    - Validate LOGFIRE_TOKEN tokens first via /v1/info.
+    - Otherwise use global user auth for username.
+    - Then load local project credentials from --data-dir and print project URL.
+  CREATE packages/logfire-api/src/cli/commands/clean.ts:
+    - Delete local .gitignore and logfire_credentials.json under --data-dir.
+    - Do not create or delete JS CLI log files.
+    - If `--logs` is accepted for Python compatibility, treat it as a no-op with a clear message.
+    - Prompt before deleting.
+  CREATE packages/logfire-api/src/cli/commands/readTokens.ts:
+    - Require --project org/project for create.
+    - Print token to stdout.
+  CREATE packages/logfire-api/src/cli/commands/info.ts:
+    - Print logfire package version, platform, Node version, and selected related package versions.
+
+Task 8: Node SDK local credential loading
+  CREATE packages/logfire-node/src/credentials.ts:
+    - Read `.logfire/logfire_credentials.json` synchronously.
+    - Validate required fields.
+    - Return undefined if missing.
+    - Throw only when file exists but is invalid and no higher-precedence token exists.
+  MODIFY packages/logfire-node/src/logfireConfig.ts:
+    - Add a JS option for the credentials directory, e.g. dataDir?: string.
+    - Resolve token as: config token -> LOGFIRE_TOKEN -> local credentials token.
+    - Resolve credentials directory as: config dataDir -> LOGFIRE_CREDENTIALS_DIR -> ".logfire".
+    - Resolve base URL as: config advanced.baseUrl -> LOGFIRE_BASE_URL -> local credentials logfire_api_url -> token-region inference.
+    - Preserve token-provider behavior: function token still requires explicit base URL.
+  MODIFY packages/logfire-node/src/__test__/logfireConfig.test.ts:
+    - Add precedence tests.
+    - Add dataDir / LOGFIRE_CREDENTIALS_DIR tests.
+    - Add invalid local creds behavior.
+    - Add `sendToLogfire: 'if-token-present'` with local creds.
+
+Task 9: Documentation
+  MODIFY docs/configuration.md:
+    - Add local credentials to Node token precedence.
+    - State browser never reads local credentials.
+  MODIFY docs/reference/environment-variables.md:
+    - Mention `.logfire/logfire_credentials.json` for Node local development.
+  CREATE or MODIFY docs/reference/cli.md:
+    - Document supported JS CLI commands and explicitly excluded commands.
+  MODIFY README.md or docs/get-started.md:
+    - Add `npx logfire auth` and `npx logfire projects use <project>`.
+
+Task 10: Validation and release notes
+  CREATE .changeset/<name>.md:
+    - Add release notes for `logfire` CLI and `@pydantic/logfire-node` local credentials.
+  RUN:
+    - pnpm --filter logfire test
+    - pnpm --filter @pydantic/logfire-node test
+    - pnpm --filter logfire typecheck
+    - pnpm --filter @pydantic/logfire-node typecheck
+    - pnpm run format-check
+```
+
+### Integration Points
+
+```yaml
+NPM_BIN:
+  - packages/logfire-api/package.json
+  - Add "bin" so `npx logfire` resolves to the built CLI.
+
+BUILD:
+  - packages/logfire-api/vite.config.ts
+  - Add CLI entry with `pack.entry`, not `entries`.
+  - Preserve shebang via the source file and existing Vite+ behavior.
+  - Keep `outExtensions` mapping so the bin can point at `dist/cli.js`.
+
+NODE_CONFIG:
+  - packages/logfire-node/src/logfireConfig.ts
+  - Add local credential fallback after explicit/env tokens.
+
+AUTH_STORE:
+  - ~/.logfire/default.toml
+  - Python-compatible user-token store.
+
+PROJECT_CREDS:
+  - .logfire/logfire_credentials.json
+  - Python-compatible write-token store.
+
+BROWSER:
+  - packages/logfire-browser/src/index.ts
+  - No changes expected except tests/docs confirming no local credential behavior.
+```
+
+## Validation
+
+```bash
+# Focused CLI/shared package tests
+pnpm --filter logfire test
+pnpm --filter logfire typecheck
+
+# Focused Node config tests
+pnpm --filter @pydantic/logfire-node test
+pnpm --filter @pydantic/logfire-node typecheck
+
+# Formatting
+pnpm run format-check
+
+# Optional broader check before PR
+pnpm run check
+```
+
+### Required Test Coverage
+
+- [ ] `auth` writes Python-compatible `~/.logfire/default.toml`.
+- [ ] `auth logout` removes all tokens or a selected region/base URL.
+- [ ] `whoami` handles env token, multiple env tokens, global user token, local project credentials, and missing credentials.
+- [ ] `projects list` sorts and prints writable projects.
+- [ ] `projects new` handles org selection, default org, invalid project names, duplicate names, backend errors, and writes credentials.
+- [ ] `projects use` handles exact match, ambiguous match, missing project with choose-all, missing project with give-up, no projects, write-token errors, and writes credentials.
+- [ ] `read-tokens create` validates `--project org/project` and prints token to stdout.
+- [ ] Node `configure()` precedence: explicit token > env token > local credentials.
+- [ ] Node `configure()` uses local credentials base URL when no explicit/env base URL is set.
+- [ ] Browser package has no credential-loading imports or behavior.
+
+## Unknowns & Risks
+
+- Backend endpoint contracts may have drifted from the Python SDK tests; mock tests should encode the observed Python paths, and one manual authenticated smoke test is useful before release.
+- Browser opening during `auth` is platform-sensitive and should degrade to printing the URL when opening fails.
+- Vite+ CLI entry configuration is easy to mistype. Add a packaging-oriented test or build assertion that `dist/cli.js` exists, starts with `#!/usr/bin/env node`, and is executable.
+- The narrow TOML parser should intentionally tolerate comments and unrelated sections, as proven in POC, but tests should lock that behavior.
+
+**Confidence: 8/10** for one-pass implementation success with `prompt`, `run`, `inspect`, and `gateway` excluded.


### PR DESCRIPTION
## Why

Give JavaScript users the same onboarding flow Python users have. `npx logfire auth` and `npx logfire projects use/new` mean local Node apps and examples work without copying a write token into `.env`, and reusing the Python SDK's on-disk credential formats lets a developer authenticated with either SDK use the other.

## What

A Node-only CLI shipped through the existing `logfire` package (`"bin": { "logfire": "./dist/cli.js" }`):

- `auth` / `auth logout` — device-code flow; user tokens in `~/.logfire/default.toml`
- `projects list` / `new` / `use` — write per-project credentials to `.logfire/logfire_credentials.json`
- `whoami`, `clean`, `read-tokens --project <org>/<project> create`, `info`
- Global `--version`, `--region`, `--base-url`

`@pydantic/logfire-node` now reads local project credentials when no explicit `token` and no `LOGFIRE_TOKEN` are set (precedence: config token → `LOGFIRE_TOKEN` → local credentials), and uses the credentials' `logfire_api_url` as the base URL when none is otherwise configured. `dataDir` / `LOGFIRE_CREDENTIALS_DIR` configure the lookup directory.

## Compatibility & safety

- On-disk formats match the Python SDK: global TOML user tokens (parsed/written by a narrow Python-compatible reader/writer — no new dependency) and JSON per-project write tokens.
- Region/base-url logic was extracted into a small side-effect-free `tokenBaseUrl` helper so CLI code does not pull in the OpenTelemetry runtime config module. CLI/credential code is reachable only through the package `bin`, so browser and Cloudflare Worker bundles never resolve `node:fs` or receive a write token.
- `run`, `inspect`, `gateway`, and `prompt` from the Python CLI are intentionally excluded.

## Notes

- `sanitizeProjectName` was aligned to Python's `sanitize_project_name` (strips all non-alphanumerics rather than introducing hyphens) so both SDKs suggest identical default project names; ported the Python test cases.
- Docs added/updated: new `docs/reference/cli.md`, plus Node credential precedence and browser exclusion in `configuration.md` / `environment-variables.md`, and onboarding in `get-started.md`.
- Validation: `vp check` clean for `logfire` and `@pydantic/logfire-node`; 347 + 77 tests pass; built `dist/cli.js` verified (shebang preserved, executable, `--help` / `--version` / `info` run).