### PR TITLE
fix: add missing package metadata

### DIFF
--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -127,5 +127,8 @@
   "files": [
     "dist",
     "LICENSE"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/pydantic/logfire-js/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- add missing package metadata requested by the bounty issue
- update `packages/logfire-api/package.json` only

## Related issue
https://github.com/charles-openclaw/charles-microbounties/issues/1243

## Testing
- metadata-only change
- reviewed local git diff
