### PR TITLE
Send logfire-js user agent when exporting traces, logs, and metrics

### DIFF
--- a/.changeset/great-hoops-punch.md
+++ b/.changeset/great-hoops-punch.md
@@ -1,0 +1,6 @@
+---
+'@pydantic/logfire-cf-workers': patch
+'@pydantic/logfire-node': patch
+---
+
+Send a `logfire-js/<version>` User-Agent when exporting traces, logs, and metrics

--- a/.changeset/great-hoops-punch.md
+++ b/.changeset/great-hoops-punch.md
@@ -1,6 +1,7 @@
 ---
+'@pydantic/otel-cf-workers': minor
 '@pydantic/logfire-cf-workers': patch
 '@pydantic/logfire-node': patch
 ---
 
-Send a `logfire-js/<version>` User-Agent when exporting traces, logs, and metrics
+Send a `logfire-js/<version>` User-Agent when exporting traces, logs, and metrics. The Cloudflare Workers OTLP exporter now sends a default `otel-cf-workers/<version>` identifier and accepts a `userAgent` option that is prepended to it.

--- a/packages/logfire-cf-workers/src/exportTailEventsToLogfire.ts
+++ b/packages/logfire-cf-workers/src/exportTailEventsToLogfire.ts
@@ -1,3 +1,4 @@
+import { OTLP_EXPORTER_USER_AGENT } from '@pydantic/otel-cf-workers'
 import { resolveBaseUrl } from 'logfire'
 
 import { USER_AGENT } from './userAgent'
@@ -28,7 +29,7 @@ export async function exportTailEventsToLogfire(
       headers: {
         Authorization: token,
         'Content-Type': 'application/json',
-        'User-Agent': USER_AGENT,
+        'User-Agent': `${USER_AGENT} ${OTLP_EXPORTER_USER_AGENT}`,
       },
       method: 'POST',
     })

--- a/packages/logfire-cf-workers/src/exportTailEventsToLogfire.ts
+++ b/packages/logfire-cf-workers/src/exportTailEventsToLogfire.ts
@@ -1,5 +1,7 @@
 import { resolveBaseUrl } from 'logfire'
 
+import { USER_AGENT } from './userAgent'
+
 // simplified interface from CF
 export interface TraceItem {
   logs: { message: unknown[] }[]
@@ -26,6 +28,7 @@ export async function exportTailEventsToLogfire(
       headers: {
         Authorization: token,
         'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
       },
       method: 'POST',
     })

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -96,10 +96,6 @@ describe('User-Agent', () => {
     await exportTailEventsToLogfire(events, { LOGFIRE_TOKEN: 'test-token' })
 
     expect(fetchMock).toHaveBeenCalledOnce()
-    const call = fetchMock.mock.calls[0]
-    if (!call) {
-      throw new Error('fetch was not called')
-    }
-    expect(call[1]).toMatchObject({ headers: { 'User-Agent': USER_AGENT } })
+    expect(fetchMock.mock.lastCall?.[1]).toMatchObject({ headers: { 'User-Agent': USER_AGENT } })
   })
 })

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vite-plus/test'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
 import { instrument as instrumentFunction, startPendingSpan, withSettings, withTags } from 'logfire'
 import * as packageRoot from '@pydantic/logfire-cf-workers'
 
