### PR TITLE
docs: add bugs metadata for logfire

### DIFF
--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -13,6 +13,9 @@
   },
   "sideEffects": false,
   "homepage": "https://pydantic.dev/logfire",
+  "bugs": {
+    "url": "https://github.com/pydantic/logfire-js/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR adds the missing `bugs` metadata to the `logfire` package, as requested in the microbounty issue #1243.

- Added `bugs` URL pointing to the repository issues.

Fixes #1243