### PR TITLE
Use the span end time for tail sampling duration on end events

### DIFF
--- a/.changeset/tail-sampling-end-duration.md
+++ b/.changeset/tail-sampling-end-duration.md
@@ -1,5 +1,5 @@
 ---
-'@pydantic/logfire-api': patch
+'logfire': patch
 ---
 
 Fix tail sampling duration for span end events. `TailSamplingSpanInfo.duration` was computed from the span's start time even when the span was ending, so a trace whose slowness happened inside the ending span (for example a root span with no later children) never crossed `durationThreshold` and was dropped. End events now use the span's end time, matching Python Logfire's behavior.

--- a/.changeset/tail-sampling-end-duration.md
+++ b/.changeset/tail-sampling-end-duration.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-api': patch
+---
+
+Fix tail sampling duration for span end events. `TailSamplingSpanInfo.duration` was computed from the span's start time even when the span was ending, so a trace whose slowness happened inside the ending span (for example a root span with no later children) never crossed `durationThreshold` and was dropped. End events now use the span's end time, matching Python Logfire's behavior.

--- a/packages/logfire-api/src/TailSamplingProcessor.ts
+++ b/packages/logfire-api/src/TailSamplingProcessor.ts
@@ -133,7 +133,10 @@ export class TailSamplingProcessor implements SpanProcessor {
       return false
     }
 
-    const duration = hrTimeToSeconds(span.startTime) - hrTimeToSeconds(buffer.startTime)
+    // Match Python logfire: duration runs from the trace start to the start or end of this span,
+    // depending on which event is being checked.
+    const spanTime = event === 'end' ? span.endTime : span.startTime
+    const duration = hrTimeToSeconds(spanTime) - hrTimeToSeconds(buffer.startTime)
     const level = SpanLevel.fromSpan(span)
 
     const info: TailSamplingSpanInfo = { context, duration, event, level, span }

--- a/packages/logfire-api/src/sampling.test.ts
+++ b/packages/logfire-api/src/sampling.test.ts
@@ -162,7 +162,7 @@ function makeSpan(options: {
     droppedLinksCount: 0,
     duration: [0, 0],
     ended: !recording,
-    endTime: options.endTime ?? [0, 0],
+    endTime: options.endTime ?? options.startTime ?? [1000, 0],
     events: [],
     instrumentationScope: { name: 'test-scope' },
     isRecording: () => recording,

--- a/packages/logfire-api/src/sampling.test.ts
+++ b/packages/logfire-api/src/sampling.test.ts
@@ -144,6 +144,7 @@ type TestSpan = ReadableSpan &
 
 function makeSpan(options: {
   attributes?: Record<string, unknown>
+  endTime?: [number, number]
   name?: string
   parentSpanContext?: object
   recording?: boolean
@@ -161,7 +162,7 @@ function makeSpan(options: {
     droppedLinksCount: 0,
     duration: [0, 0],
     ended: !recording,
-    endTime: [0, 0],
+    endTime: options.endTime ?? [0, 0],
     events: [],
     instrumentationScope: { name: 'test-scope' },
     isRecording: () => recording,
@@ -353,6 +354,56 @@ describe('TailSamplingProcessor', () => {
     processor.onStart(child, ROOT_CONTEXT)
 
     expect(getPendingSpanNames(downstream.calls)).toEqual(['root', 'slow child'])
+  })
+
+  test('flushes when the ending root span crosses the duration threshold', () => {
+    const downstream = makeProcessor()
+    const tail = levelOrDuration({ durationThreshold: 2.0 }).tail
+    if (tail === undefined) {
+      throw new Error('expected tail sampler')
+    }
+    const processor = new TailSamplingProcessor(downstream, tail)
+
+    const root = makeSpan({ endTime: [1010, 0], name: 'slow root', startTime: [1000, 0] })
+    processor.onStart(root, ROOT_CONTEXT)
+    expect(downstream.calls).toHaveLength(0)
+
+    root.setRecording(false)
+    processor.onEnd(root)
+    expect(downstream.calls).toEqual([
+      { event: 'start', span: root },
+      { event: 'end', span: root },
+    ])
+  })
+
+  test('flushes when an ending child span crosses the duration threshold', () => {
+    const downstream = makeProcessor()
+    const tail = levelOrDuration({ durationThreshold: 2.0 }).tail
+    if (tail === undefined) {
+      throw new Error('expected tail sampler')
+    }
+    const processor = new TailSamplingProcessor(downstream, tail)
+
+    const root = makeSpan({ name: 'root', startTime: [1000, 0] })
+    processor.onStart(root, ROOT_CONTEXT)
+
+    const child = makeSpan({
+      endTime: [1005, 0],
+      name: 'slow child',
+      parentSpanContext: root.spanContext(),
+      spanId: 'child00000000000',
+      startTime: [1001, 0],
+    })
+    processor.onStart(child, ROOT_CONTEXT)
+    expect(downstream.calls).toHaveLength(0)
+
+    child.setRecording(false)
+    processor.onEnd(child)
+    expect(downstream.calls).toEqual([
+      { event: 'start', span: root },
+      { event: 'start', span: child },
+      { event: 'end', span: child },
+    ])
   })
 
   test('emits pending spans for later children after acceptance from onEnd', () => {


### PR DESCRIPTION
Fixes #179.

`TailSamplingProcessor.checkSpan` (packages/logfire-api/src/TailSamplingProcessor.ts:136) computed the tail callback's `duration` from `span.startTime` on both start and end events, so the time spent inside the ending span was invisible to the sampler. The final check when a root span ends always saw duration 0, which meant `levelOrDuration({ durationThreshold })` could never keep a trace whose only slow part was the ending span itself. End events now use `span.endTime`, matching Python Logfire's `TailSamplingSpanInfo.duration` (`span.end_time or span.start_time` in logfire/sampling/_tail_sampling.py).

Two regression tests (slow root-only trace, slow child with no later activity) fail on current main and pass with the fix. Ran `pnpm run check` from the root, all green. I also verified it end to end with a small script in examples/node using `levelOrDuration({ durationThreshold: 2.0 })` and a root-only span sleeping 3s: on main the trace is dropped, with this change it's exported. Patch changeset for `@pydantic/logfire-api` included.

honest note: I worked on this with Claude Code and reviewed the final diff myself before opening it. still a college freshman finding my way around observability internals, so please point out anything I got wrong :)