### PR TITLE
End the Analytics Engine span when a write rejects

### DIFF
--- a/.changeset/ae-span-error-handling.md
+++ b/.changeset/ae-span-error-handling.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+End the Analytics Engine span when a write rejects, and record the error on it. `instrumentAnalyticsEngineDataset` called `span.end()` only on the success path, so a failed `writeDataPoint` left the span unended and it was never exported, losing the operation from the trace and leaving the failure invisible. It now records the exception, sets the span status to `ERROR`, and ends the span in a `finally` block, matching the other Cloudflare instrumentations.

--- a/packages/otel-cf-workers/src/instrumentation/analytics-engine.ts
+++ b/packages/otel-cf-workers/src/instrumentation/analytics-engine.ts
@@ -1,5 +1,5 @@
-import type { Attributes, SpanOptions } from '@opentelemetry/api'
-import { SpanKind, trace } from '@opentelemetry/api'
+import type { Attributes, Exception, SpanOptions } from '@opentelemetry/api'
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
 import { ATTR_DB_NAMESPACE, ATTR_DB_OPERATION_NAME, ATTR_DB_QUERY_TEXT, ATTR_DB_SYSTEM_NAME } from '@opentelemetry/semantic-conventions'
 import { wrap } from '../wrap.js'
 
@@ -39,13 +39,20 @@ function instrumentAEFn(fn: Function, name: string, operation: string) {
         attributes,
       }
       return tracer.startActiveSpan(`Analytics Engine ${name} ${operation}`, options, async (span) => {
-        const result = await Reflect.apply(target, thisArg, argArray)
-        const extraAttrsFn = AEAttributes[operation]
-        const extraAttrs = extraAttrsFn ? extraAttrsFn(argArray, result) : {}
-        span.setAttributes(extraAttrs)
-        span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${argArray[0]}`)
-        span.end()
-        return result
+        try {
+          const result = await Reflect.apply(target, thisArg, argArray)
+          const extraAttrsFn = AEAttributes[operation]
+          const extraAttrs = extraAttrsFn ? extraAttrsFn(argArray, result) : {}
+          span.setAttributes(extraAttrs)
+          span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${argArray[0]}`)
+          return result
+        } catch (error) {
+          span.recordException(error as Exception)
+          span.setStatus({ code: SpanStatusCode.ERROR })
+          throw error
+        } finally {
+          span.end()
+        }
       })
     },
   }

--- a/packages/otel-cf-workers/test/instrumentation/analytics-engine.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/analytics-engine.test.ts
@@ -1,5 +1,36 @@
-import { describe, expect, it } from 'vitest'
-import { AEAttributes } from '../../src/instrumentation/analytics-engine'
+/// <reference types="@cloudflare/workers-types/experimental" />
+
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
+import { context, SpanStatusCode, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '../../src/context'
+import { AEAttributes, instrumentAnalyticsEngineDataset } from '../../src/instrumentation/analytics-engine'
+
+const exporter = new InMemorySpanExporter()
+
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+
+trace.setGlobalTracerProvider(provider)
+context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+
+const dataset = {
+  writeDataPoint: vitest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+} as unknown as AnalyticsEngineDataset
+
+// The Workers type declares `writeDataPoint` as returning void, but the instrumented proxy is
+// async, so the tests await it through this narrower view.
+type AsyncDataset = { writeDataPoint: (point: AnalyticsEngineDataPoint) => Promise<void> }
+
+function instrumentAsync(name: string): AsyncDataset {
+  return instrumentAnalyticsEngineDataset(dataset, name) as unknown as AsyncDataset
+}
+
+beforeEach(() => {
+  exporter.reset()
+  vitest.resetAllMocks()
+})
 
 describe('Analytics Engine attributes', () => {
   it('handles partial data points without optional arrays', () => {
@@ -17,5 +48,33 @@ describe('Analytics Engine attributes', () => {
       'db.cf.ae.doubles': 2,
       'db.cf.ae.blobs': 1,
     })
+  })
+})
+
+describe('Analytics Engine instrumentation', () => {
+  it('ends the span for a successful write', async () => {
+    const instrument = instrumentAsync('my-dataset')
+    await expect(instrument.writeDataPoint({ blobs: ['b'], doubles: [1], indexes: ['idx'] })).resolves.toBe(undefined)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.name).toBe('Analytics Engine my-dataset writeDataPoint')
+    expect(spans[0]?.status.code).toBe(SpanStatusCode.UNSET)
+    expect(spans[0]?.attributes['db.cf.ae.indexes']).toBe(1)
+  })
+
+  it('ends the span and records the error when the write rejects', async () => {
+    const error = new Error('write failed')
+    ;(dataset.writeDataPoint as ReturnType<typeof vitest.fn<() => Promise<void>>>).mockRejectedValue(error)
+
+    const instrument = instrumentAsync('my-dataset')
+    await expect(instrument.writeDataPoint({ indexes: ['idx'] })).rejects.toBe(error)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.name).toBe('Analytics Engine my-dataset writeDataPoint')
+    expect(spans[0]?.status).toEqual({ code: SpanStatusCode.ERROR })
+    expect(spans[0]?.events.map((event) => event.name)).toEqual(['exception'])
+    expect(spans[0]?.events[0]?.attributes?.['exception.message']).toBe('write failed')
   })
 })


### PR DESCRIPTION
`instrumentAEFn` in `packages/otel-cf-workers/src/instrumentation/analytics-engine.ts` called `span.end()` only on the success path, with no try/catch/finally around the wrapped call. So when `writeDataPoint` rejects, the span is never ended and never exported: the operation disappears from the trace entirely and the failure leaves no trace at all, which is the opposite of what you want from a failed write. Every sibling instrumentation in the package already guards this, for example `do-storage.ts` records the exception, sets `ERROR`, and ends the span in a `finally`.

This applies that same shape here, so a rejected write now ends its span with an `exception` event and `ERROR` status and still rethrows the original error unchanged.

The instrumented behavior had no test coverage at all before this, only the attribute helper did, so I added two cases against an `InMemorySpanExporter`: one for the success path and one for the rejection. The rejection test fails on current main with `expected [] to have a length of 1`, which is the missing span. Ran `pnpm run check` from the root, all green. Patch changeset for `@pydantic/otel-cf-workers` included.

quick disclosure: Claude Code helped me put this together and I read the final diff myself. Freshman still learning my way around the Workers runtime, so corrections welcome :)