### PR TITLE
Match Python general format for numeric evaluation bodies

### DIFF
--- a/.changeset/python-general-format.md
+++ b/.changeset/python-general-format.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Match Python's `format(value, 'g')` when rendering numeric evaluation values in the `gen_ai.evaluation.result` log body. Values between 1e-6 and 1e-4 now use scientific notation as Python does instead of long fixed-point decimals, and a value whose sixth significant digit rounds away no longer emits a stray trailing decimal point, for example `-10515.` for `-10515.04`.

--- a/.changeset/python-general-format.md
+++ b/.changeset/python-general-format.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Match Python's `format(value, 'g')` when rendering numeric evaluation values in the `gen_ai.evaluation.result` log body. Values between 1e-6 and 1e-4 now use scientific notation as Python does instead of long fixed-point decimals, a value whose sixth significant digit rounds away no longer emits a stray trailing decimal point (for example `-10515.` for `-10515.04`), and ties now round half to even as Python does rather than away from zero, so `1 / 512` renders as `0.00195312`.
+Match Python's `format(value, 'g')` when rendering numeric evaluation values in the `gen_ai.evaluation.result` log body. Values between 1e-6 and 1e-4 now use scientific notation as Python does instead of long fixed-point decimals, a value whose sixth significant digit rounds away no longer emits a stray trailing decimal point (for example `-10515.` for `-10515.04`), and rounding now runs on the binary double with half-to-even ties, so `1 / 512` renders as `0.00195312`, `0.1234555` as `0.123455`, and `Number.MIN_VALUE` as `4.94066e-324`.

--- a/.changeset/python-general-format.md
+++ b/.changeset/python-general-format.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Match Python's `format(value, 'g')` when rendering numeric evaluation values in the `gen_ai.evaluation.result` log body. Values between 1e-6 and 1e-4 now use scientific notation as Python does instead of long fixed-point decimals, and a value whose sixth significant digit rounds away no longer emits a stray trailing decimal point, for example `-10515.` for `-10515.04`.
+Match Python's `format(value, 'g')` when rendering numeric evaluation values in the `gen_ai.evaluation.result` log body. Values between 1e-6 and 1e-4 now use scientific notation as Python does instead of long fixed-point decimals, a value whose sixth significant digit rounds away no longer emits a stray trailing decimal point (for example `-10515.` for `-10515.04`), and ties now round half to even as Python does rather than away from zero, so `1 / 512` renders as `0.00195312`.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -101,6 +101,22 @@ class HalfEvenTieScore extends Evaluator {
   }
 }
 
+class BinaryRoundingScore extends Evaluator {
+  static override evaluatorName = 'BinaryRoundingScore'
+  evaluate(): number {
+    // Really 0.123455499..., so rounding the binary value gives a different digit than rounding
+    // the shortest decimal text would.
+    return 0.1234555
+  }
+}
+
+class SmallestSubnormalScore extends Evaluator {
+  static override evaluatorName = 'SmallestSubnormalScore'
+  evaluate(): number {
+    return Number.MIN_VALUE
+  }
+}
+
 class CategoryLabel extends Evaluator {
   static override evaluatorName = 'CategoryLabel'
   evaluate(): string {
@@ -236,6 +252,22 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
       'evaluation: SubMilliScore=8.65742e-05',
       'evaluation: MicroScore=2.325e-06',
       'evaluation: RoundsToWholeScore=-10515',
+    ])
+  })
+
+  it('rounds the binary value rather than its shortest decimal form', async () => {
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new BinaryRoundingScore(), new SmallestSubnormalScore()],
+      target: 't',
+    })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+    // CPython: format(0.1234555, 'g') == '0.123455' and format(5e-324, 'g') == '4.94066e-324'
+    expect(logs.map((log) => log.body)).toEqual([
+      'evaluation: BinaryRoundingScore=0.123455',
+      'evaluation: SmallestSubnormalScore=4.94066e-324',
     ])
   })
 

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -72,6 +72,27 @@ class LargeIntegerScore extends Evaluator {
   }
 }
 
