### PR TITLE
Make the distributedTracing option win over its environment variable

### DIFF
--- a/.changeset/distributed-tracing-precedence.md
+++ b/.changeset/distributed-tracing-precedence.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Fix `distributedTracing` precedence in Node `configure()`. An explicit `distributedTracing: false` was overridden by `LOGFIRE_DISTRIBUTED_TRACING=true`, while an explicit `true` correctly won over the environment. The code option now always wins, matching every other configure() setting, and an empty `LOGFIRE_DISTRIBUTED_TRACING` value is treated as unset instead of disabling distributed tracing.

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -549,6 +549,12 @@ describe('logfire config', () => {
       configure({ sendToLogfire: false })
       expect(logfireConfig.distributedTracing).toBe(true)
     })
+
+    it('a whitespace-only LOGFIRE_DISTRIBUTED_TRACING is treated as unset', () => {
+      process.env['LOGFIRE_DISTRIBUTED_TRACING'] = '   '
+      configure({ sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(true)
+    })
   })
 
   function makeCredentialsDir(credentials: { logfire_api_url: string; project_name: string; project_url: string; token: string }): string {

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -503,6 +503,54 @@ describe('logfire config', () => {
     }).toThrow('Remote variables require an API key')
   })
 
+  describe('distributed tracing', () => {
+    const originalDistributedTracing = process.env['LOGFIRE_DISTRIBUTED_TRACING']
+
+    afterEach(() => {
+      if (originalDistributedTracing === undefined) {
+        delete process.env['LOGFIRE_DISTRIBUTED_TRACING']
+      } else {
+        process.env['LOGFIRE_DISTRIBUTED_TRACING'] = originalDistributedTracing
+      }
+    })
+
+    it('defaults to true when neither the option nor the environment variable is set', () => {
+      delete process.env['LOGFIRE_DISTRIBUTED_TRACING']
+      configure({ sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(true)
+    })
+
+    it('an explicit false option wins over LOGFIRE_DISTRIBUTED_TRACING=true', () => {
+      process.env['LOGFIRE_DISTRIBUTED_TRACING'] = 'true'
+      configure({ distributedTracing: false, sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(false)
+    })
+
+    it('an explicit true option wins over LOGFIRE_DISTRIBUTED_TRACING=false', () => {
+      process.env['LOGFIRE_DISTRIBUTED_TRACING'] = 'false'
+      configure({ distributedTracing: true, sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(true)
+    })
+
+    it('LOGFIRE_DISTRIBUTED_TRACING=false disables distributed tracing when the option is omitted', () => {
+      process.env['LOGFIRE_DISTRIBUTED_TRACING'] = 'false'
+      configure({ sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(false)
+    })
+
+    it('LOGFIRE_DISTRIBUTED_TRACING=true enables distributed tracing when the option is omitted', () => {
+      process.env['LOGFIRE_DISTRIBUTED_TRACING'] = 'true'
+      configure({ sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(true)
+    })
+
+    it('an empty LOGFIRE_DISTRIBUTED_TRACING is treated as unset', () => {
+      process.env['LOGFIRE_DISTRIBUTED_TRACING'] = ''
+      configure({ sendToLogfire: false })
+      expect(logfireConfig.distributedTracing).toBe(true)
+    })
+  })
+
   function makeCredentialsDir(credentials: { logfire_api_url: string; project_name: string; project_url: string; token: string }): string {
     const dataDir = makeTmpDir()
     writeFileSync(join(dataDir, 'logfire_credentials.json'), `${JSON.stringify(credentials)}\n`)

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -449,9 +449,15 @@ function resolveAuthorizationHeaders(token: LogfireToken | undefined): Authoriza
   }
 }
 
-function resolveDistributedTracing(option: LogfireConfigOptions['distributedTracing']) {
-  const envDistributedTracing = process.env['LOGFIRE_DISTRIBUTED_TRACING']
-  return (option ?? envDistributedTracing === undefined) ? true : envDistributedTracing === 'true'
+function resolveDistributedTracing(option: LogfireConfigOptions['distributedTracing']): boolean {
+  if (option !== undefined) {
+    return option
+  }
+  const envDistributedTracing = readNonEmptyEnv(process.env, 'LOGFIRE_DISTRIBUTED_TRACING')
+  if (envDistributedTracing !== undefined) {
+    return envDistributedTracing === 'true'
+  }
+  return true
 }
 
 function requiresRemoteVariables(options: VariablesConfigOptions): boolean {


### PR DESCRIPTION
Fixes #176.

`resolveDistributedTracing` in `packages/logfire-node/src/logfireConfig.ts` combined the code option and the env var in a single expression (`option ?? envDistributedTracing === undefined`), so an explicit `distributedTracing: false` fell through to the environment and `LOGFIRE_DISTRIBUTED_TRACING=true` silently re-enabled distributed tracing. Every other configure() setting lets the code option win over the environment, so this makes distributedTracing do the same: option first, then the env var (read via `readNonEmptyEnv`, so an empty value now counts as unset instead of disabling tracing), then the default of `true`. Includes six regression tests covering the precedence matrix and a patch changeset for `@pydantic/logfire-node`.

Ran `pnpm run check` from the root, everything green.

quick disclosure: I built this with Claude Code helping me along and read through the final diff myself before opening it. freshman still learning the ropes here, so I'd genuinely appreciate any corrections :)