### PR TITLE
chore: add logfire bugs metadata

### DIFF
--- a/.changeset/logfire-bugs-metadata.md
+++ b/.changeset/logfire-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"logfire": patch
+---
+
+Add npm bugs metadata for the Logfire package.

--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -13,6 +13,9 @@
   },
   "sideEffects": false,
   "homepage": "https://pydantic.dev/logfire",
+  "bugs": {
+    "url": "https://github.com/pydantic/logfire-js/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for the `logfire` package
- add a patch changeset for the metadata update

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('packages/logfire-api/package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
