### PR TITLE
Remove legacy replay trace ID metadata

### DIFF
--- a/.changeset/quiet-replays-share-sessions.md
+++ b/.changeset/quiet-replays-share-sessions.md
@@ -1,0 +1,6 @@
+---
+'@pydantic/logfire-browser': patch
+'@pydantic/logfire-session-replay': minor
+---
+
+Remove the experimental `getTraceContext` option and `meta.traceIds` chunk field. Correlate recordings with browser spans through their shared browser session id and replay time bounds.

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -273,8 +273,7 @@ loaded and sampled into `full` or `buffer` mode include
 `logfire.session_replay.active` and `logfire.session_replay.mode`. Those active
 attributes are truthful best-effort annotations, not the primary correlation
 key; early spans should be correlated to replay by browser session id and replay
-time bounds. The browser SDK does not populate replay `traceIds` from
-active-span polling.
+time bounds. Replay chunks do not include per-trace correlation metadata.
 
 Before lazy replay startup completes, after startup failure, and after replay is
 stopped, the facade reports `mode: 'off'` and `recording: false`. Its `stop()`

--- a/packages/logfire-browser/package.json
+++ b/packages/logfire-browser/package.json
@@ -65,7 +65,7 @@
     "web-vitals": "catalog:"
   },
   "peerDependencies": {
-    "@pydantic/logfire-session-replay": "workspace:^0.2.0",
+    "@pydantic/logfire-session-replay": "workspace:^0.2.0 || ^0.3.0",
     "@opentelemetry/sdk-trace-web": "catalog:",
     "@opentelemetry/semantic-conventions": "catalog:"
   },

--- a/packages/logfire-browser/src/sessionReplay.test.ts
+++ b/packages/logfire-browser/src/sessionReplay.test.ts
@@ -140,7 +140,6 @@ describe('startBrowserSessionReplay', () => {
       sessionSampleRate: 0.25,
       token: 'direct-token',
     })
-    expect(replayConfig).not.toHaveProperty('getTraceContext')
     expect(replayConfig).not.toHaveProperty('sessionIdleTimeoutMs')
     expect(replayConfig).not.toHaveProperty('maxSessionDurationMs')
     const reportedError = new Error('reported by replay')

--- a/packages/logfire-browser/src/sessionReplay.ts
+++ b/packages/logfire-browser/src/sessionReplay.ts
@@ -137,10 +137,7 @@ interface BrowserSessionReplayTelemetryOptions {
   traceUrl: string
 }
 
-type ReplayConfigComparable = Omit<
-  PeerSessionReplayConfig,
-  'getTraceContext' | 'maxSessionDurationMs' | 'now' | 'random' | 'sessionIdleTimeoutMs'
->
+type ReplayConfigComparable = Omit<PeerSessionReplayConfig, 'maxSessionDurationMs' | 'now' | 'random' | 'sessionIdleTimeoutMs'>
 type ReplayConfigAssignable = BrowserSessionReplayPackageConfig extends ReplayConfigComparable ? true : never
 function assertReplayConfigAssignable(_value: ReplayConfigAssignable): void {
   return undefined

--- a/packages/logfire-session-replay/README.md
+++ b/packages/logfire-session-replay/README.md
@@ -44,7 +44,7 @@ const replay = startSessionReplay({
     account_tier: currentAccount.tier,
     beta_user: currentUser.isBeta,
   }),
-  getTraceContext: () => getCurrentTraceContext(),
+  getSessionId: () => getSharedBrowserSessionId(),
 })
 
 await replay.flush()
@@ -105,7 +105,6 @@ The decompressed body shape is:
     errorCount,
     hasFullSnapshot,
     urls,
-    traceIds,
     distinctId,
     sessionAttributes,
   },
@@ -215,10 +214,9 @@ not automatically promote the replay buffer.
 
 Use `getSessionId` to share a session id with another SDK layer. The
 `@pydantic/logfire-browser` integration passes its browser RUM session id through
-this hook when top-level `sessionReplay` is configured.
-
-Use `getTraceContext` to stamp active trace ids into the replay stream so the
-replay can be linked to browser traces and errors.
+this hook when top-level `sessionReplay` is configured. Other integrations must
+record the same value as `browser.session.id` on their browser spans so Logfire
+can correlate those spans with the replay over its time bounds.
 
 ## Browser SDK Integration
 

--- a/packages/logfire-session-replay/src/extract.test.ts
+++ b/packages/logfire-session-replay/src/extract.test.ts
@@ -20,7 +20,6 @@ const events: RrwebEvent[] = [
   },
   { type: EventType.IncrementalSnapshot, data: { source: IncrementalSource.Input, text: 'x' }, timestamp: 150 },
   { type: EventType.Custom, data: { tag: CustomTag.Error, payload: { message: 'boom' } }, timestamp: 160 },
