### PR TITLE
Restore the reviewed R9 cleanup path

### DIFF
--- a/plans/031-browser-stable-release-runbook.md
+++ b/plans/031-browser-stable-release-runbook.md
@@ -35,11 +35,9 @@ the downstream handoff, and only then retire the feature branch.
 - [x] Registry-installed browser checks re-exercise parent `CX-1`, `CX-5`, and
       `CX-8`; the R1-R8 verification records remain applicable to the exact
       published source.
-- [x] The downstream Platform handoff is recorded, the feature branch is absent,
-      its squash-equivalent content is verified after the evidence gate, and
-      existing `alpha` dist-tags remain unchanged. GitHub's automatic branch
-      deletion preempted the planned explicit post-evidence deletion; the exact
-      tree comparison and later no-publication snapshot record the recovery.
+- [ ] The downstream Platform handoff is recorded, the feature branch is deleted
+      only after all evidence is green, and existing `alpha` dist-tags remain
+      unchanged.
 - [ ] Publication/handoff evidence is merged to `main` through a dedicated
       evidence PR before branch deletion; a final cleanup PR records deletion
       with a conditional terminal gate, and the roadmap becomes complete only
@@ -572,28 +570,8 @@ Task 8: Delete the feature branch and merge the final cleanup record
 - Consumer acceptance: `CX-10A`, `CX-10B`, `CX-10C`, and `CX-10` are
   **DIRECTLY VERIFIED**. `CX-10F` is **VERIFIED WITH RECORDED RECOVERY** for the
   skipped GitHub-release step and immediate-registry age-policy exception.
-  R9 remains conditional on the cleanup PR, its no-publication main run, and
-  its terminal evidence comment.
-- Evidence PR #163 was approved at exact head `e10c8d6`, with a successful
-  exact-head build and zero unresolved review threads, then squash-merged as
-  `f93e28a7fcaa4ffe6e9a6e56a789ae9e120b9910`. Main run
-  [29275885492](https://github.com/pydantic/logfire-js/actions/runs/29275885492)
-  passed and reported `There are no new packages that should be published`;
-  GitHub release creation skipped. The complete registry/dist-tag snapshot and
-  both stable release refs were unchanged after the run.
-- The remote feature branch `petyosi/browser-rum-alpha-release` was already
-  absent when the post-evidence cleanup gate ran, consistent with repository
-  automatic branch deletion. Its
-  final head `c54393e` and feature squash merge `6760a47c` have the identical
-  tree `c574694065bb7c9b6d1739b230c73cc46319e54b`, proving no feature-branch
-  content was omitted by squash. Browser `alpha=0.17.0-alpha.2` and replay
-  `alpha=0.1.0-alpha.1` remain unchanged.
-- This cleanup record deliberately leaves R9 `IN PROGRESS` and the roadmap
-  `ACTIVE`. For cleanup PR #164, R9 becomes `VERIFIED` and the roadmap becomes
-  `COMPLETE` only after the merged PR's terminal evidence comment records its
-  exact successful main run, no published packages, skipped GitHub release
-  creation, an unchanged complete registry/ref snapshot, and continued feature
-  branch absence.
+  R9 remains conditional on the evidence/cleanup PRs, their no-publication main
+  runs, and verified feature-branch deletion.
 
 - Task 1 rehearsal used an exact synthetic commit in a disposable clone so the
   verifier could enforce its clean-live-tree and immutable-ref preconditions

--- a/plans/roadmaps/001-browser-rum-release-remediation.md
+++ b/plans/roadmaps/001-browser-rum-release-remediation.md
@@ -372,14 +372,7 @@ The roadmap separates stable contracts by independent consumer-visible failure b
   release runbook generated on 2026-07-13 with explicit SHA/review/check gates,
   isolated Version Packages pack/consumer evidence, public npm/GitHub
   verification, downstream handoff, and branch-deletion authorization.
-- **Completion evidence**: Evidence PR #163 was squash-merged as `f93e28a7`.
-  Its exact main run
-  [29275885492](https://github.com/pydantic/logfire-js/actions/runs/29275885492)
-  passed, reported no packages to publish, and skipped GitHub release creation;
-  the complete registry/dist-tag and stable-release-ref snapshot was unchanged.
-  The feature branch is absent remotely, and its final tree is identical to the
-  feature squash merge tree. Final completion remains conditional on cleanup PR
-  #164's successful no-publication main run and terminal evidence comment.
+- **Completion evidence**: Pending.
 - **Publication evidence**: PR #161 merged as `6760a47c`; Version Packages PR
   #162 merged as `1f3b1cbd`. Main publication run
   [29275066883](https://github.com/pydantic/logfire-js/actions/runs/29275066883)
@@ -391,11 +384,9 @@ The roadmap separates stable contracts by independent consumer-visible failure b
   their refs were rechecked directly.
   The downstream stable-contract handoff is recorded on
   [Platform PR #25595](https://github.com/pydantic/platform/pull/25595#issuecomment-4961379232).
-  R9 remains `IN PROGRESS` and the roadmap remains `ACTIVE` until cleanup PR
-  #164 merges and its terminal comment records the exact successful main run,
-  no published packages, skipped GitHub release creation, unchanged registry
-  and release refs, and continued feature-branch absence. At that point R9 is
-  `VERIFIED` and this roadmap is `COMPLETE` without another main push.
+  R9 remains `IN PROGRESS` and the roadmap remains `ACTIVE` until the durable
+  evidence merge, verified branch deletion, cleanup merge, and that cleanup
+  PR's terminal no-publication comment are complete.
 
 ## Integration Checkpoints
 
@@ -436,13 +427,6 @@ The roadmap separates stable contracts by independent consumer-visible failure b
 
 ### 2026-07-13
 
-- Merged durable publication evidence PR #163 as `f93e28a7`; exact main run
-  29275885492 passed with no packages to publish and no public-state change.
-  Verified `petyosi/browser-rum-alpha-release` is absent and that its final tree
-  exactly matches feature squash merge `6760a47c`. Cleanup PR #164 is the last
-  conditional gate; its post-merge terminal comment must record a green exact
-  main run, no publication, unchanged registry/release refs, and branch absence
-  before R9/roadmap completion is asserted.
 - Published and directly verified the official browser `0.17.0` and replay
   `0.1.0` stable packages through feature PR #161 and Version Packages PR #162.
   Exact registry consumers passed, GitHub tags/releases point to publication


### PR DESCRIPTION
## Summary

- revert the documentation-only cleanup commit that was sent directly to main by an unexpected local push mapping
- restore the exact pre-cleanup evidence tree without rewriting history
- allow the same cleanup record to return through the intended CI and CodeRabbit-reviewed pull request

## Safety

The direct-push main run 29276121713 passed and reported that there were no packages to publish; GitHub release creation was skipped. This revert changes only the two R9 planning documents and does not alter package versions, changesets, or release metadata.