### PR TITLE
Mark D1 batch statement spans as errors when the batch fails

### DIFF
--- a/.changeset/d1-batch-subspan-status.md
+++ b/.changeset/d1-batch-subspan-status.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+Mark the per-statement spans of a D1 batch as errors when the batch fails. `instrumentD1Fn` created one span per query in a `batch()` call but only set `ERROR` on the parent span, so a failed batch showed every query as apparently successful underneath a failed parent. The statement spans now carry the error status too, while the exception itself stays on the parent so it is not duplicated once per statement.

--- a/packages/otel-cf-workers/src/instrumentation/d1.ts
+++ b/packages/otel-cf-workers/src/instrumentation/d1.ts
@@ -125,6 +125,11 @@ export function instrumentD1Fn(fn: Function, dbName: string, operation: string):
           } catch (error) {
             span.recordException(error as Exception)
             span.setStatus({ code: SpanStatusCode.ERROR })
+            // The whole batch failed, so none of its queries succeeded. The exception itself stays
+            // on the parent so it is not duplicated once per statement.
+            subSpans.forEach((s) => {
+              s.setStatus({ code: SpanStatusCode.ERROR })
+            })
             throw error
           } finally {
             subSpans.forEach((s) => {

--- a/packages/otel-cf-workers/test/instrumentation/d1.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/d1.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="@cloudflare/workers-types/experimental" />
+
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
+import { context, SpanStatusCode, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '../../src/context'
+import { instrumentD1 } from '../../src/instrumentation/d1'
+
+const exporter = new InMemorySpanExporter()
+
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+
+trace.setGlobalTracerProvider(provider)
+context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+
+const batchMock = vitest.fn<() => Promise<D1Result[]>>()
+const database = { batch: batchMock } as unknown as D1Database
+
+function emptyMeta(): D1Meta {
+  return {
+    changed_db: false,
+    changes: 0,
+    duration: 1,
+    last_row_id: 0,
+    rows_read: 0,
+    rows_written: 0,
+    size_after: 0,
+  } as unknown as D1Meta
+}
+
+function statements(): D1PreparedStatement[] {
+  return [
+    { params: [], statement: 'select 1' },
+    { params: [], statement: 'select 2' },
+  ] as unknown as D1PreparedStatement[]
+}
+
+beforeEach(() => {
+  exporter.reset()
+  vitest.resetAllMocks()
+})
+
+describe('D1 batch instrumentation', () => {
+  it('records a span per statement on success', async () => {
+    batchMock.mockResolvedValue([
+      { meta: emptyMeta(), results: [], success: true },
+      { meta: emptyMeta(), results: [], success: true },
+    ] as unknown as D1Result[])
+
+    const instrument = instrumentD1(database, 'my-db')
+    await instrument.batch(statements())
+
+    const spans = exporter.getFinishedSpans()
+    const querySpans = spans.filter((span) => span.name === 'my-db batch > query')
+    expect(querySpans).toHaveLength(2)
+    expect(querySpans.map((span) => span.attributes['db.query.text'])).toEqual(['select 1', 'select 2'])
+  })
+
+  it('marks every statement span as an error when the batch rejects', async () => {
+    const error = new Error('batch failed')
+    batchMock.mockRejectedValue(error)
+
+    const instrument = instrumentD1(database, 'my-db')
+    await expect(instrument.batch(statements())).rejects.toBe(error)
+
+    const spans = exporter.getFinishedSpans()
+    const parent = spans.find((span) => span.name === 'my-db batch')
+    const querySpans = spans.filter((span) => span.name === 'my-db batch > query')
+
+    expect(parent?.status.code).toBe(SpanStatusCode.ERROR)
+    expect(querySpans).toHaveLength(2)
+    for (const span of querySpans) {
+      expect(span.status.code).toBe(SpanStatusCode.ERROR)
+    }
+  })
+})


### PR DESCRIPTION
`instrumentD1Fn` creates one span per statement in a `batch()` call (`packages/otel-cf-workers/src/instrumentation/d1.ts:116`), but the catch only sets `ERROR` on the parent span. The statement spans are ended in the `finally` with their status still `UNSET`, so a failed batch renders as a failed parent with a set of apparently successful queries underneath it, which reads exactly backwards from what happened.

This sets the error status on the statement spans too. I left the exception itself on the parent rather than recording it once per statement, since it is one failure rather than N, but say the word if you would rather each statement span carried it.

There was no test file for the D1 bindings, so I added one covering a successful batch and a rejected one. The rejection test fails on current main with `expected +0 to be 2`, that being `UNSET` where `ERROR` was expected. Ran the repo preflight and `pnpm run check`, both green. Patch changeset for `@pydantic/otel-cf-workers` included.

Worth noting this one hid from the sweep I used for #201, #203 and #204: d1.ts pairs `recordException` and `setStatus` three times each, so it looked balanced, and only reading the batch branch showed the sub-spans were missed.

quick disclosure: built with Claude Code's help and I read the final diff myself. Freshman still learning, so corrections welcome :)