### PR TITLE
Capture structured Error.cause data

### DIFF
--- a/.changeset/logfire-bugs-metadata.md
+++ b/.changeset/logfire-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+"logfire": patch
+---
+
+Add npm bugs metadata for the Logfire package.

--- a/.changeset/tame-errors-cause.md
+++ b/.changeset/tame-errors-cause.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Include `Error.cause` chains in recorded exception stacktraces and as structured `exception.cause` attributes.

--- a/examples/express/.env.example
+++ b/examples/express/.env.example
@@ -1,5 +1,5 @@
 # Used for reporting traces to Logfire
 # Change the URL if you're using a different Logfire instance
 # LOGFIRE_BASE_URL=https://logfire-api.pydantic.dev/
-LOGFIRE_WRITE_TOKEN=your-write-token
+LOGFIRE_TOKEN=your-write-token
 EXPRESS_PORT=8080

--- a/examples/express/app.ts
+++ b/examples/express/app.ts
@@ -5,6 +5,28 @@ import * as logfire from '@pydantic/logfire-node'
 const PORT: number = parseInt(process.env.EXPRESS_PORT || '8080')
 const app: Express = express()
 
+function createStructuredCauseDemoError(): Error {
+  const databaseCause = Object.assign(new Error('database connection rejected'), {
+    attempt: 3,
+    details: {
+      host: 'primary-db.internal',
+      pool: 'checkout-writes',
+      retryable: true,
+    },
+    statusCode: 503,
+  })
+
+  const serviceCause = Object.assign(new Error('checkout storage call failed', { cause: databaseCause }), {
+    operation: 'checkout.create_order',
+    requestId: 'demo-request-structured-cause',
+  })
+
+  return Object.assign(new Error('structured Error.cause demo failed', { cause: serviceCause }), {
+    cartId: 'cart_demo_123',
+    customerTier: 'enterprise',
+  })
+}
+
 function getRandomNumber(min: number, max: number) {
   return Math.floor(Math.random() * (max - min) + min)
 }
@@ -24,13 +46,21 @@ app.get('/rolldice', (req, res) => {
   res.send(getRandomNumber(1, 6).toString())
 })
 
+app.get('/structured-cause-error', (_req, _res) => {
+  throw createStructuredCauseDemoError()
+})
+
 // Report an error to Logfire, using the Express error handler.
 app.use((err: Error, _req: Request, res: Response, _next: () => unknown) => {
-  logfire.reportError(err.message, err)
+  logfire.reportError(err.message, err, {
+    demo: 'structured-error-cause',
+    expectedAttributes: ['exception.cause', 'logfire.json_schema'],
+  })
   res.status(500)
   res.send('An error occured')
 })
 
 app.listen(PORT, () => {
   console.log(`Listening for requests on http://localhost:${PORT}/rolldice`)
+  console.log(`Structured cause demo: http://localhost:${PORT}/structured-cause-error`)
 })

--- a/examples/express/app.ts
+++ b/examples/express/app.ts
@@ -58,6 +58,7 @@ app.use((err: Error, _req: Request, res: Response, _next: () => unknown) => {
   })
   res.status(500)
   res.send('An error occurred')
