### PR TITLE
Record http.url on cache spans for string and URL keys

### DIFF
--- a/.changeset/cache-url-attribute.md
+++ b/.changeset/cache-url-attribute.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+Record `http.url` on Cache spans when the key is a string or a `URL`, not just a `Request`. The Cache methods accept `RequestInfo | URL`, but the attribute was read from `argArray[0].url`, which only exists on a `Request`, so `caches.default.match('https://example.com/x')` produced a span with no URL at all. Malformed keys now omit the attribute instead of letting URL parsing throw into the caller.

--- a/packages/otel-cf-workers/src/instrumentation/cache.ts
+++ b/packages/otel-cf-workers/src/instrumentation/cache.ts
@@ -6,18 +6,44 @@ type CacheFns = Cache[keyof Cache]
 
 const tracer = trace.getTracer('cache instrumentation')
 
-function sanitiseURL(url: string): string {
-  const u = new URL(url)
-  return `${u.protocol}//${u.host}${u.pathname}${u.search}`
+function sanitiseURL(url: string): string | undefined {
+  try {
+    const u = new URL(url)
+    return `${u.protocol}//${u.host}${u.pathname}${u.search}`
+  } catch {
+    // Never let attribute building break the caller's cache call.
+    return undefined
+  }
+}
+
+/**
+ * The Cache methods accept `RequestInfo | URL`, so the key can be a `Request`, a bare string, or a
+ * `URL`, and only the first of those carries a `url` property.
+ */
+function cacheKeyUrl(key: unknown): string | undefined {
+  if (typeof key === 'string') {
+    return sanitiseURL(key)
+  }
+  if (key instanceof URL) {
+    return sanitiseURL(key.href)
+  }
+  if (typeof key === 'object' && key !== null) {
+    const requestUrl = (key as { url?: unknown }).url
+    if (typeof requestUrl === 'string') {
+      return sanitiseURL(requestUrl)
+    }
+  }
+  return undefined
 }
 
 function instrumentFunction<T extends CacheFns>(fn: T, cacheName: string, op: string): T {
   const handler: ProxyHandler<typeof fn> = {
     async apply(target, thisArg, argArray) {
+      const url = cacheKeyUrl(argArray[0])
       const attributes = {
         'cache.name': cacheName,
         'cache.operation': op,
-        ...(argArray[0].url !== undefined ? { 'http.url': sanitiseURL(argArray[0].url) } : {}),
+        ...(url !== undefined ? { 'http.url': url } : {}),
       }
       const options: SpanOptions = { kind: SpanKind.CLIENT, attributes }
       return tracer.startActiveSpan(`Cache ${cacheName} ${op}`, options, async (span) => {

--- a/packages/otel-cf-workers/test/instrumentation/cache.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/cache.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="@cloudflare/workers-types/experimental" />
+
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { beforeEach, describe, expect, it, vitest } from 'vitest'
+import { context, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '../../src/context'
+import { instrumentGlobalCache } from '../../src/instrumentation/cache'
+
+const exporter = new InMemorySpanExporter()
+
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+
+trace.setGlobalTracerProvider(provider)
+context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+
+type CacheKey = Request | string | URL
+type MatchFn = (key: CacheKey) => Promise<Response | undefined>
+interface DefaultCache {
+  match: MatchFn
+}
+
+const matchMock = vitest.fn<MatchFn>()
+const globalWithCaches = globalThis as unknown as { caches: { default: DefaultCache } }
+
+// The global `caches` binding is typed as the DOM CacheStorage here, which has no `default`, so the
+// instrumented cache is reached through an explicitly typed view of globalThis instead.
+function instrumentedDefaultCache(): DefaultCache {
+  globalWithCaches.caches = {
+    default: { match: matchMock } as DefaultCache,
+    open: vitest.fn<() => Promise<unknown>>(),
+  } as unknown as { default: DefaultCache }
+  instrumentGlobalCache()
+  return globalWithCaches.caches.default
+}
+
+beforeEach(() => {
+  exporter.reset()
+  vitest.resetAllMocks()
+})
+
+function matchedSpanUrl(): unknown {
+  const spans = exporter.getFinishedSpans()
+  expect(spans).toHaveLength(1)
+  return spans[0]?.attributes['http.url']
+}
+
+describe('cache instrumentation http.url', () => {
+  it('records the url for a Request argument', async () => {
+    await instrumentedDefaultCache().match(new Request('https://example.com/a?q=1'))
+    expect(matchedSpanUrl()).toBe('https://example.com/a?q=1')
+  })
+
+  it('records the url for a string argument', async () => {
+    await instrumentedDefaultCache().match('https://example.com/b?q=2')
+    expect(matchedSpanUrl()).toBe('https://example.com/b?q=2')
+  })
+
+  it('records the url for a URL argument', async () => {
+    await instrumentedDefaultCache().match(new URL('https://example.com/c?q=3'))
+    expect(matchedSpanUrl()).toBe('https://example.com/c?q=3')
+  })
+
+  it('omits the url when the key cannot be parsed', async () => {
+    await instrumentedDefaultCache().match('not-a-url')
+    expect(matchedSpanUrl()).toBeUndefined()
+  })
+})


### PR DESCRIPTION
The Cache methods accept `RequestInfo | URL`, so the key can be a `Request`, a bare string, or a `URL`. `instrumentFunction` in `packages/otel-cf-workers/src/instrumentation/cache.ts` read the url as `argArray[0].url`, which only exists on a `Request`, so `caches.default.match('https://example.com/x')` and the `URL` form both produced a cache span with no `http.url` at all. Two of the three documented input shapes lost the attribute.

This pulls the url out of whichever shape was passed. I also made `sanitiseURL` return undefined instead of throwing on something unparseable, because it runs while building the span attributes, before the span exists, so a throw there would have surfaced inside the caller's own cache call rather than as a failed span.

There was no test file for the cache bindings, so I added one covering all three key shapes plus an unparseable one. The string and URL cases fail on current main with `expected undefined to be 'https://example.com/...'`. Ran the repo preflight and `pnpm run check`, both green. Patch changeset for `@pydantic/otel-cf-workers` included.

quick disclosure: worked through this with Claude Code and read the final diff myself. Freshman still learning, so if you would rather keep the attribute Request-only I am happy to drop it :)