@@ -35,5 +35,71 @@ describe('cf-workers default export', () => {
     expect(packageJson.exports['.']?.['default']).toBe('./dist/index.js')
     expect(packageJson.exports['.']?.['types']).toBe('./dist/index.d.ts')
     expect(readdirSync(new URL('../dist', import.meta.url)).sort()).toEqual(['index.d.ts', 'index.js'])
+  })
+})
+
+// Mirror the PACKAGE_VERSION define from vite.config.ts so the expected value
+// matches what Vite substituted at test-compile time, regardless of whether
+// npm_package_version is populated in the current shell.
+const expectedUserAgent = `logfire-js/${process.env['npm_package_version'] ?? '0.0.0'}`
+
+describe('User-Agent', () => {
+  afterEach(() => {
+    vi.doUnmock('@pydantic/otel-cf-workers')
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('USER_AGENT constant equals logfire-js/<package-version>', async () => {
+    vi.resetModules()
+    const { USER_AGENT } = await import('./userAgent')
+    expect(USER_AGENT).toBe(expectedUserAgent)
+  })
+
+  it('in-process exporter config includes User-Agent header', async () => {
+    vi.resetModules()
+
+    type InProcessConfigFn = (env: Record<string, string | undefined>) => {
+      exporter: { headers: Record<string, string>; url: string }
+    }
+
+    let capturedConfigFn: InProcessConfigFn | undefined
+
+    vi.doMock('@pydantic/otel-cf-workers', () => ({
+      instrument: (handler: unknown, configFn: InProcessConfigFn): unknown => {
+        capturedConfigFn = configFn
+        return handler
+      },
+      instrumentDO: (doClass: unknown): unknown => doClass,
+    }))
+
+    const [{ instrumentInProcess }, { USER_AGENT }] = await Promise.all([import('./index'), import('./userAgent')])
+
+    instrumentInProcess({}, { service: { name: 'test-service' } })
+
+    expect(capturedConfigFn).toBeDefined()
+    const config = capturedConfigFn?.({ LOGFIRE_TOKEN: 'test-token' })
+    expect(config?.exporter.headers['User-Agent']).toBe(USER_AGENT)
+  })
+
+  it('exportTailEventsToLogfire sends User-Agent header', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    vi.resetModules()
+    const [{ exportTailEventsToLogfire }, { USER_AGENT }] = await Promise.all([
+      import('./exportTailEventsToLogfire'),
+      import('./userAgent'),
+    ])
+
+    const events = [{ logs: [{ message: [{ resourceSpans: [] }] }] }]
+    await exportTailEventsToLogfire(events, { LOGFIRE_TOKEN: 'test-token' })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const call = fetchMock.mock.calls[0]
+    if (!call) {
+      throw new Error('fetch was not called')
+    }
+    expect(call[1]).toMatchObject({ headers: { 'User-Agent': USER_AGENT } })
   })
 })

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -56,11 +56,11 @@ describe('User-Agent', () => {
     expect(USER_AGENT).toBe(expectedUserAgent)
   })
 
-  it('in-process exporter config includes User-Agent header', async () => {
+  it('in-process exporter config prepends the logfire-js user agent', async () => {
     vi.resetModules()
 
     type InProcessConfigFn = (env: Record<string, string | undefined>) => {
-      exporter: { headers: Record<string, string>; url: string }
+      exporter: { headers: Record<string, string>; url: string; userAgent: string }
     }
 
     let capturedConfigFn: InProcessConfigFn | undefined
@@ -71,6 +71,7 @@ describe('User-Agent', () => {
         return handler
       },
       instrumentDO: (doClass: unknown): unknown => doClass,
+      OTLP_EXPORTER_USER_AGENT: 'otel-cf-workers/0.0.0',
     }))
 
     const [{ instrumentInProcess }, { USER_AGENT }] = await Promise.all([import('./index'), import('./userAgent')])
@@ -79,23 +80,37 @@ describe('User-Agent', () => {
 
     expect(capturedConfigFn).toBeDefined()
     const config = capturedConfigFn?.({ LOGFIRE_TOKEN: 'test-token' })
-    expect(config?.exporter.headers['User-Agent']).toBe(USER_AGENT)
+    expect(config?.exporter).toEqual({
+      headers: { Authorization: 'test-token' },
+      url: 'https://logfire-us.pydantic.dev/v1/traces',
+      userAgent: USER_AGENT,
+    })
   })
 
-  it('exportTailEventsToLogfire sends User-Agent header', async () => {
+  it('exportTailEventsToLogfire sends the two-product User-Agent header', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'))
     vi.stubGlobal('fetch', fetchMock)
 
     vi.resetModules()
-    const [{ exportTailEventsToLogfire }, { USER_AGENT }] = await Promise.all([
+    const [{ exportTailEventsToLogfire }, { USER_AGENT }, { OTLP_EXPORTER_USER_AGENT }] = await Promise.all([
       import('./exportTailEventsToLogfire'),
       import('./userAgent'),
+      import('@pydantic/otel-cf-workers'),
     ])
 
     const events = [{ logs: [{ message: [{ resourceSpans: [] }] }] }]
     await exportTailEventsToLogfire(events, { LOGFIRE_TOKEN: 'test-token' })
 
     expect(fetchMock).toHaveBeenCalledOnce()
-    expect(fetchMock.mock.lastCall?.[1]).toMatchObject({ headers: { 'User-Agent': USER_AGENT } })
+    expect(fetchMock.mock.lastCall?.[0]).toBe('https://logfire-us.pydantic.dev/v1/traces')
+    expect(fetchMock.mock.lastCall?.[1]).toEqual({
+      body: JSON.stringify({ resourceSpans: [] }),
+      headers: {
+        Authorization: 'test-token',
+        'Content-Type': 'application/json',
+        'User-Agent': `${USER_AGENT} ${OTLP_EXPORTER_USER_AGENT}`,
+      },
+      method: 'POST',
+    })
   })
 })

--- a/packages/logfire-cf-workers/src/index.ts
+++ b/packages/logfire-cf-workers/src/index.ts
@@ -96,8 +96,9 @@ function getInProcessConfig(config: InProcessConfigOptions): (env: Env) => Trace
       ...config,
       additionalSpanProcessors,
       exporter: {
-        headers: { Authorization: token, 'User-Agent': USER_AGENT },
+        headers: { Authorization: token },
         url: `${baseUrl}/v1/traces`,
+        userAgent: USER_AGENT,
       },
       idGenerator: new ULIDGenerator(),
       postProcessor: (spans: ReadableSpan[]) => postProcessAttributes(spans),

--- a/packages/logfire-cf-workers/src/index.ts
+++ b/packages/logfire-cf-workers/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from 'logfire'
 
 import { exportTailEventsToLogfire } from './exportTailEventsToLogfire'
+import { USER_AGENT } from './userAgent'
 import { LogfireCloudflareConsoleSpanExporter } from './LogfireCloudflareConsoleSpanExporter'
 import { TailWorkerExporter } from './TailWorkerExporter'
 export * from './exportTailEventsToLogfire'
@@ -95,7 +96,7 @@ function getInProcessConfig(config: InProcessConfigOptions): (env: Env) => Trace
       ...config,
       additionalSpanProcessors,
       exporter: {
-        headers: { Authorization: token },
+        headers: { Authorization: token, 'User-Agent': USER_AGENT },
         url: `${baseUrl}/v1/traces`,
       },
       idGenerator: new ULIDGenerator(),

--- a/packages/logfire-cf-workers/src/userAgent.ts
+++ b/packages/logfire-cf-workers/src/userAgent.ts
@@ -1,0 +1,1 @@
+export const USER_AGENT: string = `logfire-js/${PACKAGE_VERSION}`

--- a/packages/logfire-cf-workers/src/vite-env.d.ts
+++ b/packages/logfire-cf-workers/src/vite-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vite/client" />
 /// <reference types="@cloudflare/workers-types" />
+declare const PACKAGE_VERSION: string

--- a/packages/logfire-node/src/__test__/userAgent.test.ts
+++ b/packages/logfire-node/src/__test__/userAgent.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+// Mirror the PACKAGE_VERSION define from vite.config.ts so the expected value
+// matches what Vite substituted at test-compile time, regardless of whether
+// npm_package_version is populated in the current shell.
+const expectedUserAgent = `logfire-js/${process.env['npm_package_version'] ?? '0.0.0'}`
+
+describe('User-Agent', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.doUnmock('@opentelemetry/exporter-logs-otlp-proto')
+    vi.doUnmock('@opentelemetry/exporter-metrics-otlp-proto')
+    vi.doUnmock('@opentelemetry/exporter-trace-otlp-proto')
+  })
+
+  it('USER_AGENT constant equals logfire-js/<package-version>', async () => {
+    const { USER_AGENT } = await import('../logfireConfig')
+    expect(USER_AGENT).toBe(expectedUserAgent)
+  })
+
+  it('traceExporter passes userAgent to OTLPTraceExporter', async () => {
+    const OTLPTraceExporterMock = vi.fn<(options: Record<string, unknown>) => void>()
+
+    vi.doMock('@opentelemetry/exporter-trace-otlp-proto', () => ({
+      OTLPTraceExporter: OTLPTraceExporterMock,
+    }))
+
+    const { logfireConfig } = await import('../logfireConfig')
+    Object.assign(logfireConfig, {
+      authorizationHeaders: { Authorization: 'test-token' },
+      sendToLogfire: true,
+      token: 'test-token',
+      traceExporterUrl: 'https://logfire-api.pydantic.dev/v1/traces',
+    })
+
+    const { traceExporter } = await import('../traceExporter')
+    traceExporter()
+
+    expect(OTLPTraceExporterMock).toHaveBeenCalledOnce()
+    expect(OTLPTraceExporterMock).toHaveBeenCalledWith(expect.objectContaining({ userAgent: expectedUserAgent }))
+  })
+
+  it('metricExporter passes userAgent to OTLPMetricExporter', async () => {
+    const OTLPMetricExporterMock = vi.fn<(options: Record<string, unknown>) => void>()
+
+    vi.doMock('@opentelemetry/exporter-metrics-otlp-proto', () => ({
+      OTLPMetricExporter: OTLPMetricExporterMock,
+    }))
+
+    const { logfireConfig } = await import('../logfireConfig')
+    Object.assign(logfireConfig, {
+      authorizationHeaders: { Authorization: 'test-token' },
+      metricExporterUrl: 'https://logfire-api.pydantic.dev/v1/metrics',
+      sendToLogfire: true,
+      token: 'test-token',
+    })
+
+    const { metricExporter } = await import('../metricExporter')
+    metricExporter()
+
+    expect(OTLPMetricExporterMock).toHaveBeenCalledOnce()
+    expect(OTLPMetricExporterMock).toHaveBeenCalledWith(expect.objectContaining({ userAgent: expectedUserAgent }))
+  })
+
+  it('logfireLogRecordProcessor passes userAgent to OTLPLogExporter', async () => {
+    const OTLPLogExporterMock = vi.fn<(options: Record<string, unknown>) => void>()
+
+    vi.doMock('@opentelemetry/exporter-logs-otlp-proto', () => ({
+      OTLPLogExporter: OTLPLogExporterMock,
+    }))
+
+    const { logfireConfig } = await import('../logfireConfig')
+    Object.assign(logfireConfig, {
+      authorizationHeaders: { Authorization: 'test-token' },
+      logsExporterUrl: 'https://logfire-api.pydantic.dev/v1/logs',
+      sendToLogfire: true,
+      token: 'test-token',
+    })
+
+    const { logfireLogRecordProcessor } = await import('../logsExporter')
+    logfireLogRecordProcessor()
+
+    expect(OTLPLogExporterMock).toHaveBeenCalledOnce()
+    expect(OTLPLogExporterMock).toHaveBeenCalledWith(expect.objectContaining({ userAgent: expectedUserAgent }))
+  })
+})

--- a/packages/logfire-node/src/__test__/userAgent.test.ts
+++ b/packages/logfire-node/src/__test__/userAgent.test.ts
@@ -40,7 +40,11 @@ describe('User-Agent', () => {
     traceExporter()
 
     expect(OTLPTraceExporterMock).toHaveBeenCalledOnce()
-    expect(OTLPTraceExporterMock).toHaveBeenCalledWith(expect.objectContaining({ userAgent: expectedUserAgent }))
+    expect(OTLPTraceExporterMock).toHaveBeenCalledWith({
+      headers: { Authorization: 'test-token' },
+      url: 'https://logfire-api.pydantic.dev/v1/traces',
+      userAgent: expectedUserAgent,
+    })
   })
 
   it('metricExporter passes userAgent to OTLPMetricExporter', async () => {
@@ -62,7 +66,11 @@ describe('User-Agent', () => {
     metricExporter()
 
     expect(OTLPMetricExporterMock).toHaveBeenCalledOnce()
-    expect(OTLPMetricExporterMock).toHaveBeenCalledWith(expect.objectContaining({ userAgent: expectedUserAgent }))
+    expect(OTLPMetricExporterMock).toHaveBeenCalledWith({
+      headers: { Authorization: 'test-token' },
+      url: 'https://logfire-api.pydantic.dev/v1/metrics',
+      userAgent: expectedUserAgent,
+    })
   })
 
   it('logfireLogRecordProcessor passes userAgent to OTLPLogExporter', async () => {
@@ -84,6 +92,10 @@ describe('User-Agent', () => {
     logfireLogRecordProcessor()
 
     expect(OTLPLogExporterMock).toHaveBeenCalledOnce()
-    expect(OTLPLogExporterMock).toHaveBeenCalledWith(expect.objectContaining({ userAgent: expectedUserAgent }))
+    expect(OTLPLogExporterMock).toHaveBeenCalledWith({
+      headers: { Authorization: 'test-token' },
+      url: 'https://logfire-api.pydantic.dev/v1/logs',
+      userAgent: expectedUserAgent,
+    })
   })
 })

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -175,6 +175,8 @@ export interface LogfireConfigOptions {
   variables?: VariablesConfigOptions
 }
 
+export const USER_AGENT: string = `logfire-js/${PACKAGE_VERSION}`
+
 const DEFAULT_OTEL_SCOPE = 'logfire'
 const TRACE_ENDPOINT_PATH = 'v1/traces'
 const METRIC_ENDPOINT_PATH = 'v1/metrics'

--- a/packages/logfire-node/src/logsExporter.ts
+++ b/packages/logfire-node/src/logsExporter.ts
@@ -2,7 +2,7 @@ import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-proto'
 import type { LogRecordExporter, LogRecordProcessor } from '@opentelemetry/sdk-logs'
 import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs'
 
-import { logfireConfig } from './logfireConfig'
+import { logfireConfig, USER_AGENT } from './logfireConfig'
 
 type BatchLogRecordProcessorConstructor = {
   legacy: new (exporter: LogRecordExporter) => LogRecordProcessor
@@ -40,6 +40,7 @@ export function logfireLogRecordProcessor(): LogRecordProcessor | null {
     new OTLPLogExporter({
       headers: logfireConfig.authorizationHeaders,
       url: logfireConfig.logsExporterUrl,
+      userAgent: USER_AGENT,
     })
   )
 }

--- a/packages/logfire-node/src/metricExporter.ts
+++ b/packages/logfire-node/src/metricExporter.ts
@@ -2,7 +2,7 @@ import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto'
 import type { PeriodicExportingMetricReaderOptions, PushMetricExporter } from '@opentelemetry/sdk-metrics'
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 
-import { logfireConfig } from './logfireConfig'
+import { logfireConfig, USER_AGENT } from './logfireConfig'
 import { VoidMetricExporter } from './VoidMetricExporter'
 
 export type PeriodicMetricReaderOptions = Omit<PeriodicExportingMetricReaderOptions, 'exporter'>
@@ -19,6 +19,7 @@ export function metricExporter(): PushMetricExporter {
   return new OTLPMetricExporter({
     headers: logfireConfig.authorizationHeaders,
     url: logfireConfig.metricExporterUrl,
+    userAgent: USER_AGENT,
   })
 }
 

--- a/packages/logfire-node/src/traceExporter.ts
+++ b/packages/logfire-node/src/traceExporter.ts
@@ -3,7 +3,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
 import type { ReadableSpan, Span, SpanExporter, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-import { logfireConfig } from './logfireConfig'
+import { logfireConfig, USER_AGENT } from './logfireConfig'
 import { LogfireConsoleSpanExporter } from './LogfireConsoleSpanExporter'
 import type { ConsoleConfig } from './consoleOptions'
 import { resolveConsoleOptions } from './consoleOptions'
@@ -30,6 +30,7 @@ export function traceExporter(): SpanExporter {
   return new OTLPTraceExporter({
     headers: logfireConfig.authorizationHeaders,
     url: logfireConfig.traceExporterUrl,
+    userAgent: USER_AGENT,
   })
 }
 

--- a/packages/otel-cf-workers/src/exporter.ts
+++ b/packages/otel-cf-workers/src/exporter.ts
@@ -28,10 +28,20 @@ export class OTLPExporter implements SpanExporter {
   private readonly url: string
   constructor(config: OTLPExporterConfig) {
     this.url = config.url
+    const headers: Record<string, string> = {}
+    let headerUserAgent: string | undefined
+    for (const [key, value] of Object.entries(config.headers ?? {})) {
+      if (key.toLowerCase() === 'user-agent') {
+        headerUserAgent = value
+      } else {
+        headers[key] = value
+      }
+    }
+    const prefix = config.userAgent ?? headerUserAgent
     this.headers = {
       ...defaultHeaders,
-      'user-agent': config.userAgent === undefined ? OTLP_EXPORTER_USER_AGENT : `${config.userAgent} ${OTLP_EXPORTER_USER_AGENT}`,
-      ...config.headers,
+      ...headers,
+      'user-agent': prefix === undefined ? OTLP_EXPORTER_USER_AGENT : `${prefix} ${OTLP_EXPORTER_USER_AGENT}`,
     }
   }
 

--- a/packages/otel-cf-workers/src/exporter.ts
+++ b/packages/otel-cf-workers/src/exporter.ts
@@ -8,7 +8,15 @@ import { unwrap } from './wrap.js'
 export interface OTLPExporterConfig {
   url: string
   headers?: Record<string, string>
+  /**
+   * Product identifier prepended to the exporter's default User-Agent,
+   * following the OTLP recommendation that distributions retain the default
+   * exporter identifier.
+   */
+  userAgent?: string
 }
+
+export const OTLP_EXPORTER_USER_AGENT: string = `otel-cf-workers/${PACKAGE_VERSION}`
 
 const defaultHeaders: Record<string, string> = {
   accept: 'application/json',
@@ -20,7 +28,11 @@ export class OTLPExporter implements SpanExporter {
   private readonly url: string
   constructor(config: OTLPExporterConfig) {
     this.url = config.url
-    this.headers = { ...defaultHeaders, ...config.headers }
+    this.headers = {
+      ...defaultHeaders,
+      'user-agent': config.userAgent === undefined ? OTLP_EXPORTER_USER_AGENT : `${config.userAgent} ${OTLP_EXPORTER_USER_AGENT}`,
+      ...config.headers,
+    }
   }
 
   export(items: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {

--- a/packages/otel-cf-workers/test/exporter.test.ts
+++ b/packages/otel-cf-workers/test/exporter.test.ts
@@ -49,4 +49,34 @@ describe('OTLPExporter user agent', () => {
       'user-agent': `logfire-js/1.2.3 ${OTLP_EXPORTER_USER_AGENT}`,
     })
   })
+
+  it('prepends a lowercase user-agent header to the default identifier', async () => {
+    expect(await exportedHeaders({ url: 'https://example.com/v1/traces', headers: { 'user-agent': 'custom/1.0' } })).toEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'user-agent': `custom/1.0 ${OTLP_EXPORTER_USER_AGENT}`,
+    })
+  })
+
+  it('prepends a capitalized User-Agent header without duplicating the key', async () => {
+    expect(await exportedHeaders({ url: 'https://example.com/v1/traces', headers: { 'User-Agent': 'custom/1.0' } })).toEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'user-agent': `custom/1.0 ${OTLP_EXPORTER_USER_AGENT}`,
+    })
+  })
+
+  it('gives the userAgent option precedence over a User-Agent header', async () => {
+    expect(
+      await exportedHeaders({
+        url: 'https://example.com/v1/traces',
+        headers: { 'User-Agent': 'header/1.0' },
+        userAgent: 'option/1.0',
+      })
+    ).toEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'user-agent': `option/1.0 ${OTLP_EXPORTER_USER_AGENT}`,
+    })
+  })
 })

