### PR TITLE
Mark the email handler span as an error when it throws

### DIFF
--- a/.changeset/email-error-status.md
+++ b/.changeset/email-error-status.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+Set the span status to `ERROR` when an email handler throws. The handler recorded the exception on its span but left the status `UNSET`, so a failed email invocation did not read as failed and was missed by error filters, unlike the fetch, alarm, and Durable Object handlers which already set it.

--- a/packages/otel-cf-workers/src/instrumentation/email.ts
+++ b/packages/otel-cf-workers/src/instrumentation/email.ts
@@ -1,5 +1,5 @@
 import type { Exception, SpanOptions } from '@opentelemetry/api'
-import { context as api_context, SpanKind, trace } from '@opentelemetry/api'
+import { context as api_context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
 import type { Initialiser } from '../config'
 import { setConfig } from '../config'
 import { ATTR_FAAS_TRIGGER, ATTR_MESSAGING_DESTINATION_NAME, ATTR_RPC_MESSAGE_ID } from '../semconv.js'
@@ -46,7 +46,7 @@ function headerAttributes(message: { headers: Headers }): Record<string, unknown
   return Object.fromEntries([...message.headers].map(([key, value]) => [`email.header.${key}`, value] as const))
 }
 
-async function executeEmailHandler(emailFn: EmailHandler, [message, env, ctx]: EmailHandlerArgs): Promise<void> {
+export async function executeEmailHandler(emailFn: EmailHandler, [message, env, ctx]: EmailHandlerArgs): Promise<void> {
   const tracer = trace.getTracer('emailHandler')
   const messageId = message.headers.get('Message-Id')
   const options = {
@@ -64,6 +64,7 @@ async function executeEmailHandler(emailFn: EmailHandler, [message, env, ctx]: E
       span.end()
     } catch (error) {
       span.recordException(error as Exception)
+      span.setStatus({ code: SpanStatusCode.ERROR })
       span.end()
       throw error
     }

--- a/packages/otel-cf-workers/test/instrumentation/email.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/email.test.ts
@@ -1,0 +1,83 @@
+/// <reference types="@cloudflare/workers-types" />
+
+import type { Span, Tracer } from '@opentelemetry/api'
+import { context as apiContext, SpanStatusCode, trace } from '@opentelemetry/api'
+import { describe, expect, it, vitest } from 'vitest'
+import { AsyncLocalStorageContextManager } from '../../src/context'
+import { executeEmailHandler } from '../../src/instrumentation/email'
+import type { EmailHandlerArgs } from '../../src/instrumentation/email'
+
+apiContext.setGlobalContextManager(new AsyncLocalStorageContextManager())
+
+function createSpan() {
+  return {
+    end: vitest.fn<() => void>(),
+    recordException: vitest.fn<(exception: unknown) => void>(),
+    setAttribute: vitest.fn<(key: string, value: unknown) => void>(),
+    setAttributes: vitest.fn<(attributes: Record<string, unknown>) => void>(),
+    setStatus: vitest.fn<(status: { code: SpanStatusCode }) => void>(),
+  }
+}
+
+function mockTracer(span: Span): Tracer {
+  return {
+    async startActiveSpan(_name: string, ...args: unknown[]) {
+      const fn = args.at(-1) as (span: Span) => Promise<unknown>
+      return fn(span)
+    },
+  } as unknown as Tracer
+}
+
+function createMessage(): EmailHandlerArgs[0] {
+  return {
+    from: 'sender@example.com',
+    headers: new Headers({ Subject: 'Hello' }),
+    raw: new ReadableStream(),
+    rawSize: 0,
+    to: 'recipient@example.com',
+    setReject: () => undefined,
+  } as unknown as EmailHandlerArgs[0]
+}
+
+function createExecutionContext(): EmailHandlerArgs[2] {
+  return {
+    passThroughOnException: () => undefined,
+    props: {},
+    waitUntil: () => undefined,
+  } as unknown as EmailHandlerArgs[2]
+}
+
+describe('executeEmailHandler', () => {
+  it('ends the span without an error status when the handler succeeds', async () => {
+    const span = createSpan()
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(mockTracer(span as unknown as Span))
+    const emailFn = vitest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+    try {
+      await executeEmailHandler(emailFn, [createMessage(), {}, createExecutionContext()])
+
+      expect(span.recordException).not.toHaveBeenCalled()
+      expect(span.setStatus).not.toHaveBeenCalled()
+      expect(span.end).toHaveBeenCalledTimes(1)
+    } finally {
+      getTracer.mockRestore()
+    }
+  })
+
+  it('marks the span as an error when the handler throws', async () => {
+    const span = createSpan()
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(mockTracer(span as unknown as Span))
+    const error = new Error('email handler boom')
+    const emailFn = vitest.fn<() => Promise<void>>().mockRejectedValue(error)
+
+    try {
+      await expect(executeEmailHandler(emailFn, [createMessage(), {}, createExecutionContext()])).rejects.toBe(error)
+
+      expect(span.recordException).toHaveBeenCalledWith(error)
+      expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR })
+      expect(span.end).toHaveBeenCalledTimes(1)
+    } finally {
+      getTracer.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
`executeEmailHandler` in `packages/otel-cf-workers/src/instrumentation/email.ts` records the exception on its span but never sets the span status, so it stays `UNSET`. A failed email invocation therefore does not read as failed: it carries an exception event but is not picked up by anything filtering on error status. The fetch handler, the alarm handler, and every storage binding already set `ERROR` alongside `recordException`, so the email handler was the only one missing it.

I found this by sweeping the instrumentation directory for files where the `recordException` count and the `SpanStatusCode.ERROR` count disagree, which is the same approach as #201 and #203. Email was the only remaining mismatch besides the queue consumer, which I have left alone since #203 is already touching that file.

There was no test file for the email handler, so I added one covering the success path and the throwing path. It needed `executeEmailHandler` exported, which also lines it up with `executeFetchHandler` and `executeQueueHandler` that are already exported and tested the same way. The throwing test fails on current main. Ran the repo preflight and `pnpm run check`, both green, and a patch changeset for `@pydantic/otel-cf-workers` is included.

quick disclosure: built this with Claude Code's help and read the final diff myself. Freshman still finding my feet here, so say the word if you would rather not export the handler just for a test :)