### PR TITLE
Generate a default service.instance.id resource attribute

### DIFF
--- a/.changeset/default-service-instance-id.md
+++ b/.changeset/default-service-instance-id.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Generate a default `service.instance.id` resource attribute, matching Python Logfire's `fallback_resource_attributes`. The value is a random UUID as 32 lowercase hex characters, stays stable for the lifetime of one `configure()` call, and is shared by traces, metrics, and logs. It is applied at the lowest precedence, so both the `resourceAttributes` option and `OTEL_RESOURCE_ATTRIBUTES` still override it.

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -1131,4 +1131,41 @@ describe('sdk lifecycle helpers', () => {
       'service.namespace': 'env-company',
     })
   })
+
+  it('generates a default service.instance.id shared by every signal', () => {
+    start()
+
+    const instanceId = getLatestResourceAttributes()['service.instance.id']
+    expect(typeof instanceId).toBe('string')
+    expect(instanceId).toMatch(/^[0-9a-f]{32}$/u)
+    expect(getLatestVariablesRuntimeOptions().resourceAttributes['service.instance.id']).toBe(instanceId)
+  })
+
+  it('generates a different service.instance.id for each configuration', () => {
+    start()
+    const firstInstanceId = getLatestResourceAttributes()['service.instance.id']
+
+    start()
+    const secondInstanceId = getLatestResourceAttributes()['service.instance.id']
+
+    expect(firstInstanceId).not.toBe(secondInstanceId)
+  })
+
+  it('lets configured resource attributes override the generated service.instance.id', () => {
+    Object.assign(logfireConfig, {
+      resourceAttributes: { 'service.instance.id': 'configured-instance' },
+    })
+
+    start()
+
+    expect(getLatestResourceAttributes()['service.instance.id']).toBe('configured-instance')
+  })
+
+  it('lets OTEL_RESOURCE_ATTRIBUTES override the generated service.instance.id', () => {
+    process.env['OTEL_RESOURCE_ATTRIBUTES'] = 'service.instance.id=env-instance'
+
+    start()
+
+    expect(getLatestResourceAttributes()['service.instance.id']).toBe('env-instance')
+  })
 })

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -12,6 +12,7 @@ import type { MetricReader } from '@opentelemetry/sdk-metrics'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { ParentBasedSampler, TraceIdRatioBasedSampler } from '@opentelemetry/sdk-trace-base'
 import {
+  ATTR_SERVICE_INSTANCE_ID,
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
   ATTR_TELEMETRY_SDK_LANGUAGE,
@@ -329,7 +330,10 @@ export function start(): void {
     diag.setLogger(new DiagConsoleLogger(), logfireConfig.diagLogLevel)
   }
 
-  const resource = resourceFromAttributes(logfireConfig.resourceAttributes)
+  // Low-precedence fallback, matching Python Logfire's `fallback_resource_attributes`: every
+  // later merge wins, so `resourceAttributes` and `OTEL_RESOURCE_ATTRIBUTES` still override it.
+  const resource = resourceFromAttributes({ [ATTR_SERVICE_INSTANCE_ID]: crypto.randomUUID().replaceAll('-', '') })
+    .merge(resourceFromAttributes(logfireConfig.resourceAttributes))
     .merge(
       resourceFromAttributes(
         removeEmptyKeys({


### PR DESCRIPTION
Fixes #196.

`sdk.ts` built the resource as `resourceFromAttributes(resourceAttributes).merge(logfire attributes).merge(detectResources({ detectors: [envDetector] }))` and never set `service.instance.id`, so telemetry from separate processes or restarts was indistinguishable unless the app supplied one itself. This starts the merge chain with a generated value instead, which keeps it at the lowest precedence: because `Resource.merge` lets the argument win, both the `resourceAttributes` option and `OTEL_RESOURCE_ATTRIBUTES` still override it. That mirrors Python Logfire, which puts `'service.instance.id': uuid4().hex` in `fallback_resource_attributes` for the same reason (logfire/_internal/config.py, `build_resource`), so the format matches too: a UUID as 32 lowercase hex characters. One resource object feeds the NodeSDK, so traces, metrics, and logs all share the value, and it stays stable for the lifetime of a `configure()` call.

Four tests cover the cases listed in the issue, two of which fail on current main. I also checked it end to end rather than only through the mocks: pointing `advanced.baseUrl` at a local HTTP server and reading the captured OTLP export, main sends no `service.instance.id` at all, this branch sends a 32 hex character value, and with `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=...` the environment value is what gets exported. Ran `pnpm run check` from the root, all green. Patch changeset for `@pydantic/logfire-node` included.

I scoped this to `logfire-node` to match the issue rather than touching the browser and Workers packages, and left the resource-detectors idea from #113 alone. If you would rather handle instance identity as part of that separate design, feel free to close this, no hard feelings.

honest note: Claude Code helped me put this together and I read through the final diff myself before opening it. I'm a freshman still learning OTel resource semantics, so corrections are genuinely welcome :)