### PR TITLE
Fix release publish package metadata

### DIFF
--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -94,7 +94,7 @@
     "preview": "vp preview",
     "typecheck": "tsc",
     "prepack": "cp ../../LICENSE .",
-    "postpack": "rm LICENSE",
+    "postpublish": "rm LICENSE",
     "test": "vp test"
   },
   "dependencies": {

--- a/packages/logfire-browser/package.json
+++ b/packages/logfire-browser/package.json
@@ -49,7 +49,7 @@
     "preview": "vp preview",
     "typecheck": "tsc",
     "prepack": "cp ../../LICENSE .",
-    "postpack": "rm LICENSE",
+    "postpublish": "rm LICENSE",
     "test": "vp test --passWithNoTests"
   },
   "dependencies": {

--- a/packages/logfire-cf-workers/package.json
+++ b/packages/logfire-cf-workers/package.json
@@ -50,7 +50,7 @@
     "preview": "vp preview",
     "typecheck": "tsc",
     "prepack": "cp ../../LICENSE .",
-    "postpack": "rm LICENSE",
+    "postpublish": "rm LICENSE",
     "test": "vp test --passWithNoTests"
   },
   "dependencies": {

--- a/packages/logfire-node/package.json
+++ b/packages/logfire-node/package.json
@@ -69,7 +69,7 @@
     "preview": "vp preview",
     "typecheck": "tsc",
     "prepack": "cp ../../LICENSE .",
-    "postpack": "rm LICENSE",
+    "postpublish": "rm LICENSE",
     "test": "vp test --passWithNoTests"
   },
   "dependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   'js-yaml': ^4.1.0
   'p-retry': ^6.2.1
   typescript: ^6.0.3
+  vitest: 'npm:@voidzero-dev/vite-plus-test@0.1.22'
   zod: ^3.23.8
 
 allowBuilds:


### PR DESCRIPTION
## Summary
- Add the missing `vitest` catalog entry used by `packages/logfire-api`.
- Move package `LICENSE` cleanup from `postpack` to `postpublish` for all publishable packages.

## Root Cause
After #142 fixed the frozen-lockfile failure, the main release job reached `changesets/action` publish mode and failed inside `pnpm run release`.

The first publish blocker was:

```text
[ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC] No catalog entry 'vitest' was found for catalog 'default'.
```

`packages/logfire-api/package.json` uses `"vitest": "catalog:"`, but `pnpm-workspace.yaml` only had a `vitest` override, not a catalog entry.

While verifying the fix with `pnpm publish --dry-run`, pnpm 11 exposed a second publish lifecycle issue: `postpack` removed the copied `LICENSE` before pnpm finished publishing, causing an `ENOENT` on `LICENSE`. Moving cleanup to `postpublish` keeps `LICENSE` present through packing/publish and still cleans it afterward.

## Verification
- `pnpm publish -r --access public --dry-run --no-git-checks`
- `vp install --frozen-lockfile`
- `vp check`
- `vp run --filter "./packages/*" build`