+})
 
 app.listen(PORT, () => {
   console.log(`Listening for requests on http://localhost:${PORT}/rolldice`)

--- a/examples/express/app.ts
+++ b/examples/express/app.ts
@@ -57,8 +57,7 @@ app.use((err: Error, _req: Request, res: Response, _next: () => unknown) => {
     expectedAttributes: ['exception.cause', 'logfire.json_schema'],
   })
   res.status(500)
-  res.send('An error occured')
-})
+  res.send('An error occurred')
 
 app.listen(PORT, () => {
   console.log(`Listening for requests on http://localhost:${PORT}/rolldice`)

--- a/examples/node/.env
+++ b/examples/node/.env
@@ -1,2 +1,0 @@
-LOGFIRE_BASE_URL=http://localhost:8000
-LOGFIRE_TOKEN=test-e2e-write-token

--- a/packages/logfire-api/package.json
+++ b/packages/logfire-api/package.json
@@ -13,6 +13,9 @@
   },
   "sideEffects": false,
   "homepage": "https://pydantic.dev/logfire",
+  "bugs": {
+    "url": "https://github.com/pydantic/logfire-js/issues"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -649,6 +649,100 @@ describe('span', () => {
     expect(spanMock.end).toHaveBeenCalledOnce()
   })
 
+  test('sync callback throws Error with nested causes - records full cause chain', () => {
+    const databaseCause = Object.assign(new Error('database unavailable'), {
+      details: { host: 'primary-db', retryable: true },
+      statusCode: 503,
+    })
+    databaseCause.stack = 'Error: database unavailable\n    at query (db.ts:12:3)'
+    const serviceCause = Object.assign(new TypeError('checkout storage failed', { cause: databaseCause }), {
+      operation: 'checkout.create_order',
+      requestId: 'req_nested_span',
+    })
+    serviceCause.stack = 'TypeError: checkout storage failed\n    at saveOrder (checkout.ts:8:1)'
+    const error = new Error('request failed', { cause: serviceCause })
+    error.stack = 'Error: request failed\n    at handler (app.ts:4:1)'
+    const expectedStack = `${error.stack}\nCaused by: ${serviceCause.stack}\nCaused by: ${databaseCause.stack}`
+
+    expect(() =>
+      span('test', {
+        callback: () => {
+          throw error
+        },
+      })
+    ).toThrow(error)
+
+    expect(spanMock.recordException).toHaveBeenCalledWith({
+      message: 'request failed',
+      name: 'Error',
+      stack: expectedStack,
+    })
+    const causeAttribute = spanMock.setAttribute.mock.calls.find(([key]) => key === 'exception.cause')?.[1]
+    expect(JSON.parse(causeAttribute as string)).toEqual({
+      cause: {
+        details: { host: 'primary-db', retryable: true },
+        message: 'database unavailable',
+        stacktrace: databaseCause.stack,
+        statusCode: 503,
+        type: 'Error',
+      },
+      message: 'checkout storage failed',
+      operation: 'checkout.create_order',
+      requestId: 'req_nested_span',
+      stacktrace: serviceCause.stack,
+      type: 'TypeError',
+    })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('sync callback throws Error with circular causes - records circular marker', () => {
+    const databaseCause = Object.assign(new Error('database unavailable'), {
+      details: { host: 'primary-db' },
+    })
+    databaseCause.stack = 'Error: database unavailable\n    at query (db.ts:12:3)'
+    const serviceCause = Object.assign(new Error('checkout storage failed', { cause: databaseCause }), {
+      operation: 'checkout.create_order',
+    })
+    serviceCause.stack = 'Error: checkout storage failed\n    at saveOrder (checkout.ts:8:1)'
+    const error = new Error('request failed', { cause: serviceCause })
+    error.stack = 'Error: request failed\n    at handler (app.ts:4:1)'
+    ;(databaseCause as Error & { cause: Error }).cause = error
+    const expectedStack = `${error.stack}\nCaused by: ${serviceCause.stack}\nCaused by: ${databaseCause.stack}\nCaused by: [Circular cause: Error: request failed]`
+
+    expect(() =>
+      span('test', {
+        callback: () => {
+          throw error
+        },
+      })
+    ).toThrow(error)
+
+    expect(spanMock.recordException).toHaveBeenCalledWith({
+      message: 'request failed',
+      name: 'Error',
+      stack: expectedStack,
+    })
+    const causeAttribute = spanMock.setAttribute.mock.calls.find(([key]) => key === 'exception.cause')?.[1]
+    expect(JSON.parse(causeAttribute as string)).toEqual({
+      cause: {
+        cause: {
+          circular: true,
+          message: 'request failed',
+          type: 'Error',
+        },
+        details: { host: 'primary-db' },
+        message: 'database unavailable',
+        stacktrace: databaseCause.stack,
+        type: 'Error',
+      },
+      message: 'checkout storage failed',
+      operation: 'checkout.create_order',
+      stacktrace: serviceCause.stack,
+      type: 'Error',
+    })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
   test('sync callback throws string - records exception without fingerprint', () => {
     expect(() =>
       span('test', {
@@ -788,6 +882,88 @@ describe('reportError', () => {
       stack: expectedStack,
     })
     expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: request failed' })
+  })
+
+  test('records nested Error cause chain in reportError stacktrace', () => {
+    const databaseCause = Object.assign(new Error('database unavailable'), {
+      details: { host: 'primary-db', retryable: true },
+      statusCode: 503,
+    })
+    databaseCause.stack = 'Error: database unavailable\n    at query (db.ts:12:3)'
+    const serviceCause = Object.assign(new TypeError('checkout storage failed', { cause: databaseCause }), {
+      operation: 'checkout.create_order',
+      requestId: 'req_nested_report_error',
+    })
+    serviceCause.stack = 'TypeError: checkout storage failed\n    at saveOrder (checkout.ts:8:1)'
+    const error = new Error('request failed', { cause: serviceCause })
+    error.stack = 'Error: request failed\n    at handler (app.ts:4:1)'
+    const expectedStack = `${error.stack}\nCaused by: ${serviceCause.stack}\nCaused by: ${databaseCause.stack}`
+
+    reportError('Caught error', error)
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTR_EXCEPTION_STACKTRACE]).toBe(expectedStack)
+    expect(JSON.parse(attributes['exception.cause'] as string)).toEqual({
+      cause: {
+        details: { host: 'primary-db', retryable: true },
+        message: 'database unavailable',
+        stacktrace: databaseCause.stack,
+        statusCode: 503,
+        type: 'Error',
+      },
+      message: 'checkout storage failed',
+      operation: 'checkout.create_order',
+      requestId: 'req_nested_report_error',
+      stacktrace: serviceCause.stack,
+      type: 'TypeError',
+    })
+    expect(spanMock.recordException).toHaveBeenCalledWith({
+      message: 'request failed',
+      name: 'Error',
+      stack: expectedStack,
+    })
+  })
+
+  test('records circular Error cause chain in reportError stacktrace', () => {
+    const databaseCause = Object.assign(new Error('database unavailable'), {
+      details: { host: 'primary-db' },
+    })
+    databaseCause.stack = 'Error: database unavailable\n    at query (db.ts:12:3)'
+    const serviceCause = Object.assign(new Error('checkout storage failed', { cause: databaseCause }), {
+      operation: 'checkout.create_order',
+    })
+    serviceCause.stack = 'Error: checkout storage failed\n    at saveOrder (checkout.ts:8:1)'
+    const error = new Error('request failed', { cause: serviceCause })
+    error.stack = 'Error: request failed\n    at handler (app.ts:4:1)'
+    ;(databaseCause as Error & { cause: Error }).cause = error
+    const expectedStack = `${error.stack}\nCaused by: ${serviceCause.stack}\nCaused by: ${databaseCause.stack}\nCaused by: [Circular cause: Error: request failed]`
+
+    reportError('Caught error', error)
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTR_EXCEPTION_STACKTRACE]).toBe(expectedStack)
+    expect(JSON.parse(attributes['exception.cause'] as string)).toEqual({
+      cause: {
+        cause: {
+          circular: true,
+          message: 'request failed',
+          type: 'Error',
+        },
+        details: { host: 'primary-db' },
+        message: 'database unavailable',
+        stacktrace: databaseCause.stack,
+        type: 'Error',
+      },
+      message: 'checkout storage failed',
+      operation: 'checkout.create_order',
+      stacktrace: serviceCause.stack,
+      type: 'Error',
+    })
+    expect(spanMock.recordException).toHaveBeenCalledWith({
+      message: 'request failed',
+      name: 'Error',
+      stack: expectedStack,
+    })
   })
 
   test('applies fourth-argument tags', () => {

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -586,6 +586,69 @@ describe('span', () => {
     expect(spanMock.end).toHaveBeenCalledOnce()
   })
 
+  test('sync callback throws Error with cause - records cause chain in exception stacktrace', () => {
+    const cause = Object.assign(new TypeError('database unavailable'), {
+      details: { retryable: true },
+      statusCode: 503,
+    })
+    cause.stack = 'TypeError: database unavailable\n    at query (db.ts:12:3)'
+    const error = new Error('request failed', { cause })
+    error.stack = 'Error: request failed\n    at handler (app.ts:8:1)'
+    const expectedStack = `${error.stack}\nCaused by: ${cause.stack}`
+
+    expect(() =>
+      span('test', {
+        attributes: { payload: { id: '123' } },
+        callback: () => {
+          throw error
+        },
+      })
+    ).toThrow(error)
+
+    expect(spanMock.recordException).toHaveBeenCalledWith({
+      message: 'request failed',
+      name: 'Error',
+      stack: expectedStack,
+    })
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: request failed' })
+    const causeAttribute = spanMock.setAttribute.mock.calls.find(([key]) => key === 'exception.cause')?.[1]
+    expect(JSON.parse(causeAttribute as string)).toEqual({
+      details: { retryable: true },
+      message: 'database unavailable',
+      stacktrace: cause.stack,
+      statusCode: 503,
+      type: 'TypeError',
+    })
+    const schemaAttribute = spanMock.setAttribute.mock.calls.find(([key]) => key === JSON_SCHEMA_KEY)?.[1]
+    expect(JSON.parse(schemaAttribute as string)).toMatchObject({
+      properties: {
+        'exception.cause': {
+          properties: {
+            details: {
+              properties: {
+                retryable: { type: 'boolean' },
+              },
+              type: 'object',
+            },
+            message: { type: 'string' },
+            stacktrace: { type: 'string' },
+            statusCode: { type: 'number' },
+            type: { type: 'string' },
+          },
+          type: 'object',
+        },
+        payload: {
+          properties: {
+            id: { type: 'string' },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
   test('sync callback throws string - records exception without fingerprint', () => {
     expect(() =>
       span('test', {
@@ -675,6 +738,56 @@ describe('reportError', () => {
     expect(attributes['path']).toBe('/users')
     expect(spanMock.recordException).toHaveBeenCalledWith(error)
     expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: legacy' })
+  })
+
+  test('records Error cause chain in reportError stacktrace', () => {
+    const cause = Object.assign(new TypeError('database unavailable'), {
+      details: { retryable: true },
+      statusCode: 503,
+    })
+    cause.stack = 'TypeError: database unavailable\n    at query (db.ts:12:3)'
+    const error = new Error('request failed', { cause })
+    error.stack = 'Error: request failed\n    at handler (app.ts:8:1)'
+    const expectedStack = `${error.stack}\nCaused by: ${cause.stack}`
+
+    reportError('Caught error', error)
+
+    const attributes = (mocks.tracerMock.startSpan.mock.calls[0]?.[1] as { attributes: Record<string, unknown> }).attributes
+    expect(attributes[ATTR_EXCEPTION_MESSAGE]).toBe('request failed')
+    expect(attributes[ATTR_EXCEPTION_STACKTRACE]).toBe(expectedStack)
+    expect(JSON.parse(attributes['exception.cause'] as string)).toEqual({
+      details: { retryable: true },
+      message: 'database unavailable',
+      stacktrace: cause.stack,
+      statusCode: 503,
+      type: 'TypeError',
+    })
+    expect(JSON.parse(attributes[JSON_SCHEMA_KEY] as string)).toMatchObject({
+      properties: {
+        'exception.cause': {
+          properties: {
+            details: {
+              properties: {
+                retryable: { type: 'boolean' },
+              },
+              type: 'object',
+            },
+            message: { type: 'string' },
+            stacktrace: { type: 'string' },
+            statusCode: { type: 'number' },
+            type: { type: 'string' },
+          },
+          type: 'object',
+        },
+      },
+      type: 'object',
+    })
+    expect(spanMock.recordException).toHaveBeenCalledWith({
+      message: 'request failed',
+      name: 'Error',
+      stack: expectedStack,
+    })
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: request failed' })
   })
 
   test('applies fourth-argument tags', () => {

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -199,6 +199,21 @@ function getStartActiveSpanAttributes(callIndex = 0): Record<string, unknown> {
   return (mocks.tracerMock.startActiveSpan.mock.calls[callIndex]?.[1] as { attributes: Record<string, unknown> }).attributes
 }
 
+function errorWithThrowingCauseStack(): Error {
+  const normalizationFailure = new Error('cause stack getter failed')
+  const cause = new Error('cause failed')
+  Object.defineProperty(cause, 'stack', {
+    configurable: true,
+    get() {
+      throw normalizationFailure
+    },
+  })
+
+  const error = new Error('original failure', { cause })
+  error.stack = 'Error: original failure\n    at handler (app.ts:8:1)'
+  return error
+}
+
 describe('info', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -743,6 +758,26 @@ describe('span', () => {
     expect(spanMock.end).toHaveBeenCalledOnce()
   })
 
+  test('sync callback preserves original Error when cause normalization throws', () => {
+    const error = errorWithThrowingCauseStack()
+    let caught: unknown
+
+    try {
+      span('test', {
+        callback: () => {
+          throw error
+        },
+      })
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBe(error)
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: original failure' })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
   test('sync callback throws string - records exception without fingerprint', () => {
     expect(() =>
       span('test', {
@@ -964,6 +999,18 @@ describe('reportError', () => {
       name: 'Error',
       stack: expectedStack,
     })
+  })
+
+  test('does not throw when cause normalization fails', () => {
+    const error = errorWithThrowingCauseStack()
+
+    expect(() => {
+      reportError('Caught error', error)
+    }).not.toThrow()
+
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: original failure' })
+    expect(spanMock.end).toHaveBeenCalledOnce()
   })
 
   test('applies fourth-argument tags', () => {

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -694,19 +694,32 @@ export function instrument<F extends InstrumentableFunction>(fn: F, options: Ins
 
 function recordSpanException(span: Span, thrown: unknown, spanSerializationAttributes: Record<string, unknown> = {}): void {
   const isError = thrown instanceof Error
-  const errorMessage = isError ? thrown.message : String(thrown)
-  const errorName = isError ? thrown.name : 'Error'
+  const errorMessage = isError ? getSafeErrorMessage(thrown) : stringifyThrownValue(thrown)
+  const errorName = isError ? getSafeErrorName(thrown) : 'Error'
+  let recordExceptionValue: Error | Exception | string = isError ? thrown : errorMessage
+  let causeValue: unknown
 
-  span.recordException(isError ? normalizeRecordException(thrown) : String(thrown))
+  if (isError) {
+    try {
+      recordExceptionValue = normalizeRecordException(thrown)
+      if (thrown.cause !== undefined) {
+        causeValue = normalizeErrorCause(thrown)
+      }
+    } catch {
+      recordExceptionValue = thrown
+    }
+  }
+
+  span.recordException(recordExceptionValue)
   span.setStatus({ code: SpanStatusCode.ERROR, message: `${errorName}: ${errorMessage}` })
   span.setAttribute(ATTRIBUTES_LEVEL_KEY, Level.Error)
 
   if (isError && logfireApiConfig.enableErrorFingerprinting) {
-    span.setAttribute(ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY, computeFingerprint(thrown))
+    recordErrorFingerprint(span, thrown)
   }
 
-  if (isError && thrown.cause !== undefined) {
-    recordSerializedAttributes(span, { ...spanSerializationAttributes, [ATTR_EXCEPTION_CAUSE]: normalizeErrorCause(thrown) }, [
+  if (causeValue !== undefined) {
+    recordSerializedAttributes(span, { ...spanSerializationAttributes, [ATTR_EXCEPTION_CAUSE]: causeValue }, [
       ATTR_EXCEPTION_CAUSE,
       JSON_SCHEMA_KEY,
       JSON_NULL_FIELDS_KEY,
@@ -729,6 +742,56 @@ function stringifyThrownValue(thrown: unknown): string {
     return String(thrown)
   } catch {
     return 'Unknown error'
+  }
+}
+
+function getSafeErrorMessage(error: Error): string {
+  try {
+    return typeof error.message === 'string' ? error.message : ''
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+function getSafeErrorName(error: Error): string {
+  try {
+    return typeof error.name === 'string' && error.name !== '' ? error.name : 'Error'
+  } catch {
+    return 'Error'
+  }
+}
+
+function getSafeErrorStack(error: Error): string | undefined {
+  try {
+    return typeof error.stack === 'string' ? error.stack : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function recordErrorFingerprint(span: Span, error: Error): void {
+  try {
+    safeSetSpanAttribute(span, ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY, computeFingerprint(error))
+  } catch {
+    // Error fingerprinting is best-effort and should not affect user errors.
+  }
+}
+
+function getReportErrorFallback(error: Error): NormalizedReportError {
+  const errorMessage = getSafeErrorMessage(error)
+  const attributes: Record<string, unknown> = {
+    [ATTR_EXCEPTION_MESSAGE]: errorMessage,
+  }
+  const stack = getSafeErrorStack(error)
+  if (stack !== undefined) {
+    attributes[ATTR_EXCEPTION_STACKTRACE] = stack
+  }
+
+  return {
+    attributes,
+    fingerprintSource: error,
+    recordExceptionValue: error,
+    statusMessage: `${getSafeErrorName(error)}: ${errorMessage}`,
   }
 }
 
@@ -811,15 +874,21 @@ function normalizeExceptionCause(cause: unknown, seen: WeakSet<Error> = new Weak
 
 function normalizeReportError(error: unknown): NormalizedReportError {
   if (error instanceof Error) {
-    return {
-      attributes: {
-        ...(error.cause !== undefined ? { [ATTR_EXCEPTION_CAUSE]: normalizeErrorCause(error) } : {}),
-        [ATTR_EXCEPTION_MESSAGE]: error.message,
-        [ATTR_EXCEPTION_STACKTRACE]: error.cause === undefined ? error.stack : formatErrorStackWithCauses(error),
-      },
-      fingerprintSource: error,
-      recordExceptionValue: normalizeRecordException(error),
-      statusMessage: `${error.name}: ${error.message}`,
+    try {
+      const errorMessage = getSafeErrorMessage(error)
+      const cause = error.cause
+      return {
+        attributes: {
+          ...(cause !== undefined ? { [ATTR_EXCEPTION_CAUSE]: normalizeErrorCause(error) } : {}),
+          [ATTR_EXCEPTION_MESSAGE]: errorMessage,
+          [ATTR_EXCEPTION_STACKTRACE]: cause === undefined ? getSafeErrorStack(error) : formatErrorStackWithCauses(error),
+        },
+        fingerprintSource: error,
+        recordExceptionValue: normalizeRecordException(error),
+        statusMessage: `${getSafeErrorName(error)}: ${errorMessage}`,
+      }
+    } catch {
+      return getReportErrorFallback(error)
     }
   }
 
@@ -863,7 +932,11 @@ function reportErrorWithSettings(
   }
 
   if (logfireApiConfig.enableErrorFingerprinting && normalized.fingerprintSource !== undefined) {
-    attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY] = computeFingerprint(normalized.fingerprintSource)
+    try {
+      attributes[ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY] = computeFingerprint(normalized.fingerprintSource)
+    } catch {
+      // Error fingerprinting is best-effort and should not prevent reporting.
+    }
   }
 
   const span = startSpanWithSettings(settings, message, attributes, reportErrorOptionsToLogOptions(options))

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -1,4 +1,4 @@
-import type { Attributes, Context, HrTime, Span } from '@opentelemetry/api'
+import type { Attributes, Context, Exception, HrTime, Span } from '@opentelemetry/api'
 import {
   INVALID_SPAN_CONTEXT,
   SpanStatusCode,
@@ -269,16 +269,19 @@ function buildSerializedLogfireAttributes(
 ): {
   formattedMessage: string
   newTemplate: string
+  serializationAttributes: Record<string, unknown>
   serializedAttributes: Attributes
 } {
   const { formattedMessage, extraAttributes, newTemplate } = logfireFormatWithExtras(msgTemplate, attributes, logfireApiConfig.scrubber)
   const userAttributes = { ...attributes, ...extraAttributes }
+  const serializationAttributes = { ...getBaggageSpanAttributes(userAttributes), ...userAttributes }
 
   return {
     formattedMessage,
     newTemplate,
+    serializationAttributes,
     serializedAttributes: {
-      ...serializeAttributes({ ...getBaggageSpanAttributes(userAttributes), ...userAttributes }),
+      ...serializeAttributes(serializationAttributes),
       [ATTRIBUTES_MESSAGE_TEMPLATE_KEY]: newTemplate,
       [ATTRIBUTES_MESSAGE_KEY]: formattedMessage,
       [ATTRIBUTES_LEVEL_KEY]: level,
@@ -371,7 +374,7 @@ function safeSetSpanAttribute(span: Span, key: string, value: SerializedAttribut
   try {
     span.setAttribute(key, value)
   } catch {
-    // Return recording is best-effort and must never change function outcome.
+    // Late-added metadata is best-effort and must never change function outcome.
   }
 }
 
@@ -386,6 +389,20 @@ function recordReturnAttributes(span: Span, spanSerializationAttributes: Record<
     }
   } catch {
     safeSetSpanAttribute(span, 'return', '[unserializable]')
+  }
+}
+
+function recordSerializedAttributes(span: Span, attributes: Record<string, unknown>, keys: readonly string[]): void {
+  try {
+    const serializedAttributes = serializeAttributes(attributes)
+    for (const key of keys) {
+      const serializedValue = serializedAttributes[key]
+      if (serializedValue !== undefined) {
+        safeSetSpanAttribute(span, key, serializedValue)
+      }
+    }
+  } catch {
+    // Exception metadata is best-effort and must never change error propagation.
   }
 }
 
@@ -538,7 +555,7 @@ function spanWithSettings<R>(
     return withNoopSpan(callback)
   }
 
-  const { serializedAttributes } = buildSerializedLogfireAttributes(msgTemplate, attributes, { tags, level })
+  const { serializationAttributes, serializedAttributes } = buildSerializedLogfireAttributes(msgTemplate, attributes, { tags, level })
 
   const context = parentSpan ? TheTraceAPI.setSpan(TheContextAPI.active(), parentSpan) : TheContextAPI.active()
   return logfireApiConfig.tracer.startActiveSpan(
@@ -552,7 +569,7 @@ function spanWithSettings<R>(
       try {
         result = callback(span)
       } catch (thrown) {
-        recordSpanException(span, thrown)
+        recordSpanException(span, thrown, serializationAttributes)
         span.end()
         throw thrown
       }
@@ -563,7 +580,7 @@ function spanWithSettings<R>(
             span.end()
           },
           (reason: unknown) => {
-            recordSpanException(span, reason)
+            recordSpanException(span, reason, serializationAttributes)
             span.end()
           }
         )
@@ -675,26 +692,37 @@ export function instrument<F extends InstrumentableFunction>(fn: F, options: Ins
   return instrumentWithSettings(ROOT_CLIENT_SETTINGS, fn, options)
 }
 
-function recordSpanException(span: Span, thrown: unknown): void {
+function recordSpanException(span: Span, thrown: unknown, spanSerializationAttributes: Record<string, unknown> = {}): void {
   const isError = thrown instanceof Error
   const errorMessage = isError ? thrown.message : String(thrown)
   const errorName = isError ? thrown.name : 'Error'
 
-  span.recordException(isError ? thrown : String(thrown))
+  span.recordException(isError ? normalizeRecordException(thrown) : String(thrown))
   span.setStatus({ code: SpanStatusCode.ERROR, message: `${errorName}: ${errorMessage}` })
   span.setAttribute(ATTRIBUTES_LEVEL_KEY, Level.Error)
 
   if (isError && logfireApiConfig.enableErrorFingerprinting) {
     span.setAttribute(ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY, computeFingerprint(thrown))
   }
+
+  if (isError && thrown.cause !== undefined) {
+    recordSerializedAttributes(span, { ...spanSerializationAttributes, [ATTR_EXCEPTION_CAUSE]: normalizeErrorCause(thrown) }, [
+      ATTR_EXCEPTION_CAUSE,
+      JSON_SCHEMA_KEY,
+      JSON_NULL_FIELDS_KEY,
+      ATTRIBUTES_SCRUBBED_KEY,
+    ])
+  }
 }
 
 interface NormalizedReportError {
   attributes: Record<string, unknown>
   fingerprintSource?: Error
-  recordExceptionValue: Error | string
+  recordExceptionValue: Exception
   statusMessage: string
 }
+
+const ATTR_EXCEPTION_CAUSE = 'exception.cause' as const
 
 function stringifyThrownValue(thrown: unknown): string {
   try {
@@ -704,15 +732,93 @@ function stringifyThrownValue(thrown: unknown): string {
   }
 }
 
+function formatErrorStackWithCauses(error: Error, seen: WeakSet<Error> = new WeakSet<Error>()): string {
+  if (seen.has(error)) {
+    return `[Circular cause: ${error.name}: ${error.message}]`
+  }
+  seen.add(error)
+
+  const stack = error.stack ?? `${error.name}: ${error.message}`
+  if (error.cause === undefined) {
+    return stack
+  }
+
+  const cause = error.cause instanceof Error ? formatErrorStackWithCauses(error.cause, seen) : stringifyThrownValue(error.cause)
+  return `${stack}\nCaused by: ${cause}`
+}
+
+function getErrorCode(error: Error): string | number | undefined {
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' || typeof code === 'number' ? code : undefined
+}
+
+function normalizeRecordException(error: Error): Exception {
+  if (error.cause === undefined) {
+    return error
+  }
+
+  const code = getErrorCode(error)
+  return {
+    ...(code !== undefined ? { code } : {}),
+    message: error.message,
+    name: error.name,
+    stack: formatErrorStackWithCauses(error),
+  }
+}
+
+function normalizeErrorCause(error: Error): unknown {
+  const seen = new WeakSet<Error>()
+  seen.add(error)
+  return normalizeExceptionCause(error.cause, seen)
+}
+
+function normalizeExceptionCause(cause: unknown, seen: WeakSet<Error> = new WeakSet<Error>()): unknown {
+  if (!(cause instanceof Error)) {
+    return { value: cause }
+  }
+
+  if (seen.has(cause)) {
+    return {
+      circular: true,
+      message: cause.message,
+      type: cause.name,
+    }
+  }
+  seen.add(cause)
+
+  const code = getErrorCode(cause)
+  const normalized: Record<string, unknown> = {
+    message: cause.message,
+    stacktrace: cause.stack,
+    type: cause.name,
+    ...(code !== undefined ? { code } : {}),
+  }
+
+  for (const [key, value] of Object.entries(cause)) {
+    if (['cause', 'code', 'message', 'name', 'stack'].includes(key)) {
+      continue
+    }
+    normalized[key] = value
+  }
+
+  if (cause.cause !== undefined) {
+    normalized['cause'] = normalizeExceptionCause(cause.cause, seen)
+  }
+
+  seen.delete(cause)
+  return normalized
+}
+
 function normalizeReportError(error: unknown): NormalizedReportError {
   if (error instanceof Error) {
     return {
       attributes: {
+        ...(error.cause !== undefined ? { [ATTR_EXCEPTION_CAUSE]: normalizeErrorCause(error) } : {}),
         [ATTR_EXCEPTION_MESSAGE]: error.message,
-        [ATTR_EXCEPTION_STACKTRACE]: error.stack,
+        [ATTR_EXCEPTION_STACKTRACE]: error.cause === undefined ? error.stack : formatErrorStackWithCauses(error),
       },
       fingerprintSource: error,
-      recordExceptionValue: error,
+      recordExceptionValue: normalizeRecordException(error),
       statusMessage: `${error.name}: ${error.message}`,
     }
   }


### PR DESCRIPTION
## Summary

- include `Error.cause` chains in recorded exception stacktraces for `reportError()` and span/instrument callback failures
- add a structured `exception.cause` Logfire attribute that uses the existing JSON serialization + `logfire.json_schema` metadata path
- preserve useful enumerable cause metadata such as `code`, `statusCode`, `details`, `operation`, and nested causes
- add an Express demo endpoint at `/structured-cause-error` so the resulting shape can be inspected in the Logfire UI

## Context

A user reported that the JavaScript SDK currently omits `Error.cause`, which is often where the actionable debugging context lives. Upstream OpenTelemetry JS currently maps exceptions to `exception.type`, `exception.message`, and `exception.stacktrace`, so passing a raw JS `Error` to `recordException()` loses `cause`.

Relevant upstream context:

- OTel JS issue: `recordException should support chained exceptions`  
  https://github.com/open-telemetry/opentelemetry-js/issues/4227
- OTel semantic conventions issue tracking the cross-language representation problem  
  https://github.com/open-telemetry/semantic-conventions/issues/941
- OTel JS follow-up to consider adding `exception.cause?.stack` into `ATTR_EXCEPTION_STACKTRACE`  
  https://github.com/open-telemetry/opentelemetry-js/issues/6423
- OTel JS logs exception PR discussion where `exception.cause` was called out as a follow-up  
  https://github.com/open-telemetry/opentelemetry-js/pull/6385
- Current OTel JS `Span.recordException()` implementation only reads `code/name`, `message`, and `stack`  
  https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/sdk-trace/src/Span.ts

## Approach

This keeps the standard OTel attributes useful by appending the cause chain to `exception.stacktrace`. That matches the upstream direction in open-telemetry/opentelemetry-js#6423 and is compatible with generic OTel consumers.

For Logfire specifically, we also emit `exception.cause` as a serialized JSON object using the SDK's existing object serialization mechanism. That gives the Logfire UI structured data with `logfire.json_schema`, instead of flattening all cause information into an opaque stack string. The structured object is recursive, handles circular chains, and includes enumerable custom fields on caused errors.

This avoids introducing a new dependency or waiting on OTel semantic-convention changes while still leaving the standard `exception.*` surface intact.

## Validation

- `vp run logfire#test -- -t "cause chain"`
- `vp run logfire#typecheck`
- `vp run logfire#test`
- `vp fmt --check packages/logfire-api/src/index.ts packages/logfire-api/src/index.test.ts .changeset/tame-errors-cause.md`
- `pnpm build`
- `pnpm --dir examples/express exec tsc --noEmit`
- local Express smoke test with `LOGFIRE_SEND_TO_LOGFIRE=false` against `/structured-cause-error`
