### PR TITLE
Make Cloudflare header capture opt-in

### DIFF
--- a/.changeset/calm-headers-warn.md
+++ b/.changeset/calm-headers-warn.md
@@ -1,0 +1,10 @@
+---
+"@pydantic/logfire-cf-workers": major
+"@pydantic/otel-cf-workers": major
+---
+
+Stop capturing all Cloudflare Worker request and response headers by default.
+Header span attributes now require explicit opt-in through
+`captureHeaders.request` and `captureHeaders.response`, using case-insensitive
+header name arrays, predicate functions, or `true` when full capture is
+intentionally required.

--- a/packages/logfire-cf-workers/README.md
+++ b/packages/logfire-cf-workers/README.md
@@ -61,6 +61,11 @@ export default instrumentWorker(handler, {
   service: {
     name: 'my-worker',
   },
+  fetch: {
+    captureHeaders: {
+      request: ['x-request-id'],
+    },
+  },
   handlers: {
     fetch: {
       captureHeaders: {

--- a/packages/logfire-cf-workers/README.md
+++ b/packages/logfire-cf-workers/README.md
@@ -52,6 +52,29 @@ export const Counter = instrumentDO(CounterDurableObject, {
 })
 ```
 
+Request and response headers are not captured as span attributes by default. To
+record specific headers, use the Cloudflare OpenTelemetry config fields exposed
+through this package's existing `fetch` and `handlers` options:
+
+```ts
+export default instrumentWorker(handler, {
+  service: {
+    name: 'my-worker',
+  },
+  handlers: {
+    fetch: {
+      captureHeaders: {
+        request: ['x-request-id'],
+        response: ['cache-control'],
+      },
+    },
+  },
+})
+```
+
+Logfire scrubbing still helps redact sensitive attributes before export, but it
+is a backstop. Prefer explicit header capture over capturing every header.
+
 ## Runtime lifecycle
 
 Cloudflare Workers do not have a process-style shutdown hook. Logfire relies on

--- a/packages/otel-cf-workers/README.md
+++ b/packages/otel-cf-workers/README.md
@@ -171,6 +171,44 @@ const fetchConf = (request: Request): boolean => {
 }
 ```
 
+Request and response headers are not captured as span attributes by default.
+Capture the headers you need with `captureHeaders.request` and
+`captureHeaders.response`. Header names are matched case-insensitively, and
+captured values are recorded as arrays on `http.request.header.<name>` and
+`http.response.header.<name>`.
+
+```typescript
+const fetch = {
+  captureHeaders: {
+    request: ['x-request-id'],
+    response: ['cache-control'],
+  },
+}
+```
+
+You can use a predicate for dynamic selection:
+
+```typescript
+const fetch = {
+  captureHeaders: {
+    request: (name: string) => name.startsWith('x-'),
+  },
+}
+```
+
+Set a selector to `true` only when you intentionally want to capture every
+header. This can record sensitive values such as cookies and authorization
+tokens.
+
+```typescript
+const fetch = {
+  captureHeaders: {
+    request: true,
+    response: true,
+  },
+}
+```
+
 ### Handlers
 
 The `handlers` field of the configuration overrides the way in which event handlers, such as `fetch` or `queue`, are instrumented.
@@ -185,6 +223,20 @@ Example:
 ```typescript
 const fetchConf = (request: Request): boolean => {
   return new URL(request.url).hostname === 'example.com'
+}
+```
+
+Incoming Worker fetch spans use the same explicit header capture shape under
+`handlers.fetch.captureHeaders`:
+
+```typescript
+const handlers = {
+  fetch: {
+    captureHeaders: {
+      request: ['x-request-id'],
+      response: ['cache-control'],
+    },
+  },
 }
 ```
 

--- a/packages/otel-cf-workers/src/config.ts
+++ b/packages/otel-cf-workers/src/config.ts
@@ -47,10 +47,12 @@ export function parseConfig(supplied: TraceConfig): ResolvedTraceConfig {
     return {
       fetch: {
         includeTraceContext: supplied.fetch?.includeTraceContext ?? true,
+        captureHeaders: supplied.fetch?.captureHeaders ?? {},
       },
       handlers: {
         fetch: {
           acceptTraceContext: supplied.handlers?.fetch?.acceptTraceContext ?? true,
+          captureHeaders: supplied.handlers?.fetch?.captureHeaders ?? {},
         },
       },
       postProcessor: supplied.postProcessor ?? ((spans: ReadableSpan[]) => spans),

--- a/packages/otel-cf-workers/src/instrumentation/do.ts
+++ b/packages/otel-cf-workers/src/instrumentation/do.ts
@@ -1,7 +1,7 @@
 import type { Exception, SpanOptions } from '@opentelemetry/api'
 import { context as api_context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
 import type { Initialiser } from '../config.js'
-import { setConfig } from '../config.js'
+import { getActiveConfig, setConfig } from '../config.js'
 import { ATTR_FAAS_COLDSTART, ATTR_FAAS_TRIGGER } from '../semconv.js'
 import type { DOConstructorTrigger } from '../types.js'
 import { passthroughGet, unwrap, wrap } from '../wrap.js'
@@ -31,7 +31,7 @@ function instrumentBindingStub(stub: DurableObjectStub, nsName: string): Durable
           'do.id': target.id.toString(),
           'do.id.name': target.id.name,
         }
-        return instrumentClientFetch(fetcher, () => ({ includeTraceContext: true }), attrs)
+        return instrumentClientFetch(fetcher, (config) => ({ ...config.fetch, includeTraceContext: true }), attrs)
       } else {
         return passthroughGet(target, prop)
       }
@@ -90,6 +90,7 @@ let cold_start = true
 export type DOClass<Env = Record<string, unknown>> = new (state: DurableObjectState, env: Env) => DurableObject
 export async function executeDOFetch(fetchFn: FetchFn, request: Request, id: DurableObjectId): Promise<Response> {
   const spanContext = getParentContextFromHeaders(request.headers)
+  const captureHeaders = getActiveConfig()?.handlers?.fetch?.captureHeaders
 
   const tracer = trace.getTracer('DO fetchHandler')
   const attributes = {
@@ -97,7 +98,7 @@ export async function executeDOFetch(fetchFn: FetchFn, request: Request, id: Dur
     [ATTR_FAAS_COLDSTART]: cold_start,
   }
   cold_start = false
-  Object.assign(attributes, gatherRequestAttributes(request))
+  Object.assign(attributes, gatherRequestAttributes(request, captureHeaders?.request))
   Object.assign(attributes, gatherIncomingCfAttributes(request))
   const options: SpanOptions = {
     attributes,
@@ -111,7 +112,7 @@ export async function executeDOFetch(fetchFn: FetchFn, request: Request, id: Dur
       if (response.ok) {
         span.setStatus({ code: SpanStatusCode.OK })
       }
-      span.setAttributes(gatherResponseAttributes(response))
+      span.setAttributes(gatherResponseAttributes(response, captureHeaders?.response))
       span.end()
 
       return response

--- a/packages/otel-cf-workers/src/instrumentation/fetch.ts
+++ b/packages/otel-cf-workers/src/instrumentation/fetch.ts
@@ -107,7 +107,10 @@ function gatherHeaderAttributes(
   for (const [rawKey, value] of headers.entries()) {
     const key = rawKey.toLowerCase()
     if (shouldCaptureHeader(selector, key, value)) {
-      attrs[`${prefix}.${key}`] = [value]
+      const attrKey = `${prefix}.${key}`
+      const existingValue = attrs[attrKey]
+      const existingValues = Array.isArray(existingValue) ? existingValue.filter((item): item is string => typeof item === 'string') : []
+      attrs[attrKey] = [...existingValues, value]
     }
   }
 }

--- a/packages/otel-cf-workers/src/instrumentation/fetch.ts
+++ b/packages/otel-cf-workers/src/instrumentation/fetch.ts
@@ -11,8 +11,16 @@ import { ATTR_FAAS_COLDSTART, ATTR_FAAS_INVOCATION_ID, ATTR_FAAS_TRIGGER } from 
 import { versionAttributes } from './version.js'
 
 export type IncludeTraceContextFn = (request: Request) => boolean
+export type HeaderCapturePredicate = (name: string, value: string) => boolean
+export type HeaderCaptureSelector = boolean | readonly string[] | HeaderCapturePredicate
+export interface HeaderCaptureConfig {
+  request?: HeaderCaptureSelector
+  response?: HeaderCaptureSelector
+}
+
 export interface FetcherConfig {
   includeTraceContext?: boolean | IncludeTraceContextFn
+  captureHeaders?: HeaderCaptureConfig
 }
 
 export type AcceptTraceContextFn = (request: Request) => boolean
@@ -23,6 +31,7 @@ export interface FetchHandlerConfig {
    * @default true
    */
   acceptTraceContext?: boolean | AcceptTraceContextFn
+  captureHeaders?: HeaderCaptureConfig
 }
 
 type FetchHandler = ExportedHandlerFetchHandler
@@ -50,8 +59,38 @@ const gatherOutgoingCfAttributes = (cf: RequestInitCfProperties): Attributes => 
   return attrs
 }
 
-export function gatherRequestAttributes(request: Request): Attributes {
-  const attrs: Record<string, string | number> = {}
+function shouldCaptureHeader(selector: HeaderCaptureSelector | undefined, name: string, value: string): boolean {
+  if (selector === undefined || selector === false) {
+    return false
+  }
+
+  if (selector === true) {
+    return true
+  }
+
+  if (typeof selector === 'function') {
+    return selector(name, value)
+  }
+
+  return selector.some((headerName) => headerName.toLowerCase() === name)
+}
+
+function gatherHeaderAttributes(
+  attrs: Attributes,
+  headers: Headers,
+  prefix: 'http.request.header' | 'http.response.header',
+  selector?: HeaderCaptureSelector
+): void {
+  for (const [rawKey, value] of headers.entries()) {
+    const key = rawKey.toLowerCase()
+    if (shouldCaptureHeader(selector, key, value)) {
+      attrs[`${prefix}.${key}`] = [value]
+    }
+  }
+}
+
+export function gatherRequestAttributes(request: Request, captureHeaders?: HeaderCaptureSelector): Attributes {
+  const attrs: Attributes = {}
   const headers = request.headers
   attrs['http.request.method'] = request.method.toUpperCase()
   attrs['network.protocol.name'] = 'http'
@@ -74,9 +113,7 @@ export function gatherRequestAttributes(request: Request): Attributes {
     attrs['http.accepts'] = request.cf.clientAcceptEncoding
   }
 
-  for (const [key, value] of headers.entries()) {
-    attrs[`http.request.header.${key}`] = value
-  }
+  gatherHeaderAttributes(attrs, headers, 'http.request.header', captureHeaders)
 
   const u = new URL(request.url)
   attrs['url.full'] = `${u.protocol}//${u.host}${u.pathname}${u.search}`
@@ -88,8 +125,8 @@ export function gatherRequestAttributes(request: Request): Attributes {
   return attrs
 }
 
-export function gatherResponseAttributes(response: Response): Attributes {
-  const attrs: Record<string, string | number> = {}
+export function gatherResponseAttributes(response: Response, captureHeaders?: HeaderCaptureSelector): Attributes {
+  const attrs: Attributes = {}
   attrs['http.response.status_code'] = response.status
   const contentLength = response.headers.get('content-length')
   if (contentLength !== null) {
@@ -100,9 +137,7 @@ export function gatherResponseAttributes(response: Response): Attributes {
     attrs['http.mime_type'] = contentType
   }
 
-  for (const [key, value] of response.headers.entries()) {
-    attrs[`http.response.header.${key}`] = value
-  }
+  gatherHeaderAttributes(attrs, response.headers, 'http.response.header', captureHeaders)
   return attrs
 }
 
@@ -161,6 +196,7 @@ export async function waitUntilTrace(fn: () => Promise<unknown>): Promise<void> 
 let cold_start = true
 export async function executeFetchHandler(fetchFn: FetchHandler, [request, env, ctx]: FetchHandlerArgs): Promise<Response> {
   const spanContext = getParentContextFromRequest(request)
+  const captureHeaders = getActiveConfig()?.handlers?.fetch?.captureHeaders
 
   const tracer = trace.getTracer('fetchHandler')
   const attributes = {
@@ -169,7 +205,7 @@ export async function executeFetchHandler(fetchFn: FetchHandler, [request, env, 
     [ATTR_FAAS_INVOCATION_ID]: request.headers.get('cf-ray') ?? undefined,
   }
   cold_start = false
-  Object.assign(attributes, gatherRequestAttributes(request))
+  Object.assign(attributes, gatherRequestAttributes(request, captureHeaders?.request))
   Object.assign(attributes, gatherIncomingCfAttributes(request))
   Object.assign(attributes, versionAttributes(env))
   const options: SpanOptions = {
@@ -182,7 +218,7 @@ export async function executeFetchHandler(fetchFn: FetchHandler, [request, env, 
     const readable = span as unknown as ReadableSpan
     try {
       const response = await fetchFn(request, env, ctx)
-      span.setAttributes(gatherResponseAttributes(response))
+      span.setAttributes(gatherResponseAttributes(response, captureHeaders?.response))
 
       return response
     } catch (error) {
@@ -253,12 +289,12 @@ export function instrumentClientFetch(fetchFn: Fetcher['fetch'], configFn: getFe
               },
             })
           }
-          span.setAttributes(gatherRequestAttributes(request))
+          span.setAttributes(gatherRequestAttributes(request, config.captureHeaders?.request))
           if (request.cf) {
             span.setAttributes(gatherOutgoingCfAttributes(request.cf))
           }
           const response = await Reflect.apply(target, thisArg, [request])
-          span.setAttributes(gatherResponseAttributes(response))
+          span.setAttributes(gatherResponseAttributes(response, config.captureHeaders?.response))
           return response
         } catch (error) {
           span.recordException(error as Exception)

--- a/packages/otel-cf-workers/src/instrumentation/fetch.ts
+++ b/packages/otel-cf-workers/src/instrumentation/fetch.ts
@@ -11,8 +11,25 @@ import { ATTR_FAAS_COLDSTART, ATTR_FAAS_INVOCATION_ID, ATTR_FAAS_TRIGGER } from 
 import { versionAttributes } from './version.js'
 
 export type IncludeTraceContextFn = (request: Request) => boolean
+/**
+ * Predicate for selecting headers to record as span attributes. The header name
+ * is lowercased before this function is called; the value is passed unchanged.
+ */
 export type HeaderCapturePredicate = (name: string, value: string) => boolean
+/**
+ * Controls header capture for request/response span attributes.
+ *
+ * - `true`: capture all headers.
+ * - `string[]`: capture only these header names, matched case-insensitively.
+ * - function: capture headers when the predicate returns `true`.
+ *
+ * @default undefined No headers are captured.
+ */
 export type HeaderCaptureSelector = boolean | readonly string[] | HeaderCapturePredicate
+/**
+ * Explicit request and response header capture selectors. Header capture is
+ * disabled by default to avoid recording sensitive values.
+ */
 export interface HeaderCaptureConfig {
   request?: HeaderCaptureSelector
   response?: HeaderCaptureSelector
@@ -20,6 +37,9 @@ export interface HeaderCaptureConfig {
 
 export interface FetcherConfig {
   includeTraceContext?: boolean | IncludeTraceContextFn
+  /**
+   * Explicit header capture for outbound fetch spans.
+   */
   captureHeaders?: HeaderCaptureConfig
 }
 
@@ -31,6 +51,9 @@ export interface FetchHandlerConfig {
    * @default true
    */
   acceptTraceContext?: boolean | AcceptTraceContextFn
+  /**
+   * Explicit header capture for incoming fetch handler spans.
+   */
   captureHeaders?: HeaderCaptureConfig
 }
 

--- a/packages/otel-cf-workers/src/instrumentation/service.ts
+++ b/packages/otel-cf-workers/src/instrumentation/service.ts
@@ -9,7 +9,7 @@ export function instrumentServiceBinding(fetcher: Fetcher, envName: string): Fet
         const attrs = {
           name: `Service Binding ${envName}`,
         }
-        return instrumentClientFetch(fetcher, () => ({ includeTraceContext: true }), attrs)
+        return instrumentClientFetch(fetcher, (config) => ({ ...config.fetch, includeTraceContext: true }), attrs)
       } else {
         return passthroughGet(target, prop)
       }

--- a/packages/otel-cf-workers/src/types.ts
+++ b/packages/otel-cf-workers/src/types.ts
@@ -9,6 +9,14 @@ export type PostProcessorFn = (spans: ReadableSpan[]) => ReadableSpan[]
 
 export type ExporterConfig = OTLPExporterConfig | SpanExporter
 
+export type {
+  FetchHandlerConfig,
+  FetcherConfig,
+  HeaderCaptureConfig,
+  HeaderCapturePredicate,
+  HeaderCaptureSelector,
+} from './instrumentation/fetch.js'
+
 export interface HandlerConfig {
   fetch?: FetchHandlerConfig
 }

--- a/packages/otel-cf-workers/test/instrumentation/do.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/do.test.ts
@@ -1,8 +1,14 @@
 /// <reference types="@cloudflare/workers-types" />
 
+import type { Span, SpanOptions, Tracer, SpanStatusCode } from '@opentelemetry/api'
+import { context as apiContext, trace } from '@opentelemetry/api'
 import { describe, expect, it, vitest } from 'vitest'
+import { setConfig } from '../../src/config'
+import { AsyncLocalStorageContextManager } from '../../src/context'
 import type { ResolvedTraceConfig } from '../../src/types'
-import { instrumentDOClass } from '../../src/instrumentation/do'
+import { executeDOFetch, instrumentDOClass } from '../../src/instrumentation/do'
+
+apiContext.setGlobalContextManager(new AsyncLocalStorageContextManager())
 
 type FetchWithRequest = (request: Request) => Response | Promise<Response>
 
@@ -56,6 +62,31 @@ function createDurableObjectState(): TestDurableObjectState {
 }
 
 const resolvedConfig = {} as ResolvedTraceConfig
+
+function createSpan() {
+  return {
+    attributes: {} as Record<string, unknown>,
+    end: vitest.fn<() => void>(),
+    recordException: vitest.fn<(exception: unknown) => void>(),
+    setAttribute: vitest.fn<(key: string, value: unknown) => void>(),
+    setAttributes: vitest.fn<(attributes: Record<string, unknown>) => void>(),
+    setStatus: vitest.fn<(status: { code: SpanStatusCode }) => void>(),
+  }
+}
+
+function mockTracer(span: Span, onStart?: (name: string, args: unknown[]) => void) {
+  return {
+    async startActiveSpan(name: string, ...args: unknown[]) {
+      onStart?.(name, args)
+      const options = args.find((arg): arg is SpanOptions => typeof arg === 'object' && arg !== null && 'attributes' in arg)
+      if (options?.attributes) {
+        ;(span as Span & { attributes: Record<string, unknown> }).attributes = options.attributes as Record<string, unknown>
+      }
+      const fn = args.at(-1) as (span: Span) => Promise<unknown>
+      return fn(span)
+    },
+  } as unknown as Tracer
+}
 
 class CustomMethodDurableObject implements DurableObject {
   count = 0
@@ -131,6 +162,65 @@ describe('instrumentDOClass', () => {
       await Promise.allSettled(durableObjectState.waitUntilPromises)
     } finally {
       consoleError.mockRestore()
+    }
+  })
+})
+
+describe('executeDOFetch', () => {
+  it('uses handler header capture config for Durable Object request and response spans', async () => {
+    const span = createSpan()
+    let spanOptions: SpanOptions | undefined
+    const tracer = mockTracer(span as unknown as Span, (_name, args) => {
+      spanOptions = args[0] as SpanOptions
+    })
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(tracer)
+    const fetcher = vitest.fn<FetchWithRequest>(() => {
+      return new Response('ok', {
+        headers: {
+          'Set-Cookie': 'session=secret',
+          'X-Do-Response': 'res-1',
+        },
+      })
+    })
+    const activeContext = setConfig({
+      handlers: {
+        fetch: {
+          captureHeaders: {
+            request: ['x-do-request'],
+            response: ['x-do-response'],
+          },
+        },
+      },
+    } as unknown as ResolvedTraceConfig)
+
+    try {
+      await apiContext.with(activeContext, async () => {
+        await executeDOFetch(
+          fetcher,
+          new Request('https://example.com', {
+            headers: {
+              Authorization: 'Bearer secret',
+              'X-Do-Request': 'req-1',
+            },
+          }),
+          durableObjectId
+        )
+      })
+
+      expect(spanOptions?.attributes).toMatchObject({
+        'http.request.header.x-do-request': ['req-1'],
+      })
+      expect(spanOptions?.attributes).not.toHaveProperty('http.request.header.authorization')
+      expect(span.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'http.response.header.x-do-response': ['res-1'],
+        })
+      )
+      expect(span.setAttributes).not.toHaveBeenCalledWith(
+        expect.objectContaining({ 'http.response.header.set-cookie': ['session=secret'] })
+      )
+    } finally {
+      getTracer.mockRestore()
     }
   })
 })

--- a/packages/otel-cf-workers/test/instrumentation/fetch.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/fetch.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@cloudflare/workers-types" />
+
 import type { Span, SpanOptions, Tracer } from '@opentelemetry/api'
 import { context as apiContext, SpanStatusCode, trace } from '@opentelemetry/api'
 import { describe, expect, it, vitest } from 'vitest'
@@ -151,6 +153,19 @@ describe('gatherResponseAttributes', () => {
 
     expect(attrs['http.response.header.x-response-id']).toEqual(['res-1'])
     expect(attrs).not.toHaveProperty('http.response.header.set-cookie')
+  })
+
+  it('appends repeated response header entries to the captured value array', () => {
+    const headers = new Headers()
+    headers.append('Set-Cookie', 'session=secret')
+    headers.append('Set-Cookie', 'theme=dark')
+    headers.append('X-Response-Id', 'res-1')
+    const response = new Response('ok', { headers })
+
+    const attrs = gatherResponseAttributes(response, ['set-cookie', 'x-response-id'])
+
+    expect(attrs['http.response.header.set-cookie']).toEqual(['session=secret', 'theme=dark'])
+    expect(attrs['http.response.header.x-response-id']).toEqual(['res-1'])
   })
 })
 

--- a/packages/otel-cf-workers/test/instrumentation/fetch.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/fetch.test.ts
@@ -1,31 +1,158 @@
-import type { Span, Tracer } from '@opentelemetry/api'
+import type { Span, SpanOptions, Tracer } from '@opentelemetry/api'
 import { context as apiContext, SpanStatusCode, trace } from '@opentelemetry/api'
 import { describe, expect, it, vitest } from 'vitest'
 import { setConfig } from '../../src/config'
 import { AsyncLocalStorageContextManager } from '../../src/context'
-import { instrumentClientFetch, waitUntilTrace } from '../../src/instrumentation/fetch'
+import {
+  executeFetchHandler,
+  gatherRequestAttributes,
+  gatherResponseAttributes,
+  instrumentClientFetch,
+  waitUntilTrace,
+} from '../../src/instrumentation/fetch'
 import type { ResolvedTraceConfig } from '../../src/types'
 
 apiContext.setGlobalContextManager(new AsyncLocalStorageContextManager())
 
 function createSpan() {
   return {
+    attributes: {} as Record<string, unknown>,
     end: vitest.fn<() => void>(),
     recordException: vitest.fn<(exception: unknown) => void>(),
     setAttribute: vitest.fn<(key: string, value: unknown) => void>(),
     setAttributes: vitest.fn<(attributes: Record<string, unknown>) => void>(),
     setStatus: vitest.fn<(status: { code: SpanStatusCode }) => void>(),
+    updateName: vitest.fn<(name: string) => void>(),
   }
 }
 
-function mockTracer(span: Span) {
+function mockTracer(span: Span, onStart?: (name: string, args: unknown[]) => void) {
   return {
-    async startActiveSpan(_name: string, ...args: unknown[]) {
+    async startActiveSpan(name: string, ...args: unknown[]) {
+      onStart?.(name, args)
+      const options = args.find((arg): arg is SpanOptions => typeof arg === 'object' && arg !== null && 'attributes' in arg)
+      if (options?.attributes) {
+        ;(span as Span & { attributes: Record<string, unknown> }).attributes = options.attributes as Record<string, unknown>
+      }
       const fn = args.at(-1) as (span: Span) => Promise<unknown>
       return fn(span)
     },
   } as unknown as Tracer
 }
+
+function createExecutionContext(): ExecutionContext {
+  return {
+    passThroughOnException: vitest.fn<() => void>(),
+    props: {},
+    waitUntil: vitest.fn<(promise: Promise<unknown>) => void>(),
+  } as unknown as ExecutionContext
+}
+
+describe('gatherRequestAttributes', () => {
+  it('does not capture request headers by default', () => {
+    const request = new Request('https://example.com/path?query=1', {
+      headers: {
+        Authorization: 'Bearer secret',
+        Cookie: 'session=secret',
+        'Content-Type': 'application/json',
+        'User-Agent': 'test-agent',
+        'X-Request-Id': 'req-1',
+      },
+      method: 'POST',
+    })
+
+    const attrs = gatherRequestAttributes(request)
+
+    expect(attrs).toMatchObject({
+      'http.mime_type': 'application/json',
+      'http.request.method': 'POST',
+      'user_agent.original': 'test-agent',
+      'url.path': '/path',
+      'url.query': '?query=1',
+    })
+    expect(attrs).not.toHaveProperty('http.request.header.authorization')
+    expect(attrs).not.toHaveProperty('http.request.header.cookie')
+    expect(attrs).not.toHaveProperty('http.request.header.x-request-id')
+  })
+
+  it('captures selected request headers as arrays', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        Authorization: 'Bearer secret',
+        'X-Request-Id': 'req-1',
+      },
+    })
+
+    const attrs = gatherRequestAttributes(request, ['X-Request-ID'])
+
+    expect(attrs['http.request.header.x-request-id']).toEqual(['req-1'])
+    expect(attrs).not.toHaveProperty('http.request.header.authorization')
+  })
+
+  it('captures all request headers when explicitly enabled', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        Authorization: 'Bearer secret',
+        'X-Request-Id': 'req-1',
+      },
+    })
+
+    const attrs = gatherRequestAttributes(request, true)
+
+    expect(attrs['http.request.header.authorization']).toEqual(['Bearer secret'])
+    expect(attrs['http.request.header.x-request-id']).toEqual(['req-1'])
+  })
+
+  it('captures request headers selected by a predicate', () => {
+    const request = new Request('https://example.com', {
+      headers: {
+        'Cache-Control': 'no-cache',
+        'X-Request-Id': 'req-1',
+      },
+    })
+
+    const attrs = gatherRequestAttributes(request, (name) => name.startsWith('x-'))
+
+    expect(attrs['http.request.header.x-request-id']).toEqual(['req-1'])
+    expect(attrs).not.toHaveProperty('http.request.header.cache-control')
+  })
+})
+
+describe('gatherResponseAttributes', () => {
+  it('does not capture response headers by default', () => {
+    const response = new Response('ok', {
+      headers: {
+        'Content-Type': 'application/json',
+        'Set-Cookie': 'session=secret',
+        'X-Response-Id': 'res-1',
+      },
+      status: 201,
+    })
+
+    const attrs = gatherResponseAttributes(response)
+
+    expect(attrs).toMatchObject({
+      'http.mime_type': 'application/json',
+      'http.response.status_code': 201,
+    })
+    expect(attrs).not.toHaveProperty('http.response.header.set-cookie')
+    expect(attrs).not.toHaveProperty('http.response.header.x-response-id')
+  })
+
+  it('captures selected response headers as arrays', () => {
+    const response = new Response('ok', {
+      headers: {
+        'Set-Cookie': 'session=secret',
+        'X-Response-Id': 'res-1',
+      },
+    })
+
+    const attrs = gatherResponseAttributes(response, ['x-response-id'])
+
+    expect(attrs['http.response.header.x-response-id']).toEqual(['res-1'])
+    expect(attrs).not.toHaveProperty('http.response.header.set-cookie')
+  })
+})
 
 describe('waitUntilTrace', () => {
   it('records errors and ends the span when traced background work rejects', async () => {
@@ -46,6 +173,59 @@ describe('waitUntilTrace', () => {
 })
 
 describe('instrumentClientFetch', () => {
+  it('uses fetch header capture config for outbound request and response spans', async () => {
+    const span = createSpan()
+    const tracer = mockTracer(span as unknown as Span)
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(tracer)
+    const fetcher = vitest.fn<(request: Request) => Promise<Response>>(async () => {
+      return Promise.resolve(
+        new Response('ok', {
+          headers: {
+            'Set-Cookie': 'session=secret',
+            'X-Client-Response': 'res-1',
+          },
+        })
+      )
+    })
+    const instrumentedFetch = instrumentClientFetch(fetcher as unknown as Fetcher['fetch'], (config) => config.fetch)
+    const activeContext = setConfig({
+      fetch: {
+        captureHeaders: {
+          request: ['x-client-request'],
+          response: ['x-client-response'],
+        },
+        includeTraceContext: false,
+      },
+    } as unknown as ResolvedTraceConfig)
+
+    try {
+      await apiContext.with(activeContext, async () => {
+        await instrumentedFetch('https://example.com', {
+          headers: {
+            Authorization: 'Bearer secret',
+            'X-Client-Request': 'req-1',
+          },
+        })
+      })
+
+      const setAttributesCalls = span.setAttributes.mock.calls.map(([attrs]) => attrs)
+      expect(setAttributesCalls).toContainEqual(
+        expect.objectContaining({
+          'http.request.header.x-client-request': ['req-1'],
+        })
+      )
+      expect(setAttributesCalls).toContainEqual(
+        expect.objectContaining({
+          'http.response.header.x-client-response': ['res-1'],
+        })
+      )
+      expect(setAttributesCalls).not.toContainEqual(expect.objectContaining({ 'http.request.header.authorization': ['Bearer secret'] }))
+      expect(setAttributesCalls).not.toContainEqual(expect.objectContaining({ 'http.response.header.set-cookie': ['session=secret'] }))
+    } finally {
+      getTracer.mockRestore()
+    }
+  })
+
   it('records errors and ends the span when outbound fetch rejects', async () => {
     const error = new Error('fetch failed')
     const span = createSpan()
@@ -53,7 +233,7 @@ describe('instrumentClientFetch', () => {
     const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(tracer)
     const fetcher = vitest.fn<(request: Request) => Promise<Response>>(async () => Promise.reject(error))
     const instrumentedFetch = instrumentClientFetch(fetcher as unknown as Fetcher['fetch'], (config) => config.fetch)
-    const activeContext = setConfig({ fetch: { includeTraceContext: false } } as ResolvedTraceConfig)
+    const activeContext = setConfig({ fetch: { includeTraceContext: false } } as unknown as ResolvedTraceConfig)
 
     try {
       await apiContext.with(activeContext, async () => {
@@ -63,6 +243,66 @@ describe('instrumentClientFetch', () => {
       expect(span.recordException).toHaveBeenCalledWith(error)
       expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR })
       expect(span.end).toHaveBeenCalledTimes(1)
+    } finally {
+      getTracer.mockRestore()
+    }
+  })
+})
+
+describe('executeFetchHandler', () => {
+  it('uses handler header capture config for inbound request and response spans', async () => {
+    const span = createSpan()
+    let spanOptions: SpanOptions | undefined
+    const tracer = mockTracer(span as unknown as Span, (_name, args) => {
+      spanOptions = args[0] as SpanOptions
+    })
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(tracer)
+    const fetcher = vitest.fn<ExportedHandlerFetchHandler>(() => {
+      return new Response('ok', {
+        headers: {
+          'Set-Cookie': 'session=secret',
+          'X-Handler-Response': 'res-1',
+        },
+      })
+    })
+    const activeContext = setConfig({
+      handlers: {
+        fetch: {
+          acceptTraceContext: false,
+          captureHeaders: {
+            request: ['x-handler-request'],
+            response: ['x-handler-response'],
+          },
+        },
+      },
+    } as unknown as ResolvedTraceConfig)
+
+    try {
+      await apiContext.with(activeContext, async () => {
+        await executeFetchHandler(fetcher, [
+          new Request('https://example.com', {
+            headers: {
+              Authorization: 'Bearer secret',
+              'X-Handler-Request': 'req-1',
+            },
+          }) as Parameters<ExportedHandlerFetchHandler>[0],
+          {},
+          createExecutionContext(),
+        ])
+      })
+
+      expect(spanOptions?.attributes).toMatchObject({
+        'http.request.header.x-handler-request': ['req-1'],
+      })
+      expect(spanOptions?.attributes).not.toHaveProperty('http.request.header.authorization')
+      expect(span.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'http.response.header.x-handler-response': ['res-1'],
+        })
+      )
+      expect(span.setAttributes).not.toHaveBeenCalledWith(
+        expect.objectContaining({ 'http.response.header.set-cookie': ['session=secret'] })
+      )
     } finally {
       getTracer.mockRestore()
     }

--- a/packages/otel-cf-workers/test/instrumentation/service.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/service.test.ts
@@ -1,0 +1,86 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import type { Span, Tracer, SpanStatusCode } from '@opentelemetry/api'
+import { context as apiContext, trace } from '@opentelemetry/api'
+import { describe, expect, it, vitest } from 'vitest'
+import { setConfig } from '../../src/config'
+import { AsyncLocalStorageContextManager } from '../../src/context'
+import { instrumentServiceBinding } from '../../src/instrumentation/service'
+import type { ResolvedTraceConfig } from '../../src/types'
+
+apiContext.setGlobalContextManager(new AsyncLocalStorageContextManager())
+
+function createSpan() {
+  return {
+    end: vitest.fn<() => void>(),
+    recordException: vitest.fn<(exception: unknown) => void>(),
+    setAttributes: vitest.fn<(attributes: Record<string, unknown>) => void>(),
+    setStatus: vitest.fn<(status: { code: SpanStatusCode }) => void>(),
+  }
+}
+
+function mockTracer(span: Span) {
+  return {
+    async startActiveSpan(_name: string, ...args: unknown[]) {
+      const fn = args.at(-1) as (span: Span) => Promise<unknown>
+      return fn(span)
+    },
+  } as unknown as Tracer
+}
+
+describe('instrumentServiceBinding', () => {
+  it('uses fetch header capture config for service binding request and response spans', async () => {
+    const span = createSpan()
+    const tracer = mockTracer(span as unknown as Span)
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(tracer)
+    const fetcher = {
+      fetch: vitest.fn<Fetcher['fetch']>(async () =>
+        Promise.resolve(
+          new Response('ok', {
+            headers: {
+              'Set-Cookie': 'session=secret',
+              'X-Service-Response': 'res-1',
+            },
+          })
+        )
+      ),
+    } as unknown as Fetcher
+    const service = instrumentServiceBinding(fetcher, 'API')
+    const activeContext = setConfig({
+      fetch: {
+        captureHeaders: {
+          request: ['x-service-request'],
+          response: ['x-service-response'],
+        },
+        includeTraceContext: false,
+      },
+    } as unknown as ResolvedTraceConfig)
+
+    try {
+      await apiContext.with(activeContext, async () => {
+        await service.fetch('https://example.com', {
+          headers: {
+            Authorization: 'Bearer secret',
+            'X-Service-Request': 'req-1',
+          },
+        })
+      })
+
+      const setAttributesCalls = span.setAttributes.mock.calls.map(([attrs]) => attrs)
+      expect(setAttributesCalls).toContainEqual(
+        expect.objectContaining({
+          'http.request.header.x-service-request': ['req-1'],
+        })
+      )
+      expect(setAttributesCalls).toContainEqual(
+        expect.objectContaining({
+          'http.response.header.x-service-response': ['res-1'],
+        })
+      )
+      expect(setAttributesCalls).not.toContainEqual(expect.objectContaining({ 'http.request.header.authorization': ['Bearer secret'] }))
+      expect(setAttributesCalls).not.toContainEqual(expect.objectContaining({ 'http.response.header.set-cookie': ['session=secret'] }))
+    } finally {
+      getTracer.mockRestore()
+    }
+  })
+})

--- a/plans/021-cf-worker-header-capture-config.md
+++ b/plans/021-cf-worker-header-capture-config.md
@@ -45,9 +45,9 @@ The implementation should:
       values shaped as `string[]`.
 - [ ] Captured response headers use `http.response.header.<lowercase-name>` with
       values shaped as `string[]`.
-- [ ] Worker fetch handler spans, outbound global fetch spans, Durable Object
-      inbound fetch spans, and Durable Object stub outbound fetch spans all use
-      the same config semantics.
+- [ ] Worker fetch handler spans, outbound global fetch spans, service binding
+      outbound fetch spans, Durable Object inbound fetch spans, and Durable
+      Object stub outbound fetch spans all use the same config semantics.
 - [ ] Existing dedicated semantic attributes still appear where currently
       supported: `http.request.method`, `http.request.body.size`,
       `user_agent.original`, `http.mime_type`, `http.accepts`, `url.*`,
@@ -91,6 +91,8 @@ The implementation should:
 - `packages/otel-cf-workers/src/instrumentation/do.ts` - Durable Object inbound
   fetch spans reuse the same gather helpers, and Durable Object stubs use
   `instrumentClientFetch()`.
+- `packages/otel-cf-workers/src/instrumentation/service.ts` - service binding
+  outbound fetch spans use `instrumentClientFetch()`.
 - `packages/otel-cf-workers/src/types.ts` - public `TraceConfig`,
   `FetcherConfig`, and `FetchHandlerConfig` type surface where header capture
   config should be exposed.
@@ -231,6 +233,9 @@ Task 3: Wire request/response capture into span creation
     - Ensure Durable Object inbound fetch spans use handlers.fetch.captureHeaders.
     - Ensure Durable Object stub outbound fetch keeps includeTraceContext true
       while honoring active fetch.captureHeaders for request/response capture.
+  MODIFY packages/otel-cf-workers/src/instrumentation/service.ts:
+    - Ensure service binding outbound fetch keeps includeTraceContext true while
+      honoring active fetch.captureHeaders for request/response capture.
   PATTERN:
     - Prefer passing selectors explicitly to gather helpers over making helpers
       read global context directly.
@@ -253,6 +258,9 @@ Task 4: Tests for defaults and opt-in behavior
     - Add coverage only if config plumbing cannot be adequately covered by fetch
       tests. Prefer a focused test that proves DO inbound fetch does not capture
       sensitive headers by default and honors explicit config.
+  MODIFY packages/otel-cf-workers/test/instrumentation/service.test.ts:
+    - Add a focused regression test that proves service binding outbound fetch
+      honors explicit fetch header capture config.
 
 Task 5: Documentation and migration notes
   MODIFY packages/otel-cf-workers/README.md:
@@ -295,6 +303,8 @@ INSTRUMENTATION:
     Worker fetch handler spans and outbound fetch spans.
   - packages/otel-cf-workers/src/instrumentation/do.ts
     Durable Object inbound and stub outbound fetch spans.
+  - packages/otel-cf-workers/src/instrumentation/service.ts
+    Service binding outbound fetch spans.
 
 LOGFIRE WRAPPER:
   - packages/logfire-cf-workers/src/index.ts
@@ -349,6 +359,7 @@ pnpm run typecheck
 - [ ] Outbound fetch instrumentation uses `fetch.captureHeaders`.
 - [ ] Inbound Worker fetch instrumentation uses `handlers.fetch.captureHeaders`.
 - [ ] Durable Object fetch paths follow the same default and opt-in behavior.
+- [ ] Service binding fetch paths follow the same default and opt-in behavior.
 
 ## Unknowns & Risks
 

--- a/plans/021-cf-worker-header-capture-config.md
+++ b/plans/021-cf-worker-header-capture-config.md
@@ -11,7 +11,7 @@ The implementation should:
 - Add a first-class config surface for explicitly captured request and response
   headers on Worker inbound fetch, outbound fetch, and Durable Object fetch spans.
 - Emit captured header attributes in the OpenTelemetry semantic convention value
-  shape: a string array, usually `[value]` with the Fetch `Headers` API.
+  shape: a string array.
 - Keep existing non-header HTTP semantic attributes such as method, body size,
   status code, content type, user agent, URL, and Cloudflare metadata.
 - Document the behavior change and migration path for users who intentionally
@@ -134,10 +134,9 @@ The implementation should:
 - `Headers.entries()` returns lower-case names in standard Fetch implementations,
   but the implementation should normalize names defensively so config matching is
   case-insensitive and emitted attribute keys are lower-case.
-- Fetch `Headers` exposes combined header values as strings. Emit `[value]` for
-  captured values rather than trying to split comma-separated values; the
-  semantic convention allows either a single-item array containing the combined
-  string or multiple values depending on the library.
+- Fetch `Headers` often exposes combined header values as strings. Preserve those
+  strings rather than splitting comma-separated values, but accumulate repeated
+  entries from `headers.entries()` into the same attribute array.
 - Keep trace-context propagation separate from header capture. `traceparent`,
   `tracestate`, and `baggage` may be injected/extracted without being recorded
   as span attributes unless the user explicitly opts into capturing those header
@@ -200,7 +199,8 @@ Task 1: Header capture helpers
     - Add a helper that copies matching Headers entries into attributes under a
       supplied prefix.
     - Normalize emitted header names to lower-case.
-    - Emit captured header values as [value].
+    - Emit captured header values as arrays, appending repeated header entries to
+      the same array.
   PATTERN:
     - Keep helper functions small and local to fetch instrumentation unless tests
       show reuse pressure.

--- a/plans/021-cf-worker-header-capture-config.md
+++ b/plans/021-cf-worker-header-capture-config.md
@@ -1,0 +1,367 @@
+## Goal
+
+Change Cloudflare Worker HTTP header span attributes from capture-all-by-default to
+explicit opt-in capture in `@pydantic/otel-cf-workers`, and make the Logfire
+Cloudflare wrapper inherit that safer behavior.
+
+The implementation should:
+
+- Stop emitting `http.request.header.<key>` and `http.response.header.<key>` by
+  default.
+- Add a first-class config surface for explicitly captured request and response
+  headers on Worker inbound fetch, outbound fetch, and Durable Object fetch spans.
+- Emit captured header attributes in the OpenTelemetry semantic convention value
+  shape: a string array, usually `[value]` with the Fetch `Headers` API.
+- Keep existing non-header HTTP semantic attributes such as method, body size,
+  status code, content type, user agent, URL, and Cloudflare metadata.
+- Document the behavior change and migration path for users who intentionally
+  depended on full header capture.
+
+## Why
+
+- GitHub issue [#158](https://github.com/pydantic/logfire-js/issues/158) points
+  out that current fetch instrumentation records all headers, including cookies,
+  authorization values, and other credential-bearing headers.
+- OpenTelemetry semantic conventions explicitly warn that instrumentations should
+  require configuration for captured request and response headers because
+  capture-all behavior can leak sensitive data.
+- `@pydantic/logfire-cf-workers` has default scrubbing, but the lower-level
+  `@pydantic/otel-cf-workers` package does not, and Logfire scrubbing can be
+  disabled. The safe behavior needs to live at the instrumentation source.
+- The current implementation also emits scalar strings for header values, while
+  the semantic convention defines these attributes as `string[]`.
+
+## Success Criteria
+
+- [ ] By default, `gatherRequestAttributes()` emits no
+      `http.request.header.*` attributes.
+- [ ] By default, `gatherResponseAttributes()` emits no
+      `http.response.header.*` attributes.
+- [ ] Users can explicitly opt in to request and response header capture for
+      both `handlers.fetch` and outbound `fetch` instrumentation.
+- [ ] Explicit capture supports at least case-insensitive header-name lists and
+      an escape hatch that can intentionally capture every header.
+- [ ] Captured request headers use `http.request.header.<lowercase-name>` with
+      values shaped as `string[]`.
+- [ ] Captured response headers use `http.response.header.<lowercase-name>` with
+      values shaped as `string[]`.
+- [ ] Worker fetch handler spans, outbound global fetch spans, Durable Object
+      inbound fetch spans, and Durable Object stub outbound fetch spans all use
+      the same config semantics.
+- [ ] Existing dedicated semantic attributes still appear where currently
+      supported: `http.request.method`, `http.request.body.size`,
+      `user_agent.original`, `http.mime_type`, `http.accepts`, `url.*`,
+      `http.response.status_code`, `http.response.body.size`, and Cloudflare
+      attributes.
+- [ ] `@pydantic/logfire-cf-workers` exposes the new config through its existing
+      `fetch` and `handlers` option passthrough without adding wrapper-only
+      behavior.
+- [ ] README and changelog/changeset explain the default change and show how to
+      migrate to explicit request and response header capture.
+- [ ] Focused validation passes:
+      `vp run @pydantic/otel-cf-workers#test -- fetch`,
+      `vp run @pydantic/otel-cf-workers#test -- do`,
+      `vp run @pydantic/otel-cf-workers#typecheck`,
+      `vp run @pydantic/logfire-cf-workers#typecheck`, and relevant package
+      builds.
+
+## Clarifications
+
+### Session 2026-07-08
+
+- Q: Should the PRP lock the public header capture API to `captureHeaders` with
+  case-insensitive header-name arrays, explicit `true` for full capture, and
+  predicate functions? -> A: Yes. Use the recommended `captureHeaders` API with
+  arrays, `true`, and predicates.
+- Q: Should the PRP require major changesets for both
+  `@pydantic/otel-cf-workers` and `@pydantic/logfire-cf-workers`? -> A: Yes.
+  Treat the default span-attribute removal as semver-breaking for both packages.
+- Q: Should response header capture stay in scope alongside request header
+  capture? -> A: Yes. Disable both request and response header capture by
+  default, and allow both to be explicitly opted in.
+
+## Context
+
+### Key Files
+
+- `packages/otel-cf-workers/src/instrumentation/fetch.ts` - current source of
+  request and response header capture. `gatherRequestAttributes()` loops over all
+  request headers and `gatherResponseAttributes()` loops over all response
+  headers.
+- `packages/otel-cf-workers/src/instrumentation/do.ts` - Durable Object inbound
+  fetch spans reuse the same gather helpers, and Durable Object stubs use
+  `instrumentClientFetch()`.
+- `packages/otel-cf-workers/src/types.ts` - public `TraceConfig`,
+  `FetcherConfig`, and `FetchHandlerConfig` type surface where header capture
+  config should be exposed.
+- `packages/otel-cf-workers/src/config.ts` - normalizes supplied config into
+  `ResolvedTraceConfig`; default header capture should normalize to disabled.
+- `packages/otel-cf-workers/src/sdk.ts` - initializes global fetch
+  instrumentation and wraps Worker handlers.
+- `packages/otel-cf-workers/test/instrumentation/fetch.test.ts` - existing fetch
+  instrumentation tests. Add direct gather-helper tests and outbound fetch config
+  tests here.
+- `packages/otel-cf-workers/test/instrumentation/do.test.ts` - existing Durable
+  Object wrapper tests. Add or extend tests if DO config plumbing needs coverage.
+- `packages/logfire-cf-workers/src/index.ts` - Logfire wrapper config passthrough
+  and scrubbing/post-processing. It should not reintroduce capture-all behavior.
+- `packages/otel-cf-workers/README.md` - lower-level Cloudflare Worker
+  instrumentation docs. Add header capture configuration docs here.
+- `packages/logfire-cf-workers/README.md` - Logfire Cloudflare docs. Add a short
+  note that header capture is explicit and uses the lower-level config fields.
+- `.changeset/` - add a changeset because this changes package-visible span
+  attributes and adds public configuration.
+
+### External References
+
+- [OpenTelemetry HTTP semantic convention attributes](https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-header)
+  - `http.request.header.<key>` and `http.response.header.<key>` require explicit
+    configuration guidance.
+  - Header values are defined as arrays of strings.
+- [GitHub issue #158](https://github.com/pydantic/logfire-js/issues/158) -
+  originating report and motivation.
+
+### Gotchas
+
+- This is a behavior change for users who rely on `http.request.header.*` or
+  `http.response.header.*` being present on every Cloudflare Worker span. Treat
+  it as semver-significant.
+- `@pydantic/logfire-cf-workers` default scrubbing currently mitigates some keys
+  such as `authorization` and `cookie`, but scrubbing is not a replacement for
+  opt-in capture and can be disabled.
+- `Headers.entries()` returns lower-case names in standard Fetch implementations,
+  but the implementation should normalize names defensively so config matching is
+  case-insensitive and emitted attribute keys are lower-case.
+- Fetch `Headers` exposes combined header values as strings. Emit `[value]` for
+  captured values rather than trying to split comma-separated values; the
+  semantic convention allows either a single-item array containing the combined
+  string or multiple values depending on the library.
+- Keep trace-context propagation separate from header capture. `traceparent`,
+  `tracestate`, and `baggage` may be injected/extracted without being recorded
+  as span attributes unless the user explicitly opts into capturing those header
+  names.
+- Existing `http.mime_type` is set from `content-type` for both request and
+  response attributes. Do not remove it as part of the header-capture change.
+- The current attribute object types are `Record<string, string | number>` in
+  helper functions; captured header arrays require widening those local types to
+  OpenTelemetry `Attributes` or an equivalent value type.
+- Durable Object stub outbound fetch currently calls `instrumentClientFetch()`
+  with a fixed config function that only sets `includeTraceContext: true`. It
+  will need a deliberate path to preserve that propagation behavior while still
+  honoring the active fetch header capture config.
+
+## Implementation Blueprint
+
+### Data Models
+
+Public config shape:
+
+```ts
+export type HeaderCapturePredicate = (name: string, value: string) => boolean
+export type HeaderCaptureSelector = boolean | readonly string[] | HeaderCapturePredicate
+
+export interface HeaderCaptureConfig {
+  request?: HeaderCaptureSelector
+  response?: HeaderCaptureSelector
+}
+
+export interface FetcherConfig {
+  includeTraceContext?: boolean | IncludeTraceContextFn
+  captureHeaders?: HeaderCaptureConfig
+}
+
+export interface FetchHandlerConfig {
+  acceptTraceContext?: boolean | AcceptTraceContextFn
+  captureHeaders?: HeaderCaptureConfig
+}
+```
+
+Semantics:
+
+- `undefined`, `false`, or an empty array captures no headers.
+- `true` explicitly captures all headers.
+- `string[]` captures only those names, matched case-insensitively.
+- `HeaderCapturePredicate` is called with lower-case header name and string value.
+  Returning `true` captures that header.
+- Captured attributes use the normalized lower-case header name.
+- Captured values are arrays: `attrs["http.request.header.x-request-id"] =
+["abc"]`.
+
+### Tasks
+
+```yaml
+Task 1: Header capture helpers
+  MODIFY packages/otel-cf-workers/src/instrumentation/fetch.ts:
+    - Add HeaderCapturePredicate, HeaderCaptureSelector, and HeaderCaptureConfig types.
+    - Add a helper that normalizes a selector into "capture none", "capture all",
+      name set, or predicate.
+    - Add a helper that copies matching Headers entries into attributes under a
+      supplied prefix.
+    - Normalize emitted header names to lower-case.
+    - Emit captured header values as [value].
+  PATTERN:
+    - Keep helper functions small and local to fetch instrumentation unless tests
+      show reuse pressure.
+
+Task 2: Public config surface and defaults
+  MODIFY packages/otel-cf-workers/src/instrumentation/fetch.ts:
+    - Extend FetcherConfig with captureHeaders?: HeaderCaptureConfig.
+    - Extend FetchHandlerConfig with captureHeaders?: HeaderCaptureConfig.
+  MODIFY packages/otel-cf-workers/src/types.ts:
+    - Ensure ResolvedTraceConfig still marks fetch and handlers.fetch as required.
+  MODIFY packages/otel-cf-workers/src/config.ts:
+    - Preserve includeTraceContext and acceptTraceContext defaults.
+    - Normalize captureHeaders to an object with request/response disabled by
+      default, or preserve undefined with helper-level defaults.
+  GOTCHA:
+    - Do not default to true for compatibility; the explicit goal is safer
+      default behavior.
+
+Task 3: Wire request/response capture into span creation
+  MODIFY packages/otel-cf-workers/src/instrumentation/fetch.ts:
+    - Change gatherRequestAttributes(request) to accept an optional
+      HeaderCaptureSelector for request headers.
+    - Change gatherResponseAttributes(response) to accept an optional
+      HeaderCaptureSelector for response headers.
+    - In executeFetchHandler(), use active handlers.fetch.captureHeaders
+      selectors for inbound request and response.
+    - In instrumentClientFetch(), use active fetch.captureHeaders selectors for
+      outbound request and response.
+  MODIFY packages/otel-cf-workers/src/instrumentation/do.ts:
+    - Ensure Durable Object inbound fetch spans use handlers.fetch.captureHeaders.
+    - Ensure Durable Object stub outbound fetch keeps includeTraceContext true
+      while honoring active fetch.captureHeaders for request/response capture.
+  PATTERN:
+    - Prefer passing selectors explicitly to gather helpers over making helpers
+      read global context directly.
+
+Task 4: Tests for defaults and opt-in behavior
+  MODIFY packages/otel-cf-workers/test/instrumentation/fetch.test.ts:
+    - Add direct tests for gatherRequestAttributes default behavior:
+      Authorization, Cookie, and X-Request-Id are not emitted as header
+      attributes by default.
+    - Add direct tests for gatherResponseAttributes default behavior:
+      Set-Cookie and X-Response-Id are not emitted by default.
+    - Add tests for string-list selectors, including mixed-case config names.
+    - Add tests for true selectors capturing all headers.
+    - Add tests for predicate selectors capturing selected names.
+    - Assert captured values are arrays, not scalar strings.
+    - Assert existing dedicated attributes still appear where expected.
+    - Add outbound instrumentClientFetch tests that verify the resolved fetch
+      config controls request and response header capture.
+  MODIFY packages/otel-cf-workers/test/instrumentation/do.test.ts:
+    - Add coverage only if config plumbing cannot be adequately covered by fetch
+      tests. Prefer a focused test that proves DO inbound fetch does not capture
+      sensitive headers by default and honors explicit config.
+
+Task 5: Documentation and migration notes
+  MODIFY packages/otel-cf-workers/README.md:
+    - Under Fetch configuration, document captureHeaders.request and
+      captureHeaders.response.
+    - Include examples:
+        fetch: { captureHeaders: { request: ["x-request-id"] } }
+        handlers: { fetch: { captureHeaders: { response: ["cache-control"] } } }
+        captureHeaders: { request: true, response: true } for intentional full
+        capture with a warning.
+    - State that no request/response headers are captured by default.
+  MODIFY packages/logfire-cf-workers/README.md:
+    - Add a short Logfire-specific note and point users to the same config shape.
+    - Mention that Logfire scrubbing remains useful but capture is now explicit.
+
+Task 6: Release metadata
+  CREATE .changeset/<generated-name>.md:
+    - Bump @pydantic/otel-cf-workers for the default behavior change and new
+      config.
+    - Bump @pydantic/logfire-cf-workers because its exported instrumentation
+      behavior changes through the dependency.
+    - Use major bumps for both packages.
+  NOTE:
+    - The changeset should clearly call out the migration path:
+      set captureHeaders.request/response to explicit header names, or true if
+      full capture is intentionally required.
+```
+
+### Integration Points
+
+```yaml
+CONFIG:
+  - packages/otel-cf-workers/src/types.ts
+    Public TraceConfig type surface.
+  - packages/otel-cf-workers/src/config.ts
+    Default normalization for fetch and handlers.fetch.
+
+INSTRUMENTATION:
+  - packages/otel-cf-workers/src/instrumentation/fetch.ts
+    Worker fetch handler spans and outbound fetch spans.
+  - packages/otel-cf-workers/src/instrumentation/do.ts
+    Durable Object inbound and stub outbound fetch spans.
+
+LOGFIRE WRAPPER:
+  - packages/logfire-cf-workers/src/index.ts
+    Config passthrough through ConfigOptionsBase should automatically expose
+    the new lower-level fields.
+
+DOCS:
+  - packages/otel-cf-workers/README.md
+  - packages/logfire-cf-workers/README.md
+
+RELEASE:
+  - .changeset/*.md
+```
+
+## Validation
+
+Run focused validation while implementing:
+
+```bash
+vp run @pydantic/otel-cf-workers#test -- fetch
+vp run @pydantic/otel-cf-workers#test -- do
+vp run @pydantic/otel-cf-workers#typecheck
+vp run @pydantic/logfire-cf-workers#typecheck
+```
+
+Run package builds before opening a PR:
+
+```bash
+vp run @pydantic/otel-cf-workers#build
+vp run @pydantic/logfire-cf-workers#build
+```
+
+If the implementation touches shared config or exported types in a broader way,
+also run:
+
+```bash
+pnpm run test
+pnpm run typecheck
+```
+
+### Required Test Coverage
+
+- [ ] Default request header capture is disabled.
+- [ ] Default response header capture is disabled.
+- [ ] Sensitive request headers are not emitted by default.
+- [ ] Sensitive response headers are not emitted by default.
+- [ ] Name-list selectors match case-insensitively.
+- [ ] Predicate selectors can capture a subset of headers.
+- [ ] Explicit `true` selectors capture all headers.
+- [ ] Captured header values are arrays.
+- [ ] Dedicated non-header HTTP semantic attributes still appear.
+- [ ] Outbound fetch instrumentation uses `fetch.captureHeaders`.
+- [ ] Inbound Worker fetch instrumentation uses `handlers.fetch.captureHeaders`.
+- [ ] Durable Object fetch paths follow the same default and opt-in behavior.
+
+## Unknowns & Risks
+
+- Some users may have relied on all response headers as well as request headers.
+  The issue text names request headers, but OpenTelemetry gives the same guidance
+  for response headers, and the local code captures both by default. This PRP
+  intentionally changes both request and response header capture defaults.
+- Predicate config functions make the public API more flexible but require clear
+  examples and direct tests. The PRP intentionally includes predicates as part of
+  the committed API.
+- Durable Object stub outbound fetch currently has special trace-context behavior.
+  Be careful not to regress propagation while adding header capture config.
+- `postProcessor` can already remove or redact attributes. It should remain a
+  backstop, not the recommended way to avoid sensitive header capture.
+
+**Confidence: 8/10** for one-pass implementation success.


### PR DESCRIPTION
## Summary

Fixes #158.

This changes Cloudflare Worker fetch instrumentation so request and response headers are no longer captured as span attributes by default. Header capture is now explicit via `captureHeaders.request` and `captureHeaders.response`, supporting case-insensitive header name arrays, predicate functions, or `true` for intentional full capture.

The change also updates Durable Object fetch paths, documents the migration path in both Cloudflare READMEs, adds focused tests, and includes major changesets for `@pydantic/otel-cf-workers` and `@pydantic/logfire-cf-workers` because the default span attributes are changing.

## Validation

- `vp check --fix .changeset/calm-headers-warn.md packages/logfire-cf-workers/README.md packages/otel-cf-workers/README.md packages/otel-cf-workers/src/config.ts packages/otel-cf-workers/src/instrumentation/do.ts packages/otel-cf-workers/src/instrumentation/fetch.ts packages/otel-cf-workers/src/types.ts packages/otel-cf-workers/test/instrumentation/do.test.ts packages/otel-cf-workers/test/instrumentation/fetch.test.ts plans/021-cf-worker-header-capture-config.md`
- `vp run @pydantic/otel-cf-workers#test -- fetch`
- `vp run @pydantic/otel-cf-workers#test -- do`
- `vp run @pydantic/otel-cf-workers#test`
- `vp run @pydantic/otel-cf-workers#typecheck`
- `vp run @pydantic/logfire-cf-workers#typecheck`
- `vp run @pydantic/otel-cf-workers#build`
- `vp run @pydantic/logfire-cf-workers#build`
- Push hook also ran package builds/tests across the workspace.