--- a/packages/otel-cf-workers/test/exporter.test.ts
+++ b/packages/otel-cf-workers/test/exporter.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { OTLPExporterConfig } from '../src/exporter'
+import { OTLP_EXPORTER_USER_AGENT, OTLPExporter } from '../src/exporter'
+
+// Mirror the PACKAGE_VERSION define from vite.config.ts so the expected value
+// matches what Vite substituted at test-compile time, regardless of whether
+// npm_package_version is populated in the current shell.
+const expectedDefaultUserAgent = `otel-cf-workers/${process.env.npm_package_version ?? '0.0.0'}`
+
+async function exportedHeaders(config: OTLPExporterConfig): Promise<unknown> {
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'))
+  vi.stubGlobal('fetch', fetchMock)
+
+  const exporter = new OTLPExporter(config)
+  await new Promise<void>((resolve, reject) => {
+    exporter.export([], (result) => {
+      if (result.error) {
+        reject(result.error)
+      } else {
+        resolve()
+      }
+    })
+  })
+
+  return fetchMock.mock.lastCall?.[1]?.headers
+}
+
+describe('OTLPExporter user agent', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('OTLP_EXPORTER_USER_AGENT equals otel-cf-workers/<package-version>', () => {
+    expect(OTLP_EXPORTER_USER_AGENT).toBe(expectedDefaultUserAgent)
+  })
+
+  it('sends the default exporter identifier when no userAgent is configured', async () => {
+    expect(await exportedHeaders({ url: 'https://example.com/v1/traces' })).toEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'user-agent': OTLP_EXPORTER_USER_AGENT,
+    })
+  })
+
+  it('prepends the configured userAgent to the default identifier', async () => {
+    expect(await exportedHeaders({ url: 'https://example.com/v1/traces', userAgent: 'logfire-js/1.2.3' })).toEqual({
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'user-agent': `logfire-js/1.2.3 ${OTLP_EXPORTER_USER_AGENT}`,
+    })
+  })
+})


### PR DESCRIPTION
Identifies the SDK to the Logfire backend on OTLP export requests.

- `@pydantic/logfire-node`: passes `userAgent` to the trace, metric, and log OTLP exporters, resulting in `User-Agent: logfire-js/<version> OTel-OTLP-Exporter-JavaScript/<otel-version>`.
- `@pydantic/logfire-cf-workers`: adds a `User-Agent: logfire-js/<version>` header to the in-process exporter and the tail event export fetch.

The browser package is unchanged because `User-Agent` is a forbidden header in browsers.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.