### PR TITLE
Add browser RUM route and session dimensions

### DIFF
--- a/.changeset/browser-rum-custom-dimensions.md
+++ b/.changeset/browser-rum-custom-dimensions.md
@@ -1,6 +1,6 @@
 ---
-'@pydantic/logfire-browser': patch
-'@pydantic/logfire-session-replay': patch
+'@pydantic/logfire-browser': minor
+'@pydantic/logfire-session-replay': minor
 ---
 
 Add per-span route names and bounded, per-session custom RUM dimensions to browser spans and session replay metadata.

--- a/.changeset/browser-rum-custom-dimensions.md
+++ b/.changeset/browser-rum-custom-dimensions.md
@@ -1,0 +1,6 @@
+---
+'@pydantic/logfire-browser': patch
+'@pydantic/logfire-session-replay': patch
+---
+
+Add per-span route names and bounded, per-session custom RUM dimensions to browser spans and session replay metadata.

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -68,6 +68,36 @@ of total duration by default. Each span gets `session.id` and
 `browser.session.id`; `session.id` is the OpenTelemetry semantic attribute and
 `browser.session.id` is emitted for Logfire Platform compatibility.
 
+Use `getRouteName` for the application's normalized route template and
+`getSessionAttributes` for low-cardinality dimensions that should remain stable
+for a browser session:
+
+```ts
+logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'web-app',
+  rum: {
+    session: {
+      getRouteName: () => router.currentRoute.value.matched.at(-1)?.path,
+      getSessionAttributes: () => ({
+        account_tier: currentAccount.tier,
+        beta_user: currentUser.isBeta,
+      }),
+    },
+  },
+})
+```
+
+`getRouteName` is evaluated for each span and becomes `logfire.page.route`.
+`getSessionAttributes` is evaluated once per browser session, persisted across
+same-tab reloads, and refreshed when the session rotates. Accepted values
+become span attributes prefixed with `logfire.session.` and are copied into
+replay chunk metadata when replay is enabled. Keys must match
+`^[a-z][a-z0-9_]{0,63}$`; at most 20 entries are retained. Values must be
+booleans, finite numbers, or strings no longer than 200 Unicode code points.
+Invalid entries are omitted. Treat these dimensions as low-cardinality,
+non-PII data because they are stored in `sessionStorage`.
+
 Session-enabled spans also get `logfire.page.url.full` and
 `logfire.page.url.path` by default for current page context. The full value is
 `location.origin + location.pathname`, while the path value is
@@ -188,7 +218,7 @@ uses unit `1`.
 Metric data point attributes are intentionally low-cardinality:
 `web_vital.name` and `web_vital.rating` by default. They do not include
 `session.id`, `browser.session.id`, `logfire.page.url.full`,
-`logfire.page.url.path`, Web Vital
+`logfire.page.url.path`, `logfire.page.route`, `logfire.session.*`, Web Vital
 ids/deltas, DOM selectors, attribution fields, or raw PerformanceEntry data. Use
 spans for raw-sample drilldown, session/replay correlation, exact page context,
 and attribution selectors. When metrics are configured, Logfire Platform should

--- a/examples/browser-rum-replay/README.md
+++ b/examples/browser-rum-replay/README.md
@@ -4,7 +4,7 @@ This example is an end-to-end browser telemetry workbench. It sends:
 
 - browser traces and manual Logfire spans
 - automatic document-load, fetch, XHR, and click/change spans
-- RUM session attributes on browser spans
+- normalized route names and bounded RUM session dimensions on browser spans
 - Core Web Vitals spans and native histogram metrics
 - rrweb session replay chunks through a local backend proxy
 - replay custom events for console, fetch/XHR, navigation, and errors
@@ -86,9 +86,14 @@ In traces/logs:
 - spans named `web_vital.lcp`, `web_vital.inp`, `web_vital.cls`,
   `web_vital.fcp`, and `web_vital.ttfb`
 - `session.id` and `browser.session.id` on browser spans
+- `logfire.page.route` with a normalized route template
+- `logfire.session.account_tier`, `logfire.session.app_region`, and
+  `logfire.session.experiment_variant`
 - `logfire.session_replay.active` and `logfire.session_replay.mode` on spans
   while replay is active
-- sanitized URL attributes such as `logfire.page.url.path=/orders/:id`
+- normalized route attributes such as `logfire.page.route=/orders/:id`
+- privacy-safe default URL attributes that retain the actual path, such as
+  `logfire.page.url.path=/orders/1234`
 
 In metrics:
 
@@ -103,6 +108,7 @@ In replay:
 
 - replay chunks uploaded to `/client-replay/:sessionId?seq=...`
 - the replay session id matching `session.id` / `browser.session.id`
+- matching unprefixed dimensions in `meta.sessionAttributes`
 - masked input values from the form
 - blocked content under `[data-logfire-block]`
 - custom replay events for console, navigation, fetch/XHR, and reported errors

