### PR TITLE
Record exceptions from rejected zone.js promises in span callbacks

### DIFF
--- a/.changeset/thenable-exception-recording.md
+++ b/.changeset/thenable-exception-recording.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Record the exception on the span when a zone.js style promise returned from a `span()` callback rejects. Native promise rejections already recorded the error and set the span status to `ERROR`, but the zone.js branch only ended the span, so in Angular applications a failing span looked successful and carried no exception.

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -837,35 +837,42 @@ describe('span', () => {
 
   test('records the exception when a zone.js style promise rejects', async () => {
     const error = new Error('zone-oops')
-    // Not a native Promise, but exposes `then` and `finally` the way a zone.js promise does.
-    const settled = Promise.reject(error).catch(() => undefined)
-    const zonePromise = {
-      finally: (onFinally: () => void) => {
-        settled.then(onFinally, onFinally)
-        return zonePromise
-      },
-      then: (_onFulfilled: undefined, onRejected: (reason: unknown) => void) => {
-        settled.then(
-          () => {
-            onRejected(error)
-          },
-          () => {
-            onRejected(error)
-          }
-        )
-        return zonePromise
-      },
+    // zone.js patches the global Promise, so an intrinsic promise from a native async function
+    // fails `instanceof Promise` while still exposing `then` and `finally`.
+    // Typed as a bare thenable, not a Promise, so the callback is not treated as async.
+    type ZonePromiseLike = { finally: (onFinally: () => void) => unknown; then: (...args: never[]) => unknown }
+    const intrinsic = Promise.reject(error) as unknown as ZonePromiseLike
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    const OriginalPromise = globalThis.Promise
+    const ZoneAwarePromise = function ZoneAwarePromise() {
+      // Stands in for zone.js replacing the global Promise binding.
+    }
+    globalThis.Promise = ZoneAwarePromise as unknown as PromiseConstructor
+
+    let result: unknown
+    try {
+      result = span('test', { callback: () => intrinsic })
+    } finally {
+      globalThis.Promise = OriginalPromise
     }
 
-    const result = span('test', { callback: () => zonePromise })
-
-    expect(result).toBe(zonePromise)
-    await settled
-    await Promise.resolve()
+    expect(result).toBe(intrinsic)
+    // The original rejection still reaches the caller.
+    await expect(intrinsic as unknown as Promise<never>).rejects.toBe(error)
+    await new OriginalPromise<void>((resolve) => {
+      setTimeout(resolve, 0)
+    })
 
     expect(spanMock.recordException).toHaveBeenCalledWith(error)
     expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: zone-oops' })
     expect(spanMock.end).toHaveBeenCalledOnce()
+    // A second derived chain would leave the rejection unhandled.
+    expect(unhandled).toEqual([])
+    process.off('unhandledRejection', onUnhandled)
   })
 
   test('thenable callback result is returned untouched', () => {

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -875,6 +875,45 @@ describe('span', () => {
     process.off('unhandledRejection', onUnhandled)
   })
 
+  test('falls back to finally when the then getter throws', () => {
+    let onFinally: (() => void) | undefined
+    const value = {
+      finally: (callback: () => void) => {
+        onFinally = callback
+        return undefined
+      },
+      // A lazy proxy or ORM model can throw on an unknown property read.
+      get then() {
+        throw new Error('then getter boom')
+      },
+    }
+
+    const result = span('test', { callback: () => value })
+
+    // Probing for a subscription must not turn a successful callback into a throw.
+    expect(result).toBe(value)
+    expect(spanMock.end).not.toHaveBeenCalled()
+    onFinally?.()
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
+  test('ends the span once when then throws after registering its handlers', () => {
+    const value = {
+      finally: () => {
+        throw new Error('finally must not be a second subscription')
+      },
+      then: (onFulfilled: () => void) => {
+        onFulfilled()
+        throw new Error('then call boom')
+      },
+    }
+
+    const result = span('test', { callback: () => value })
+
+    expect(result).toBe(value)
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
   test('thenable callback result is returned untouched', () => {
     const then = vi.fn<() => void>()
     const lazyThenable = { then }

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -835,6 +835,39 @@ describe('span', () => {
     expect(spanMock.end).toHaveBeenCalledOnce()
   })
 
+  test('records the exception when a zone.js style promise rejects', async () => {
+    const error = new Error('zone-oops')
+    // Not a native Promise, but exposes `then` and `finally` the way a zone.js promise does.
+    const settled = Promise.reject(error).catch(() => undefined)
+    const zonePromise = {
+      finally: (onFinally: () => void) => {
+        settled.then(onFinally, onFinally)
+        return zonePromise
+      },
+      then: (_onFulfilled: undefined, onRejected: (reason: unknown) => void) => {
+        settled.then(
+          () => {
+            onRejected(error)
+          },
+          () => {
+            onRejected(error)
+          }
+        )
+        return zonePromise
+      },
+    }
+
+    const result = span('test', { callback: () => zonePromise })
+
+    expect(result).toBe(zonePromise)
+    await settled
+    await Promise.resolve()
+
+    expect(spanMock.recordException).toHaveBeenCalledWith(error)
+    expect(spanMock.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.ERROR, message: 'Error: zone-oops' })
+    expect(spanMock.end).toHaveBeenCalledOnce()
+  })
+
   test('thenable callback result is returned untouched', () => {
     const then = vi.fn<() => void>()
     const lazyThenable = { then }

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -626,21 +626,30 @@ function spanWithSettings<R>(
         )
         // we need this clunky detection because of zone.js promises
       } else if (typeof result === 'object' && result !== null && 'finally' in result && typeof result.finally === 'function') {
+        // `finally` is only the gate, so arbitrary lazy thenables are still left alone. The
+        // settlement itself is observed through a single `then` subscription: two subscriptions
+        // would leave the chain returned by `finally` rejected and unhandled even when the caller
+        // handles the original. `result` is returned untouched, so the rejection still reaches
+        // the caller.
         const resultWithFinally = result as {
           finally: (onFinally: () => void) => unknown
-          then?: (onFulfilled: undefined, onRejected: (reason: unknown) => void) => unknown
+          then?: (onFulfilled: () => void, onRejected: (reason: unknown) => void) => unknown
         }
-        // A zone.js promise rejecting has to record the exception just like a native one does.
-        // The returned chain is deliberately ignored: `result` itself is handed back to the
-        // caller, so the rejection still reaches them.
         if (typeof resultWithFinally.then === 'function') {
-          resultWithFinally.then(undefined, (reason: unknown) => {
-            recordSpanException(span, reason, serializationAttributes)
+          resultWithFinally.then(
+            () => {
+              span.end()
+            },
+            (reason: unknown) => {
+              recordSpanException(span, reason, serializationAttributes)
+              span.end()
+            }
+          )
+        } else {
+          resultWithFinally.finally(() => {
+            span.end()
           })
         }
-        resultWithFinally.finally(() => {
-          span.end()
-        })
       } else {
         span.end()
       }

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -635,16 +635,35 @@ function spanWithSettings<R>(
           finally: (onFinally: () => void) => unknown
           then?: (onFulfilled: () => void, onRejected: (reason: unknown) => void) => unknown
         }
-        if (typeof resultWithFinally.then === 'function') {
-          resultWithFinally.then(
-            () => {
-              span.end()
-            },
-            (reason: unknown) => {
-              recordSpanException(span, reason, serializationAttributes)
+        let then: unknown
+        try {
+          // Reading `then` runs a getter that belongs to the caller, so it must not turn a
+          // callback that already succeeded into a throw. `finally` gated this branch and was the
+          // only subscription before, so it stays the fallback when `then` is unusable.
+          then = resultWithFinally.then
+        } catch {
+          then = undefined
+        }
+        if (typeof then === 'function') {
+          // The cached reference is what gets called: a stateful getter can return a function on
+          // one read and throw on the next.
+          let ended = false
+          const endSpan = () => {
+            if (!ended) {
+              ended = true
               span.end()
             }
-          )
+          }
+          try {
+            ;(then as NonNullable<typeof resultWithFinally.then>).call(result, endSpan, (reason: unknown) => {
+              recordSpanException(span, reason, serializationAttributes)
+              endSpan()
+            })
+          } catch {
+            // `then` may already have registered the handlers, so end the span here instead of
+            // adding a second subscription, and guard against ending it twice if it did.
+            endSpan()
+          }
         } else {
           resultWithFinally.finally(() => {
             span.end()

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -626,7 +626,18 @@ function spanWithSettings<R>(
         )
         // we need this clunky detection because of zone.js promises
       } else if (typeof result === 'object' && result !== null && 'finally' in result && typeof result.finally === 'function') {
-        const resultWithFinally = result as { finally: (onFinally: () => void) => unknown }
+        const resultWithFinally = result as {
+          finally: (onFinally: () => void) => unknown
+          then?: (onFulfilled: undefined, onRejected: (reason: unknown) => void) => unknown
+        }
+        // A zone.js promise rejecting has to record the exception just like a native one does.
+        // The returned chain is deliberately ignored: `result` itself is handed back to the
+        // caller, so the rejection still reaches them.
+        if (typeof resultWithFinally.then === 'function') {
+          resultWithFinally.then(undefined, (reason: unknown) => {
+            recordSpanException(span, reason, serializationAttributes)
+          })
+        }
         resultWithFinally.finally(() => {
           span.end()
         })

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -333,7 +333,7 @@ function isHrTime(value: unknown): value is HrTime {
   return Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number'
 }
 
-type ThenMethod = (onFulfilled: (value: never) => unknown) => unknown
+type ThenMethod = (onFulfilled: (value: never) => unknown, onRejected?: (reason: unknown) => unknown) => unknown
 
 /**
  * Returns the value's `then` method, or undefined when it has none.
@@ -631,22 +631,12 @@ function spanWithSettings<R>(
         // would leave the chain returned by `finally` rejected and unhandled even when the caller
         // handles the original. `result` is returned untouched, so the rejection still reaches
         // the caller.
-        const resultWithFinally = result as {
-          finally: (onFinally: () => void) => unknown
-          then?: (onFulfilled: () => void, onRejected: (reason: unknown) => void) => unknown
-        }
-        let then: unknown
-        try {
-          // Reading `then` runs a getter that belongs to the caller, so it must not turn a
-          // callback that already succeeded into a throw. `finally` gated this branch and was the
-          // only subscription before, so it stays the fallback when `then` is unusable.
-          then = resultWithFinally.then
-        } catch {
-          then = undefined
-        }
-        if (typeof then === 'function') {
-          // The cached reference is what gets called: a stateful getter can return a function on
-          // one read and throw on the next.
+        const resultWithFinally = result as { finally: (onFinally: () => void) => unknown }
+        // Reading `then` runs a getter that belongs to the caller, so it must not turn a callback
+        // that already succeeded into a throw. `finally` gated this branch and was the only
+        // subscription before, so it stays the fallback when `then` is unusable.
+        const thenMethod = getThenMethod(result)
+        if (thenMethod !== undefined) {
           let ended = false
           const endSpan = () => {
             if (!ended) {
@@ -655,7 +645,7 @@ function spanWithSettings<R>(
             }
           }
           try {
-            ;(then as NonNullable<typeof resultWithFinally.then>).call(result, endSpan, (reason: unknown) => {
+            thenMethod.call(result, endSpan, (reason: unknown) => {
               recordSpanException(span, reason, serializationAttributes)
               endSpan()
             })


### PR DESCRIPTION
In `spanWithSettings` (`packages/logfire-api/src/index.ts`) a callback returning a native promise gets `recordSpanException` on rejection, which records the error and sets the span status to `ERROR`. The zone.js branch right below it, the one the "clunky detection" comment refers to, only attaches `.finally(() => span.end())`. So under zone.js, which is to say in Angular apps, a span whose callback rejects ends up looking successful: no exception event and no error status, even though the rejection still propagates to the caller.

This adds the rejection handler to that branch when the value also exposes `then`, reusing the same `recordSpanException` call as the native path. The returned chain is ignored on purpose, exactly as the native branch does, so `result` is still handed back untouched and the caller keeps seeing the rejection. I deliberately kept this scoped to the `.finally` branch rather than treating every thenable as a promise, because the existing "thenable callback result is returned untouched" test pins the behavior for values that only have `then`.

The new test builds a non-native object exposing `then` and `finally` the way a zone.js promise does, and it fails on current main with zero calls to `recordException`. Ran the repo preflight and `pnpm run check`, both green. Patch changeset for `logfire` included.

quick disclosure: worked through this with Claude Code and reviewed the diff myself. Freshman here, and I do not have a real Angular app to hand, so if the zone.js shape I mocked is off I would be glad to be corrected :)