### PR TITLE
Match Python repr when formatting string evaluation bodies

### DIFF
--- a/.changeset/python-string-repr.md
+++ b/.changeset/python-string-repr.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Match CPython's `repr()` when rendering string evaluation values in the `gen_ai.evaluation.result` log body. Values containing an apostrophe now switch to double quotes instead of escaping it, and control characters such as newlines and tabs are escaped rather than emitted literally, which previously broke the single-line body across multiple lines.

--- a/.changeset/python-string-repr.md
+++ b/.changeset/python-string-repr.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Match CPython's `repr()` when rendering string evaluation values in the `gen_ai.evaluation.result` log body. Values containing an apostrophe now switch to double quotes instead of escaping it, and control characters such as newlines and tabs are escaped rather than emitted literally, which previously broke the single-line body across multiple lines.
+Match CPython's `repr()` when rendering string evaluation values in the `gen_ai.evaluation.result` log body. Values containing an apostrophe but no double quote now switch to double quotes instead of escaping the apostrophe, and control characters such as newlines and tabs are escaped rather than emitted literally, which previously broke the single-line body across multiple lines.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -79,6 +79,27 @@ class CategoryLabel extends Evaluator {
   }
 }
 
+class ApostropheLabel extends Evaluator {
+  static override evaluatorName = 'ApostropheLabel'
+  evaluate(): string {
+    return "the model's answer"
+  }
+}
+
+class BothQuotesLabel extends Evaluator {
+  static override evaluatorName = 'BothQuotesLabel'
+  evaluate(): string {
+    return `both ' and "`
+  }
+}
+
+class ControlCharLabel extends Evaluator {
+  static override evaluatorName = 'ControlCharLabel'
+  evaluate(): string {
+    return 'line\nbreak\tand\\slash'
+  }
+}
+
 class WithReason extends Evaluator {
   static override evaluatorName = 'WithReason'
   evaluate(): EvaluatorOutput {
@@ -191,6 +212,23 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
       await waitForEvaluations()
     })
     expect(logs.map((log) => log.body)).toEqual(['evaluation: TinyScore=1.23e-07', 'evaluation: LargeIntegerScore=1.23457e+06'])
+  })
+
+  it('formats string result bodies like Python repr', async () => {
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new ApostropheLabel(), new BothQuotesLabel(), new ControlCharLabel()],
+      target: 't',
+    })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+    // Expected values are `repr()` output from CPython for the same three strings.
+    expect(logs.map((log) => log.body)).toEqual([
+      `evaluation: ApostropheLabel="the model's answer"`,
+      `evaluation: BothQuotesLabel='both \\' and "'`,
+      `evaluation: ControlCharLabel='line\\nbreak\\tand\\\\slash'`,
+    ])
   })
 
   it('string output → score.label only (no value)', async () => {

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -146,8 +146,40 @@ function formatPythonGeneralNumber(value: number): string {
     .replace(/e([+-])(\d)$/u, 'e$10$2')
 }
 
+// Python's `str.isprintable()` treats the Unicode "Other" and "Separator" categories as
+// non-printable, except the ASCII space.
+const PYTHON_NON_PRINTABLE = /[\p{C}\p{Z}]/u
+const PYTHON_SHORT_ESCAPES: Record<string, string> = { '\t': '\\t', '\n': '\\n', '\r': '\\r' }
+
 function pythonStringRepr(value: string): string {
-  return `'${value.replace(/\\/gu, '\\\\').replace(/'/gu, "\\'")}'`
+  // CPython prefers single quotes, switching to double quotes only when the value contains a
+  // single quote and no double quote, and escapes just the quote character it ends up using.
+  const quote = value.includes("'") && !value.includes('"') ? '"' : "'"
+  let escaped = ''
+  for (const char of value) {
+    if (char === '\\' || char === quote) {
+      escaped += `\\${char}`
+      continue
+    }
+    const shortEscape = PYTHON_SHORT_ESCAPES[char]
+    if (shortEscape !== undefined) {
+      escaped += shortEscape
+      continue
+    }
+    if (char !== ' ' && PYTHON_NON_PRINTABLE.test(char)) {
+      const codePoint = char.codePointAt(0) ?? 0
+      if (codePoint < 0x100) {
+        escaped += `\\x${codePoint.toString(16).padStart(2, '0')}`
+      } else if (codePoint < 0x10000) {
+        escaped += `\\u${codePoint.toString(16).padStart(4, '0')}`
+      } else {
+        escaped += `\\U${codePoint.toString(16).padStart(8, '0')}`
+      }
+      continue
+    }
+    escaped += char
+  }
+  return `${quote}${escaped}${quote}`
 }
 
 function applyBaggage(attrs: Record<string, unknown>, baggage: Record<string, unknown> | undefined): void {


### PR DESCRIPTION
`evals/constants.ts` says the evals wire format must stay byte-identical to Python pydantic-evals, and `_otel_emit.py`'s `_format_score` renders string values with `repr(value)`. The JS side in `packages/logfire-api/src/evals/otelEmit.ts` approximated that with `'` + escaped backslashes and quotes, which diverges in two ways that show up in ordinary eval labels and reasons.

An apostrophe is the common one: CPython renders `the model's answer` as `"the model's answer"`, switching to double quotes rather than escaping, while we emitted `'the model\\'s answer'`. The worse one is control characters. A value containing a newline was emitted literally, so the `gen_ai.evaluation.result` body stopped being one line, where Python escapes it to `\\n`. Tabs, carriage returns, and other non-printables had the same problem. This rewrites the helper to follow CPython: prefer single quotes, use double quotes when the value has a single quote and no double quote, escape only the quote actually used, and escape anything Python considers non-printable (the Unicode Other and Separator categories except the ASCII space) as `\\n`/`\\t`/`\\r` or `\\xNN`/`\\uXXXX`/`\\UXXXXXXXX`.

The new test in `online.test.ts` covers the apostrophe, both-quotes, and control-character cases and fails on current main. Beyond that I fuzzed the helper against real CPython `repr()` over 4005 generated strings mixing both quote types, backslashes, C0 controls, DEL, U+0085, NBSP, U+200B, U+2028, a private-use character, accented Latin, CJK, and an astral emoji, with zero mismatches. Ran `pnpm run check` from the root, all green. Patch changeset for `logfire` included.

Existing bodies for booleans and numbers were already correct, so this only touches the string path. quick disclosure: I worked through this with Claude Code and reviewed the final diff myself. Freshman here still learning the codebase, so tell me if I have the parity target wrong :)