+class SubMilliScore extends Evaluator {
+  static override evaluatorName = 'SubMilliScore'
+  evaluate(): number {
+    return 8.65742e-5
+  }
+}
+
+class MicroScore extends Evaluator {
+  static override evaluatorName = 'MicroScore'
+  evaluate(): number {
+    return 2.325e-6
+  }
+}
+
+class RoundsToWholeScore extends Evaluator {
+  static override evaluatorName = 'RoundsToWholeScore'
+  evaluate(): number {
+    return -10515.04
+  }
+}
+
 class CategoryLabel extends Evaluator {
   static override evaluatorName = 'CategoryLabel'
   evaluate(): string {
@@ -191,6 +212,23 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
       await waitForEvaluations()
     })
     expect(logs.map((log) => log.body)).toEqual(['evaluation: TinyScore=1.23e-07', 'evaluation: LargeIntegerScore=1.23457e+06'])
+  })
+
+  it('switches to scientific notation below 1e-4 like Python general format', async () => {
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new SubMilliScore(), new MicroScore(), new RoundsToWholeScore()],
+      target: 't',
+    })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+    // Expected values are `format(value, 'g')` output from CPython for the same three numbers.
+    expect(logs.map((log) => log.body)).toEqual([
+      'evaluation: SubMilliScore=8.65742e-05',
+      'evaluation: MicroScore=2.325e-06',
+      'evaluation: RoundsToWholeScore=-10515',
+    ])
   })
 
   it('string output → score.label only (no value)', async () => {

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -93,6 +93,14 @@ class RoundsToWholeScore extends Evaluator {
   }
 }
 
+class HalfEvenTieScore extends Evaluator {
+  static override evaluatorName = 'HalfEvenTieScore'
+  evaluate(): number {
+    // 1 / 512 is exact in binary and its seventh significant digit is a tie.
+    return 1 / 512
+  }
+}
+
 class CategoryLabel extends Evaluator {
   static override evaluatorName = 'CategoryLabel'
   evaluate(): string {
@@ -229,6 +237,16 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
       'evaluation: MicroScore=2.325e-06',
       'evaluation: RoundsToWholeScore=-10515',
     ])
+  })
+
+  it('rounds ties to even like Python rather than away from zero', async () => {
+    const fn = withOnlineEvaluation(async () => 'x', { evaluators: [new HalfEvenTieScore()], target: 't' })
+    const { logs } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+    // CPython: format(1 / 512, 'g') == '0.00195312'
+    expect(logs[0]!.body).toBe('evaluation: HalfEvenTieScore=0.00195312')
   })
 
   it('string output → score.label only (no value)', async () => {

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -126,6 +126,12 @@ function emit(body: string, attrs: Record<string, unknown>, parentRef?: SpanRefe
 // Python's default `format(value, 'g')` precision. Both formatters round half to even, the same
 // way Python does, which `toPrecision` and `toFixed` do not: they round half away from zero, so a
 // tie such as `1 / 512` came out as 0.00195313 instead of Python's 0.00195312.
+//
+// `roundingMode` needs Node 19+, Chrome 106+, Firefox 116+, or Safari 16.4+. Older runtimes
+// ignore the option and fall back to half-away-from-zero, which only affects exact ties: the
+// fixed-versus-scientific choice and the trailing-zero trimming below are unaffected, so those
+// runtimes still land on Python's answer everywhere except a tie, and never do worse than the
+// previous `toPrecision` implementation.
 const PYTHON_GENERAL_PRECISION = 6
 const PYTHON_ROUNDING_OPTIONS = {
   maximumSignificantDigits: PYTHON_GENERAL_PRECISION,

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -123,8 +123,18 @@ function emit(body: string, attrs: Record<string, unknown>, parentRef?: SpanRefe
   })
 }
 
-// Python's default `format(value, 'g')` precision.
+// Python's default `format(value, 'g')` precision. Both formatters round half to even, the same
+// way Python does, which `toPrecision` and `toFixed` do not: they round half away from zero, so a
+// tie such as `1 / 512` came out as 0.00195313 instead of Python's 0.00195312.
 const PYTHON_GENERAL_PRECISION = 6
+const PYTHON_ROUNDING_OPTIONS = {
+  maximumSignificantDigits: PYTHON_GENERAL_PRECISION,
+  minimumSignificantDigits: 1,
+  roundingMode: 'halfEven',
+  useGrouping: false,
+} as const
+const PYTHON_FIXED_FORMAT = new Intl.NumberFormat('en-US', PYTHON_ROUNDING_OPTIONS)
+const PYTHON_SCIENTIFIC_FORMAT = new Intl.NumberFormat('en-US', { ...PYTHON_ROUNDING_OPTIONS, notation: 'scientific' })
 
 function formatPythonGeneralNumber(value: number): string {
   if (Number.isNaN(value)) {
@@ -145,19 +155,14 @@ function formatPythonGeneralNumber(value: number): string {
   // Python's `g` decides between fixed and scientific from the exponent left *after* rounding to
   // `PYTHON_GENERAL_PRECISION` significant digits, using scientific when it lands below -4 or at
   // or above the precision, and it always writes at least two exponent digits.
-  const exponential = value.toExponential(PYTHON_GENERAL_PRECISION - 1)
-  const separator = exponential.indexOf('e')
-  const exponent = Number(exponential.slice(separator + 1))
+  const scientific = PYTHON_SCIENTIFIC_FORMAT.format(value)
+  const separator = scientific.indexOf('E')
+  const exponent = Number(scientific.slice(separator + 1))
   if (exponent < -4 || exponent >= PYTHON_GENERAL_PRECISION) {
-    const mantissa = stripTrailingZeros(exponential.slice(0, separator))
     const sign = exponent < 0 ? '-' : '+'
-    return `${mantissa}e${sign}${Math.abs(exponent).toString().padStart(2, '0')}`
+    return `${scientific.slice(0, separator)}e${sign}${Math.abs(exponent).toString().padStart(2, '0')}`
   }
-  return stripTrailingZeros(value.toFixed(Math.max(0, PYTHON_GENERAL_PRECISION - 1 - exponent)))
-}
-
-function stripTrailingZeros(text: string): string {
-  return text.includes('.') ? text.replace(/\.?0+$/u, '') : text
+  return PYTHON_FIXED_FORMAT.format(value)
 }
 
 function pythonStringRepr(value: string): string {

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -123,25 +123,18 @@ function emit(body: string, attrs: Record<string, unknown>, parentRef?: SpanRefe
   })
 }
 
-// Python's default `format(value, 'g')` precision. Both formatters round half to even, the same
-// way Python does, which `toPrecision` and `toFixed` do not: they round half away from zero, so a
-// tie such as `1 / 512` came out as 0.00195313 instead of Python's 0.00195312.
-//
-// `roundingMode` needs Node 19+, Chrome 106+, Firefox 116+, or Safari 16.4+. Older runtimes
-// ignore the option and fall back to half-away-from-zero, which only affects exact ties: the
-// fixed-versus-scientific choice and the trailing-zero trimming below are unaffected, so those
-// runtimes still land on Python's answer everywhere except a tie, and never do worse than the
-// previous `toPrecision` implementation.
+// Python's default `format(value, 'g')` precision.
 const PYTHON_GENERAL_PRECISION = 6
-const PYTHON_ROUNDING_OPTIONS = {
-  maximumSignificantDigits: PYTHON_GENERAL_PRECISION,
-  minimumSignificantDigits: 1,
-  roundingMode: 'halfEven',
-  useGrouping: false,
-} as const
-const PYTHON_FIXED_FORMAT = new Intl.NumberFormat('en-US', PYTHON_ROUNDING_OPTIONS)
-const PYTHON_SCIENTIFIC_FORMAT = new Intl.NumberFormat('en-US', { ...PYTHON_ROUNDING_OPTIONS, notation: 'scientific' })
 
+/**
+ * Reproduce CPython's `format(value, 'g')`.
+ *
+ * The rounding has to happen on the binary value rather than on any decimal string, because a
+ * double is rarely the decimal it prints as: `0.1234555` is really 0.123455499..., which CPython
+ * rounds down to `0.123455`. Formatting the shortest round-trip text instead rounds the literal
+ * ties upward and gets `0.123456`. So the significand and exponent are pulled straight out of the
+ * IEEE-754 bits and expanded to exact decimal digits with BigInt, then rounded half to even.
+ */
 function formatPythonGeneralNumber(value: number): string {
   if (Number.isNaN(value)) {
     return 'nan'
@@ -158,17 +151,79 @@ function formatPythonGeneralNumber(value: number): string {
   if (Number.isInteger(value) && Math.abs(value) < 1e6) {
     return String(value)
   }
-  // Python's `g` decides between fixed and scientific from the exponent left *after* rounding to
-  // `PYTHON_GENERAL_PRECISION` significant digits, using scientific when it lands below -4 or at
-  // or above the precision, and it always writes at least two exponent digits.
-  const scientific = PYTHON_SCIENTIFIC_FORMAT.format(value)
-  const separator = scientific.indexOf('E')
-  const exponent = Number(scientific.slice(separator + 1))
-  if (exponent < -4 || exponent >= PYTHON_GENERAL_PRECISION) {
-    const sign = exponent < 0 ? '-' : '+'
-    return `${scientific.slice(0, separator)}e${sign}${Math.abs(exponent).toString().padStart(2, '0')}`
+
+  const sign = value < 0 ? '-' : ''
+  const { digits, pointExponent } = roundToSignificantDigits(exactDecimalDigits(Math.abs(value)))
+
+  // `g` uses scientific notation once the exponent drops below -4 or reaches the precision, and
+  // always writes at least two exponent digits.
+  if (pointExponent < -4 || pointExponent >= PYTHON_GENERAL_PRECISION) {
+    const mantissa = stripTrailingZeros(`${digits.slice(0, 1)}.${digits.slice(1)}`)
+    const exponentSign = pointExponent < 0 ? '-' : '+'
+    return `${sign}${mantissa}e${exponentSign}${Math.abs(pointExponent).toString().padStart(2, '0')}`
   }
-  return PYTHON_FIXED_FORMAT.format(value)
+  if (pointExponent < 0) {
+    return `${sign}${stripTrailingZeros(`0.${'0'.repeat(-pointExponent - 1)}${digits}`)}`
+  }
+  const whole = digits.slice(0, pointExponent + 1)
+  const fraction = digits.slice(pointExponent + 1)
+  return `${sign}${stripTrailingZeros(fraction.length === 0 ? whole : `${whole}.${fraction}`)}`
+}
+
+/**
+ * Every finite double is exactly `significand * 2 ** exponent`, which has a finite decimal
+ * expansion. Returns all of its digits plus the base-10 exponent of the leading one.
+ */
+function exactDecimalDigits(magnitude: number): { digits: string; pointExponent: number } {
+  const view = new DataView(new ArrayBuffer(8))
+  view.setFloat64(0, magnitude)
+  const high = view.getUint32(0)
+  const low = view.getUint32(4)
+  const biasedExponent = (high >>> 20) & 0x7ff
+  const fraction = (BigInt(high & 0xfffff) << 32n) | BigInt(low)
+  // A zero biased exponent means subnormal, so there is no implicit leading one.
+  const significand = biasedExponent === 0 ? fraction : fraction | (1n << 52n)
+  const exponent = biasedExponent === 0 ? -1074 : biasedExponent - 1075
+
+  if (exponent >= 0) {
+    const digits = (significand << BigInt(exponent)).toString()
+    return { digits, pointExponent: digits.length - 1 }
+  }
+  // Scaling by 5 ** -exponent turns the binary fraction into an exact decimal one.
+  const digits = (significand * 5n ** BigInt(-exponent)).toString()
+  return { digits, pointExponent: digits.length - 1 + exponent }
+}
+
+function roundToSignificantDigits(exact: { digits: string; pointExponent: number }): { digits: string; pointExponent: number } {
+  let pointExponent = exact.pointExponent
+  let kept = exact.digits.slice(0, PYTHON_GENERAL_PRECISION).padEnd(PYTHON_GENERAL_PRECISION, '0')
+  const dropped = exact.digits.slice(PYTHON_GENERAL_PRECISION)
+  if (dropped.length === 0) {
+    return { digits: kept, pointExponent }
+  }
+
+  const first = dropped[0] ?? '0'
+  const isExactHalf = first === '5' && /^0*$/u.test(dropped.slice(1))
+  const lastKept = kept.charCodeAt(PYTHON_GENERAL_PRECISION - 1) - 48
+  // Half to even on an exact tie, otherwise ordinary nearest.
+  const roundUp = first > '5' || (isExactHalf ? lastKept % 2 === 1 : first === '5')
+  if (!roundUp) {
+    return { digits: kept, pointExponent }
+  }
+
+  const bumped = (BigInt(kept) + 1n).toString()
+  if (bumped.length > PYTHON_GENERAL_PRECISION) {
+    // 999999 carried into 1000000, so the leading digit moved up a place.
+    kept = bumped.slice(0, PYTHON_GENERAL_PRECISION)
+    pointExponent += 1
+  } else {
+    kept = bumped.padStart(PYTHON_GENERAL_PRECISION, '0')
+  }
+  return { digits: kept, pointExponent }
+}
+
+function stripTrailingZeros(text: string): string {
+  return text.includes('.') ? text.replace(/\.?0+$/u, '') : text
 }
 
 function pythonStringRepr(value: string): string {

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -123,6 +123,9 @@ function emit(body: string, attrs: Record<string, unknown>, parentRef?: SpanRefe
   })
 }
 
+// Python's default `format(value, 'g')` precision.
+const PYTHON_GENERAL_PRECISION = 6
+
 function formatPythonGeneralNumber(value: number): string {
   if (Number.isNaN(value)) {
     return 'nan'
@@ -139,11 +142,22 @@ function formatPythonGeneralNumber(value: number): string {
   if (Number.isInteger(value) && Math.abs(value) < 1e6) {
     return String(value)
   }
-  return value
-    .toPrecision(6)
-    .replace(/(\.\d*?)0+(e|$)/u, '$1$2')
-    .replace(/\.e/u, 'e')
-    .replace(/e([+-])(\d)$/u, 'e$10$2')
+  // Python's `g` decides between fixed and scientific from the exponent left *after* rounding to
+  // `PYTHON_GENERAL_PRECISION` significant digits, using scientific when it lands below -4 or at
+  // or above the precision, and it always writes at least two exponent digits.
+  const exponential = value.toExponential(PYTHON_GENERAL_PRECISION - 1)
+  const separator = exponential.indexOf('e')
+  const exponent = Number(exponential.slice(separator + 1))
+  if (exponent < -4 || exponent >= PYTHON_GENERAL_PRECISION) {
+    const mantissa = stripTrailingZeros(exponential.slice(0, separator))
+    const sign = exponent < 0 ? '-' : '+'
+    return `${mantissa}e${sign}${Math.abs(exponent).toString().padStart(2, '0')}`
+  }
+  return stripTrailingZeros(value.toFixed(Math.max(0, PYTHON_GENERAL_PRECISION - 1 - exponent)))
+}
+
+function stripTrailingZeros(text: string): string {
+  return text.includes('.') ? text.replace(/\.?0+$/u, '') : text
 }
 
 function pythonStringRepr(value: string): string {


### PR DESCRIPTION
Python's `_format_score` renders numeric evaluation values with `format(value, 'g')`, and `evals/constants.ts` says this wire format has to stay identical to pydantic-evals. `formatPythonGeneralNumber` in `packages/logfire-api/src/evals/otelEmit.ts` approximated that with `toPrecision(6)` plus a regex cleanup, which drifts in two ways.

The first is the notation threshold. Python switches to scientific once the exponent drops below -4, while `toPrecision` stays fixed down to about 1e-7, so a score of `8.65742e-05` was written as `0.0000865742` instead of `8.65742e-05`. The second is a malformed result: when the sixth significant digit rounds away, the regex stripped the trailing zeros but left the decimal point behind, so `-10515.04` came out as `-10515.` where Python gives `-10515`. This reworks the helper to pick the notation from the exponent left after rounding to six significant digits, the same rule Python uses, and to drop a trailing point along with the zeros.

The new test in `online.test.ts` covers both cases and fails on current main. I also fuzzed the helper against real CPython `format(value, 'g')`: the old code missed 543 of 3012 generated values, the new one matches on 6025 values spanning 1e-300 to 1e300, negatives, and the boundaries at 1e-4, 1e-5, and 1e6. Ran `pnpm run check` from the root, all green. Patch changeset for `logfire` included.

Small note, this sits next to #198 which fixes the string branch of the same function's sibling, but the two do not overlap. quick disclosure: built with Claude Code's help and I went over the final diff myself. Freshman here, so if the parity target is wrong I would rather hear it than guess :)