### PR TITLE
Add 'Part of the Pydantic Stack' footer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,14 @@ try {
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development instructions.
 
+## Part of the Pydantic Stack
+
+The Pydantic Stack is everything you need to ship production-grade AI agents:
+
+- [Pydantic AI](https://pydantic.dev/pydantic-ai?utm_source=github&utm_medium=readme&utm_campaign=logfire-js) - Type-safe agent framework
+- [Pydantic Logfire](https://pydantic.dev/logfire?utm_source=github&utm_medium=readme&utm_campaign=logfire-js) - AI-first, full-stack observability
+- [Logfire AI Gateway](https://pydantic.dev/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=logfire-js) - Unified LLM proxy
+
 ## License
 
 MIT


### PR DESCRIPTION
Adds a short "Part of the Pydantic Stack" footer to the README so readers can discover the other products in one place. 