### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -27,6 +27,9 @@
     "monitoring"
   ],
   "version": "0.20.0",
+  "bugs": {
+    "url": "https://github.com/pydantic/logfire-js/issues"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/logfire-api/package.json`.

Fixes npm tooling unable to resolve package metadata.