### PR TITLE
Upgrade Zod to v4

### DIFF
--- a/.changeset/tidy-zebras-smile.md
+++ b/.changeset/tidy-zebras-smile.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Upgrade the internal dataset validation dependency to Zod 4.

--- a/packages/logfire-api/src/evals/serialization/dataset.ts
+++ b/packages/logfire-api/src/evals/serialization/dataset.ts
@@ -47,7 +47,7 @@ export interface SerializedDataset {
   report_evaluators?: EncodedEvaluator[]
 }
 
-const encodedEvaluatorSchema: z.ZodType<EncodedEvaluator> = z.union([z.string(), z.record(z.unknown())])
+const encodedEvaluatorSchema: z.ZodType<EncodedEvaluator> = z.union([z.string(), z.record(z.string(), z.unknown())])
 const serializedCaseSchema = z.object({
   evaluators: z.array(encodedEvaluatorSchema).optional(),
   expected_output: z.unknown().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ catalogs:
       specifier: ^5.3.0
       version: 5.3.0
     zod:
-      specifier: ^3.23.8
-      version: 3.25.76
+      specifier: ^4.0.0
+      version: 4.4.3
 
 overrides:
   '@opentelemetry/core@<2.8.0': 2.8.0
@@ -441,7 +441,7 @@ importers:
         version: 6.2.1
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@opentelemetry/api':
         specifier: 'catalog:'
@@ -3097,10 +3097,6 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3747,8 +3743,8 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zone.js@0.15.1:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
@@ -6196,8 +6192,6 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  object-assign@4.1.1: {}
-
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
@@ -6900,6 +6894,6 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zone.js@0.15.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ catalog:
   typescript: ^6.0.3
   vitest: 4.1.9
   web-vitals: ^5.3.0
-  zod: ^3.23.8
+  zod: ^4.0.0
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Summary

- upgrade the workspace Zod catalog entry from v3 to v4
- update eval dataset record validation for the Zod 4 API
- add a patch changeset for `logfire`

## Why

Zod is used internally to validate serialized eval datasets. Moving to Zod 4 keeps that runtime dependency current while preserving the existing validation behavior.

## User impact

No public API changes are expected. Invalid eval dataset inputs continue to fail with structured Zod validation errors.

## Validation

- `vp run logfire#test` (453 tests passed)
- `vp run logfire#typecheck`
- `vp run logfire#build`
- repository pre-push build and test suite
