### PR TITLE
Expose OpenTelemetry SpanKind in manual span APIs

### DIFF
--- a/.changeset/manual-span-kind.md
+++ b/.changeset/manual-span-kind.md
@@ -1,0 +1,6 @@
+---
+'logfire': minor
+---
+
+Allow manual spans and instrumented functions to set OpenTelemetry `SpanKind`, including matching kinds for pending-span placeholders.
+

--- a/docs/packages/logfire.md
+++ b/docs/packages/logfire.md
@@ -130,6 +130,26 @@ await logfire.span('fetch user profile', {
 })
 ```
 
+Set `kind` when a manual span represents a remote operation. This preserves
+OpenTelemetry service topology and dependency semantics:
+
+```ts
+import { SpanKind } from '@opentelemetry/api'
+import * as logfire from 'logfire'
+
+await logfire.span('request inventory service', {
+  kind: SpanKind.CLIENT,
+  attributes: { 'server.address': 'inventory.internal' },
+  callback: async () => fetch('https://inventory.internal/items'),
+})
+```
+
+`span()`, `startSpan()`, `startPendingSpan()`, and `instrument()` accept
+`SpanKind.CLIENT`, `SpanKind.SERVER`, `SpanKind.PRODUCER`, or
+`SpanKind.CONSUMER`. Omitting `kind` keeps OpenTelemetry's default
+`SpanKind.INTERNAL` behavior. Pending placeholders use the same kind as their
+real span.
+
 Use `startSpan()` when you need to control the span lifetime yourself:
 
 ```ts
@@ -344,3 +364,4 @@ Use a runtime package unless your platform already configures OpenTelemetry:
 - [`@pydantic/logfire-node`](node.md) for Node.js
 - [`@pydantic/logfire-browser`](browser.md) for browsers
 - [`@pydantic/logfire-cf-workers`](cloudflare.md) for Cloudflare Workers