-  { type: EventType.Custom, data: { tag: CustomTag.Trace, payload: { traceId: 'abc', spanId: 'def' } }, timestamp: 170 },
   { type: EventType.Meta, data: { href: 'https://app.example.com/b' }, timestamp: 180 },
 ]
 
@@ -37,7 +36,6 @@ describe('computeChunkMeta', () => {
       errorCount: 1,
       hasFullSnapshot: true,
       urls: ['https://app.example.com/a', 'https://app.example.com/b'],
-      traceIds: ['abc'],
       distinctId: 'user-42',
     })
   })
@@ -66,7 +64,6 @@ describe('computeChunkMeta', () => {
         account_tier: 'pro',
         beta_user: true,
       },
-      traceIds: [],
       urls: [],
     })
     expect(computeChunkMeta(0, [], undefined, {})).not.toHaveProperty('sessionAttributes')

--- a/packages/logfire-session-replay/src/extract.ts
+++ b/packages/logfire-session-replay/src/extract.ts
@@ -22,7 +22,6 @@ export function computeChunkMeta(
   let errorCount = 0
   let hasFullSnapshot = false
   const urls = new Set<string>()
-  const traceIds = new Set<string>()
 
   for (const event of events) {
     if (event.timestamp < firstTimestamp) {
@@ -55,11 +54,6 @@ export function computeChunkMeta(
       const payload = asRecord(data['payload'])
       if (tag === CustomTag.Error) {
         errorCount++
-      } else if (tag === CustomTag.Trace) {
-        const traceId = asString(payload?.['traceId'])
-        if (traceId !== undefined) {
-          traceIds.add(traceId)
-        }
       } else if (tag === CustomTag.Console) {
         if (payload?.['level'] === 'error') {
           errorCount++
@@ -83,7 +77,6 @@ export function computeChunkMeta(
     errorCount,
     hasFullSnapshot,
     urls: [...urls],
-    traceIds: [...traceIds],
     ...(distinctId !== undefined && distinctId.length > 0 ? { distinctId } : {}),
     ...(Object.keys(sessionAttributes).length === 0 ? {} : { sessionAttributes: { ...sessionAttributes } }),
   }

--- a/packages/logfire-session-replay/src/index.test.ts
+++ b/packages/logfire-session-replay/src/index.test.ts
@@ -372,27 +372,7 @@ describe('startSessionReplay full mode', () => {
   })
 })
 
-describe('startSessionReplay correlation and errors', () => {
-  it('stamps trace context only when trace id changes', async () => {
-    vi.useFakeTimers()
-    const { fetchImpl } = recordingFetch()
-    const traces = ['A', 'A', 'B']
-    let index = 0
-    const replay = startSessionReplay(
-      baseConfig(fetchImpl, { getTraceContext: () => ({ traceId: traces[index++] ?? '', spanId: 'span' }) })
-    )
-
-    await vi.advanceTimersByTimeAsync(1_000)
-    await vi.advanceTimersByTimeAsync(1_000)
-    await vi.advanceTimersByTimeAsync(1_000)
-
-    expect(handle.addCustomEvent.mock.calls.filter((call) => call[0] === CustomTag.Trace)).toEqual([
-      [CustomTag.Trace, { traceId: 'A', spanId: 'span' }],
-      [CustomTag.Trace, { traceId: 'B', spanId: 'span' }],
-    ])
-    await replay.stop()
-  })
-
+describe('startSessionReplay errors', () => {
   it('surfaces window errors and promise rejections as custom events', async () => {
     const { fetchImpl } = recordingFetch()
     const replay = startSessionReplay(baseConfig(fetchImpl))
@@ -435,21 +415,10 @@ describe('startSessionReplay correlation and errors', () => {
     await replay.stop()
   })
 
-  it('contains throwing trace callbacks and coerces non-string rejection messages', async () => {
-    vi.useFakeTimers()
-    const onError = vi.fn<() => void>()
+  it('coerces non-string rejection messages', async () => {
     const { fetchImpl } = recordingFetch()
-    const replay = startSessionReplay(
-      baseConfig(fetchImpl, {
-        getTraceContext: () => {
-          throw new Error('trace callback failed')
-        },
-        onError,
-      })
-    )
+    const replay = startSessionReplay(baseConfig(fetchImpl))
 
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'trace callback failed' }))
     dispatchRejection({ message: 42, stack: 'STACK' })
     expect(handle.addCustomEvent).toHaveBeenCalledWith(CustomTag.Error, { message: '42', stack: 'STACK' })
     await replay.stop()

--- a/packages/logfire-session-replay/src/index.ts
+++ b/packages/logfire-session-replay/src/index.ts
@@ -240,28 +240,6 @@ function createActiveRuntime(options: {
       }
     }
 
-    let lastTraceId: string | undefined
-    if (config.getTraceContext !== undefined) {
-      const traceTimer = setInterval(() => {
-        if (!active) {
-          return
-        }
-        try {
-          const context = config.getTraceContext?.()
-          const traceId = context?.traceId
-          if (traceId !== undefined && traceId.length > 0 && traceId !== lastTraceId) {
-            lastTraceId = traceId
-            addCustomEvent(CustomTag.Trace, { traceId, spanId: context?.spanId })
-          }
-        } catch (error) {
-          safeReportError(config.onError, error)
-        }
-      }, SESSION_MONITOR_INTERVAL_MS)
-      cleanup.push(() => {
-        clearInterval(traceTimer)
-      })
-    }
-
     const handleError = (payload: { message: string; source?: string; stack?: string }) => {
       if (!isRuntimeActive()) {
         return
@@ -393,7 +371,6 @@ function resolveConfig(config: SessionReplayConfig): ResolvedSessionReplayConfig
     maxSessionDurationMs: config.maxSessionDurationMs ?? DEFAULTS.maxSessionDurationMs,
     distinctId: config.distinctId ?? DEFAULTS.distinctId,
     getDistinctId: config.getDistinctId,
-    getTraceContext: config.getTraceContext,
     captureConsole: config.captureConsole ?? DEFAULTS.captureConsole,
     captureNetwork: config.captureNetwork ?? DEFAULTS.captureNetwork,
     captureNavigation: config.captureNavigation ?? DEFAULTS.captureNavigation,

--- a/packages/logfire-session-replay/src/transport.test.ts
+++ b/packages/logfire-session-replay/src/transport.test.ts
@@ -34,7 +34,6 @@ function makeConfig(fetchImpl: typeof fetch): ResolvedSessionReplayConfig {
     maxSessionDurationMs: 10_000,
     distinctId: 'user-1',
     getDistinctId: undefined,
-    getTraceContext: undefined,
     captureConsole: true,
     captureNetwork: true,
     captureNavigation: true,
@@ -109,6 +108,7 @@ describe('ReplayTransport full mode', () => {
     expect(envelope.meta.clickCount).toBe(1)
     expect(envelope.meta.hasFullSnapshot).toBe(true)
     expect(envelope.meta.distinctId).toBe('user-1')
+    expect(envelope.meta).not.toHaveProperty('traceIds')
   })
 
   it('copies one session snapshot into every chunk and omits an empty snapshot', async () => {

--- a/packages/logfire-session-replay/src/types.ts
+++ b/packages/logfire-session-replay/src/types.ts
@@ -33,7 +33,6 @@ export const MouseInteractions = {
 
 export const CustomTag = {
   Error: 'logfire.error',
-  Trace: 'logfire.trace',
   Console: 'logfire.console',
   Network: 'logfire.network',
   Navigation: 'logfire.navigation',
@@ -79,7 +78,6 @@ export interface ChunkMeta {
   errorCount: number
   hasFullSnapshot: boolean
   urls: string[]
-  traceIds: string[]
   distinctId?: string
   sessionAttributes?: SessionAttributes
 }
@@ -144,7 +142,6 @@ export interface SessionReplayConfig {
 
   distinctId?: string
   getDistinctId?: () => string | undefined
-  getTraceContext?: () => { traceId?: string; spanId?: string } | undefined
 
   captureConsole?: boolean
   captureNetwork?: boolean
@@ -176,7 +173,6 @@ export interface ResolvedSessionReplayConfig {
   maxSessionDurationMs: number
   distinctId: string
   getDistinctId: (() => string | undefined) | undefined
-  getTraceContext: (() => { traceId?: string; spanId?: string } | undefined) | undefined
   captureConsole: boolean
   captureNetwork: boolean
   captureNavigation: boolean


### PR DESCRIPTION
## Summary

- remove the experimental getTraceContext option and its one-second active-trace polling
- stop emitting logfire.trace replay events and omit meta.traceIds from version 1 chunk envelopes
- document browser-session correlation as the sole replay-to-span contract
- keep @pydantic/logfire-browser compatible with both recorder 0.2 and 0.3

## Compatibility

@pydantic/logfire-browser already supplies the shared browser session ID and never supplied getTraceContext, so its runtime behavior is unchanged. The recorder receives a minor release because its experimental public configuration and envelope types change; the browser adapter receives a patch release.

Older recorder releases can continue sending traceIds to servers that accept the version 1 envelope. Server-side persistence cleanup is intentionally separate.

## Validation

- pnpm run check
- focused recorder tests: 151 passed
- focused browser tests: 168 passed
- packed @pydantic/logfire-browser and verified its published optional peer range is ^0.2.0 || ^0.3.0