### PR TITLE
End the queue producer span when a send rejects

### DIFF
--- a/.changeset/queue-send-error-handling.md
+++ b/.changeset/queue-send-error-handling.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+End the queue producer span when a send rejects, and record the error on it. `instrumentQueueSend` and `instrumentQueueSendBatch` called `span.end()` only after the wrapped call resolved, so a failed `queue.send()` or `queue.sendBatch()` left the span unended and it was never exported, dropping the operation from the trace and hiding the failure. Both now record the exception, set the span status to `ERROR`, and end the span in a `finally` block, matching the queue consumer handler in the same file and the other Cloudflare instrumentations.

--- a/packages/otel-cf-workers/src/instrumentation/queue.ts
+++ b/packages/otel-cf-workers/src/instrumentation/queue.ts
@@ -1,5 +1,5 @@
 import type { Attributes, Exception, SpanOptions } from '@opentelemetry/api'
-import { SpanKind, context as api_context, trace } from '@opentelemetry/api'
+import { SpanKind, SpanStatusCode, context as api_context, trace } from '@opentelemetry/api'
 import type { Initialiser } from '../config.js'
 import { setConfig } from '../config.js'
 import { ATTR_FAAS_TRIGGER } from '../semconv.js'
@@ -193,8 +193,15 @@ function instrumentQueueSend(fn: Queue['send'], name: string): Queue['send'] {
     apply: async (target, thisArg, argArray) => {
       return tracer.startActiveSpan(`Queues ${name} send`, async (span) => {
         span.setAttribute('queue.operation', 'send')
-        await Reflect.apply(target, unwrap(thisArg), argArray)
-        span.end()
+        try {
+          await Reflect.apply(target, unwrap(thisArg), argArray)
+        } catch (error) {
+          span.recordException(error as Exception)
+          span.setStatus({ code: SpanStatusCode.ERROR })
+          throw error
+        } finally {
+          span.end()
+        }
       })
     },
   }
@@ -207,8 +214,15 @@ function instrumentQueueSendBatch(fn: Queue['sendBatch'], name: string): Queue['
     apply: async (target, thisArg, argArray) => {
       return tracer.startActiveSpan(`Queues ${name} sendBatch`, async (span) => {
         span.setAttribute('queue.operation', 'sendBatch')
-        await Reflect.apply(target, unwrap(thisArg), argArray)
-        span.end()
+        try {
+          await Reflect.apply(target, unwrap(thisArg), argArray)
+        } catch (error) {
+          span.recordException(error as Exception)
+          span.setStatus({ code: SpanStatusCode.ERROR })
+          throw error
+        } finally {
+          span.end()
+        }
       })
     },
   }

--- a/packages/otel-cf-workers/test/instrumentation/queue.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/queue.test.ts
@@ -1,0 +1,68 @@
+/// <reference types="@cloudflare/workers-types/experimental" />
+
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
+import { context, SpanStatusCode, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '../../src/context'
+import { instrumentQueueSender } from '../../src/instrumentation/queue'
+
+const exporter = new InMemorySpanExporter()
+
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+
+trace.setGlobalTracerProvider(provider)
+context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+
+const sendMock = vitest.fn<() => Promise<void>>()
+const sendBatchMock = vitest.fn<() => Promise<void>>()
+const queue = { send: sendMock, sendBatch: sendBatchMock } as unknown as Queue
+
+beforeEach(() => {
+  exporter.reset()
+  vitest.resetAllMocks()
+})
+
+describe('queue sender instrumentation', () => {
+  it('ends the span for a successful send', async () => {
+    const instrument = instrumentQueueSender(queue, 'my-queue')
+    await expect(instrument.send('body')).resolves.toBe(undefined)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.name).toBe('Queues my-queue send')
+    expect(spans[0]?.attributes['queue.operation']).toBe('send')
+    expect(spans[0]?.status.code).toBe(SpanStatusCode.UNSET)
+  })
+
+  it('ends the span and records the error when a send rejects', async () => {
+    const error = new Error('send failed')
+    sendMock.mockRejectedValue(error)
+
+    const instrument = instrumentQueueSender(queue, 'my-queue')
+    await expect(instrument.send('body')).rejects.toBe(error)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.name).toBe('Queues my-queue send')
+    expect(spans[0]?.status).toEqual({ code: SpanStatusCode.ERROR })
+    expect(spans[0]?.events.map((event) => event.name)).toEqual(['exception'])
+    expect(spans[0]?.events[0]?.attributes?.['exception.message']).toBe('send failed')
+  })
+
+  it('ends the span and records the error when a sendBatch rejects', async () => {
+    const error = new Error('sendBatch failed')
+    sendBatchMock.mockRejectedValue(error)
+
+    const instrument = instrumentQueueSender(queue, 'my-queue')
+    await expect(instrument.sendBatch([{ body: 'one' }])).rejects.toBe(error)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.name).toBe('Queues my-queue sendBatch')
+    expect(spans[0]?.attributes['queue.operation']).toBe('sendBatch')
+    expect(spans[0]?.status).toEqual({ code: SpanStatusCode.ERROR })
+    expect(spans[0]?.events.map((event) => event.name)).toEqual(['exception'])
+  })
+})


### PR DESCRIPTION
`instrumentQueueSend` and `instrumentQueueSendBatch` in `packages/otel-cf-workers/src/instrumentation/queue.ts` called `span.end()` only after the wrapped call resolved, with nothing wrapping it. So a rejected `queue.send()` or `queue.sendBatch()` leaves its span unended and therefore never exported: the send disappears from the trace and the failure leaves no record, which is exactly when you would want the span. The queue consumer handler further up the same file already guards its own path, and the other bindings do too, so the producer side was the odd one out.

Both now record the exception, set `ERROR`, and end the span in a `finally`, rethrowing the original error untouched. This is the same fix as #201 for Analytics Engine, found by sweeping the instrumentation directory for files whose `span.end()` count exceeded their `finally` count.

There was no test file for the queue bindings, so I added one covering a successful send plus both rejection paths. The two rejection tests fail on current main with `expected [] to have a length of 1`, which is the span that never arrives. Ran the repo preflight and `pnpm run check`, both green. Patch changeset for `@pydantic/otel-cf-workers` included.

quick disclosure: built with Claude Code's help and I went through the diff myself before opening. Freshman still learning the Workers side, so tell me if the producer span should behave differently on failure :)