### PR TITLE
Support OpenTelemetry logs SDK constructor changes

### DIFF
--- a/.changeset/soft-clouds-logs-sdk.md
+++ b/.changeset/soft-clouds-logs-sdk.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Support both legacy and options-object BatchLogRecordProcessor constructor shapes across OpenTelemetry SDK logs releases.

--- a/packages/logfire-node/src/__test__/logsExporter.test.ts
+++ b/packages/logfire-node/src/__test__/logsExporter.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+import type { LogRecordExporter } from '@opentelemetry/sdk-logs'
+
+const EXPORT_SUCCESS = { code: 0 }
+
+function makeExporter(): LogRecordExporter {
+  return {
+    export: (_logs, resultCallback) => {
+      resultCallback(EXPORT_SUCCESS)
+    },
+    forceFlush: async () => Promise.resolve(),
+    shutdown: async () => Promise.resolve(),
+  }
+}
+
+async function importWithBatchLogRecordProcessor(BatchLogRecordProcessor: unknown) {
+  vi.resetModules()
+  vi.doMock('@opentelemetry/sdk-logs', () => ({
+    BatchLogRecordProcessor,
+  }))
+  return import('../logsExporter')
+}
+
+describe('logsExporter', () => {
+  afterEach(() => {
+    vi.doUnmock('@opentelemetry/sdk-logs')
+    vi.resetModules()
+  })
+
+  it('constructs BatchLogRecordProcessor with the options-object shape when supported', async () => {
+    const constructorArgs: unknown[] = []
+
+    const OptionsBatchLogRecordProcessorBase = (_options: { exporter?: unknown }) => undefined
+
+    function OptionsBatchLogRecordProcessor(this: object, options: { exporter?: unknown }) {
+      constructorArgs.push(options)
+    }
+    Object.setPrototypeOf(OptionsBatchLogRecordProcessor, OptionsBatchLogRecordProcessorBase)
+
+    const { makeBatchLogRecordProcessor } = await importWithBatchLogRecordProcessor(OptionsBatchLogRecordProcessor)
+    const exporter = makeExporter()
+
+    const processor = makeBatchLogRecordProcessor(exporter)
+
+    expect(processor).toBeInstanceOf(OptionsBatchLogRecordProcessor)
+    expect(constructorArgs).toEqual([{ exporter }])
+  })
+
+  it('falls back to the legacy exporter-argument shape when options are not supported', async () => {
+    const constructorArgs: unknown[] = []
+
+    const LegacyBatchLogRecordProcessorBase = (_exporter: unknown, _config?: unknown) => undefined
+
+    function LegacyBatchLogRecordProcessor(this: object, exporter: unknown) {
+      constructorArgs.push(exporter)
+    }
+    Object.setPrototypeOf(LegacyBatchLogRecordProcessor, LegacyBatchLogRecordProcessorBase)
+
+    const { makeBatchLogRecordProcessor } = await importWithBatchLogRecordProcessor(LegacyBatchLogRecordProcessor)
+    const exporter = makeExporter()
+
+    const processor = makeBatchLogRecordProcessor(exporter)
+
+    expect(processor).toBeInstanceOf(LegacyBatchLogRecordProcessor)
+    expect(constructorArgs).toEqual([exporter])
+  })
+})

--- a/packages/logfire-node/src/logsExporter.ts
+++ b/packages/logfire-node/src/logsExporter.ts
@@ -1,8 +1,28 @@
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-proto'
-import type { LogRecordProcessor } from '@opentelemetry/sdk-logs'
+import type { LogRecordExporter, LogRecordProcessor } from '@opentelemetry/sdk-logs'
 import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs'
 
 import { logfireConfig } from './logfireConfig'
+
+type BatchLogRecordProcessorConstructor = {
+  legacy: new (exporter: LogRecordExporter) => LogRecordProcessor
+  options: new (options: { exporter: LogRecordExporter }) => LogRecordProcessor
+}
+
+export function makeBatchLogRecordProcessor(exporter: LogRecordExporter): LogRecordProcessor {
+  const Constructor = BatchLogRecordProcessor as unknown as BatchLogRecordProcessorConstructor['legacy'] &
+    BatchLogRecordProcessorConstructor['options']
+  const BaseConstructor = Object.getPrototypeOf(BatchLogRecordProcessor) as { readonly length: number } | null
+
+  // @opentelemetry/sdk-logs changed the constructor from `(exporter, config?)`
+  // to `({ exporter, ...config })` in 0.220. Support both shapes because our
+  // peer range deliberately spans the experimental 0.x logs package.
+  if (BaseConstructor?.length === 2) {
+    return new Constructor(exporter)
+  }
+
+  return new Constructor({ exporter })
+}
 
 /**
  * Returns a `BatchLogRecordProcessor` wired to the Logfire OTLP /v1/logs endpoint.
@@ -16,7 +36,7 @@ export function logfireLogRecordProcessor(): LogRecordProcessor | null {
   if (!logfireConfig.sendToLogfire || !(typeof token === 'function' || (token !== undefined && token !== ''))) {
     return null
   }
-  return new BatchLogRecordProcessor(
+  return makeBatchLogRecordProcessor(
     new OTLPLogExporter({
       headers: logfireConfig.authorizationHeaders,
       url: logfireConfig.logsExporterUrl,


### PR DESCRIPTION
## Summary

Support both `BatchLogRecordProcessor` constructor shapes from `@opentelemetry/sdk-logs`.

OpenTelemetry SDK logs `0.220.0` changed the processor constructor from the legacy `(exporter, config?)` form to an options object containing `exporter`. `@pydantic/logfire-node` already allows a broad experimental SDK logs peer range, so this keeps current `0.219.x` installs working while allowing consumers to resolve `0.220.x` once it clears the minimum release age policy.

## Changes

- Add a small constructor compatibility helper for Logfire's logs exporter processor.
- Add tests covering both the options-object and legacy constructor shapes.
- Add a patch changeset for `@pydantic/logfire-node`.

## Validation

- `vp run @pydantic/logfire-node#test`
- `vp run @pydantic/logfire-node#typecheck`
- `pnpm run format-check`
- Push hook package build/test suite
