### PR TITLE
Stop onStart throwing on a non-absolute http.url

### DIFF
--- a/.changeset/span-processor-url-guard.md
+++ b/.changeset/span-processor-url-guard.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-browser': patch
+---
+
+Stop `LogfireSpanProcessor.onStart` throwing when a span carries an `http.url` that is not an absolute URL. The processor parsed the attribute with `new URL()` while renaming fetch spans, so a relative or non-string value raised `TypeError: Invalid URL` out of `onStart` and broke span creation for the application. Unparseable values now leave the span name unchanged.

--- a/packages/logfire-browser/src/LogfireSpanProcessor.test.ts
+++ b/packages/logfire-browser/src/LogfireSpanProcessor.test.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Context } from '@opentelemetry/api'
+import { ROOT_CONTEXT } from '@opentelemetry/api'
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-web'
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import { LogfireSpanProcessor } from './LogfireSpanProcessor'
+
+function makeWrapped(): SpanProcessor & { started: Span[] } {
+  const started: Span[] = []
+  return {
+    forceFlush: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    onEnd: vi.fn<(span: ReadableSpan) => void>(),
+    onStart: vi.fn<(span: Span, parentContext: Context) => void>((span) => {
+      started.push(span)
+    }),
+    shutdown: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    started,
+  }
+}
+
+function makeSpan(attributes: Record<string, unknown>, name = 'GET'): Span {
+  return { attributes, name } as unknown as Span
+}
+
+describe('LogfireSpanProcessor', () => {
+  it('appends the path to fetch span names', () => {
+    const wrapped = makeWrapped()
+    const processor = new LogfireSpanProcessor(wrapped, false)
+    const span = makeSpan({ 'http.url': 'https://example.com/api/thing?q=1' })
+
+    processor.onStart(span, ROOT_CONTEXT)
+
+    expect(span.name).toBe('GET /api/thing')
+    expect(wrapped.onStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the name alone when http.url is not an absolute url', () => {
+    const wrapped = makeWrapped()
+    const processor = new LogfireSpanProcessor(wrapped, false)
+    const span = makeSpan({ 'http.url': '/api/thing' })
+
+    expect(() => {
+      processor.onStart(span, ROOT_CONTEXT)
+    }).not.toThrow()
+    expect(span.name).toBe('GET')
+    expect(wrapped.onStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the name alone when http.url is not a string', () => {
+    const wrapped = makeWrapped()
+    const processor = new LogfireSpanProcessor(wrapped, false)
+    const span = makeSpan({ 'http.url': 42 })
+
+    expect(() => {
+      processor.onStart(span, ROOT_CONTEXT)
+    }).not.toThrow()
+    expect(span.name).toBe('GET')
+    expect(wrapped.onStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('renames interaction spans from the event type and target', () => {
+    const wrapped = makeWrapped()
+    const processor = new LogfireSpanProcessor(wrapped, false)
+    const span = makeSpan({ event_type: 'click', target_xpath: '//button[1]' })
+
+    processor.onStart(span, ROOT_CONTEXT)
+
+    expect(span.name).toBe('click //button[1]')
+  })
+})

--- a/packages/logfire-browser/src/LogfireSpanProcessor.ts
+++ b/packages/logfire-browser/src/LogfireSpanProcessor.ts
@@ -94,6 +94,21 @@ class LogfireConsoleSpanExporter implements SpanExporter {
   }
 }
 
+/**
+ * `onStart` runs for every span, so a `http.url` that is not an absolute URL must not throw out of
+ * it and break the caller's span creation. Anything unparseable just leaves the name as it was.
+ */
+function urlPathname(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  try {
+    return new URL(value).pathname
+  } catch {
+    return undefined
+  }
+}
+
 export class LogfireSpanProcessor implements SpanProcessor {
   private readonly console?: SpanProcessor
   private readonly wrapped: SpanProcessor
@@ -120,9 +135,9 @@ export class LogfireSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     // make the fetch spans more descriptive
-    if (ATTR_HTTP_URL in span.attributes) {
-      const url = new URL(span.attributes[ATTR_HTTP_URL] as string)
-      Reflect.set(span, 'name', `${span.name} ${url.pathname}`)
+    const pathname = urlPathname(span.attributes[ATTR_HTTP_URL])
+    if (pathname !== undefined) {
+      Reflect.set(span, 'name', `${span.name} ${pathname}`)
     }
 
     // same for the interaction spans


### PR DESCRIPTION
`LogfireSpanProcessor.onStart` renames fetch spans by parsing the `http.url` attribute with `new URL(...)`, with nothing around it (`packages/logfire-browser/src/LogfireSpanProcessor.ts`). `onStart` runs for every span, so an `http.url` that is not an absolute URL raises `TypeError: Invalid URL` out of the processor and into the application's own span creation. A relative value like `/api/thing` or a non-string value both do it. That makes instrumentation break user code, which is the wrong direction for a tracing SDK.

The parse now returns undefined instead of throwing and the span name is left as it was, which follows the same shape as `resolveUrl` in `telemetryUrls.ts` where URL parsing is already guarded this way.

There was no test file for this processor, so I added one covering the fetch rename, the interaction rename, and both unparseable cases. The two unparseable tests fail on current main with `TypeError: Invalid URL`. Ran the repo preflight and `pnpm run check`, both green. Patch changeset for `@pydantic/logfire-browser` included.

For what it is worth I did not find a first-party instrumentation that emits a relative `http.url` today, so this is defence in depth rather than a bug someone is currently hitting. It seemed worth guarding anyway given the blast radius if it ever happens.

quick disclosure: built with Claude Code's help and I read the diff myself. Freshman still learning, so push back if you would rather leave the parse unguarded :)