+

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -1,4 +1,4 @@
-import type { Attributes, Context, Exception, HrTime, Span } from '@opentelemetry/api'
+import type { Attributes, Context, Exception, HrTime, Span, SpanKind } from '@opentelemetry/api'
 import {
   INVALID_SPAN_CONTEXT,
   SpanStatusCode,
@@ -84,7 +84,15 @@ export interface LogOptions {
   tags?: string[]
 }
 
-export type StartPendingSpanOptions = Omit<LogOptions, 'log'>
+export interface SpanOptions extends LogOptions {
+  /**
+   * The OpenTelemetry kind for this span.
+   * Defaults to SpanKind.INTERNAL.
+   */
+  kind?: SpanKind
+}
+
+export type StartPendingSpanOptions = Omit<SpanOptions, 'log'>
 
 export interface LogfireClientSettings {
   level?: LogFireLevel
@@ -119,6 +127,11 @@ export interface InstrumentOptions {
    */
   level?: LogFireLevel
   /**
+   * The OpenTelemetry kind for the instrumented call span.
+   * Defaults to SpanKind.INTERNAL.
+   */
+  kind?: SpanKind
+  /**
    * The message template for the instrumented call span.
    */
   message?: string
@@ -148,6 +161,12 @@ interface LogfireSpanStart {
 type LevelSource = 'default' | 'explicit'
 
 interface ResolvedLogOptions extends Omit<LogOptions, 'level' | 'tags'> {
+  level: LogFireLevel
+  levelSource: LevelSource
+  tags: string[]
+}
+
+interface ResolvedSpanOptions extends Omit<SpanOptions, 'level' | 'tags'> {
   level: LogFireLevel
   levelSource: LevelSource
   tags: string[]
@@ -197,6 +216,10 @@ function resolveLogOptions(settings: ResolvedLogfireClientSettings, options: Log
     merged.levelSource = 'explicit'
   }
   return merged
+}
+
+function resolveSpanOptions(settings: ResolvedLogfireClientSettings, options: SpanOptions | undefined): ResolvedSpanOptions {
+  return resolveLogOptions(settings, options)
 }
 
 function resolveLogLevel(
@@ -415,9 +438,9 @@ function startSpanWithSettings(
   settings: ResolvedLogfireClientSettings,
   msgTemplate: string,
   attributes: Record<string, unknown> = {},
-  options: LogOptions = {}
+  options: SpanOptions = {}
 ): Span {
-  const resolvedOptions = resolveLogOptions(settings, options)
+  const resolvedOptions = resolveSpanOptions(settings, options)
   if (shouldFilterLevel(resolvedOptions.level, resolvedOptions.levelSource, resolvedOptions.log === true)) {
     return getNoopSpan()
   }
@@ -425,14 +448,17 @@ function startSpanWithSettings(
 
   const span = logfireApiConfig.tracer.startSpan(
     spanStart.name,
-    { attributes: spanStart.attributes },
+    {
+      attributes: spanStart.attributes,
+      ...(resolvedOptions.kind === undefined ? {} : { kind: resolvedOptions.kind }),
+    },
     getSpanStartContext(resolvedOptions.parentSpan)
   )
 
   return span
 }
 
-export function startSpan(msgTemplate: string, attributes: Record<string, unknown> = {}, options: LogOptions = {}): Span {
+export function startSpan(msgTemplate: string, attributes: Record<string, unknown> = {}, options: SpanOptions = {}): Span {
   return startSpanWithSettings(ROOT_CLIENT_SETTINGS, msgTemplate, attributes, options)
 }
 
@@ -446,7 +472,7 @@ function startPendingSpanWithSettings(
   attributes: Record<string, unknown> = {},
   options: StartPendingSpanOptions = {}
 ): Span {
-  const resolvedOptions = resolveLogOptions(settings, options)
+  const resolvedOptions = resolveSpanOptions(settings, options)
   if (shouldFilterLevel(resolvedOptions.level, resolvedOptions.levelSource, false)) {
     return getNoopSpan()
   }
@@ -454,7 +480,10 @@ function startPendingSpanWithSettings(
   const parentContext = getSpanStartContext(resolvedOptions.parentSpan)
   const realSpan = logfireApiConfig.tracer.startSpan(
     spanStart.name,
-    { attributes: spanStart.attributes },
+    {
+      attributes: spanStart.attributes,
+      ...(resolvedOptions.kind === undefined ? {} : { kind: resolvedOptions.kind }),
+    },
     setPendingSpanSuppressed(parentContext)
   )
 
@@ -477,6 +506,7 @@ function startPendingSpanWithSettings(
         [ATTRIBUTES_SPAN_TYPE_KEY]: 'pending_span',
       },
       startTime,
+      ...(resolvedOptions.kind === undefined ? {} : { kind: resolvedOptions.kind }),
     },
     TheTraceAPI.setSpan(parentContext, realSpan)
   )
@@ -494,12 +524,13 @@ export function startPendingSpan(
 }
 
 type SpanCallback<R> = (activeSpan: Span) => R
-type SpanArgsVariant1<R> = [Record<string, unknown>, LogOptions, SpanCallback<R>]
+type SpanArgsVariant1<R> = [Record<string, unknown>, SpanOptions, SpanCallback<R>]
 type SpanArgsVariant2<R> = [
   {
     _spanName?: string
     attributes?: Record<string, unknown>
     callback: SpanCallback<R>
+    kind?: SpanKind
     level?: LogFireLevel
     parentSpan?: Span
     tags?: string[]
@@ -513,7 +544,7 @@ type SpanArgsVariant2<R> = [
  * The span will be ended automatically after the function call.
  */
 export function span<R>(msgTemplate: string, options: SpanArgsVariant2<R>[0]): R
-export function span<R>(msgTemplate: string, attributes: Record<string, unknown>, options: LogOptions, callback: (span: Span) => R): R
+export function span<R>(msgTemplate: string, attributes: Record<string, unknown>, options: SpanOptions, callback: (span: Span) => R): R
 export function span<R>(msgTemplate: string, ...args: SpanArgsVariant1<R> | SpanArgsVariant2<R>): R {
   return spanWithSettings(ROOT_CLIENT_SETTINGS, msgTemplate, ...args)
 }
@@ -526,6 +557,7 @@ function spanWithSettings<R>(
   let attributes: Record<string, unknown>
   let level: LogFireLevel
   let levelSource: LevelSource
+  let kind: SpanKind | undefined
   let tags: string[]
   let callback!: SpanCallback<R>
   let parentSpan: Span | undefined
@@ -536,15 +568,17 @@ function spanWithSettings<R>(
     attributes = args[0].attributes ?? {}
     level = resolvedLevel.level
     levelSource = resolvedLevel.source
+    kind = options.kind
     tags = mergeTags(settings.tags, options.tags)
     callback = options.callback
     parentSpan = options.parentSpan
     spanName = options._spanName
   } else {
-    const options = resolveLogOptions(settings, args[1])
+    const options = resolveSpanOptions(settings, args[1])
     attributes = args[0]
     level = options.level
     levelSource = options.levelSource
+    kind = options.kind
     tags = options.tags
     parentSpan = options.parentSpan
     spanName = options._spanName
@@ -562,6 +596,7 @@ function spanWithSettings<R>(
     spanName ?? msgTemplate,
     {
       attributes: serializedAttributes,
+      ...(kind === undefined ? {} : { kind }),
     },
     context,
     (span: Span) => {
@@ -672,6 +707,9 @@ function instrumentWithSettings<F extends InstrumentableFunction>(
     }
     if (options.level !== undefined) {
       spanOptions.level = options.level
+    }
+    if (options.kind !== undefined) {
+      spanOptions.kind = options.kind
     }
     if (options.parentSpan !== undefined) {
       spanOptions.parentSpan = options.parentSpan
@@ -966,7 +1004,7 @@ export interface LogfireClient {
   reportError(message: string, error: unknown, extraAttributes?: Record<string, unknown>, options?: ReportErrorOptions): void
   span: typeof span
   startPendingSpan(message: string, attributes?: Record<string, unknown>, options?: StartPendingSpanOptions): Span
-  startSpan(message: string, attributes?: Record<string, unknown>, options?: LogOptions): Span
+  startSpan(message: string, attributes?: Record<string, unknown>, options?: SpanOptions): Span
   trace(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   warning(message: string, attributes?: Record<string, unknown>, options?: LogOptions): void
   withSettings(settings: LogfireClientSettings): LogfireClient
@@ -1095,3 +1133,4 @@ const defaultExport: {
 }
 
 export default defaultExport
+

--- a/packages/logfire-api/src/startPendingSpan.integration.test.ts
+++ b/packages/logfire-api/src/startPendingSpan.integration.test.ts
@@ -1,11 +1,11 @@
 import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-import { trace as TraceAPI } from '@opentelemetry/api'
+import { SpanKind, trace as TraceAPI } from '@opentelemetry/api'
 import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { describe, expect, test } from 'vite-plus/test'
 
 import { ATTRIBUTES_SPAN_TYPE_KEY } from './constants'
-import { configureLogfireApi, startPendingSpan } from './index'
+import { configureLogfireApi, instrument, span, startPendingSpan, startSpan } from './index'
 import { PendingSpanProcessor } from './PendingSpanProcessor'
 import { TailSamplingProcessor } from './TailSamplingProcessor'
 
@@ -31,6 +31,36 @@ function pendingSpans(spans: ReadableSpan[]): ReadableSpan[] {
 }
 
 describe('startPendingSpan integration', () => {
+  test('exports requested span kinds across manual span APIs and pending placeholders', async () => {
+    const spans = await collectSpans(
+      (primary) => [primary],
+      () => {
+        startSpan('internal operation').end()
+        startSpan('client request', {}, { kind: SpanKind.CLIENT }).end()
+        span('server handler', { kind: SpanKind.SERVER, callback: () => undefined })
+        span('produce job', {}, { kind: SpanKind.PRODUCER }, () => undefined)
+        startPendingSpan('consume job', {}, { kind: SpanKind.CONSUMER }).end()
+        instrument(() => undefined, { kind: SpanKind.CLIENT, message: 'instrumented request' })()
+      }
+    )
+
+    expect(
+      spans.map((span) => ({
+        kind: span.kind,
+        name: span.name,
+      }))
+    ).toEqual([
+      { kind: SpanKind.INTERNAL, name: 'internal operation' },
+      { kind: SpanKind.CLIENT, name: 'client request' },
+      { kind: SpanKind.SERVER, name: 'server handler' },
+      { kind: SpanKind.PRODUCER, name: 'produce job' },
+      { kind: SpanKind.CONSUMER, name: 'consume job' },
+      { kind: SpanKind.CONSUMER, name: 'consume job' },
+      { kind: SpanKind.CLIENT, name: 'instrumented request' },
+    ])
+    expect(pendingSpans(spans).map((span) => span.kind)).toEqual([SpanKind.CONSUMER])
+  })
+
   test('emits one manual pending span with non-tail automatic pending processing installed', async () => {
     const spans = await collectSpans(
       (primary) => [primary, new PendingSpanProcessor(primary)],
@@ -61,3 +91,4 @@ describe('startPendingSpan integration', () => {
     expect(spans.map((span) => span.attributes[ATTRIBUTES_SPAN_TYPE_KEY])).toEqual(['pending_span', 'span'])
   })
 })
+


### PR DESCRIPTION
## Summary

- add a dedicated `SpanOptions` type with optional OpenTelemetry `SpanKind`
- forward `kind` through `span()`, `startSpan()`, `startPendingSpan()`, and `instrument()`
- preserve the requested kind on pending-span placeholders while keeping the default `INTERNAL` behavior
- document a manual remote-operation example and add a `logfire` minor changeset

## Testing

- workspace package build
- `vp run logfire#test` (434 tests passed)
- `vp run logfire#typecheck`
- targeted lint for the changed TypeScript files
- `vp fmt --check`
- `vp check`

Fixes #171