--- a/examples/browser-rum-replay/src/main.ts
+++ b/examples/browser-rum-replay/src/main.ts
@@ -59,9 +59,11 @@ logfire.configure({
   },
   rum: {
     session: {
-      urlAttributes: (url) => ({
-        full: `${url.origin}${routeTemplate(url.pathname)}`,
-        path: routeTemplate(url.pathname),
+      getRouteName: () => routeTemplate(window.location.pathname),
+      getSessionAttributes: () => ({
+        account_tier: 'trial',
+        app_region: 'eu',
+        experiment_variant: 'catalog_b',
       }),
     },
     webVitals: {

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -76,6 +76,37 @@ or 4 hours of total duration by default. Spans get `session.id` and
 `browser.session.id`; `session.id` is the OpenTelemetry semantic attribute and
 `browser.session.id` is emitted for Logfire Platform compatibility.
 
+Use `getRouteName` for the application's normalized route template and
+`getSessionAttributes` for low-cardinality dimensions that should remain stable
+for a browser session:
+
+```js
+logfire.configure({
+  traceUrl: '/client-traces',
+  serviceName: 'browser-app',
+  rum: {
+    session: {
+      getRouteName: () => router.currentRoute.value.matched.at(-1)?.path,
+      getSessionAttributes: () => ({
+        account_tier: currentAccount.tier,
+        beta_user: currentUser.isBeta,
+      }),
+    },
+  },
+})
+```
+
+`getRouteName` is evaluated for each span and becomes `logfire.page.route`.
+`getSessionAttributes` is evaluated once for each browser session, persisted
+across same-tab reloads, and refreshed when the session rotates. Accepted
+values become span attributes prefixed with `logfire.session.` and are also
+copied into replay chunk metadata when replay is enabled. Invalid entries are
+omitted. Keys must match
+`^[a-z][a-z0-9_]{0,63}$`; at most 20 entries are retained. Values must be
+booleans, finite numbers, or strings no longer than 200 Unicode code points.
+Treat these dimensions as non-PII: they are persisted in `sessionStorage` for
+the session lifetime.
+
 By default, session-enabled spans also get `logfire.page.url.full` and
 `logfire.page.url.path` from the current page URL. The full value is
 `location.origin + location.pathname`, while the path value is
@@ -199,7 +230,7 @@ uses unit `1`.
 Metric data point attributes are intentionally low-cardinality:
 `web_vital.name` and `web_vital.rating` by default. They do not include
 `session.id`, `browser.session.id`, `logfire.page.url.full`,
-`logfire.page.url.path`, Web Vital
+`logfire.page.url.path`, `logfire.page.route`, `logfire.session.*`, Web Vital
 ids/deltas, DOM selectors, attribution fields, or raw PerformanceEntry data. Use
 spans for raw-sample drilldown, session/replay correlation, exact page context,
 and attribution selectors. When metrics are configured, Logfire Platform should

--- a/packages/logfire-browser/package.json
+++ b/packages/logfire-browser/package.json
@@ -65,7 +65,7 @@
     "web-vitals": "catalog:"
   },
   "peerDependencies": {
-    "@pydantic/logfire-session-replay": "workspace:^",
+    "@pydantic/logfire-session-replay": "workspace:^0.1.0 || ^0.2.0",
     "@opentelemetry/sdk-trace-web": "catalog:",
     "@opentelemetry/semantic-conventions": "catalog:"
   },

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
@@ -110,6 +110,93 @@ describe('BrowserSessionSpanProcessor', () => {
     })
   })
 
+  it('stamps session dimensions and evaluates the route for each span', () => {
+    let route = '/products/:id'
+    const processor = createProcessor({
+      getRouteName: () => route,
+      getSessionAttributes: () => ({
+        account_tier: 'pro',
+        beta_user: true,
+        seats: 12,
+      }),
+      urlAttributes: false,
+    })
+    const firstSpan = createSpan()
+    const secondSpan = createSpan()
+
+    startSpan(processor, firstSpan)
+    route = ''
+    startSpan(processor, secondSpan)
+
+    expect(firstSpan.attributes).toEqual({
+      'browser.session.id': 'session-1',
+      'logfire.page.route': '/products/:id',
+      'logfire.session.account_tier': 'pro',
+      'logfire.session.beta_user': true,
+      'logfire.session.seats': 12,
+      'session.id': 'session-1',
+    })
+    expect(secondSpan.attributes['logfire.page.route']).toBe('')
+  })
+
+  it('keeps route evaluation independent from URL sanitization failures', () => {
+    setLocation({ href: 'https://example.com/dashboard' })
+    const span = createSpan()
+
+    startSpan(
+      createProcessor({
+        getRouteName: () => '/dashboard',
+        urlAttributes: () => {
+          throw new Error('cannot sanitize')
+        },
+      }),
+      span
+    )
+
+    expect(span.attributes).toMatchObject({
+      'browser.session.id': 'session-1',
+      'logfire.page.route': '/dashboard',
+      'session.id': 'session-1',
+    })
+    expect(span.attributes).not.toHaveProperty('logfire.page.url.full')
+  })
+
+  it.each([
+    ['absent', undefined],
+    ['undefined', () => undefined],
+    ['non-string', () => 123 as never],
+    [
+      'throwing',
+      () => {
+        throw new Error('router unavailable')
+      },
+    ],
+  ])('omits a %s route result without suppressing other attributes', (_name, getRouteName) => {
+    const replayState = new BrowserSessionReplayState()
+    replayState.setReplay(createReplayRuntime('full'))
+    const span = createSpan()
+
+    startSpan(
+      createProcessor(
+        {
+          ...(getRouteName === undefined ? {} : { getRouteName }),
+          getSessionAttributes: () => ({ tier: 'pro' }),
+          urlAttributes: false,
+        },
+        replayState
+      ),
+      span
+    )
+
+    expect(span.attributes).toEqual({
+      'browser.session.id': 'session-1',
+      'logfire.session.tier': 'pro',
+      'logfire.session_replay.active': true,
+      'logfire.session_replay.mode': 'full',
+      'session.id': 'session-1',
+    })
+  })
+
   it('suppresses URL attributes when configured', () => {
     setLocation({ href: 'https://example.com/dashboard?tab=activity#recent' })
     const span = createSpan()

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
@@ -117,6 +117,8 @@ describe('BrowserSessionSpanProcessor', () => {
       getSessionAttributes: () => ({
         account_tier: 'pro',
         beta_user: true,
+        empty_label: '',
+        paid: false,
         seats: 12,
       }),
       urlAttributes: false,
@@ -133,6 +135,8 @@ describe('BrowserSessionSpanProcessor', () => {
       'logfire.page.route': '/products/:id',
       'logfire.session.account_tier': 'pro',
       'logfire.session.beta_user': true,
+      'logfire.session.empty_label': '',
+      'logfire.session.paid': false,
       'logfire.session.seats': 12,
       'session.id': 'session-1',
     })
@@ -153,12 +157,11 @@ describe('BrowserSessionSpanProcessor', () => {
       span
     )
 
-    expect(span.attributes).toMatchObject({
+    expect(span.attributes).toEqual({
       'browser.session.id': 'session-1',
       'logfire.page.route': '/dashboard',
       'session.id': 'session-1',
     })
-    expect(span.attributes).not.toHaveProperty('logfire.page.url.full')
   })
 
   it.each([

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.ts
@@ -8,6 +8,7 @@ const ATTR_SESSION_ID = 'session.id'
 const ATTR_BROWSER_SESSION_ID = 'browser.session.id'
 const ATTR_SESSION_REPLAY_ACTIVE = 'logfire.session_replay.active'
 const ATTR_SESSION_REPLAY_MODE = 'logfire.session_replay.mode'
+const ATTR_LOGFIRE_PAGE_ROUTE = 'logfire.page.route'
 const ATTR_LOGFIRE_PAGE_URL_FULL = 'logfire.page.url.full'
 const ATTR_LOGFIRE_PAGE_URL_PATH = 'logfire.page.url.path'
 
@@ -50,6 +51,9 @@ export class BrowserSessionSpanProcessor implements SpanProcessor {
     const session = this.sessionManager.touch()
     span.setAttribute(ATTR_SESSION_ID, session.id)
     span.setAttribute(ATTR_BROWSER_SESSION_ID, session.id)
+    for (const [key, value] of Object.entries(session.sessionAttributes ?? {})) {
+      span.setAttribute(`logfire.session.${key}`, value)
+    }
 
     let replayState: ReturnType<BrowserSessionReplayState['getState']>
     try {
@@ -62,6 +66,11 @@ export class BrowserSessionSpanProcessor implements SpanProcessor {
       span.setAttribute(ATTR_SESSION_REPLAY_MODE, replayState.mode)
     }
 
+    const routeName = this.sessionManager.getRouteName()
+    if (routeName !== undefined) {
+      span.setAttribute(ATTR_LOGFIRE_PAGE_ROUTE, routeName)
+    }
+
     const url = getCurrentUrl()
     if (url === undefined) {
       return
@@ -71,7 +80,7 @@ export class BrowserSessionSpanProcessor implements SpanProcessor {
     try {
       urlAttributes = this.sessionManager.getUrlAttributes(url)
     } catch {
-      return
+      urlAttributes = undefined
     }
 
     if (urlAttributes?.full !== undefined) {

--- a/packages/logfire-browser/src/browserConfigure.integration.test.ts
+++ b/packages/logfire-browser/src/browserConfigure.integration.test.ts
@@ -225,7 +225,13 @@ describe('public browser configure startup ordering', () => {
     optionalFeatureMocks.metricsStartupError = new Error('metrics startup failed')
     const cleanup = configure({
       metrics: { metricUrl: '/client-metrics' },
-      rum: { webVitals: { metrics: true } },
+      rum: {
+        session: {
+          getRouteName: () => '/integration',
+          getSessionAttributes: () => ({ account_tier: 'pro' }),
+        },
+        webVitals: { metrics: true },
+      },
       spanProcessors: [new SimpleSpanProcessor(exporter)],
       traceUrl: '/client-traces',
     })
@@ -236,6 +242,8 @@ describe('public browser configure startup ordering', () => {
       optionalFeatureMocks.reportFcp()
       const span = exporter.getFinishedSpans().find(({ name }) => name === 'web_vital.fcp')
       expect(span?.attributes['logfire.span_type']).toBe('log')
+      expect(span?.attributes['logfire.page.route']).toBe('/integration')
+      expect(span?.attributes['logfire.session.account_tier']).toBe('pro')
       expect(diagWarn).toHaveBeenCalledWith(
         'logfire-browser: browser metrics did not start; continuing Web Vitals with span reporting only'
       )

--- a/packages/logfire-browser/src/browserMetrics.test.ts
+++ b/packages/logfire-browser/src/browserMetrics.test.ts
@@ -264,8 +264,10 @@ describe('browser metrics runtime', () => {
       defaultAttributes: () =>
         ({
           'browser.session.id': 'browser-session-1',
+          'logfire.page.route': '/products/:id',
           'logfire.page.url.full': 'https://example.com/products/123?token=secret',
           'logfire.page.url.path': '/products/123',
+          'logfire.session.account_tier': 'pro',
           'session.id': 'session-1',
           'url.full': 'https://example.com/products/123?token=secret',
           'url.path': '/products/:id',

--- a/packages/logfire-browser/src/browserMetrics.ts
+++ b/packages/logfire-browser/src/browserMetrics.ts
@@ -98,6 +98,7 @@ const WEB_VITAL_METRIC_INSTRUMENTS: Record<WebVitalName, WebVitalMetricInstrumen
 
 const DISALLOWED_WEB_VITAL_METRIC_ATTRIBUTES = new Set([
   'browser.session.id',
+  'logfire.page.route',
   'logfire.page.url.full',
   'logfire.page.url.path',
   'session.id',
@@ -119,6 +120,7 @@ function isWebVitalName(name: string): name is WebVitalName {
 function isDisallowedWebVitalMetricAttribute(key: string): boolean {
   return (
     DISALLOWED_WEB_VITAL_METRIC_ATTRIBUTES.has(key) ||
+    key.startsWith('logfire.session.') ||
     key.startsWith('web_vital.cls.') ||
     key.startsWith('web_vital.fcp.') ||
     key.startsWith('web_vital.inp.') ||

--- a/packages/logfire-browser/src/browserSession.test.ts
+++ b/packages/logfire-browser/src/browserSession.test.ts
@@ -40,6 +40,16 @@ class ThrowingStorage extends MemoryStorage {
   }
 }
 
+class ThrowingWriteStorage extends MemoryStorage {
+  seed(key: string, value: string): void {
+    super.setItem(key, value)
+  }
+
+  override setItem(_key: string, _value: string): void {
+    throw new Error('storage is read-only')
+  }
+}
+
 class CountingStorage extends MemoryStorage {
   getItemCalls = 0
   setItemCalls = 0
@@ -90,6 +100,8 @@ describe('BrowserSessionManager', () => {
     const getSessionAttributes = vi.fn<() => Record<string, string | number | boolean | undefined>>(() => ({
       account_tier: 'pro',
       beta_user: true,
+      empty_label: '',
+      paid: false,
       seats: 12,
       invalid: Number.NaN,
     }))
@@ -104,11 +116,15 @@ describe('BrowserSessionManager', () => {
     expect(firstManager.touch().sessionAttributes).toEqual({
       account_tier: 'pro',
       beta_user: true,
+      empty_label: '',
+      paid: false,
       seats: 12,
     })
     expect(firstManager.touch().sessionAttributes).toEqual({
       account_tier: 'pro',
       beta_user: true,
+      empty_label: '',
+      paid: false,
       seats: 12,
     })
     expect(getSessionAttributes).toHaveBeenCalledTimes(1)
@@ -124,6 +140,8 @@ describe('BrowserSessionManager', () => {
     expect(secondManager.touch().sessionAttributes).toEqual({
       account_tier: 'pro',
       beta_user: true,
+      empty_label: '',
+      paid: false,
       seats: 12,
     })
     expect(secondCallback).not.toHaveBeenCalled()
@@ -148,15 +166,89 @@ describe('BrowserSessionManager', () => {
       storageKey: 'test-session',
     })
 
-    expect(manager.touch()).toMatchObject({
+    expect(manager.touch()).toEqual({
       id: 'legacy-session',
+      lastActivityAt: 1_100,
       sessionAttributes: { account_tier: 'pro' },
+      startedAt: 1_000,
     })
     expect(getSessionAttributes).toHaveBeenCalledTimes(1)
-    expect(JSON.parse(storage.getItem('test-session') ?? '')).toMatchObject({
+    expect(JSON.parse(storage.getItem('test-session') ?? '')).toEqual({
       id: 'legacy-session',
+      lastActivityAt: 1_000,
       sessionAttributes: { account_tier: 'pro' },
+      startedAt: 1_000,
     })
+  })
+
+  it('does not hydrate an explicit empty session attribute snapshot', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      'test-session',
+      JSON.stringify({
+        id: 'evaluated-session',
+        lastActivityAt: 1_000,
+        sessionAttributes: {},
+        startedAt: 1_000,
+      })
+    )
+    const getSessionAttributes = vi.fn<() => Record<string, string>>(() => ({ account_tier: 'pro' }))
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getSessionAttributes,
+      now: () => 1_100,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(manager.touch().sessionAttributes).toEqual({})
+    expect(getSessionAttributes).not.toHaveBeenCalled()
+  })
+
+  it('abandons a legacy id when its hydrated snapshot cannot be persisted', () => {
+    const storage = new ThrowingWriteStorage()
+    storage.seed(
+      'test-session',
+      JSON.stringify({
+        id: 'legacy-session',
+        lastActivityAt: 1_000,
+        startedAt: 1_000,
+      })
+    )
+    const generateId = createIdGenerator()
+    const firstCallback = vi.fn<() => Record<string, string>>(() => ({ account_tier: 'pro' }))
+    const firstManager = new BrowserSessionManager({
+      generateId,
+      getSessionAttributes: firstCallback,
+      now: () => 1_100,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(firstManager.touch()).toEqual({
+      id: 'session-1',
+      lastActivityAt: 1_100,
+      sessionAttributes: { account_tier: 'pro' },
+      startedAt: 1_100,
+    })
+    expect(firstCallback).toHaveBeenCalledTimes(1)
+
+    const secondCallback = vi.fn<() => Record<string, string>>(() => ({ account_tier: 'free' }))
+    const secondManager = new BrowserSessionManager({
+      generateId,
+      getSessionAttributes: secondCallback,
+      now: () => 1_200,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(secondManager.touch()).toEqual({
+      id: 'session-2',
+      lastActivityAt: 1_200,
+      sessionAttributes: { account_tier: 'free' },
+      startedAt: 1_200,
+    })
+    expect(secondCallback).toHaveBeenCalledTimes(1)
   })
 
   it('captures a fresh snapshot when the session rotates', () => {

--- a/packages/logfire-browser/src/browserSession.test.ts
+++ b/packages/logfire-browser/src/browserSession.test.ts
@@ -85,6 +85,241 @@ describe('BrowserSessionManager', () => {
     expect(secondManager.getSession().id).toBe(firstSession.id)
   })
 
+  it('snapshots, bounds, and persists session attributes once per session', () => {
+    const storage = new MemoryStorage()
+    const getSessionAttributes = vi.fn<() => Record<string, string | number | boolean | undefined>>(() => ({
+      account_tier: 'pro',
+      beta_user: true,
+      seats: 12,
+      invalid: Number.NaN,
+    }))
+    const firstManager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getSessionAttributes,
+      now: () => 1_000,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(firstManager.touch().sessionAttributes).toEqual({
+      account_tier: 'pro',
+      beta_user: true,
+      seats: 12,
+    })
+    expect(firstManager.touch().sessionAttributes).toEqual({
+      account_tier: 'pro',
+      beta_user: true,
+      seats: 12,
+    })
+    expect(getSessionAttributes).toHaveBeenCalledTimes(1)
+
+    const secondCallback = vi.fn<() => Record<string, string>>(() => ({ account_tier: 'free' }))
+    const secondManager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getSessionAttributes: secondCallback,
+      now: () => 2_000,
+      storage,
+      storageKey: 'test-session',
+    })
+    expect(secondManager.touch().sessionAttributes).toEqual({
+      account_tier: 'pro',
+      beta_user: true,
+      seats: 12,
+    })
+    expect(secondCallback).not.toHaveBeenCalled()
+  })
+
+  it('hydrates legacy stored sessions without changing their id', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      'test-session',
+      JSON.stringify({
+        id: 'legacy-session',
+        lastActivityAt: 1_000,
+        startedAt: 1_000,
+      })
+    )
+    const getSessionAttributes = vi.fn<() => Record<string, string>>(() => ({ account_tier: 'pro' }))
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getSessionAttributes,
+      now: () => 1_100,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(manager.touch()).toMatchObject({
+      id: 'legacy-session',
+      sessionAttributes: { account_tier: 'pro' },
+    })
+    expect(getSessionAttributes).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(storage.getItem('test-session') ?? '')).toMatchObject({
+      id: 'legacy-session',
+      sessionAttributes: { account_tier: 'pro' },
+    })
+  })
+
+  it('captures a fresh snapshot when the session rotates', () => {
+    let now = 1_000
+    let tier = 'pro'
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getSessionAttributes: () => ({ tier }),
+      idleTimeoutMs: 100,
+      maxDurationMs: 1_000,
+      now: () => now,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+    })
+
+    expect(manager.touch().sessionAttributes).toEqual({ tier: 'pro' })
+    tier = 'enterprise'
+    expect(manager.touch().sessionAttributes).toEqual({ tier: 'pro' })
+    now = 1_101
+    expect(manager.touch().sessionAttributes).toEqual({ tier: 'enterprise' })
+  })
+
+  it('silently contains hostile session and route callbacks', () => {
+    const sessionCallback = vi.fn<() => Record<string, string>>(() => {
+      throw new Error('session dimensions unavailable')
+    })
+    const routeCallback = vi.fn<() => string>(() => {
+      throw new Error('router unavailable')
+    })
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getRouteName: routeCallback,
+      getSessionAttributes: sessionCallback,
+      now: () => 1_000,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+    })
+
+    expect(manager.touch().sessionAttributes).toEqual({})
+    expect(manager.getRouteName()).toBeUndefined()
+    expect(sessionCallback).toHaveBeenCalledTimes(1)
+    expect(routeCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('enforces the complete session attribute boundary without mutating input', () => {
+    const source: Record<string, unknown> = {
+      Invalid: 'uppercase',
+      invalid_infinity: Number.POSITIVE_INFINITY,
+      invalid_nan: Number.NaN,
+      invalid_object: {},
+      invalid_string: '🚀'.repeat(201),
+      skipped: undefined,
+      valid_unicode: '🚀'.repeat(200),
+    }
+    for (let index = 0; index < 25; index++) {
+      source[`valid_${index.toString()}`] = index
+    }
+    source['invalid-key'] = 'dash'
+    source[`a${'b'.repeat(64)}`] = 'too long'
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getSessionAttributes: () => source as Record<string, string | number | boolean | undefined>,
+      now: () => 1_000,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+    })
+
+    const attributes = manager.touch().sessionAttributes
+    source['valid_unicode'] = 'changed'
+
+    expect(attributes?.['valid_unicode']).toBe('🚀'.repeat(200))
+    expect(Object.keys(attributes ?? {})).toHaveLength(20)
+    expect(attributes?.['valid_18']).toBe(18)
+    expect(attributes?.['valid_19']).toBeUndefined()
+    expect(attributes?.['Invalid']).toBeUndefined()
+    expect(Object.isFrozen(attributes)).toBe(true)
+  })
+
+  it('accepts plain and null-prototype records while containing hostile containers and properties', () => {
+    const inherited = Object.create({ inherited: 'ignored' }) as Record<string, string>
+    inherited['own'] = 'also rejected with its custom prototype'
+    const nullPrototype = Object.assign(Object.create(null) as Record<string, string>, { tier: 'pro' })
+    const frozen = Object.freeze({ tier: 'frozen' })
+    const sealed = Object.seal({ tier: 'sealed' })
+    const throwingProperty = Object.defineProperty({ healthy: true }, 'broken', {
+      enumerable: true,
+      get: () => {
+        throw new Error('property unavailable')
+      },
+    })
+    class Dimensions {
+      tier = 'pro'
+    }
+    const prototypeProxy = new Proxy(
+      {},
+      {
+        getPrototypeOf: () => {
+          throw new Error('prototype unavailable')
+        },
+      }
+    )
+    const enumerationProxy = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error('enumeration unavailable')
+        },
+      }
+    )
+    const values: unknown[] = [
+      nullPrototype,
+      frozen,
+      sealed,
+      throwingProperty,
+      inherited,
+      [],
+      () => ({}),
+      new Date(),
+      new Dimensions(),
+      prototypeProxy,
+      enumerationProxy,
+    ]
+    const expected = [{ tier: 'pro' }, { tier: 'frozen' }, { tier: 'sealed' }, { healthy: true }, {}, {}, {}, {}, {}, {}, {}]
+
+    expect(
+      values.map((value) => {
+        const manager = new BrowserSessionManager({
+          generateId: createIdGenerator(),
+          getSessionAttributes: () => value as Record<string, string | number | boolean | undefined>,
+          now: () => 1_000,
+          storage: new MemoryStorage(),
+          storageKey: 'test-session',
+        })
+        return manager.touch().sessionAttributes
+      })
+    ).toEqual(expected)
+  })
+
+  it('revalidates tampered persisted attributes', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      'test-session',
+      JSON.stringify({
+        id: 'stored-session',
+        lastActivityAt: 1_000,
+        sessionAttributes: {
+          account_tier: 'pro',
+          nested: { secret: true },
+          seats: Number.POSITIVE_INFINITY,
+        },
+        startedAt: 1_000,
+      })
+    )
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      now: () => 1_100,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(manager.touch().sessionAttributes).toEqual({ account_tier: 'pro' })
+  })
+
   it('falls back to memory when storage throws', () => {
     const manager = new BrowserSessionManager({
       generateId: createIdGenerator(),

--- a/packages/logfire-browser/src/browserSession.ts
+++ b/packages/logfire-browser/src/browserSession.ts
@@ -304,7 +304,7 @@ export class BrowserSessionManager {
     if (this.memorySession !== undefined && !this.isExpired(this.memorySession, now)) {
       return this.memorySession
     }
-    const storedSession = this.readSession()
+    const storedSession = this.readSession(now)
     if (storedSession !== undefined && !this.isExpired(storedSession, now)) {
       return storedSession
     }
@@ -316,7 +316,7 @@ export class BrowserSessionManager {
     return now - session.lastActivityAt > this.idleTimeoutMs || now - session.startedAt > this.maxDurationMs
   }
 
-  private readSession(): BrowserSessionState | undefined {
+  private readSession(now: number): BrowserSessionState | undefined {
     if (this.storage !== null) {
       try {
         const value = this.storage.getItem(this.storageKey)
@@ -326,7 +326,17 @@ export class BrowserSessionManager {
             const session = this.prepareStoredSession(parsedValue)
             this.memorySession = session
             if (hasOwn(parsedValue, 'sessionAttributes') || this.sessionAttributesCallback !== undefined) {
-              this.writeSession(session)
+              const persisted = this.writeSession(session)
+              if (!persisted && !hasOwn(parsedValue, 'sessionAttributes') && this.sessionAttributesCallback !== undefined) {
+                const replacementSession = {
+                  ...session,
+                  id: this.generateId(),
+                  lastActivityAt: now,
+                  startedAt: now,
+                }
+                this.writeSession(replacementSession)
+                return replacementSession
+              }
             }
             return session
           }
@@ -363,16 +373,18 @@ export class BrowserSessionManager {
     return session
   }
 
-  private writeSession(session: BrowserSessionState): void {
+  private writeSession(session: BrowserSessionState): boolean {
     this.memorySession = session
     if (this.storage === null) {
-      return
+      return false
     }
 
     try {
       this.storage.setItem(this.storageKey, JSON.stringify(session))
+      return true
     } catch {
       // Session identity is best-effort in constrained browser contexts.
+      return false
     }
   }
 

--- a/packages/logfire-browser/src/browserSession.ts
+++ b/packages/logfire-browser/src/browserSession.ts
@@ -1,6 +1,13 @@
 import type { BrowserWebVitalsOptions } from './webVitals'
 
 export const BROWSER_SESSION_ACTIVITY_WRITE_DELAY_MS = 1_000
+const MAX_SESSION_ATTRIBUTES = 20
+const MAX_SESSION_ATTRIBUTE_STRING_CODE_POINTS = 200
+const SESSION_ATTRIBUTE_KEY_PATTERN = /^[a-z][a-z0-9_]{0,63}$/u
+
+export type BrowserSessionAttributeValue = string | number | boolean
+export type BrowserSessionAttributesInput = Record<string, BrowserSessionAttributeValue | undefined>
+export type BrowserSessionAttributes = Record<string, BrowserSessionAttributeValue>
 
 export interface BrowserSessionUrlAttributes {
   full?: string
@@ -8,6 +15,16 @@ export interface BrowserSessionUrlAttributes {
 }
 
 export interface BrowserSessionOptions {
+  /**
+   * Returns the application's current normalized, low-cardinality route name.
+   * The callback is evaluated independently for every new browser span.
+   */
+  getRouteName?: () => string | undefined
+  /**
+   * Returns low-cardinality, non-PII dimensions to snapshot once per browser
+   * session. Invalid or oversized entries are omitted.
+   */
+  getSessionAttributes?: () => BrowserSessionAttributesInput
   /**
    * Session inactivity timeout. Defaults to 30 minutes. Replay startup touches
    * the session once before lazy loading; subsequent replay events only peek
@@ -37,6 +54,7 @@ export interface BrowserSessionState {
   id: string
   startedAt: number
   lastActivityAt: number
+  sessionAttributes?: BrowserSessionAttributes
 }
 
 export interface RUMOptions {
@@ -114,8 +132,78 @@ function isBrowserSessionState(value: unknown): value is BrowserSessionState {
   )
 }
 
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.hasOwn(value, key)
+}
+
+function hasAtMostCodePoints(value: string, maximum: number): boolean {
+  let count = 0
+  for (const codePoint of value) {
+    count += codePoint.length > 0 ? 1 : 0
+    if (count > maximum) {
+      return false
+    }
+  }
+  return true
+}
+
+function normalizeBrowserSessionAttributes(value: unknown): BrowserSessionAttributes {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return Object.freeze({})
+  }
+
+  let prototype: object | null
+  try {
+    prototype = Object.getPrototypeOf(value) as object | null
+  } catch {
+    return Object.freeze({})
+  }
+  if (prototype !== Object.prototype && prototype !== null) {
+    return Object.freeze({})
+  }
+
+  let keys: string[]
+  try {
+    keys = Object.keys(value)
+  } catch {
+    return Object.freeze({})
+  }
+
+  const attributes: BrowserSessionAttributes = {}
+  let accepted = 0
+  for (const key of keys) {
+    if (!SESSION_ATTRIBUTE_KEY_PATTERN.test(key)) {
+      continue
+    }
+
+    let attributeValue: unknown
+    try {
+      attributeValue = Reflect.get(value, key)
+    } catch {
+      continue
+    }
+
+    const valid =
+      typeof attributeValue === 'boolean' ||
+      (typeof attributeValue === 'number' && Number.isFinite(attributeValue)) ||
+      (typeof attributeValue === 'string' && hasAtMostCodePoints(attributeValue, MAX_SESSION_ATTRIBUTE_STRING_CODE_POINTS))
+    if (!valid) {
+      continue
+    }
+
+    attributes[key] = attributeValue as BrowserSessionAttributeValue
+    accepted += 1
+    if (accepted === MAX_SESSION_ATTRIBUTES) {
+      break
+    }
+  }
+  return Object.freeze(attributes)
+}
+
 export class BrowserSessionManager {
   private readonly generateId: () => string
+  private readonly routeNameCallback: BrowserSessionOptions['getRouteName'] | undefined
+  private readonly sessionAttributesCallback: BrowserSessionOptions['getSessionAttributes'] | undefined
   private readonly idleTimeoutMs: number
   private readonly maxDurationMs: number
   private readonly now: () => number
@@ -128,6 +216,8 @@ export class BrowserSessionManager {
 
   constructor(options: BrowserSessionManagerOptions = {}) {
     this.generateId = options.generateId ?? generateBrowserSessionId
+    this.routeNameCallback = options.getRouteName
+    this.sessionAttributesCallback = options.getSessionAttributes
     this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_BROWSER_SESSION_OPTIONS.idleTimeoutMs
     this.maxDurationMs = options.maxDurationMs ?? DEFAULT_BROWSER_SESSION_OPTIONS.maxDurationMs
     this.now = options.now ?? Date.now
@@ -142,6 +232,11 @@ export class BrowserSessionManager {
 
   peekSessionId(): string | undefined {
     return this.memorySession?.id
+  }
+
+  peekSessionAttributes(): BrowserSessionAttributes | undefined {
+    const attributes = this.memorySession?.sessionAttributes
+    return attributes === undefined ? undefined : Object.freeze({ ...attributes })
   }
 
   touch(): BrowserSessionState {
@@ -184,11 +279,21 @@ export class BrowserSessionManager {
     }
   }
 
+  getRouteName(): string | undefined {
+    try {
+      const routeName = this.routeNameCallback?.()
+      return typeof routeName === 'string' ? routeName : undefined
+    } catch {
+      return undefined
+    }
+  }
+
   private createSession(now: number): BrowserSessionState {
     const session: BrowserSessionState = {
       id: this.generateId(),
       lastActivityAt: now,
       startedAt: now,
+      ...(this.sessionAttributesCallback === undefined ? {} : { sessionAttributes: this.captureSessionAttributes() }),
     }
     this.flushPendingStorage()
     this.writeSession(session)
@@ -218,8 +323,12 @@ export class BrowserSessionManager {
         if (value !== null) {
           const parsedValue: unknown = JSON.parse(value)
           if (isBrowserSessionState(parsedValue)) {
-            this.memorySession = parsedValue
-            return parsedValue
+            const session = this.prepareStoredSession(parsedValue)
+            this.memorySession = session
+            if (hasOwn(parsedValue, 'sessionAttributes') || this.sessionAttributesCallback !== undefined) {
+              this.writeSession(session)
+            }
+            return session
           }
         }
       } catch {
@@ -228,6 +337,30 @@ export class BrowserSessionManager {
     }
 
     return this.memorySession
+  }
+
+  private captureSessionAttributes(): BrowserSessionAttributes {
+    try {
+      return normalizeBrowserSessionAttributes(this.sessionAttributesCallback?.())
+    } catch {
+      return Object.freeze({})
+    }
+  }
+
+  private prepareStoredSession(session: BrowserSessionState): BrowserSessionState {
+    if (hasOwn(session, 'sessionAttributes')) {
+      return {
+        ...session,
+        sessionAttributes: normalizeBrowserSessionAttributes(session.sessionAttributes),
+      }
+    }
+    if (this.sessionAttributesCallback !== undefined) {
+      return {
+        ...session,
+        sessionAttributes: this.captureSessionAttributes(),
+      }
+    }
+    return session
   }
 
   private writeSession(session: BrowserSessionState): void {

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -74,7 +74,14 @@ import { assertBrowserReplayUrl, createTelemetryUrlPatterns, isBrowserReplayUrlV
 export { DiagLogLevel } from '@opentelemetry/api'
 export * from 'logfire'
 export { getBrowserSessionId } from './browserSession'
-export type { BrowserSessionOptions, BrowserSessionUrlAttributes, RUMOptions } from './browserSession'
+export type {
+  BrowserSessionAttributes,
+  BrowserSessionAttributesInput,
+  BrowserSessionAttributeValue,
+  BrowserSessionOptions,
+  BrowserSessionUrlAttributes,
+  RUMOptions,
+} from './browserSession'
 export type { BrowserMetricsOptions, BrowserWebVitalsMetricOptions } from './browserMetrics'
 export type { BrowserSessionReplayOptions } from './sessionReplay'
 export type { BrowserWebVitalsOptions } from './webVitals'

--- a/packages/logfire-browser/src/sessionReplay.test.ts
+++ b/packages/logfire-browser/src/sessionReplay.test.ts
@@ -154,8 +154,74 @@ describe('startBrowserSessionReplay', () => {
     expect(touchSpy).toHaveBeenCalledTimes(1)
     expect(replayConfig?.getSessionId?.()).toBe('browser-session-1')
     expect(replayConfig?.getSessionId?.()).toBe('browser-session-1')
+    expect(replayConfig?.getSessionAttributes?.()).toEqual({})
     expect(touchSpy).toHaveBeenCalledTimes(1)
     expect(getSessionSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes the browser session snapshot to replay without touching the session again', async () => {
+    const manager = new BrowserSessionManager({
+      generateId: () => 'browser-session-1',
+      getSessionAttributes: () => ({ account_tier: 'pro', beta_user: true }),
+      now: () => 1_000,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+    })
+    const touchSpy = vi.spyOn(manager, 'touch')
+    let replayConfig: BrowserSessionReplayPackageConfig | undefined
+    const replayModule: BrowserSessionReplayModule = {
+      startSessionReplay: (config) => {
+        replayConfig = config
+        return createReplayRuntime()
+      },
+    }
+
+    await startBrowserSessionReplay({ load: () => replayModule, replayUrl: '/logfire/replay' }, manager, new BrowserSessionReplayState(), {
+      traceUrl: '/logfire/traces',
+    })
+
+    expect(replayConfig?.getSessionAttributes?.()).toEqual({
+      account_tier: 'pro',
+      beta_user: true,
+    })
+    expect(touchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards a fresh non-touching snapshot after browser-session reset', async () => {
+    let id = 0
+    let tier = 'pro'
+    const manager = new BrowserSessionManager({
+      generateId: () => {
+        id += 1
+        return `browser-session-${id.toString()}`
+      },
+      getSessionAttributes: () => ({ account_tier: tier }),
+      now: () => 1_000,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+    })
+    const touchSpy = vi.spyOn(manager, 'touch')
+    let replayConfig: BrowserSessionReplayPackageConfig | undefined
+    const replayModule: BrowserSessionReplayModule = {
+      startSessionReplay: (config) => {
+        replayConfig = config
+        return createReplayRuntime()
+      },
+    }
+
+    await startBrowserSessionReplay({ load: () => replayModule, replayUrl: '/logfire/replay' }, manager, new BrowserSessionReplayState(), {
+      traceUrl: '/logfire/traces',
+    })
+    const touchCallsAfterStartup = touchSpy.mock.calls.length
+    expect(replayConfig?.getSessionAttributes?.()).toEqual({ account_tier: 'pro' })
+
+    tier = 'enterprise'
+    manager.reset()
+
+    expect(replayConfig?.getSessionId?.()).toBe('browser-session-2')
+    expect(replayConfig?.getSessionAttributes?.()).toEqual({ account_tier: 'enterprise' })
+    expect(replayConfig?.getSessionAttributes?.()).toEqual({ account_tier: 'enterprise' })
+    expect(touchSpy).toHaveBeenCalledTimes(touchCallsAfterStartup)
   })
 
   it('leaves privacy options absent so the replay package owns safe defaults', async () => {

--- a/packages/logfire-browser/src/sessionReplay.ts
+++ b/packages/logfire-browser/src/sessionReplay.ts
@@ -28,6 +28,7 @@ export interface BrowserSessionReplayPackageConfig {
   headers?: () => MaybePromise<Record<string, string>>
   token?: string | (() => MaybePromise<string>)
   getSessionId?: () => string | undefined
+  getSessionAttributes?: () => Record<string, string | number | boolean | undefined>
   sessionSampleRate?: number
   onErrorSampleRate?: number
   maskAllText?: boolean
@@ -184,6 +185,7 @@ function createReplayConfig(
 ): BrowserSessionReplayPackageConfig {
   const config: BrowserSessionReplayPackageConfig = {
     getSessionId: () => browserSessionManager.peekSessionId(),
+    getSessionAttributes: () => browserSessionManager.peekSessionAttributes() ?? {},
     ignoreUrlPatterns: [
       ...createTelemetryUrlPatterns([
         { kind: 'exact', url: telemetryOptions.traceUrl },

--- a/packages/logfire-browser/test-fixtures/rum-dimensions/index.html
+++ b/packages/logfire-browser/test-fixtures/rum-dimensions/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logfire RUM dimensions acceptance</title>
+  </head>
+  <body>
+    <main>
+      <h1>RUM dimensions acceptance</h1>
+      <button id="interaction" type="button">Interaction</button>
+      <p id="status">starting</p>
+    </main>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/packages/logfire-browser/test-fixtures/rum-dimensions/main.ts
+++ b/packages/logfire-browser/test-fixtures/rum-dimensions/main.ts
@@ -1,0 +1,258 @@
+import * as logfire from '../../dist/index.js'
+
+type Phase = 'starting' | 'before-reload' | 'after-reload' | 'rotated' | 'complete' | 'failed'
+type Scenario = 'normal' | 'hostile'
+
+interface AcceptanceState {
+  callbackCount: number
+  error?: string
+  phase: Phase
+  scenario: Scenario
+}
+
+declare global {
+  interface Window {
+    __logfireRumDimensions: AcceptanceState
+  }
+}
+
+const scenario: Scenario = window.location.pathname.startsWith('/hostile/') ? 'hostile' : 'normal'
+const phaseKey = `logfire-rum-dimensions-phase-${scenario}`
+const callbackCountKey = `logfire-rum-dimensions-callback-count-${scenario}`
+const initialPhase = sessionStorage.getItem(phaseKey)
+const state: AcceptanceState = {
+  callbackCount: readCallbackCount(),
+  phase: initialPhase === 'after-reload' ? 'after-reload' : 'starting',
+  scenario,
+}
+Reflect.set(window, '__logfireRumDimensions', state)
+
+let routeName = '/projects/:project_id'
+let replayRuntime: { flush(): Promise<void> } | undefined
+let markReplayReady!: () => void
+const replayReady = new Promise<void>((resolve) => {
+  markReplayReady = resolve
+})
+const uninstrumentedFetch = window.fetch
+const uninstrumentedXhrOpen = Reflect.get(XMLHttpRequest.prototype, 'open')
+
+const cleanup = logfire.configure({
+  autoInstrumentations: {
+    '@opentelemetry/instrumentation-document-load': { enabled: true },
+    '@opentelemetry/instrumentation-fetch': { enabled: true },
+    '@opentelemetry/instrumentation-user-interaction': { enabled: true, eventNames: ['click'] },
+    '@opentelemetry/instrumentation-xml-http-request': { enabled: true },
+  },
+  batchSpanProcessorConfig: {
+    maxExportBatchSize: 8,
+    scheduledDelayMillis: 100,
+  },
+  metrics: {
+    metricReaderConfig: {
+      exportIntervalMillis: 60_000,
+      exportTimeoutMillis: 2_000,
+    },
+    metricUrl: '/client-metrics',
+  },
+  rum: {
+    session: {
+      getRouteName:
+        scenario === 'hostile'
+          ? () => {
+              throw new Error('hostile route callback')
+            }
+          : () => routeName,
+      getSessionAttributes: scenario === 'hostile' ? hostileDimensions : normalDimensions,
+      idleTimeoutMs: 2_000,
+    },
+    webVitals: {
+      metrics: true,
+      reportAllChanges: true,
+    },
+  },
+  serviceName: `rum-dimensions-${scenario}`,
+  sessionReplay: {
+    captureConsole: false,
+    captureNavigation: false,
+    captureNetwork: false,
+    flushIntervalMs: 60_000,
+    ignoreUrlPatterns: [/\/receipts(?:\/|$)/u],
+    load: async () => {
+      const replayModule = await import('lf-rum-dimensions-recorder')
+      return {
+        startSessionReplay(config) {
+          const runtime = replayModule.startSessionReplay(config)
+          replayRuntime = runtime
+          markReplayReady()
+          return runtime
+        },
+      }
+    },
+    replayUrl: '/client-replay',
+    sessionSampleRate: 1,
+  },
+  traceUrl: '/client-traces',
+})
+
+run().catch(fail)
+
+async function run(): Promise<void> {
+  await replayReady
+  await waitUntil(
+    () => window.fetch !== uninstrumentedFetch && Reflect.get(XMLHttpRequest.prototype, 'open') !== uninstrumentedXhrOpen,
+    'automatic fetch/XHR instrumentation'
+  )
+
+  if (scenario === 'hostile') {
+    state.phase = 'before-reload'
+    logfire.info('hostile-dimensions')
+    document.querySelector<HTMLButtonElement>('#interaction')?.click()
+    await replayRuntime?.flush()
+    await cleanup()
+    complete()
+    return
+  }
+
+  if (initialPhase !== 'after-reload') {
+    state.phase = 'before-reload'
+    setStatus('before-reload')
+    logfire.info('normal-before-reload')
+    const durationSpan = logfire.startSpan('normal-duration')
+    durationSpan.end()
+    logfire.reportError('normal-error', new Error('fixture error'))
+    await fetch('/api/fetch')
+    await xhr('/api/xhr')
+    document.querySelector<HTMLButtonElement>('#interaction')?.click()
+    // Fetch/XHR instrumentation waits briefly for resource-timing entries
+    // before ending its spans.
+    await delay(500)
+    await replayRuntime?.flush()
+    sessionStorage.setItem(phaseKey, 'after-reload')
+    await cleanup()
+    window.location.reload()
+    return
+  }
+
+  state.phase = 'after-reload'
+  setStatus('after-reload')
+  logfire.info('normal-after-reload')
+  routeName = '/settings'
+  await delay(2_100)
+  logfire.info('normal-after-rotation')
+  logfire.info('normal-callback-count', {
+    'acceptance.callback_count': readCallbackCount(),
+  })
+  state.phase = 'rotated'
+  setStatus('rotated')
+
+  // Replay observes external browser-session rotation on its one-second poll.
+  await delay(1_100)
+  document.querySelector('#status')?.setAttribute('data-replay-session', 'rotated')
+  await replayRuntime?.flush()
+  await cleanup()
+
+  const omittedRouteCleanup = logfire.configure({
+    autoInstrumentations: false,
+    batchSpanProcessorConfig: {
+      maxExportBatchSize: 8,
+      scheduledDelayMillis: 100,
+    },
+    rum: { session: true },
+    serviceName: 'rum-dimensions-normal',
+    traceUrl: '/client-traces',
+  })
+  logfire.info('normal-route-omitted')
+  await omittedRouteCleanup()
+  complete()
+}
+
+function normalDimensions(): Record<string, string | number | boolean> {
+  const generation = incrementCallbackCount()
+  return {
+    account_tier: generation === 1 ? 'pro' : 'enterprise',
+    app_region: 'eu',
+    beta_user: true,
+    generation,
+  }
+}
+
+function hostileDimensions(): Record<string, string | number | boolean | undefined> {
+  incrementCallbackCount()
+  const dimensions: Record<string, unknown> = {
+    Invalid: 'uppercase',
+    account_tier: 'pro',
+    invalid_infinity: Number.POSITIVE_INFINITY,
+    invalid_nested: { secret: true },
+    invalid_string: '🚀'.repeat(201),
+    valid_unicode: '🚀'.repeat(200),
+  }
+  Object.defineProperty(dimensions, 'broken', {
+    enumerable: true,
+    get: () => {
+      throw new Error('hostile property')
+    },
+  })
+  for (let index = 0; index < 25; index++) {
+    dimensions[`valid_${index.toString()}`] = index
+  }
+  return dimensions as Record<string, string | number | boolean | undefined>
+}
+
+function incrementCallbackCount(): number {
+  const count = readCallbackCount() + 1
+  sessionStorage.setItem(callbackCountKey, count.toString())
+  state.callbackCount = count
+  return count
+}
+
+function readCallbackCount(): number {
+  return Number(sessionStorage.getItem(callbackCountKey) ?? '0')
+}
+
+function complete(): void {
+  sessionStorage.removeItem(phaseKey)
+  state.callbackCount = readCallbackCount()
+  state.phase = 'complete'
+  setStatus('complete')
+}
+
+function fail(error: unknown): void {
+  state.error = error instanceof Error ? (error.stack ?? error.message) : String(error)
+  state.phase = 'failed'
+  setStatus('failed')
+}
+
+function setStatus(value: string): void {
+  document.querySelector('#status')?.replaceChildren(value)
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds)
+  })
+}
+
+async function xhr(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest()
+    request.open('GET', url)
+    request.addEventListener('load', () => {
+      resolve()
+    })
+    request.addEventListener('error', () => {
+      reject(new Error(`XHR failed: ${url}`))
+    })
+    request.send()
+  })
+}
+
+async function waitUntil(predicate: () => boolean, description: string, deadline = Date.now() + 5_000): Promise<void> {
+  if (predicate()) {
+    return
+  }
+  if (Date.now() >= deadline) {
+    throw new Error(`timed out waiting for ${description}`)
+  }
+  await delay(10)
+  return waitUntil(predicate, description, deadline)
+}

--- a/packages/logfire-browser/test-fixtures/rum-dimensions/recorder.d.ts
+++ b/packages/logfire-browser/test-fixtures/rum-dimensions/recorder.d.ts
@@ -1,0 +1,3 @@
+declare module 'lf-rum-dimensions-recorder' {
+  export { startSessionReplay } from '@pydantic/logfire-session-replay'
+}

--- a/packages/logfire-browser/test-fixtures/rum-dimensions/verify.mjs
+++ b/packages/logfire-browser/test-fixtures/rum-dimensions/verify.mjs
@@ -1,0 +1,275 @@
+/* eslint-disable typescript/no-unsafe-argument, typescript/no-unsafe-assignment, typescript/no-unsafe-call, typescript/no-unsafe-member-access, typescript/no-unsafe-return, typescript/restrict-template-expressions, typescript/strict-boolean-expressions */
+import { gunzipSync } from 'node:zlib'
+
+const scenario = process.argv[2]
+assert(scenario === 'normal' || scenario === 'hostile', 'usage: verify.mjs normal|hostile [--phase <phase>]')
+const phase = parsePhase(scenario)
+const snapshot = await pollForEvidence(Date.now() + 30_000, scenario, phase)
+
+if (scenario === 'normal') {
+  verifyNormal(snapshot, phase)
+} else {
+  verifyHostile(snapshot)
+}
+
+console.log(
+  JSON.stringify(
+    {
+      metricPoints: snapshot.metricPoints.length,
+      phase,
+      replayReceipts: snapshot.replays.length,
+      scenario,
+      sessionIds: [...new Set(snapshot.spans.map((span) => attribute(span, 'session.id')).filter(Boolean))],
+      spanCount: snapshot.spans.length,
+    },
+    null,
+    2
+  )
+)
+
+function verifyNormal(snapshot, requestedPhase) {
+  const named = new Map(snapshot.spans.map((span) => [span.name, span]))
+  const before = required(named, 'normal-before-reload')
+  const firstSession = attribute(before, 'session.id')
+  const beforeRoute = '/projects/:project_id'
+  const beforePath = '/projects/123'
+  const beforeUrl = 'http://127.0.0.1:4180/projects/123'
+  const representatives = [
+    before,
+    required(named, 'normal-duration'),
+    required(named, 'normal-error'),
+    requiredScopeWithRoute(snapshot.spans, 'instrumentation-document-load', beforeRoute),
+    requiredScopeWithRoute(snapshot.spans, 'instrumentation-fetch', beforeRoute),
+    requiredScopeWithRoute(snapshot.spans, 'instrumentation-user-interaction', beforeRoute),
+    requiredScopeWithRoute(snapshot.spans, 'instrumentation-xml-http-request', beforeRoute),
+    requiredSpanWithRoute(snapshot.spans, (span) => span.name.startsWith('web_vital.'), beforeRoute, 'Web Vital'),
+  ]
+  for (const span of representatives) {
+    assertEqual(`${span.name} route`, attribute(span, 'logfire.page.route'), beforeRoute)
+    assertEqual(`${span.name} page URL path`, attribute(span, 'logfire.page.url.path'), beforePath)
+    assertEqual(`${span.name} page URL full`, attribute(span, 'logfire.page.url.full'), beforeUrl)
+    assertEqual(`${span.name} session tier`, attribute(span, 'logfire.session.account_tier'), 'pro')
+  }
+
+  const firstReplays = snapshot.replays.filter(({ sessionId }) => sessionId === firstSession)
+  assert(firstReplays.length > 0, 'missing first-session replay chunks')
+  assertReplayChunks('first session', firstReplays, dimensions('pro', 1))
+  if (requestedPhase === 'before-reload') {
+    return
+  }
+
+  const after = required(named, 'normal-after-reload')
+  assertEqual('same-tab persisted session', attribute(after, 'session.id'), firstSession)
+  assertEqual('route after reload', attribute(after, 'logfire.page.route'), beforeRoute)
+  assertEqual('persisted account tier', attribute(after, 'logfire.session.account_tier'), 'pro')
+  if (requestedPhase === 'after-reload') {
+    return
+  }
+
+  const rotated = required(named, 'normal-after-rotation')
+  const rotatedSession = attribute(rotated, 'session.id')
+  assert(rotatedSession !== firstSession, 'idle expiry did not rotate the browser session')
+  assertEqual('route after state change', attribute(rotated, 'logfire.page.route'), '/settings')
+  assertEqual('rotated account tier', attribute(rotated, 'logfire.session.account_tier'), 'enterprise')
+  assertEqual('callback count', attribute(required(named, 'normal-callback-count'), 'acceptance.callback_count'), 2)
+
+  const rotatedReplays = snapshot.replays.filter(({ sessionId }) => sessionId === rotatedSession)
+  assert(rotatedReplays.length > 0, 'missing rotated-session replay chunks')
+  assertReplayChunks('rotated session', rotatedReplays, dimensions('enterprise', 2))
+
+  const omitted = required(named, 'normal-route-omitted')
+  assertEqual('omitted route callback', attribute(omitted, 'logfire.page.route'), undefined)
+  assertEqual('omitted route keeps page URL', attribute(omitted, 'logfire.page.url.path'), beforePath)
+
+  assert(snapshot.metricPoints.length > 0, 'missing Web Vital metric points')
+  for (const point of snapshot.metricPoints) {
+    assertDeepEqual('Web Vital metric attribute keys', (point.attributes ?? []).map(({ key }) => key).sort(), [
+      'web_vital.name',
+      'web_vital.rating',
+    ])
+  }
+}
+
+function verifyHostile(snapshot) {
+  const span = snapshot.spans.find(({ name }) => name === 'hostile-dimensions')
+  assert(span !== undefined, 'missing hostile span')
+  assertEqual('session id retained', typeof attribute(span, 'session.id'), 'string')
+  assertEqual('default URL retained', attribute(span, 'logfire.page.url.path'), '/hostile/')
+  assertEqual('throwing route omitted', attribute(span, 'logfire.page.route'), undefined)
+  assertEqual('replay remained active', attribute(span, 'logfire.session_replay.active'), true)
+
+  const sessionDimensions = Object.fromEntries(
+    (span.attributes ?? [])
+      .filter(({ key }) => key.startsWith('logfire.session.'))
+      .map(({ key, value }) => [key.slice('logfire.session.'.length), otlpValue(value)])
+  )
+  assertEqual('hostile cap', Object.keys(sessionDimensions).length, 20)
+  assertEqual('valid value retained', sessionDimensions.account_tier, 'pro')
+  assertEqual('Unicode boundary retained', sessionDimensions.valid_unicode, '🚀'.repeat(200))
+  for (const key of ['Invalid', 'invalid_infinity', 'invalid_nested', 'invalid_string', 'broken', 'valid_18']) {
+    assertEqual(`invalid or capped ${key}`, sessionDimensions[key], undefined)
+  }
+  assert(snapshot.replays.length > 0, 'missing hostile replay')
+  assertReplayChunks('hostile session', snapshot.replays, sessionDimensions)
+}
+
+function assertReplayChunks(label, replays, expectedDimensions) {
+  for (const replay of replays) {
+    assertEqual(`${label} envelope version`, replay.envelope.version, 1)
+    assertDeepEqual(
+      `${label} seq ${String(replay.envelope.meta?.seq)} dimensions`,
+      replay.envelope.meta?.sessionAttributes,
+      expectedDimensions
+    )
+  }
+}
+
+function dimensions(accountTier, generation) {
+  return {
+    account_tier: accountTier,
+    app_region: 'eu',
+    beta_user: true,
+    generation,
+  }
+}
+
+async function pollForEvidence(deadline, selectedScenario, requestedPhase) {
+  const snapshot = await readSnapshot(selectedScenario)
+  if (hasRequiredEvidence(snapshot, selectedScenario, requestedPhase)) {
+    return snapshot
+  }
+  if (Date.now() >= deadline) {
+    throw new Error(`timed out waiting for ${selectedScenario} ${requestedPhase} receipts`)
+  }
+  await new Promise((resolve) => {
+    setTimeout(resolve, 50)
+  })
+  return pollForEvidence(deadline, selectedScenario, requestedPhase)
+}
+
+async function readSnapshot(selectedScenario) {
+  const response = await fetch('http://127.0.0.1:4180/receipts')
+  assert(response.ok, `receipt request failed: ${response.status}`)
+  const { receipts } = await response.json()
+  const serviceName = `rum-dimensions-${selectedScenario}`
+  const traces = receipts.filter(({ kind }) => kind === 'trace').map(decodeJson)
+  const metrics = receipts.filter(({ kind }) => kind === 'metric').map(decodeJson)
+  const spans = traces.flatMap((payload) => collectSpans(payload, serviceName))
+  const sessionIds = new Set(spans.map((span) => attribute(span, 'session.id')).filter(Boolean))
+  const replays = receipts
+    .filter(({ kind }) => kind === 'replay')
+    .map((receipt) => ({
+      envelope: decodeReplay(receipt),
+      sessionId: new URL(receipt.url, 'http://127.0.0.1').pathname.split('/').at(-1),
+    }))
+    .filter(({ sessionId }) => sessionIds.has(sessionId))
+  return {
+    metricPoints: metrics.flatMap((payload) => collectMetricPoints(payload, serviceName)),
+    replays,
+    spans,
+  }
+}
+
+function collectSpans(payload, serviceName) {
+  return (payload.resourceSpans ?? [])
+    .filter((resource) => resourceAttribute(resource.resource, 'service.name') === serviceName)
+    .flatMap((resource) =>
+      (resource.scopeSpans ?? []).flatMap((scope) =>
+        (scope.spans ?? []).map((span) => ({
+          ...span,
+          scopeName: scope.scope?.name,
+        }))
+      )
+    )
+}
+
+function collectMetricPoints(payload, serviceName) {
+  return (payload.resourceMetrics ?? [])
+    .filter((resource) => resourceAttribute(resource.resource, 'service.name') === serviceName)
+    .flatMap((resource) =>
+      (resource.scopeMetrics ?? []).flatMap((scope) => (scope.metrics ?? []).flatMap((metric) => metric.histogram?.dataPoints ?? []))
+    )
+}
+
+function hasRequiredEvidence(snapshot, selectedScenario, requestedPhase) {
+  if (selectedScenario === 'hostile') {
+    return snapshot.spans.some(({ name }) => name === 'hostile-dimensions') && snapshot.replays.length > 0
+  }
+  if (requestedPhase === 'before-reload') {
+    return snapshot.spans.some(({ name }) => name === 'normal-before-reload') && snapshot.replays.length > 0
+  }
+  if (requestedPhase === 'after-reload') {
+    return snapshot.spans.some(({ name }) => name === 'normal-after-reload')
+  }
+  return (
+    snapshot.spans.some(({ name }) => name === 'normal-after-rotation') &&
+    snapshot.spans.some(({ name }) => name === 'normal-route-omitted') &&
+    new Set(snapshot.replays.map(({ sessionId }) => sessionId)).size >= 2 &&
+    snapshot.metricPoints.length > 0
+  )
+}
+
+function parsePhase(selectedScenario) {
+  const phaseIndex = process.argv.indexOf('--phase')
+  const defaultPhase = selectedScenario === 'normal' ? 'rotated' : 'hostile'
+  if (phaseIndex === -1) {
+    return defaultPhase
+  }
+  const requested = process.argv[phaseIndex + 1]
+  const allowed = selectedScenario === 'normal' ? ['before-reload', 'after-reload', 'rotated'] : ['hostile']
+  assert(allowed.includes(requested), `invalid phase ${requested} for ${selectedScenario}`)
+  return requested
+}
+
+function requiredScopeWithRoute(spans, scopeFragment, route) {
+  return requiredSpanWithRoute(spans, (span) => span.scopeName?.includes(scopeFragment), route, scopeFragment)
+}
+
+function requiredSpanWithRoute(spans, predicate, route, label) {
+  const span = spans.find((candidate) => predicate(candidate) && attribute(candidate, 'logfire.page.route') === route)
+  assert(span !== undefined, `missing ${label} span with route ${route}`)
+  return span
+}
+
+function attribute(span, key) {
+  return otlpValue(span?.attributes?.find((item) => item.key === key)?.value)
+}
+
+function resourceAttribute(resource, key) {
+  return otlpValue(resource?.attributes?.find((item) => item.key === key)?.value)
+}
+
+function otlpValue(value) {
+  return value?.stringValue ?? value?.boolValue ?? value?.intValue ?? value?.doubleValue
+}
+
+function required(map, key) {
+  const value = map.get(key)
+  assert(value !== undefined, `missing span ${key}`)
+  return value
+}
+
+function decodeJson(receipt) {
+  return JSON.parse(Buffer.from(receipt.body, 'base64').toString('utf8'))
+}
+
+function decodeReplay(receipt) {
+  return JSON.parse(gunzipSync(Buffer.from(receipt.body, 'base64')).toString('utf8'))
+}
+
+function assertDeepEqual(label, actual, expected) {
+  assert(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${label}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`
+  )
+}
+
+function assertEqual(label, actual, expected) {
+  assert(actual === expected, `${label}: expected ${String(expected)}, received ${String(actual)}`)
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message)
+  }
+}

--- a/packages/logfire-browser/test-fixtures/rum-dimensions/vite.config.ts
+++ b/packages/logfire-browser/test-fixtures/rum-dimensions/vite.config.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vite-plus'
+
+interface Receipt {
+  body: string
+  kind: 'trace' | 'metric' | 'replay'
+  url: string
+}
+
+const fixtureDirectory = dirname(fileURLToPath(import.meta.url))
+const packageDirectory = resolve(fixtureDirectory, '../..')
+const recorderEntrypoint = resolve(packageDirectory, '../logfire-session-replay/dist/index.js')
+const require = createRequire(recorderEntrypoint)
+const rrwebEntrypoint = require.resolve('rrweb').replace(/dist\/rrweb\.cjs$/u, 'dist/rrweb.js')
+const fflateEntrypoint = resolve(dirname(require.resolve('fflate/package.json')), 'esm/browser.js')
+const recorderModuleId = 'lf-rum-dimensions-recorder'
+const resolvedRecorderModuleId = `\0${recorderModuleId}`
+const receipts: Receipt[] = []
+
+function loadRecorderModule(): string {
+  return readFileSync(recorderEntrypoint, 'utf8')
+    .replaceAll('from"rrweb"', `from${JSON.stringify(rrwebEntrypoint)}`)
+    .replaceAll('from"fflate"', `from${JSON.stringify(fflateEntrypoint)}`)
+}
+
+export default defineConfig({
+  root: fixtureDirectory,
+  plugins: [
+    {
+      name: 'logfire-rum-dimensions-recorder-runtime',
+      resolveId(id) {
+        return id === recorderModuleId ? resolvedRecorderModuleId : undefined
+      },
+      load(id) {
+        return id === resolvedRecorderModuleId ? loadRecorderModule() : undefined
+      },
+    },
+    {
+      name: 'logfire-rum-dimensions-receipts',
+      configureServer(server) {
+        server.middlewares.use((request, response, next) => {
+          const url = new URL(request.url ?? '/', 'http://127.0.0.1')
+          if (request.method === 'GET' && url.pathname === '/receipts') {
+            response.setHeader('content-type', 'application/json')
+            response.end(JSON.stringify({ receipts }))
+            return
+          }
+          if (request.method === 'POST' && url.pathname === '/receipts/reset') {
+            receipts.length = 0
+            response.statusCode = 204
+            response.end()
+            return
+          }
+          if (url.pathname.startsWith('/api/')) {
+            response.statusCode = 200
+            response.setHeader('content-type', 'application/json')
+            response.end('{}')
+            return
+          }
+
+          const kind = endpointKind(url.pathname)
+          if (request.method !== 'POST' || kind === undefined) {
+            next()
+            return
+          }
+          const chunks: Buffer[] = []
+          request.on('data', (chunk: Buffer) => {
+            chunks.push(chunk)
+          })
+          request.on('end', () => {
+            receipts.push({
+              body: Buffer.concat(chunks).toString('base64'),
+              kind,
+              url: request.url ?? '/',
+            })
+            response.statusCode = 200
+            response.setHeader('content-type', 'application/json')
+            response.end('{}')
+          })
+        })
+      },
+    },
+  ],
+  server: {
+    host: '127.0.0.1',
+    port: 4180,
+    strictPort: true,
+  },
+})
+
+function endpointKind(pathname: string): Receipt['kind'] | undefined {
+  if (pathname.endsWith('/client-traces')) {
+    return 'trace'
+  }
+  if (pathname.endsWith('/client-metrics')) {
+    return 'metric'
+  }
+  if (/\/client-replay\/[^/]+$/u.test(pathname)) {
+    return 'replay'
+  }
+  return undefined
+}

--- a/packages/logfire-session-replay/README.md
+++ b/packages/logfire-session-replay/README.md
@@ -40,6 +40,10 @@ const replay = startSessionReplay({
   blockSelector: '[data-logfire-block]',
 
   distinctId: currentUser?.id,
+  getSessionAttributes: () => ({
+    account_tier: currentAccount.tier,
+    beta_user: currentUser.isBeta,
+  }),
   getTraceContext: () => getCurrentTraceContext(),
 })
 
@@ -103,10 +107,19 @@ The decompressed body shape is:
     urls,
     traceIds,
     distinctId,
+    sessionAttributes,
   },
   events,
 }
 ```
+
+`getSessionAttributes` is snapshotted once for every replay session. Keys must
+match `^[a-z][a-z0-9_]{0,63}$`; at most 20 entries are retained. Values must be
+booleans, finite numbers, or strings no longer than 200 Unicode code points.
+Invalid entries are omitted, and callback failures are reported through
+`onError` without stopping replay. The optional `meta.sessionAttributes` field
+is omitted when the snapshot is empty. Keep these dimensions low-cardinality
+and free of personal or sensitive data.
 
 ## Direct Token Escape Hatch
 

--- a/packages/logfire-session-replay/src/extract.test.ts
+++ b/packages/logfire-session-replay/src/extract.test.ts
@@ -52,6 +52,16 @@ describe('computeChunkMeta', () => {
     expect(meta.distinctId).toBeUndefined()
   })
 
+  it('includes non-empty session attributes without changing the envelope version', () => {
+    expect(computeChunkMeta(0, [], undefined, { account_tier: 'pro', beta_user: true })).toMatchObject({
+      sessionAttributes: {
+        account_tier: 'pro',
+        beta_user: true,
+      },
+    })
+    expect(computeChunkMeta(0, [], undefined, {})).not.toHaveProperty('sessionAttributes')
+  })
+
   it('counts console.error custom events as errors', () => {
     expect(
       computeChunkMeta(0, [

--- a/packages/logfire-session-replay/src/extract.test.ts
+++ b/packages/logfire-session-replay/src/extract.test.ts
@@ -53,11 +53,21 @@ describe('computeChunkMeta', () => {
   })
 
   it('includes non-empty session attributes without changing the envelope version', () => {
-    expect(computeChunkMeta(0, [], undefined, { account_tier: 'pro', beta_user: true })).toMatchObject({
+    expect(computeChunkMeta(0, [], undefined, { account_tier: 'pro', beta_user: true })).toEqual({
+      clickCount: 0,
+      errorCount: 0,
+      eventCount: 0,
+      firstTimestamp: 0,
+      hasFullSnapshot: false,
+      keypressCount: 0,
+      lastTimestamp: 0,
+      seq: 0,
       sessionAttributes: {
         account_tier: 'pro',
         beta_user: true,
       },
+      traceIds: [],
+      urls: [],
     })
     expect(computeChunkMeta(0, [], undefined, {})).not.toHaveProperty('sessionAttributes')
   })

--- a/packages/logfire-session-replay/src/extract.ts
+++ b/packages/logfire-session-replay/src/extract.ts
@@ -1,5 +1,5 @@
 import { CustomTag, EventType, IncrementalSource, MouseInteractions } from './types'
-import type { ChunkMeta, RrwebEvent } from './types'
+import type { ChunkMeta, RrwebEvent, SessionAttributes } from './types'
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined
@@ -9,7 +9,12 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
-export function computeChunkMeta(seq: number, events: RrwebEvent[], distinctId?: string): ChunkMeta {
+export function computeChunkMeta(
+  seq: number,
+  events: RrwebEvent[],
+  distinctId?: string,
+  sessionAttributes: SessionAttributes = {}
+): ChunkMeta {
   let firstTimestamp = Number.POSITIVE_INFINITY
   let lastTimestamp = 0
   let clickCount = 0
@@ -80,5 +85,6 @@ export function computeChunkMeta(seq: number, events: RrwebEvent[], distinctId?:
     urls: [...urls],
     traceIds: [...traceIds],
     ...(distinctId !== undefined && distinctId.length > 0 ? { distinctId } : {}),
+    ...(Object.keys(sessionAttributes).length === 0 ? {} : { sessionAttributes: { ...sessionAttributes } }),
   }
 }

--- a/packages/logfire-session-replay/src/index.test.ts
+++ b/packages/logfire-session-replay/src/index.test.ts
@@ -261,12 +261,15 @@ describe('startSessionReplay full mode', () => {
 
   it('uses external getSessionId and creates a fresh runtime when it changes', async () => {
     let sessionId = 'external-1'
+    let accountTier = 'pro'
+    const getSessionAttributes = vi.fn(() => ({ account_tier: accountTier }))
     const { calls, fetchImpl } = recordingFetch()
     const start = vi.spyOn(recorderMod, 'startRecording')
-    const replay = startSessionReplay(baseConfig(fetchImpl, { getSessionId: () => sessionId }))
+    const replay = startSessionReplay(baseConfig(fetchImpl, { getSessionAttributes, getSessionId: () => sessionId }))
     expect(replay.getSessionId()).toBe('external-1')
     emit(fullSnapshot)
 
+    accountTier = 'enterprise'
     sessionId = 'external-2'
     emit(click)
     expect(replay.recording).toBe(false)
@@ -281,6 +284,11 @@ describe('startSessionReplay full mode', () => {
       'https://app.example.com/replay/external-1?seq=0',
       'https://app.example.com/replay/external-2?seq=0',
     ])
+    expect(calls.map((call) => decodeBody(call.init.body).meta.sessionAttributes)).toEqual([
+      { account_tier: 'pro' },
+      { account_tier: 'enterprise' },
+    ])
+    expect(getSessionAttributes).toHaveBeenCalledTimes(2)
   })
 
   it('starts interval flushing in full mode', async () => {
@@ -593,6 +601,27 @@ describe('startSessionReplay lifecycle', () => {
     emit(fullSnapshot)
     await expect(replay.flush()).resolves.toBeUndefined()
     await expect(replay.stop()).resolves.toBeUndefined()
+  })
+
+  it('contains and reports a throwing session attributes callback', async () => {
+    const { calls, fetchImpl } = recordingFetch()
+    const callbackError = new Error('session dimensions unavailable')
+    const onError = vi.fn<(error: unknown) => void>()
+    const replay = startSessionReplay(
+      baseConfig(fetchImpl, {
+        getSessionAttributes: () => {
+          throw callbackError
+        },
+        onError,
+      })
+    )
+
+    emit(fullSnapshot)
+    await replay.flush()
+    await replay.stop()
+
+    expect(onError).toHaveBeenCalledExactlyOnceWith(callbackError)
+    expect(decodeBody(calls[0]!.init.body).meta).not.toHaveProperty('sessionAttributes')
   })
 
   it('does not leak a rejected fire-and-forget pagehide flush when onError throws', async () => {

--- a/packages/logfire-session-replay/src/index.ts
+++ b/packages/logfire-session-replay/src/index.ts
@@ -1,6 +1,7 @@
 import { captureConsole, captureNavigation, captureNetwork } from './capture'
 import { startRecording } from './recorder'
 import { decideSamplingMode } from './sampling'
+import { snapshotSessionAttributes } from './sessionAttributes'
 import { safeSessionStorage, SessionManager } from './session'
 import { ReplayTransport } from './transport'
 import { CustomTag, DEFAULTS } from './types'
@@ -14,6 +15,9 @@ export type {
   NetworkPayload,
   RrwebEvent,
   SamplingMode,
+  SessionAttributes,
+  SessionAttributesInput,
+  SessionAttributeValue,
   SessionReplayConfig,
 } from './types'
 export { CHUNK_ENVELOPE_VERSION, CustomTag, EventType, IncrementalSource, MouseInteractions } from './types'
@@ -189,7 +193,10 @@ function createActiveRuntime(options: {
   sessionId: string
 }): ActiveRuntime {
   const { config, getSessionId, mode, onSessionChanged, samplingModeStorage, sessionId } = options
-  const transport = new ReplayTransport(config, sessionId, mode)
+  const sessionAttributes = snapshotSessionAttributes(config.getSessionAttributes, (error) => {
+    safeReportError(config.onError, error)
+  })
+  const transport = new ReplayTransport(config, sessionId, mode, undefined, undefined, sessionAttributes)
   const cleanup: (() => void)[] = []
   let active = true
   const isRuntimeActive = () => active
@@ -373,6 +380,7 @@ function resolveConfig(config: SessionReplayConfig): ResolvedSessionReplayConfig
     headers: config.headers,
     token: config.token,
     getSessionId: config.getSessionId,
+    getSessionAttributes: config.getSessionAttributes,
     sessionSampleRate: config.sessionSampleRate ?? DEFAULTS.sessionSampleRate,
     onErrorSampleRate: config.onErrorSampleRate ?? DEFAULTS.onErrorSampleRate,
     maskAllText: config.maskAllText ?? DEFAULTS.maskAllText,

--- a/packages/logfire-session-replay/src/sessionAttributes.test.ts
+++ b/packages/logfire-session-replay/src/sessionAttributes.test.ts
@@ -9,6 +9,8 @@ describe('snapshotSessionAttributes', () => {
     const source = {
       account_tier: 'pro',
       beta_user: true,
+      empty_label: '',
+      paid: false,
       seats: 12,
       skipped: undefined,
     }
@@ -19,6 +21,8 @@ describe('snapshotSessionAttributes', () => {
     expect(attributes).toEqual({
       account_tier: 'pro',
       beta_user: true,
+      empty_label: '',
+      paid: false,
       seats: 12,
     })
     expect(Object.isFrozen(attributes)).toBe(true)

--- a/packages/logfire-session-replay/src/sessionAttributes.test.ts
+++ b/packages/logfire-session-replay/src/sessionAttributes.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { snapshotSessionAttributes } from './sessionAttributes'
+
+const ignoreError = vi.fn<(error: unknown) => void>()
+
+describe('snapshotSessionAttributes', () => {
+  it('accepts bounded primitive dimensions and freezes the snapshot', () => {
+    const source = {
+      account_tier: 'pro',
+      beta_user: true,
+      seats: 12,
+      skipped: undefined,
+    }
+
+    const attributes = snapshotSessionAttributes(() => source, ignoreError)
+    source.account_tier = 'free'
+
+    expect(attributes).toEqual({
+      account_tier: 'pro',
+      beta_user: true,
+      seats: 12,
+    })
+    expect(Object.isFrozen(attributes)).toBe(true)
+  })
+
+  it('enforces key, value, count, and Unicode code-point limits', () => {
+    const reporter = vi.fn<(error: unknown) => void>()
+    const entries: Record<string, unknown> = {
+      Invalid: 'uppercase',
+      invalid_dash: undefined,
+      invalid_object: {},
+      invalid_infinity: Number.POSITIVE_INFINITY,
+      invalid_nan: Number.NaN,
+      invalid_string: '🚀'.repeat(201),
+      valid_unicode: '🚀'.repeat(200),
+    }
+    for (let index = 0; index < 25; index++) {
+      entries[`valid_${index.toString()}`] = index
+    }
+    entries['invalid-key'] = 'dash'
+    entries[`a${'b'.repeat(64)}`] = 'too long'
+
+    const attributes = snapshotSessionAttributes(() => entries as Record<string, string | number | boolean | undefined>, reporter)
+
+    expect(attributes['valid_unicode']).toBe('🚀'.repeat(200))
+    expect(Object.keys(attributes)).toHaveLength(20)
+    expect(attributes['valid_18']).toBe(18)
+    expect(attributes['valid_19']).toBeUndefined()
+    expect(attributes['Invalid']).toBeUndefined()
+    expect(attributes['invalid-key']).toBeUndefined()
+    expect(reporter).not.toHaveBeenCalled()
+  })
+
+  it('accepts null-prototype, frozen, and sealed objects and rejects other container classes', () => {
+    const nullPrototype = Object.assign(Object.create(null) as Record<string, string>, { tier: 'pro' })
+    const frozen = Object.freeze({ tier: 'frozen' })
+    const sealed = Object.seal({ tier: 'sealed' })
+    class Dimensions {
+      tier = 'pro'
+    }
+
+    expect(snapshotSessionAttributes(() => nullPrototype, ignoreError)).toEqual({ tier: 'pro' })
+    expect(snapshotSessionAttributes(() => frozen, ignoreError)).toEqual({ tier: 'frozen' })
+    expect(snapshotSessionAttributes(() => sealed, ignoreError)).toEqual({ tier: 'sealed' })
+    expect(snapshotSessionAttributes(() => [] as never, ignoreError)).toEqual({})
+    expect(snapshotSessionAttributes(() => (() => ({})) as never, ignoreError)).toEqual({})
+    expect(snapshotSessionAttributes(() => new Date() as never, ignoreError)).toEqual({})
+    expect(snapshotSessionAttributes(() => new Dimensions() as never, ignoreError)).toEqual({})
+  })
+
+  it('reports exceptional callback, prototype, enumeration, and property access once each', () => {
+    const callbackError = new Error('callback')
+    const callbackReporter = vi.fn<(error: unknown) => void>()
+    expect(
+      snapshotSessionAttributes(() => {
+        throw callbackError
+      }, callbackReporter)
+    ).toEqual({})
+    expect(callbackReporter).toHaveBeenCalledExactlyOnceWith(callbackError)
+
+    const prototypeError = new Error('prototype')
+    const prototypeReporter = vi.fn<(error: unknown) => void>()
+    const prototypeProxy = new Proxy(
+      {},
+      {
+        getPrototypeOf: () => {
+          throw prototypeError
+        },
+      }
+    )
+    expect(snapshotSessionAttributes(() => prototypeProxy, prototypeReporter)).toEqual({})
+    expect(prototypeReporter).toHaveBeenCalledExactlyOnceWith(prototypeError)
+
+    const enumerationError = new Error('enumeration')
+    const enumerationReporter = vi.fn<(error: unknown) => void>()
+    const enumerationProxy = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw enumerationError
+        },
+      }
+    )
+    expect(snapshotSessionAttributes(() => enumerationProxy, enumerationReporter)).toEqual({})
+    expect(enumerationReporter).toHaveBeenCalledExactlyOnceWith(enumerationError)
+
+    const propertyError = new Error('property')
+    const propertyReporter = vi.fn<(error: unknown) => void>()
+    const propertyProxy = new Proxy(
+      { broken: 'ignored', healthy: true },
+      {
+        get: (target, key, receiver) => {
+          if (key === 'broken') {
+            throw propertyError
+          }
+          return Reflect.get(target, key, receiver) as unknown
+        },
+      }
+    )
+    expect(snapshotSessionAttributes(() => propertyProxy, propertyReporter)).toEqual({ healthy: true })
+    expect(propertyReporter).toHaveBeenCalledExactlyOnceWith(propertyError)
+  })
+})

--- a/packages/logfire-session-replay/src/sessionAttributes.ts
+++ b/packages/logfire-session-replay/src/sessionAttributes.ts
@@ -1,0 +1,88 @@
+import type { SessionAttributeValue, SessionAttributes, SessionAttributesInput } from './types'
+
+const MAX_SESSION_ATTRIBUTES = 20
+const MAX_SESSION_ATTRIBUTE_STRING_CODE_POINTS = 200
+const SESSION_ATTRIBUTE_KEY_PATTERN = /^[a-z][a-z0-9_]{0,63}$/u
+
+function hasAtMostCodePoints(value: string, maximum: number): boolean {
+  let count = 0
+  for (const codePoint of value) {
+    count += codePoint.length > 0 ? 1 : 0
+    if (count > maximum) {
+      return false
+    }
+  }
+  return true
+}
+
+export function snapshotSessionAttributes(
+  getSessionAttributes: (() => SessionAttributesInput) | undefined,
+  reportError: (error: unknown) => void
+): SessionAttributes {
+  if (getSessionAttributes === undefined) {
+    return Object.freeze({})
+  }
+
+  let value: unknown
+  try {
+    value = getSessionAttributes()
+  } catch (error) {
+    reportError(error)
+    return Object.freeze({})
+  }
+
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return Object.freeze({})
+  }
+
+  let prototype: object | null
+  try {
+    prototype = Object.getPrototypeOf(value) as object | null
+  } catch (error) {
+    reportError(error)
+    return Object.freeze({})
+  }
+  if (prototype !== Object.prototype && prototype !== null) {
+    return Object.freeze({})
+  }
+
+  let keys: string[]
+  try {
+    keys = Object.keys(value)
+  } catch (error) {
+    reportError(error)
+    return Object.freeze({})
+  }
+
+  const attributes: SessionAttributes = {}
+  let accepted = 0
+  for (const key of keys) {
+    if (!SESSION_ATTRIBUTE_KEY_PATTERN.test(key)) {
+      continue
+    }
+
+    let attributeValue: unknown
+    try {
+      attributeValue = Reflect.get(value, key)
+    } catch (error) {
+      reportError(error)
+      continue
+    }
+
+    const valid =
+      typeof attributeValue === 'boolean' ||
+      (typeof attributeValue === 'number' && Number.isFinite(attributeValue)) ||
+      (typeof attributeValue === 'string' && hasAtMostCodePoints(attributeValue, MAX_SESSION_ATTRIBUTE_STRING_CODE_POINTS))
+    if (!valid) {
+      continue
+    }
+
+    attributes[key] = attributeValue as SessionAttributeValue
+    accepted += 1
+    if (accepted === MAX_SESSION_ATTRIBUTES) {
+      break
+    }
+  }
+
+  return Object.freeze(attributes)
+}

--- a/packages/logfire-session-replay/src/transport.test.ts
+++ b/packages/logfire-session-replay/src/transport.test.ts
@@ -21,6 +21,7 @@ function makeConfig(fetchImpl: typeof fetch): ResolvedSessionReplayConfig {
     headers: undefined,
     token: undefined,
     getSessionId: undefined,
+    getSessionAttributes: undefined,
     sessionSampleRate: 1,
     onErrorSampleRate: 1,
     maskAllText: true,
@@ -108,6 +109,28 @@ describe('ReplayTransport full mode', () => {
     expect(envelope.meta.clickCount).toBe(1)
     expect(envelope.meta.hasFullSnapshot).toBe(true)
     expect(envelope.meta.distinctId).toBe('user-1')
+  })
+
+  it('copies one session snapshot into every chunk and omits an empty snapshot', async () => {
+    const { calls, fetchImpl } = recordingFetch()
+    const sessionAttributes = { account_tier: 'pro', beta_user: true }
+    const transport = new ReplayTransport(makeConfig(fetchImpl), 'sess-dimensions', 'full', null, immediateCompression(), sessionAttributes)
+    sessionAttributes.account_tier = 'changed'
+    transport.add(fullSnapshot)
+    await transport.flush()
+    transport.add(click)
+    await transport.flush()
+
+    expect(calls.map((call) => decodeBody(call.init.body).meta.sessionAttributes)).toEqual([
+      { account_tier: 'pro', beta_user: true },
+      { account_tier: 'pro', beta_user: true },
+    ])
+
+    const emptyRecording = recordingFetch()
+    const emptyTransport = new ReplayTransport(makeConfig(emptyRecording.fetchImpl), 'sess-empty', 'full', null, immediateCompression(), {})
+    emptyTransport.add(fullSnapshot)
+    await emptyTransport.flush()
+    expect(decodeBody(emptyRecording.calls[0]!.init.body).meta).not.toHaveProperty('sessionAttributes')
   })
 
   it('merges async headers and direct token auth', async () => {
@@ -288,7 +311,8 @@ describe('ReplayTransport retries', () => {
 
   it('splits large keepalive flushes into ordered chunks', async () => {
     const { calls, fetchImpl } = recordingFetch()
-    const transport = new ReplayTransport(makeConfig(fetchImpl), 'sess-large', 'full', null)
+    const sessionAttributes = { account_tier: 'pro', beta_user: true }
+    const transport = new ReplayTransport(makeConfig(fetchImpl), 'sess-large', 'full', null, undefined, sessionAttributes)
     const largeEvent = {
       type: EventType.IncrementalSnapshot,
       data: { text: 'x'.repeat(50_000) },
@@ -307,6 +331,11 @@ describe('ReplayTransport retries', () => {
     ])
     expect(calls.map((call) => call.init.keepalive)).toEqual([true, true, true])
     expect(calls.map((call) => decodeBody(call.init.body).events.map((event) => event.timestamp))).toEqual([[10], [20], [30]])
+    expect(calls.map((call) => decodeBody(call.init.body).meta.sessionAttributes)).toEqual([
+      sessionAttributes,
+      sessionAttributes,
+      sessionAttributes,
+    ])
   })
 })
 
@@ -545,13 +574,22 @@ describe('ReplayTransport Retry-After policy', () => {
     vi.setSystemTime(new Date(now))
     try {
       let attempts = 0
-      const fetchImpl = vi.fn(async () => {
+      const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => {
         attempts += 1
         return attempts === 1
           ? new Response(null, header === null ? { status: 429 } : { status: 429, headers: { 'retry-after': header } })
           : new Response(null, { status: 202 })
-      }) as unknown as typeof fetch
-      const transport = new ReplayTransport(makeConfig(fetchImpl), 'sess-retry-after', 'full', null, immediateCompression())
+      })
+      const fetchImpl = fetchMock as unknown as typeof fetch
+      const sessionAttributes = { account_tier: 'pro' }
+      const transport = new ReplayTransport(
+        makeConfig(fetchImpl),
+        'sess-retry-after',
+        'full',
+        null,
+        immediateCompression(),
+        sessionAttributes
+      )
       transport.add(fullSnapshot)
       const flush = transport.flush()
       await vi.advanceTimersByTimeAsync(0)
@@ -565,6 +603,10 @@ describe('ReplayTransport Retry-After policy', () => {
       }
       await flush
       expect(fetchImpl).toHaveBeenCalledTimes(2)
+      expect(fetchMock.mock.calls.map((call) => decodeBody(call[1]?.body).meta.sessionAttributes)).toEqual([
+        sessionAttributes,
+        sessionAttributes,
+      ])
     } finally {
       vi.useRealTimers()
     }

--- a/packages/logfire-session-replay/src/transport.ts
+++ b/packages/logfire-session-replay/src/transport.ts
@@ -3,7 +3,7 @@ import { gzip, gzipSync, strToU8 } from 'fflate'
 import { computeChunkMeta } from './extract'
 import { safeSessionStorage } from './session'
 import { CHUNK_ENVELOPE_VERSION, EventType } from './types'
-import type { ChunkEnvelope, ResolvedSessionReplayConfig, RrwebEvent } from './types'
+import type { ChunkEnvelope, ResolvedSessionReplayConfig, RrwebEvent, SessionAttributes } from './types'
 
 export const SEQ_STORAGE_KEY = 'lf_session_replay_seq'
 
@@ -45,16 +45,19 @@ export class ReplayTransport {
   private readonly compression: Compression
   private readonly storage: Storage | null
   private readonly sessionId: string
+  private readonly sessionAttributes: SessionAttributes
 
   constructor(
     config: ResolvedSessionReplayConfig,
     sessionId: string,
     mode: 'full' | 'buffer',
     storage: Storage | null = safeSessionStorage(),
-    compression: Compression = DEFAULT_COMPRESSION
+    compression: Compression = DEFAULT_COMPRESSION,
+    sessionAttributes: SessionAttributes = {}
   ) {
     this.config = config
     this.sessionId = sessionId
+    this.sessionAttributes = Object.freeze({ ...sessionAttributes })
     this.mode = mode
     this.storage = storage
     this.compression = compression
@@ -185,7 +188,7 @@ export class ReplayTransport {
     }
     return {
       version: CHUNK_ENVELOPE_VERSION,
-      meta: computeChunkMeta(seq, events, distinctId),
+      meta: computeChunkMeta(seq, events, distinctId, this.sessionAttributes),
       events,
     }
   }

--- a/packages/logfire-session-replay/src/types.ts
+++ b/packages/logfire-session-replay/src/types.ts
@@ -44,6 +44,9 @@ export const CHUNK_ENVELOPE_VERSION = 1 as const
 export type MaybePromise<T> = T | Promise<T>
 export type ConsoleLevel = 'log' | 'info' | 'warn' | 'error' | 'debug'
 export type SamplingMode = 'full' | 'buffer' | 'off'
+export type SessionAttributeValue = string | number | boolean
+export type SessionAttributesInput = Record<string, SessionAttributeValue | undefined>
+export type SessionAttributes = Record<string, SessionAttributeValue>
 
 export interface ConsolePayload {
   level: ConsoleLevel
@@ -78,6 +81,7 @@ export interface ChunkMeta {
   urls: string[]
   traceIds: string[]
   distinctId?: string
+  sessionAttributes?: SessionAttributes
 }
 
 export interface ChunkEnvelope {
@@ -115,6 +119,11 @@ export interface SessionReplayConfig {
    * pass its RUM session id here.
    */
   getSessionId?: () => string | undefined
+  /**
+   * Returns low-cardinality, non-PII dimensions to snapshot once per replay
+   * session. Invalid or oversized entries are omitted.
+   */
+  getSessionAttributes?: () => SessionAttributesInput
 
   /** Probability of recording each new browser session in full. */
   sessionSampleRate?: number
@@ -154,6 +163,7 @@ export interface ResolvedSessionReplayConfig {
   headers: (() => MaybePromise<Record<string, string>>) | undefined
   token: string | (() => MaybePromise<string>) | undefined
   getSessionId: (() => string | undefined) | undefined
+  getSessionAttributes: (() => SessionAttributesInput) | undefined
   sessionSampleRate: number
   onErrorSampleRate: number
   maskAllText: boolean

--- a/plans/033-browser-rum-custom-dimensions.md
+++ b/plans/033-browser-rum-custom-dimensions.md
@@ -57,7 +57,7 @@ runtime rotation for the same browser session id.
       attributes; neither `logfire.page.route` nor `logfire.session.*` is added
       implicitly (CX-5).
 - [x] Public docs and the browser RUM/replay example describe the low-cardinality,
-      non-PII contract; patch changesets cover both public packages.
+      non-PII contract; minor changesets cover both public packages.
 
 ## Assurance
 
@@ -160,7 +160,7 @@ runtime rotation for the same browser session id.
 - `packages/logfire-session-replay/src/types.ts:69-87,95-178` — `ChunkMeta`,
   `SessionReplayConfig`, and resolved configuration are public/exported. —
   **PRP impact**: the standalone callback and optional metadata map require a
-  patch release and public documentation.
+  minor release and public documentation.
 - `packages/logfire-browser/src/browserSession.test.ts`,
   `BrowserSessionSpanProcessor.test.ts`, and `sessionReplay.test.ts` — existing
   canonical tests cover stored-session reuse/rotation, exact span attributes,
@@ -362,7 +362,7 @@ runtime rotation for the same browser session id.
 - `examples/browser-rum-replay/src/main.ts` and
   `examples/browser-rum-replay/README.md` — representative application route
   and safe session-dimension configuration.
-- `.changeset/browser-rum-custom-dimensions.md` — patch notes for both
+- `.changeset/browser-rum-custom-dimensions.md` — minor notes for both
   published packages.
 
 ### Explicitly Out of Scope
@@ -682,14 +682,14 @@ Task 8: Document the bounded public contract and representative usage
     - Add fixed safe sample session dimensions such as account_tier, app_region, and experiment_variant; do not derive them from editable user ids.
     - Update trace/replay expectations and keep metrics dimensions explicitly configured.
   CREATE .changeset/browser-rum-custom-dimensions.md:
-    - Add patch entries for @pydantic/logfire-browser and @pydantic/logfire-session-replay describing normalized route and bounded session metadata support.
+    - Add minor entries for @pydantic/logfire-browser and @pydantic/logfire-session-replay describing normalized route and bounded session metadata support.
   PATTERN: packages/logfire-browser/README.md RUM Session Identity/Web Vitals/Session replay sections and examples/browser-rum-replay/src/main.ts
   ENABLES: CX-1, CX-2, CX-3, CX-4, CX-5
   VERIFY:
     - COMMAND: vp fmt --check packages/logfire-browser/README.md packages/logfire-session-replay/README.md docs/packages/browser.md examples/browser-rum-replay/src/main.ts examples/browser-rum-replay/README.md .changeset/browser-rum-custom-dimensions.md plans/033-browser-rum-custom-dimensions.md
     - EXPECTED: Public docs, example, changeset, and PRP are formatted and agree on names, limits, lifecycles, privacy guidance, replay shape, and metric exclusion.
     - COMMAND: node_modules/.bin/changeset status --output /tmp/prp033-changeset-status.json
-    - EXPECTED: Changesets parses the repository and reports browser-rum-custom-dimensions with exactly patch releases for @pydantic/logfire-browser and @pydantic/logfire-session-replay.
+    - EXPECTED: Changesets parses the repository and reports browser-rum-custom-dimensions with exactly minor releases for @pydantic/logfire-browser and @pydantic/logfire-session-replay.
 
 Task 9: Run focused and integrated package gates
   ENABLES: CX-1, CX-2, CX-3, CX-4, CX-5
@@ -734,7 +734,7 @@ DOCUMENTATION:
   - package READMEs, docs/packages/browser.md, and browser-rum-replay example — one public privacy/cardinality contract.
 
 RELEASE:
-  - .changeset/browser-rum-custom-dimensions.md — patch releases for both public packages.
+  - .changeset/browser-rum-custom-dimensions.md — minor releases for both public packages.
 ```
 
 ## Validation
@@ -845,7 +845,7 @@ compatibility.
 - All six success criteria and nine blueprint tasks are implemented. Public
   types, persisted legacy hydration and empty-snapshot sentinel behavior,
   per-session replay rotation, every-envelope metadata, documentation,
-  representative example usage, and the two-package patch changeset match the
+  representative example usage, and the two-package minor changeset match the
   PRP. Explicit exclusions held.
 - The direct built-browser fixture supplies the joint public-config Web Vital
   span/metric evidence from Task 6, alongside focused integration and metric
@@ -869,7 +869,7 @@ compatibility.
 | Focused browser tests and typecheck         | Complete browser suite passed 168 tests                                                                                                                    |
 | Affected package and fixture builds         | Both packages and the built `rum-dimensions` consumer fixture passed                                                                                       |
 | Sequential direct browser acceptance        | Normal and hostile scenarios passed on one server; phase selectors, receipt isolation, fetch/XHR spans, omitted route, replay chunks, and metrics verified |
-| Formatting, lint, typecheck, and Changesets | Passed; Changesets selects patch releases for exactly `@pydantic/logfire-browser` and `@pydantic/logfire-session-replay`                                   |
+| Formatting, lint, typecheck, and Changesets | Passed; Changesets selects minor releases for exactly `@pydantic/logfire-browser` and `@pydantic/logfire-session-replay`                                   |
 | `pnpm run check`                            | Passed all package builds, formatting, lint, typechecks, tests, and release-tooling tests                                                                  |
 | `git diff --check` and process cleanup      | Passed; browser sessions closed, Vite stopped, and port 4180 confirmed free                                                                                |
 

--- a/plans/033-browser-rum-custom-dimensions.md
+++ b/plans/033-browser-rum-custom-dimensions.md
@@ -1,0 +1,876 @@
+---
+repo: /Users/petyo/w/pydantic/logfire-js
+---
+
+# PRP 033: Browser RUM normalized routes and bounded session attributes (issues #190 and #191)
+
+## Goal
+
+Add two application-provided, low-cardinality dimensions to the browser RUM
+session configuration:
+
+- `getRouteName?: () => string | undefined`, evaluated for each new browser
+  span and emitted as `logfire.page.route`.
+- `getSessionAttributes?: () => Record<string, string | number | boolean | undefined>`,
+  evaluated into a bounded immutable snapshot for each browser session, emitted
+  as `logfire.session.<key>` on browser spans, and copied into replay chunk
+  metadata as `sessionAttributes`.
+
+The implementation must preserve existing page URL and session identity
+attributes, remain failure-contained when consumer callbacks return hostile
+runtime values or throw, exclude both new dimensions from Web Vitals metric
+labels, and preserve one session-attribute snapshot across reloads and replay
+runtime rotation for the same browser session id.
+
+## Why
+
+- Fixes [pydantic/logfire-js#190](https://github.com/pydantic/logfire-js/issues/190):
+  raw paths such as `/projects/123` fragment RUM page tables, filters, and Web
+  Vitals drilldown; applications need an explicit stable route template such as
+  `/projects/:project_id`.
+- Fixes [pydantic/logfire-js#191](https://github.com/pydantic/logfire-js/issues/191):
+  operators need a deliberately small set of safe session dimensions such as
+  account tier, tenant type, experiment variant, or application region on
+  traces and replay indexes.
+- A bounded SDK contract prevents these features from becoming an arbitrary
+  analytics/user-profile channel and keeps metric cardinality unchanged.
+- Both features share the browser session public surface and universal
+  span-processor propagation path; implementing them together gives one
+  coherent RUM-dimensions contract without coupling their distinct lifecycles.
+
+## Success Criteria
+
+- [x] Browser integrators can configure a dynamic normalized route name under
+      `rum.session`; every new span receives the current
+      `logfire.page.route` while existing page URL attributes remain unchanged
+      (CX-1).
+- [x] Browser integrators can configure up to 20 safe scalar session
+      attributes; every span in that browser session receives the same
+      `logfire.session.*` snapshot across reloads, while a new session gets a
+      fresh snapshot (CX-2).
+- [x] The same bounded snapshot appears in every replay chunk for its session,
+      including after replay observes a browser-session rotation (CX-3).
+- [x] Invalid keys/values, oversized strings, non-finite numbers, hostile
+      runtime return values, and throwing callbacks are omitted or contained
+      without stopping tracing or replay (CX-4).
+- [x] Web Vitals metrics retain only their existing configured metric
+      attributes; neither `logfire.page.route` nor `logfire.session.*` is added
+      implicitly (CX-5).
+- [x] Public docs and the browser RUM/replay example describe the low-cardinality,
+      non-PII contract; patch changesets cover both public packages.
+
+## Assurance
+
+- **Profile**: Deep
+- **Rationale**: this is a backward-compatible SDK feature, but it changes a
+  material privacy/cardinality boundary by accepting application values and
+  forwarding them to both trace telemetry and replay metadata. It also couples
+  persisted browser-session state with a separately published replay envelope
+  contract. Incorrect validation or snapshot semantics could leak user data,
+  create unbounded index cardinality, or make one session inconsistent across
+  traces and replay. The work remains one PRP because both packages can be
+  changed and validated in one integrated built-browser loop without a
+  migration or rollout dependency.
+
+## Consumer Contract
+
+### Consumer and Public Boundary
+
+- **Consumer(s)**: browser SDK integrators configuring RUM; operators filtering
+  Logfire traces and replay sessions; the Logfire replay ingest/index pipeline
+  consuming chunk metadata; standalone replay integrators using the public
+  replay configuration.
+- **Public or supported boundary**:
+  `@pydantic/logfire-browser`'s `configure({ rum: { session: ... } })` and
+  exported `BrowserSessionOptions`; emitted OpenTelemetry span attributes;
+  `@pydantic/logfire-session-replay`'s `SessionReplayConfig`, `ChunkMeta`, and
+  version-1 replay JSON envelope.
+- **Entry point and prerequisites**: a browser application configures
+  `@pydantic/logfire-browser`; replay metadata additionally requires the
+  optional `@pydantic/logfire-session-replay` peer and configured
+  `sessionReplay`.
+- **Current observable behavior**: browser-session spans receive
+  `session.id`, `browser.session.id`, `logfire.page.url.full`, and
+  `logfire.page.url.path`; replay chunks correlate by the same session id and
+  carry fixed metadata such as URLs, trace ids, and optional `distinctId`.
+  There is no normalized route or bounded custom session context.
+- **Observable promise**: applications can add one current-view route
+  dimension and a small immutable session-dimension snapshot to browser spans;
+  replay chunks carry the same session snapshot for future index filtering.
+- **Must remain compatible with**: `rum.session: true`; existing
+  `BrowserSessionOptions`; existing stored session records without custom
+  attributes; URL callback/default/disabled behavior; replay envelope version
+  1 and consumers that ignore unknown optional metadata fields; standalone
+  replay callers that omit the new callback; current replay sampling,
+  rotation, delivery, privacy, and cleanup contracts.
+- **Not claimed**: automatic route-template inference; soft-navigation Web
+  Vitals; route/session dimensions on metrics; arbitrary JSON, arrays, user
+  profiles, PII scrubbing, runtime updates to an active session snapshot;
+  Platform query/UI/index implementation; a new replay envelope version.
+
+### Acceptance Scenarios
+
+| ID     | Given                                                                                                                                                                                                       | When                                                                                                                                                                                                                    | Then                                                                                                                                                                                                                                                                                           | Exact exercise and prerequisites                                                                                                                                                                                                                                                   | Required evidence                                                                                                       |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `CX-1` | A built browser application configures `rum.session.getRouteName` from application router state, starts at `/projects/123`, and retains default URL attributes                                              | It emits document-load/view, manual duration, manual error point-event, Web Vital, click interaction, fetch, and XHR spans, changes router state to `/settings`, then emits another span                                | Every pre-change span contains `logfire.page.route=/projects/:project_id`; the post-change span contains `/settings`; all retain their existing page URL attributes; an omitted callback emits no route attribute                                                                              | Build both packages; run the loopback `rum-dimensions` Vite fixture; open it in an isolated `agent-browser` session; poll completion; decode captured OTLP trace receipts and run the fixture verifier                                                                             | DIRECT REQUIRED — exercises built public exports and real browser instrumentations                                      |
+| `CX-2` | The same public browser configuration returns safe tier, tenant type, experiment, and region values, uses a short deterministic idle timeout, and has a persisted browser session                           | It emits spans, reloads the page in the same tab before the timeout, emits again, then waits past the timeout and emits a final span                                                                                    | Pre-reload and post-reload spans have the same session id and exact `logfire.session.*` snapshot without a second callback evaluation; the post-timeout span has a new session id and a newly evaluated snapshot                                                                               | The built fixture records a callback-generation marker, spans before/after a same-tab reload, and a post-idle-timeout phase through public browser configuration; its verifier decodes trace receipts and stored callback counts                                                   | DIRECT REQUIRED — directly verifies public configuration, tab persistence, and configured rotation                      |
+| `CX-3` | Browser replay is enabled with the session attributes from CX-2 and records one chunk before browser-session expiry and one after                                                                           | The fixture flushes replay for the first session, waits past the configured idle timeout, starts a span to rotate the browser session, emits a recorder-visible action, waits for replay observation, and flushes again | Each decoded version-1 replay envelope has `meta.sessionAttributes` exactly matching spans with the same session id; all chunks for one id use one snapshot and the rotated id uses the fresh snapshot                                                                                         | The built fixture captures gzip replay receipts keyed by upload URL/session id; its verifier decodes both envelopes and joins them to OTLP spans by session id                                                                                                                     | DIRECT REQUIRED — crosses the built browser-to-peer bridge and actual replay JSON boundary                              |
+| `CX-4` | A browser integrator returns mixed valid and invalid session entries, more than 20 valid entries, invalid route/session runtime types, oversized values, non-finite numbers, or throws from either callback | Browser tracing and replay start and the application emits and flushes telemetry                                                                                                                                        | Instrumentation remains operational; valid session entries are emitted in property order up to 20, invalid entries are absent from spans and replay metadata, and a failed callback contributes no affected attributes without suppressing unrelated session, replay, route, or URL attributes | Build both packages; open the loopback fixture's `/hostile/` route in a second isolated `agent-browser` session; poll completion and run `verify.mjs hostile` to decode both OTLP and replay output; run focused browser/replay table tests for callback/container failure classes | DIRECT REQUIRED — the built scenario crosses the browser-to-real-replay bridge; unit tables exhaust exceptional classes |
+| `CX-5` | Web Vitals span and metric reporting are both enabled with route and session callbacks                                                                                                                      | The fixture reports a Web Vital and forces trace and metric export                                                                                                                                                      | The Web Vital span contains route/session dimensions, while the metric point contains only existing default and explicitly configured metric attributes and no `logfire.page.route` or `logfire.session.*` key                                                                                 | Extend the browser metrics/public configure integration harness with in-memory span and metric observations; run the focused browser package test                                                                                                                                  | DIRECT REQUIRED — exercises the public configuration and both telemetry products                                        |
+
+## Research Summary
+
+### Vetted Repository Findings
+
+- `packages/logfire-browser/src/browserSession.ts:10-40,117-204` — session
+  options, state persistence, expiry, reset, and current URL callback all live
+  in `BrowserSessionManager`; state survives manager instances via
+  `sessionStorage`. — **PRP impact**: both callbacks belong under
+  `rum.session`; the immutable session snapshot must be stored with the session
+  record, while route state must not be snapshotted.
+- `packages/logfire-browser/src/BrowserSessionSpanProcessor.ts:49-83` — one
+  processor stamps every span created by the configured web provider, including
+  Logfire point events and auto-instrumentation spans; consumer URL callback
+  errors are already contained. — **PRP impact**: add route/session propagation
+  here once, with independent failure boundaries so one callback cannot suppress
+  unrelated attributes.
+- `packages/logfire-browser/src/index.ts:270-292,511-516` — Web Vitals and
+  replay imply a browser session, and the session processor is registered
+  before exporters. — **PRP impact**: no new instrumentation-specific hooks are
+  needed; existing `rum.session: false` incompatibility remains unchanged.
+- `packages/logfire-browser/src/browserMetrics.ts:130-159,206-211` — Web Vitals
+  metrics construct an independent attribute set from metric defaults and the
+  explicit metric callback. — **PRP impact**: do not pass route/session state
+  into this path; retain an exact regression test for the exclusion.
+- `packages/logfire-browser/src/sessionReplay.ts:26-48,139-147,180-196` — the
+  browser package mirrors the optional peer config, checks assignability, and
+  passes browser session id through a hot-path getter. — **PRP impact**: add a
+  matching session-attribute getter that only peeks at the already-sanitized
+  browser snapshot; preserve lazy-peer loading.
+- `packages/logfire-session-replay/src/index.ts:79-129,183-210` — replay creates
+  a new active runtime and `ReplayTransport` per observed session id. —
+  **PRP impact**: resolve and snapshot standalone session attributes at active
+  runtime/transport creation, so replay rotation naturally gets one new
+  snapshot and chunk flushes never re-evaluate consumer context.
+- `packages/logfire-session-replay/src/transport.ts:177-190` and
+  `src/extract.ts:12-83` — every envelope is created centrally and chunk
+  metadata is computed in one helper. — **PRP impact**: add one optional
+  `sessionAttributes` metadata field without changing delivery, compression, or
+  envelope version.
+- `packages/logfire-session-replay/src/types.ts:69-87,95-178` — `ChunkMeta`,
+  `SessionReplayConfig`, and resolved configuration are public/exported. —
+  **PRP impact**: the standalone callback and optional metadata map require a
+  patch release and public documentation.
+- `packages/logfire-browser/src/browserSession.test.ts`,
+  `BrowserSessionSpanProcessor.test.ts`, and `sessionReplay.test.ts` — existing
+  canonical tests cover stored-session reuse/rotation, exact span attributes,
+  hostile callback containment, and peer config forwarding. — **PRP impact**:
+  extend these seams rather than creating alternate session machinery.
+- `packages/logfire-session-replay/src/transport.test.ts:51-69,92-138` and
+  `index.test.ts` — tests already decode gzip envelopes and exercise dynamic
+  session-id rotation. — **PRP impact**: use exact envelope assertions for
+  snapshot and rotation behavior.
+- `packages/logfire-browser/test-fixtures/privacy-defaults/` — existing
+  built-package Vite fixtures load the built optional peer, capture OTLP and
+  gzip replay receipts, and verify them through a real browser. — **PRP
+  impact**: create a focused sibling fixture using this infrastructure rather
+  than treating source-level unit tests as consumer evidence.
+- `packages/logfire-browser/README.md:69-109,123-215,222-270` and
+  `docs/packages/browser.md:61-101,112-204,213-258` — public docs establish
+  tab-scoped session persistence, current page URL behavior, session-bearing
+  Web Vitals spans, low-cardinality metric exclusions, and replay/session
+  correlation. — **PRP impact**: extend those exact sections and keep package
+  README/generated-style docs synchronized.
+- `examples/browser-rum-replay/src/main.ts:20-81` already computes route
+  templates for URL and metric attributes and configures session replay. —
+  **PRP impact**: replace the URL-overloading workaround with
+  `getRouteName`, add safe example session dimensions, and keep custom metric
+  dimensions explicit.
+- GitHub issue #190 has one contributor ownership/API-placement question but no
+  maintainer answer; issue #191 has no comments; no open PR references either
+  issue as of the planning baseline. — **PRP impact**: implementation is not
+  technically blocked, but coordinate ownership before starting.
+
+### External Constraints
+
+- None. The implementation uses existing OpenTelemetry span processor,
+  session-storage, rrweb, and JSON envelope patterns; no version-sensitive
+  external API change is required.
+
+### Settled Decisions and Rejected Alternatives
+
+- **Decision**: expose both callbacks on `BrowserSessionOptions`, used as
+  `rum.session: { getRouteName, getSessionAttributes }`. —
+  **Evidence/rationale**: both dimensions require the existing session span
+  processor, and replay/Web Vitals already imply that processor.
+- **Decision**: evaluate `getRouteName` independently on every span start and
+  emit its exact string result, including an empty string; omit only
+  `undefined` or hostile non-string runtime values. Catch callback failures and
+  retain session, replay, and URL attributes. — **Evidence/rationale**: issue
+  #190 defines a current-view callback, not a session snapshot or inferred
+  template.
+- **Decision**: define session input as
+  `Record<string, string | number | boolean | undefined>` and normalized output
+  as a plain record of string/number/boolean values. Keys must match
+  `^[a-z][a-z0-9_]{0,63}$`; output keeps at most the first 20 valid own
+  enumerable string-keyed entries in ECMAScript property order. String values
+  may contain at most 200 Unicode code points; numbers must be finite; boolean
+  values are accepted; `undefined` and all other runtime types are omitted. —
+  **Evidence/rationale**: satisfies issue #191's bounded safe-pattern/scalar
+  contract while preventing nested namespace injection and non-finite OTEL
+  values.
+- **Decision**: at runtime, accept only a non-null non-array object whose
+  prototype is exactly `Object.prototype` or `null`; frozen/sealed records are
+  valid, while arrays, functions, dates, and class instances are rejected
+  wholesale. A proxy is accepted only if prototype/key/value inspection
+  succeeds under the same rules. In the browser manager, all callback and
+  inspection exceptions are silently contained. In standalone replay,
+  callback, prototype, key-enumeration, and individual property-get exceptions
+  each invoke `safeReportError(onError, error)` once for that exceptional
+  operation; invalid containers, keys, and values are ordinary omissions and
+  do not call `onError`. — **Evidence/rationale**: makes hostile runtime input
+  deterministic while matching existing replay callback reporting and browser
+  host-safety conventions.
+- **Decision**: prefix normalized browser span keys with
+  `logfire.session.` but store replay `meta.sessionAttributes` with the
+  unprefixed application keys. — **Evidence/rationale**: matches the requested
+  telemetry namespace while keeping replay JSON useful as a structured map and
+  avoiding repeated prefixes.
+- **Decision**: persist the normalized snapshot in `BrowserSessionState` and
+  never persist the callback or raw input. New sessions evaluate once. A
+  legacy valid stored record without the field is lazily hydrated once when a
+  callback is configured, while preserving its session id, then rewritten;
+  later managers reuse it without callback evaluation. Persist an explicit
+  empty record when a configured callback yields no valid entries, so reload
+  does not retry it; continue omitting the field when no callback has ever been
+  configured. — **Evidence/rationale**: preserves existing sessions across a
+  package upgrade without delaying the feature until rotation or changing
+  identity mid-session, while distinguishing "evaluated empty" from "not yet
+  configured."
+- **Decision**: standalone replay exposes the same optional
+  `getSessionAttributes` callback, validates it defensively, and snapshots it
+  once per active replay session. The browser bridge passes only the browser
+  manager's sanitized snapshot getter. — **Evidence/rationale**: the replay
+  package is independently consumable and owns the last safety boundary before
+  envelope serialization.
+- **Decision**: keep replay `CHUNK_ENVELOPE_VERSION = 1` and add optional
+  `ChunkMeta.sessionAttributes`. — **Evidence/rationale**: optional metadata is
+  additive; the issue requests future index filtering rather than a breaking
+  protocol migration.
+- **Decision**: do not alter browser metric configuration or implicit
+  attribute flow. Route remains available on Web Vitals spans; consumers who
+  deliberately need a route metric label continue using
+  `rum.webVitals.metrics.attributes`. — **Evidence/rationale**: issue #191
+  explicitly excludes metric labels, and current docs expose an explicit
+  low-cardinality metric callback.
+- **Rejected**: put `getRouteName` in `urlAttributes` or replace
+  `logfire.page.url.path`. — **Reason**: issue #190 requires an additional
+  dimension and preservation of raw/path context.
+- **Rejected**: evaluate route name only on SPA navigation events. —
+  **Reason**: fetch/XHR, interactions, errors, Web Vitals, and manual spans also
+  need the current route; universal span start is the established boundary.
+- **Rejected**: re-evaluate session attributes on every span or replay chunk. —
+  **Reason**: violates the requested immutable session snapshot and can create
+  trace/replay disagreement.
+- **Rejected**: add session attributes to resources, baggage, or metric
+  defaults. — **Reason**: resources outlive browser-session rotation, baggage
+  changes propagation semantics, and metric labels are explicitly out of
+  scope.
+- **Rejected**: accept dotted/hyphenated keys, arrays, JSON values, or already
+  prefixed keys. — **Reason**: expands the indexing and namespace surface
+  beyond the bounded contract.
+
+### Spike Evidence
+
+- None needed. Existing session rotation, persistence, universal span
+  processing, replay transport construction, gzip decoding, and built-browser
+  receipt fixtures directly establish the implementation and verification
+  paths.
+
+### Validation Baseline
+
+| Command                                             | Status                 | Observed or expected result                |
+| --------------------------------------------------- | ---------------------- | ------------------------------------------ |
+| `vp run @pydantic/logfire-browser#test`             | Verified               | 13 files, 151 tests passed at `172dffa`    |
+| `vp run @pydantic/logfire-session-replay#test`      | Verified               | 9 files, 145 tests passed at `172dffa`     |
+| `vp run @pydantic/logfire-browser#typecheck`        | Verified               | TypeScript 6.0.3 passed at `172dffa`       |
+| `vp run @pydantic/logfire-session-replay#typecheck` | Verified               | TypeScript 6.0.3 passed at `172dffa`       |
+| `vp run @pydantic/logfire-browser#build`            | Discovered but not run | Required before built-fixture verification |
+| `vp run @pydantic/logfire-session-replay#build`     | Discovered but not run | Required before built-fixture verification |
+| `pnpm run check`                                    | Discovered but not run | Final full-workspace gate                  |
+
+### Research Coverage
+
+- **Depth**: Deep
+- **Inspected**: GitHub issues/comments and open-PR references; browser public
+  config/types; session state/persistence/rotation; universal span processor;
+  Web Vitals span and metric paths; browser-to-replay bridge; replay config,
+  session observation, active runtime, transport, metadata extraction, and
+  envelope tests; built-browser privacy fixture pattern; package docs/example;
+  manifests, exact tool versions, recent browser history, Changesets pattern,
+  current commit and worktree.
+- **Not inspected**: Logfire Platform replay ingest/index/query implementation
+  because this PRP owns only the SDK producer contract; unrelated Node,
+  Cloudflare Worker, API formatting, and hosted variable packages; remote
+  OpenTelemetry/rrweb docs because no external API behavior changes.
+- **Research confidence**: HIGH for SDK implementation, bounds, and direct
+  evidence surfaces. Platform acceptance/indexing of the new optional metadata
+  remains a downstream integration concern and is explicitly out of scope.
+
+## Execution Contract
+
+- **Planned at commit**: `172dffa`
+- **Planning baseline**: clean worktree before creation of this PRP; preserve
+  this planning artifact and any later user changes.
+
+### Expected Changes
+
+- `packages/logfire-browser/src/browserSession.ts` — public callback/value types,
+  bounded snapshot normalization, persisted snapshot lifecycle, and route
+  getter.
+- `packages/logfire-browser/src/browserSession.test.ts` — validation,
+  persistence, legacy hydration, reset/rotation, and callback containment.
+- `packages/logfire-browser/src/BrowserSessionSpanProcessor.ts` — independent
+  route and session attribute propagation.
+- `packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts` — exact
+  dynamic route, immutable session, unset, invalid, and throwing behavior.
+- `packages/logfire-browser/src/sessionReplay.ts` — pass the browser-owned
+  session snapshot into the optional replay peer.
+- `packages/logfire-browser/src/sessionReplay.test.ts` — exact peer config and
+  hot-path snapshot forwarding.
+- `packages/logfire-browser/src/browserConfigure.integration.test.ts` and/or
+  `browserMetrics.test.ts` — public configure propagation and metric exclusion.
+- `packages/logfire-browser/src/index.ts` — export new public types if they are
+  not covered by existing `BrowserSessionOptions` export.
+- `packages/logfire-session-replay/src/types.ts` — standalone callback,
+  normalized type, resolved config, and optional chunk metadata field.
+- `packages/logfire-session-replay/src/sessionAttributes.ts` and
+  `sessionAttributes.test.ts` — replay-boundary normalizer and exhaustive
+  bounded validation.
+- `packages/logfire-session-replay/src/index.ts` and `index.test.ts` — resolve
+  callback and snapshot once per replay-session runtime, including rotation and
+  throwing-callback containment.
+- `packages/logfire-session-replay/src/transport.ts`,
+  `transport.test.ts`, `extract.ts`, and `extract.test.ts` — propagate the
+  immutable map into every envelope without mutating it or changing version.
+- `packages/logfire-browser/test-fixtures/rum-dimensions/` — built-package
+  real-browser fixture, receipt server, and deterministic verifier.
+- `packages/logfire-browser/README.md`,
+  `packages/logfire-session-replay/README.md`, and
+  `docs/packages/browser.md` — public behavior, limits, privacy/cardinality,
+  examples, metrics exclusion, and replay metadata.
+- `examples/browser-rum-replay/src/main.ts` and
+  `examples/browser-rum-replay/README.md` — representative application route
+  and safe session-dimension configuration.
+- `.changeset/browser-rum-custom-dimensions.md` — patch notes for both
+  published packages.
+
+### Explicitly Out of Scope
+
+- Inferring route templates from raw URLs or framework-specific router
+  integrations.
+- Soft-navigation Web Vitals or changing when Web Vitals are measured.
+- Adding route/session dimensions to metric labels, resources, baggage, replay
+  custom events, or network payloads.
+- An API to update attributes during an active browser session.
+- Accepting arrays, JSON objects, user profiles, PII, unbounded keys/values, or
+  automatic PII classification/scrubbing.
+- Platform replay ingest validation, database/index schema, filters, queries,
+  dashboards, UI, or rollout flags.
+- Changing replay envelope version, upload URL, compression, sampling,
+  delivery, lifecycle, or privacy defaults.
+- Changing session id generation, idle/max-duration semantics, or the meaning
+  of replay activity attributes.
+
+### Scope Expansion Rule
+
+Additional files may be changed when necessary to satisfy this PRP without
+changing its intent or architecture. Record each added file and rationale in
+Execution Notes. Pause for user direction if expansion materially changes
+product behavior, the public key/value contract, replay envelope compatibility,
+privacy posture, Platform requirements, or the one-PR decomposition.
+
+### Pause and Reassess If
+
+- Replay ingest rejects unknown optional `meta.sessionAttributes`, requires a
+  different field shape/name, or requires an envelope-version bump.
+- Supporting the immutable snapshot would require changing the browser session
+  id or discarding existing valid stored sessions rather than hydrating them.
+- Any browser instrumentation bypasses the configured provider/span processor,
+  so the requested route/session propagation needs per-instrumentation hooks.
+- A session callback must run asynchronously or return promises; this PRP
+  intentionally defines a synchronous snapshot.
+- Validation demonstrates route/session dimensions enter metrics through an
+  implicit path not identified in reconnaissance.
+- The implementation requires a production dependency or shared package solely
+  to avoid the small defensive replay-boundary validation helper.
+- Work overlaps uncommitted user changes in any expected source or fixture
+  path.
+
+## Context
+
+### Key Files
+
+- `packages/logfire-browser/src/browserSession.ts` — canonical browser-session
+  state, storage, expiry, and per-page callback owner.
+- `packages/logfire-browser/src/BrowserSessionSpanProcessor.ts` — universal
+  span-start augmentation boundary.
+- `packages/logfire-browser/src/index.ts` — public configure resolution,
+  processor registration, type exports, and optional feature startup.
+- `packages/logfire-browser/src/browserMetrics.ts` — separate metric attribute
+  construction that must remain independent.
+- `packages/logfire-browser/src/sessionReplay.ts` — optional peer contract and
+  browser-owned session-id bridge.
+- `packages/logfire-session-replay/src/index.ts` — standalone public entry point
+  and per-session active-runtime lifecycle.
+- `packages/logfire-session-replay/src/transport.ts` — one transport per replay
+  session and central envelope creation.
+- `packages/logfire-session-replay/src/types.ts` — exported version-1 replay
+  envelope and public config types.
+- `packages/logfire-session-replay/src/extract.ts` — deterministic metadata
+  assembly.
+- `packages/logfire-browser/test-fixtures/privacy-defaults/` — closest direct
+  built-package trace/replay receipt pattern.
+- `examples/browser-rum-replay/src/main.ts` — representative public RUM,
+  auto-instrumentation, Web Vitals, metrics, and replay consumer.
+
+### External References
+
+- [Issue #190](https://github.com/pydantic/logfire-js/issues/190) — normalized
+  route requirements and acceptance criteria.
+- [Issue #191](https://github.com/pydantic/logfire-js/issues/191) — bounded
+  session attribute requirements and acceptance criteria.
+
+### Gotchas
+
+- `BrowserSessionSpanProcessor.onStart()` currently returns early when location
+  or URL sanitization is unavailable. Route evaluation takes no URL argument
+  and session attributes already exist after `touch()`, so neither may be
+  accidentally placed behind that early return.
+- Route and URL callbacks have different lifecycles and failure boundaries.
+  A thrown route callback must not suppress URL attributes; a thrown URL
+  callback must not suppress route/session attributes.
+- Browser session storage is tab-scoped and survives reloads. Keeping the
+  snapshot only in manager memory would violate CX-2.
+- The optional stored field is also an evaluation sentinel: `{}` means a
+  configured callback already produced no valid values; absence means a legacy
+  or callback-free session that may be hydrated once if configuration later
+  supplies the callback.
+- Session storage is application-controlled and can contain stale/tampered
+  JSON. Persisted custom attributes must be revalidated without letting hostile
+  values invalidate an otherwise usable session id/timestamp record.
+- The callback's raw object must never be retained or mutated. Copy only
+  normalized scalar entries into a new plain record and copy/freeze at
+  boundaries as needed to prevent later consumer mutation from changing a
+  snapshot. A callback or key-enumeration failure produces an empty snapshot;
+  a throwing individual property getter omits only that entry and processing
+  continues.
+- Do not treat every JavaScript object as a record. Check the prototype before
+  enumerating; reject arrays, functions, dates, and class instances. Proxy trap
+  failures follow the exact browser-silent/replay-`onError` matrix above.
+- ECMAScript own-property order places integer-like keys before other strings;
+  the safe pattern begins with a lowercase letter, so accepted keys retain
+  ordinary insertion order.
+- Count only accepted entries toward the 20-entry output cap. Stop once 20
+  valid entries are copied. Invalid and `undefined` entries do not consume the
+  cap.
+- Route names are application-owned and intentionally not derived from
+  `location`; SPA state can change without a browser URL change and vice versa.
+- The replay monitor reads session id without touching browser activity. Its
+  new attribute getter must remain a peek and must not refresh session timeout.
+- `ReplayTransport` is recreated per observed session id. Snapshot once at
+  construction/activation; never call the consumer getter in `createEnvelope()`
+  or per flush.
+- Browser and replay packages cannot introduce a hard runtime dependency from
+  browser to the optional peer. Mirrored config typing and lazy loading must
+  remain intact.
+- Optional `ChunkMeta.sessionAttributes` must be omitted when empty so old
+  default envelopes remain byte-shape compatible apart from unrelated event
+  data.
+- Web Vitals are emitted both as spans and optional metrics. The span must gain
+  the dimensions through the universal processor; the metric point must not.
+- Browser instrumentation callback failures are host-safe by established
+  convention. Do not throw configuration/runtime errors for invalid dynamic
+  entries.
+
+## Implementation Blueprint
+
+### Data Models
+
+```ts
+export type BrowserSessionAttributeValue = string | number | boolean
+export type BrowserSessionAttributesInput = Record<string, BrowserSessionAttributeValue | undefined>
+export type BrowserSessionAttributes = Record<string, BrowserSessionAttributeValue>
+
+export interface BrowserSessionOptions {
+  getRouteName?: () => string | undefined
+  getSessionAttributes?: () => BrowserSessionAttributesInput
+  // existing options unchanged
+}
+
+export interface BrowserSessionState {
+  id: string
+  startedAt: number
+  lastActivityAt: number
+  sessionAttributes?: BrowserSessionAttributes
+}
+
+export interface ChunkMeta {
+  // existing fields unchanged
+  sessionAttributes?: SessionAttributes
+}
+```
+
+Constants/invariants:
+
+- `SESSION_ATTRIBUTE_KEY_PATTERN = /^[a-z][a-z0-9_]{0,63}$/u`
+- `MAX_SESSION_ATTRIBUTES = 20`
+- `MAX_SESSION_ATTRIBUTE_STRING_CODE_POINTS = 200`
+- browser span name: `logfire.session.${key}`
+- replay map field: `meta.sessionAttributes[key]`
+- empty normalized maps are represented internally as an empty record and
+  omitted from replay JSON.
+
+### Tasks
+
+```yaml
+Task 1: Define and test browser session-dimension lifecycle
+  MODIFY packages/logfire-browser/src/browserSession.ts:
+    - Add exported input/value/snapshot types and both BrowserSessionOptions callbacks.
+    - Add a bounded normalizer implementing the exact key, count, Unicode string, finite-number, boolean, undefined, own-property, and hostile-runtime contract.
+    - Capture a new plain snapshot when createSession() creates an id.
+    - Persist the snapshot with the session state and preserve it through touch().
+    - Revalidate stored snapshots; lazily hydrate legacy valid records without changing their id, then persist the upgraded record.
+    - Persist {} when a configured callback evaluates with no valid entries, while leaving the field absent for callback-free sessions, so reload does not re-run an evaluated-empty callback.
+    - Add non-touching getters for current session attributes and dynamic route name; do not expose mutable internal state.
+    - Contain callback/property-access failures and return an empty snapshot.
+  MODIFY packages/logfire-browser/src/browserSession.test.ts:
+    - Cover exact valid scalars, invalid key/type/undefined/non-finite/oversized omission, Unicode code-point boundary, property order, 20-valid-entry cap, inherited entries, Object.create(null), frozen records, rejected array/function/date/class containers, proxy traps, per-property throwing getter omission, whole-object/callback failure, and no mutation.
+    - Cover one callback evaluation per new session, manager reload reuse, legacy hydration, idle/max/reset rotation, throwing storage, and tampered persisted attributes.
+  MODIFY packages/logfire-browser/src/index.ts:
+    - Export the new public types with existing BrowserSessionOptions exports.
+  PATTERN: packages/logfire-browser/src/browserSession.ts:101-204 and browserSession.test.ts:60-203
+  ENABLES: CX-2, CX-4
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-browser#test -- src/browserSession.test.ts
+    - EXPECTED: Browser session validation and lifecycle tests pass with exact snapshot/callback counts.
+
+Task 2: Propagate dynamic route and immutable session attributes to every span
+  MODIFY packages/logfire-browser/src/BrowserSessionSpanProcessor.ts:
+    - After touch(), set every normalized session entry under logfire.session.<key>.
+    - Evaluate route name independently for each span and set logfire.page.route for string results.
+    - Keep session, replay, route, and URL failure boundaries independent; do not gate route/session on location availability.
+    - Preserve existing session id, replay state, and URL attributes exactly.
+  MODIFY packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts:
+    - Assert exact combined default session/url/route/custom attributes.
+    - Change application route state between spans and assert per-span evaluation.
+    - Cover absent, undefined, empty-string, hostile non-string, and throwing route results.
+    - Prove throwing route and URL callbacks do not suppress each other's or session/replay attributes.
+    - Prove session snapshot remains unchanged when callback source mutates until manager reset.
+  MODIFY packages/logfire-browser/src/browserConfigure.integration.test.ts:
+    - Configure through the public entry point with a real in-memory exporter and representative manual/log-like, Web Vital, fetch, and XHR spans.
+    - Assert the universal provider path carries route/session attributes without instrumentation-specific hooks.
+  PATTERN: packages/logfire-browser/src/BrowserSessionSpanProcessor.ts:49-83 and browserConfigure.integration.test.ts:99-186
+  ENABLES: CX-1, CX-2, CX-4
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-browser#test -- src/BrowserSessionSpanProcessor.test.ts src/browserConfigure.integration.test.ts
+    - EXPECTED: Dynamic route and immutable session attributes are exact on every representative browser span, with independent failure containment.
+
+Task 3: Extend standalone replay with a bounded per-session metadata snapshot
+  MODIFY packages/logfire-session-replay/src/types.ts:
+    - Add exported scalar/input/normalized session attribute types.
+    - Add optional getSessionAttributes to SessionReplayConfig and ResolvedSessionReplayConfig.
+    - Add optional sessionAttributes to ChunkMeta without changing CHUNK_ENVELOPE_VERSION.
+  CREATE packages/logfire-session-replay/src/sessionAttributes.ts:
+    - Normalize into a new plain record with the same exact key/count/value contract as Task 1.
+    - Return empty on callback/key-enumeration failure, omit only an individual throwing property, and report through the existing safe onError path only when appropriate; invalid user data remains silently omitted.
+  CREATE packages/logfire-session-replay/src/sessionAttributes.test.ts:
+    - Exhaustively cover the shared public contract, mutation isolation, every accepted/rejected container class, and exact onError call counts for callback/prototype/enumeration/property exceptions versus silent invalid omissions.
+  MODIFY packages/logfire-session-replay/src/index.ts:
+    - Resolve getSessionAttributes in config.
+    - Evaluate it once per createActiveRuntime()/session id and pass the normalized snapshot into ReplayTransport.
+    - On observed session rotation, create a fresh snapshot; never re-evaluate it per event/flush.
+  MODIFY packages/logfire-session-replay/src/index.test.ts:
+    - Assert one evaluation for multiple chunks in one session, fresh evaluation after id rotation, throwing callback containment, and exact metadata per upload session id.
+  PATTERN: packages/logfire-session-replay/src/index.ts:79-129,183-210,358-398 and src/privacy.ts
+  ENABLES: CX-3, CX-4
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-session-replay#test -- src/sessionAttributes.test.ts src/index.test.ts
+    - EXPECTED: Standalone replay snapshots exactly once per session, rotates safely, and contains invalid/throwing input.
+
+Task 4: Serialize replay session metadata through every chunk path
+  MODIFY packages/logfire-session-replay/src/transport.ts:
+    - Accept/store an immutable normalized sessionAttributes snapshot per transport.
+    - Include it in every ordinary and lifecycle envelope through central metadata creation.
+    - Omit the field for an empty snapshot and never retain/mutate caller-owned records.
+  MODIFY packages/logfire-session-replay/src/extract.ts:
+    - Extend computeChunkMeta with the optional normalized snapshot using an exact defensive copy.
+  MODIFY packages/logfire-session-replay/src/transport.test.ts:
+    - Decode gzip bodies and assert identical metadata across ordinary, split keepalive, retry, and multi-flush chunks.
+    - Assert empty omission and source-object mutation isolation.
+  MODIFY packages/logfire-session-replay/src/extract.test.ts:
+    - Assert exact optional metadata shape alongside existing derived fields.
+  PATTERN: packages/logfire-session-replay/src/transport.ts:108-159,177-225 and src/extract.ts:12-83
+  ENABLES: CX-3, CX-4
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-session-replay#test -- src/transport.test.ts src/extract.test.ts
+    - EXPECTED: Every decoded chunk path carries one exact immutable optional sessionAttributes map and envelope version remains 1.
+
+Task 5: Bridge the browser-owned snapshot into optional replay
+  MODIFY packages/logfire-browser/src/sessionReplay.ts:
+    - Add getSessionAttributes to the mirrored peer config type and preserve the compile-time assignability check.
+    - Pass a non-touching getter returning the current browser manager snapshot.
+    - Do not add getSessionAttributes to top-level BrowserSessionReplayOptions; browser integrators configure it once under rum.session.
+  MODIFY packages/logfire-browser/src/sessionReplay.test.ts:
+    - Assert the peer receives a getter, startup initializes session state before it is read, repeated reads do not touch/re-evaluate, and reset/rotation yields the new snapshot.
+    - Retain all existing optional peer and failure-containment assertions.
+  PATTERN: packages/logfire-browser/src/sessionReplay.ts:26-48,139-147,149-196
+  ENABLES: CX-3, CX-4
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-browser#test -- src/sessionReplay.test.ts
+    - EXPECTED: Browser-to-peer config remains assignable and forwards only the sanitized current-session snapshot without activity writes.
+
+Task 6: Prove Web Vitals span inclusion and metric exclusion
+  MODIFY packages/logfire-browser/src/browserMetrics.test.ts and/or browserConfigure.integration.test.ts:
+    - Configure route/session callbacks plus Web Vitals spans and metrics through public configure.
+    - Assert the finished Web Vital span has logfire.page.route and exact logfire.session.* attributes.
+    - Assert the histogram data-point attributes remain exactly web_vital.name, web_vital.rating, and any explicit metrics.attributes output; reject every implicit route/session key.
+    - Preserve the existing ability to add a deliberate low-cardinality route through rum.webVitals.metrics.attributes.
+  PATTERN: packages/logfire-browser/src/browserMetrics.ts:130-159,206-211 and browserMetrics.test.ts low-cardinality attribute test
+  ENABLES: CX-1, CX-5
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-browser#test -- -t "Web Vitals|low-cardinality|session attributes|route"
+    - EXPECTED: Web Vital spans gain both dimensions and Web Vital metrics gain neither unless explicitly supplied under a consumer-selected metric key.
+
+Task 7: Add direct built-browser trace/replay acceptance
+  CREATE packages/logfire-browser/test-fixtures/rum-dimensions/index.html:
+    - Provide deterministic normal and hostile routes plus fetch, XHR, interaction, reload, idle-expiry rotation, and status controls without external credentials.
+  CREATE packages/logfire-browser/test-fixtures/rum-dimensions/main.ts:
+    - Import built browser dist and lazy-load built replay through the established neutral virtual module.
+    - Configure dynamic getRouteName, generation-marked getSessionAttributes, Web Vitals, metrics, fetch/XHR/user-interaction auto-instrumentation, trace/replay loopback endpoints, and long automatic flush intervals.
+    - Configure a short idle timeout and run deterministic before-reload, after-reload, and post-timeout rotation phases; flush/cleanup before reporting terminal completion.
+    - On /hostile/, configure a throwing route callback and one record containing valid entries, invalid keys/values, an oversized string, a non-finite number, more than 20 valid entries, and an enumerable throwing getter; emit and flush a span plus real replay.
+    - Persist only fixture phase and callback-count markers needed to resume after reload; do not bypass the SDK session store.
+  CREATE packages/logfire-browser/test-fixtures/rum-dimensions/recorder.d.ts and vite.config.ts:
+    - Reuse the privacy-defaults built replay/rrweb/fflate virtual-module and bounded receipt middleware patterns.
+    - Bind a distinct strict loopback port, capture trace/metric/replay receipts, expose reset/read endpoints, and report progress by phase/session id.
+  CREATE packages/logfire-browser/test-fixtures/rum-dimensions/verify.mjs:
+    - Accept normal or hostile scenario selection; poll terminal state, decode OTLP trace/metric JSON and gzip replay envelopes, join trace/replay by session id, and assert every CX-1/CX-2/CX-3/CX-4 invariant exactly.
+    - For hostile, require tracing/replay completion, exact agreement on the first 20 valid entries, omission of every named invalid entry, no route attribute, and preservation of session/replay/URL attributes.
+    - Fail nonzero for missing/duplicate evidence, route/session mismatch, callback re-evaluation on reload, absent configured idle rotation, metadata drift, invalid-value leakage, metric leakage, or envelope version change.
+    - Print only bounded non-sensitive counts, ids, route templates, and key names.
+  PATTERN: packages/logfire-browser/test-fixtures/privacy-defaults/
+  ENABLES: CX-1, CX-2, CX-3, CX-4, CX-5
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-session-replay#build && vp run @pydantic/logfire-browser#build
+    - EXPECTED: Both public packages build and the fixture consumes dist output.
+    - COMMAND: vp dev --config packages/logfire-browser/test-fixtures/rum-dimensions/vite.config.ts --host 127.0.0.1 --port 4180
+    - EXPECTED: Loopback server stays active on port 4180; terminal success requires both normal and hostile fixture phases complete plus both verifier exits 0, terminal failure is either fixture phase failed, either verifier nonzero, or a 30-second per-scenario deadline; executor owns server process, port, browser sessions, and receipt cleanup.
+    - FAILURE-LOCAL: Run node packages/logfire-browser/test-fixtures/rum-dimensions/verify.mjs <normal|hostile> --phase <before-reload|after-reload|rotated|hostile> against retained receipts to isolate the failed phase without rebuilding.
+    - PROCESS-LIFECYCLE: Executor starts the Vite process, observes server-ready output, uses isolated normal and hostile agent-browser sessions, closes both, sends SIGTERM to the exact Vite process, and confirms port 4180 is free on success or failure.
+
+Task 8: Document the bounded public contract and representative usage
+  MODIFY packages/logfire-browser/README.md and docs/packages/browser.md:
+    - Document both rum.session callbacks, exact route/session lifecycle, key/value/count bounds, prefixing, invalid omission, low-cardinality/non-PII requirements, reload persistence, and new-session refresh.
+    - State that route/session attributes appear on spans/events including Web Vitals and auto-instrumentation spans but not implicitly on metrics.
+    - Show deliberate metric route configuration separately.
+  MODIFY packages/logfire-session-replay/README.md:
+    - Document standalone getSessionAttributes, per-session snapshot behavior, exact bounds, invalid omission, and optional meta.sessionAttributes.
+    - State that metadata is intended for safe dimensions, not profiles or arbitrary analytics.
+  MODIFY examples/browser-rum-replay/src/main.ts and README.md:
+    - Use getRouteName for routeTemplate(window.location.pathname) while leaving URL attributes at their privacy-safe defaults.
+    - Add fixed safe sample session dimensions such as account_tier, app_region, and experiment_variant; do not derive them from editable user ids.
+    - Update trace/replay expectations and keep metrics dimensions explicitly configured.
+  CREATE .changeset/browser-rum-custom-dimensions.md:
+    - Add patch entries for @pydantic/logfire-browser and @pydantic/logfire-session-replay describing normalized route and bounded session metadata support.
+  PATTERN: packages/logfire-browser/README.md RUM Session Identity/Web Vitals/Session replay sections and examples/browser-rum-replay/src/main.ts
+  ENABLES: CX-1, CX-2, CX-3, CX-4, CX-5
+  VERIFY:
+    - COMMAND: vp fmt --check packages/logfire-browser/README.md packages/logfire-session-replay/README.md docs/packages/browser.md examples/browser-rum-replay/src/main.ts examples/browser-rum-replay/README.md .changeset/browser-rum-custom-dimensions.md plans/033-browser-rum-custom-dimensions.md
+    - EXPECTED: Public docs, example, changeset, and PRP are formatted and agree on names, limits, lifecycles, privacy guidance, replay shape, and metric exclusion.
+    - COMMAND: node_modules/.bin/changeset status --output /tmp/prp033-changeset-status.json
+    - EXPECTED: Changesets parses the repository and reports browser-rum-custom-dimensions with exactly patch releases for @pydantic/logfire-browser and @pydantic/logfire-session-replay.
+
+Task 9: Run focused and integrated package gates
+  ENABLES: CX-1, CX-2, CX-3, CX-4, CX-5
+  VERIFY:
+    - COMMAND: vp run @pydantic/logfire-session-replay#test && vp run @pydantic/logfire-session-replay#typecheck && vp run @pydantic/logfire-session-replay#build && vp run @pydantic/logfire-browser#test && vp run @pydantic/logfire-browser#typecheck && vp run @pydantic/logfire-browser#build
+    - EXPECTED: Both affected packages pass all tests, typechecks, and builds with no skipped feature tests.
+    - FAILURE-LOCAL: Re-run the failing package phase with vp run <package>#<test|typecheck|build>; for tests, pass the exact test file or -t pattern named by Tasks 1-6.
+    - COMMAND: pnpm run check
+    - EXPECTED: The complete repository build, Vite+ checks, typechecks, tests, and release-tooling tests pass.
+    - FAILURE-LOCAL: Run the failing root script from package.json directly; affected-package diagnosis remains the focused commands above.
+```
+
+### Integration Points
+
+```yaml
+PUBLIC_BROWSER_CONFIG:
+  - packages/logfire-browser/src/browserSession.ts — both callbacks, public value types, and persisted snapshot contract.
+  - packages/logfire-browser/src/index.ts — public type export and session processor registration.
+
+SPAN_PROPAGATION:
+  - packages/logfire-browser/src/BrowserSessionSpanProcessor.ts — universal log/span/auto-instrumentation/Web Vitals augmentation.
+
+METRICS:
+  - packages/logfire-browser/src/browserMetrics.ts — intentionally independent explicit metric dimensions.
+
+OPTIONAL_PEER_BRIDGE:
+  - packages/logfire-browser/src/sessionReplay.ts — non-touching sanitized snapshot getter passed during lazy peer configuration.
+
+STANDALONE_REPLAY:
+  - packages/logfire-session-replay/src/types.ts — public callback and optional metadata schema.
+  - packages/logfire-session-replay/src/index.ts — one snapshot per active replay session.
+  - packages/logfire-session-replay/src/transport.ts — immutable snapshot on every chunk.
+  - packages/logfire-session-replay/src/extract.ts — central optional metadata assembly.
+
+PERSISTENCE:
+  - lf_browser_session sessionStorage record — optional sanitized sessionAttributes field; legacy records hydrate without id rotation.
+
+DIRECT_ACCEPTANCE:
+  - packages/logfire-browser/test-fixtures/rum-dimensions/ — built-package browser, OTLP/metric/replay receipts, reload/rotation, and exact verifier.
+
+DOCUMENTATION:
+  - package READMEs, docs/packages/browser.md, and browser-rum-replay example — one public privacy/cardinality contract.
+
+RELEASE:
+  - .changeset/browser-rum-custom-dimensions.md — patch releases for both public packages.
+```
+
+## Validation
+
+Run the following focused, direct-consumer, formatting, and integrated gates
+from the repository root:
+
+```bash
+# Focused browser package
+vp run @pydantic/logfire-browser#test
+vp run @pydantic/logfire-browser#typecheck
+vp run @pydantic/logfire-browser#build
+
+# Focused standalone replay package
+vp run @pydantic/logfire-session-replay#test
+vp run @pydantic/logfire-session-replay#typecheck
+vp run @pydantic/logfire-session-replay#build
+
+# Direct built-browser consumer acceptance
+vp dev --config packages/logfire-browser/test-fixtures/rum-dimensions/vite.config.ts --host 127.0.0.1 --port 4180
+agent-browser --session rum-dimensions open "http://127.0.0.1:4180/projects/123"
+agent-browser --session rum-dimensions wait --fn "window.__logfireRumDimensions?.phase === 'complete'"
+node packages/logfire-browser/test-fixtures/rum-dimensions/verify.mjs normal
+agent-browser --session rum-dimensions close
+agent-browser --session rum-dimensions-hostile open "http://127.0.0.1:4180/hostile/"
+agent-browser --session rum-dimensions-hostile wait --fn "window.__logfireRumDimensions?.phase === 'complete'"
+node packages/logfire-browser/test-fixtures/rum-dimensions/verify.mjs hostile
+agent-browser --session rum-dimensions-hostile close
+# Stop the exact Vite process and confirm port 4180 is free.
+
+# Docs/release artifact
+vp fmt --check packages/logfire-browser packages/logfire-session-replay docs/packages/browser.md examples/browser-rum-replay .changeset/browser-rum-custom-dimensions.md plans/033-browser-rum-custom-dimensions.md
+node_modules/.bin/changeset status --output /tmp/prp033-changeset-status.json
+
+# Integrated repository gate
+pnpm run check
+```
+
+The `CX-N` table is authoritative. Package tests provide direct public-config
+evidence for hostile input and metrics behavior; the built-browser fixture is
+required for real auto-instrumentation, reload persistence, session rotation,
+and trace-to-replay metadata correlation. Source-level tests alone do not
+satisfy CX-1, CX-2, or CX-3.
+
+## Unknowns & Risks
+
+- **Replay ingest compatibility**: this repository can prove the emitted
+  version-1 JSON shape but not Platform parser/index behavior. The optional
+  field is planned as additive. If Platform uses a closed schema that rejects
+  it or requires a different name, execution must pause rather than silently
+  ship unusable metadata.
+- **Duplicate validation logic**: browser spans require validation without a
+  runtime dependency on the optional replay peer, while standalone replay must
+  defend its own public boundary. Two small implementations may drift. Keep
+  constants, types, examples, and table-driven tests textually aligned; do not
+  add a new production package/dependency for this bounded helper.
+- **Legacy hydration**: a pre-feature stored session receives its first snapshot
+  on the first upgraded page load rather than at its historical start time.
+  This is the only compatible way to preserve the id and make the feature
+  available before rotation. Once hydrated, it is immutable.
+- **Callback side effects**: consumers may make callbacks stateful. The SDK
+  guarantees route evaluation per span and session evaluation once per
+  session/legacy hydration, so docs and tests must make counts explicit.
+- **Stored-session tampering**: same-origin application code can edit
+  `sessionStorage`. Revalidation bounds output but is not an authenticity
+  mechanism; applications remain responsible for supplying non-PII dimensions.
+- **Value length interpretation**: the public cap is 200 Unicode code points,
+  not UTF-16 code units or bytes. Implementation must not use plain
+  `string.length` for the acceptance boundary.
+- **Replay payload growth**: at maximum bounds, every replay chunk gains roughly
+  several kilobytes before gzip. This is deliberate and bounded; it must not
+  alter buffer event-byte accounting, which controls rrweb event retention
+  rather than envelope metadata.
+- **Route cardinality remains application-owned**: the SDK does not validate or
+  infer templates. Documentation is the guardrail for low-cardinality,
+  non-user-data route strings.
+- **Issue ownership**: an external contributor expressed interest in #190.
+  Confirm ownership before execution to avoid duplicated work.
+
+**Confidence: 8/10** for one-pass implementation success. The propagation,
+persistence, replay-rotation, envelope, and browser-fixture patterns all exist.
+The main residual risk is downstream replay ingest's accepted optional metadata
+schema; the PRP has an explicit pause gate rather than assuming Platform
+compatibility.
+
+## Verification Record
+
+- **Verified**: 2026-07-28 from source baseline
+  `172dffa41ef5effbdef4a8e750c059fb771fb986`, preserving the implementation,
+  PRP, and all tracked/untracked workspace changes without staging or
+  committing.
+- **Independent Deep verification**: one fresh-context read-only verifier
+  completed consumer acceptance, PRP compliance, and engineering-quality
+  passes. Its initial pass found acceptance-harness, focused-test, and
+  documentation gaps. After targeted fixes, the same verifier reproduced the
+  affected evidence and reported `READY` with no remaining blocker.
+
+| Scenario | Grade               | Direct evidence                                                                                                                                                                                                                                                                                                                                         | Limitations                                                                                                                                    |
+| -------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CX-1`   | `DIRECTLY VERIFIED` | The built browser fixture emitted document-load, manual duration, manual error, Web Vital, click, fetch, and XHR spans. The verifier required exact pre-change route, default URL, and session dimensions; required `/settings` after route state changed; and exercised a second public configuration with `getRouteName` omitted.                     | Uses the repository's loopback Vite/OTLP fixture and built package exports; no framework-specific router adapter is claimed.                   |
+| `CX-2`   | `DIRECTLY VERIFIED` | The normal browser run retained one session id and exact generation-1 snapshot across a same-tab reload, exposed callback count `2` for exactly two browser sessions, then produced a new id and generation-2 snapshot after configured idle expiry.                                                                                                    | Session persistence is exercised through browser `sessionStorage`; abrupt browser-process loss is outside the documented tab-session contract. |
+| `CX-3`   | `DIRECTLY VERIFIED` | The verifier decoded every scenario-matching gzip replay receipt. All three envelopes remained version 1; every first-session chunk contained the exact generation-1 snapshot, while every rotated-session chunk contained generation 2 and matched span attributes by session id.                                                                      | Platform ingest/index acceptance of the additive optional field remains explicitly out of scope.                                               |
+| `CX-4`   | `DIRECTLY VERIFIED` | The sequential hostile browser run retained tracing, replay, URL, and session identity while omitting the throwing route and invalid session values. It retained the first 20 valid entries in order, including the 200-code-point boundary, and replay metadata exactly matched the span map. Focused tests covered callback/container/proxy failures. | Runtime validation bounds data but does not classify or scrub PII; applications must supply safe dimensions.                                   |
+| `CX-5`   | `DIRECTLY VERIFIED` | Real Web Vital spans carried route and session dimensions. All 16 normal-run metric points contained exactly `web_vital.name` and `web_vital.rating`, with no implicit `logfire.page.route` or `logfire.session.*` keys.                                                                                                                                | Browser timing determines which standard Web Vitals produce samples; the contract is asserted across every emitted point.                      |
+
+### Compliance and Engineering Evidence
+
+- All six success criteria and nine blueprint tasks are implemented. Public
+  types, persisted legacy hydration and empty-snapshot sentinel behavior,
+  per-session replay rotation, every-envelope metadata, documentation,
+  representative example usage, and the two-package patch changeset match the
+  PRP. Explicit exclusions held.
+- The direct built-browser fixture supplies the joint public-config Web Vital
+  span/metric evidence from Task 6, alongside focused integration and metric
+  tests. This is a stronger public-boundary exercise than the originally
+  suggested fully mocked joint assertion and does not change scope.
+- Independent engineering review found the production implementation correct
+  for bounded browser/replay normalization parity, callback failure
+  containment, storage compatibility, immutable snapshots, optional-peer
+  loading, metric separation, and version-1 envelope compatibility.
+- The documented normal then hostile sequence passed on one unchanged server:
+  the final main-agent run observed 79 normal spans, three replay receipts,
+  sixteen metric points, and two replay session ids, followed by 34 hostile
+  spans, one replay receipt, and eight metric points. The independent follow-up
+  separately reproduced the sequence with 78 normal spans and the same replay,
+  metric, and hostile evidence.
+
+| Gate                                        | Result                                                                                                                                                     |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PRP structural validator                    | Passed with zero warnings                                                                                                                                  |
+| Focused replay tests and typecheck          | 93 focused tests passed; complete replay suite passed 152 tests                                                                                            |
+| Focused browser tests and typecheck         | Complete browser suite passed 166 tests                                                                                                                    |
+| Affected package and fixture builds         | Both packages and the built `rum-dimensions` consumer fixture passed                                                                                       |
+| Sequential direct browser acceptance        | Normal and hostile scenarios passed on one server; phase selectors, receipt isolation, fetch/XHR spans, omitted route, replay chunks, and metrics verified |
+| Formatting, lint, typecheck, and Changesets | Passed; Changesets selects patch releases for exactly `@pydantic/logfire-browser` and `@pydantic/logfire-session-replay`                                   |
+| `pnpm run check`                            | Passed all package builds, formatting, lint, typechecks, tests, and release-tooling tests                                                                  |
+| `git diff --check` and process cleanup      | Passed; browser sessions closed, Vite stopped, and port 4180 confirmed free                                                                                |
+
+**Final status: `VERIFIED`.**

--- a/plans/033-browser-rum-custom-dimensions.md
+++ b/plans/033-browser-rum-custom-dimensions.md
@@ -866,7 +866,7 @@ compatibility.
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | PRP structural validator                    | Passed with zero warnings                                                                                                                                  |
 | Focused replay tests and typecheck          | 93 focused tests passed; complete replay suite passed 152 tests                                                                                            |
-| Focused browser tests and typecheck         | Complete browser suite passed 166 tests                                                                                                                    |
+| Focused browser tests and typecheck         | Complete browser suite passed 168 tests                                                                                                                    |
 | Affected package and fixture builds         | Both packages and the built `rum-dimensions` consumer fixture passed                                                                                       |
 | Sequential direct browser acceptance        | Normal and hostile scenarios passed on one server; phase selectors, receipt isolation, fetch/XHR spans, omitted route, replay chunks, and metrics verified |
 | Formatting, lint, typecheck, and Changesets | Passed; Changesets selects patch releases for exactly `@pydantic/logfire-browser` and `@pydantic/logfire-session-replay`                                   |


### PR DESCRIPTION
## Summary

- add `rum.session.getRouteName` and emit `logfire.page.route` on browser spans
- add bounded, immutable `rum.session.getSessionAttributes` snapshots and emit `logfire.session.*`
- propagate the same per-session snapshot to version-1 replay metadata as `meta.sessionAttributes`
- preserve snapshots across same-tab reloads, hydrate legacy stored sessions without changing their ID, and refresh on session rotation
- document the public contract and add a built-browser trace/metric/replay acceptance fixture

Fixes #190
Fixes #191

## Public contract

Session attribute keys must match `^[a-z][a-z0-9_]{0,63}$`. The SDK retains the first 20 valid entries in property order. Values may be booleans, finite numbers, or strings of at most 200 Unicode code points; invalid entries are omitted.

The browser persists only the normalized snapshot. Existing stored sessions without the field are hydrated once while preserving their current session ID. An explicit empty snapshot is retained as the “already evaluated” sentinel.

Replay keeps envelope version 1 and adds optional `meta.sessionAttributes`. This assumes Logfire Platform replay ingest accepts the additive optional field; Platform indexing, query, and UI support are outside this PR.

## Validation

- `pnpm run check`
- browser package: 168 tests
- session replay package: 152 tests
- built-package browser acceptance for normalized routes, fetch/XHR and Web Vital spans, reload persistence, idle rotation, exact metric exclusion, replay correlation, omitted callbacks, and hostile inputs
- PRP structural validator, formatting, changeset validation (`@pydantic/logfire-browser` 0.18.0 and `@pydantic/logfire-session-replay` 0.2.0), and `git diff --check`
