### PR TITLE
Keep http.url out of Web Vital metric attributes

### DIFF
--- a/.changeset/metrics-http-url-denylist.md
+++ b/.changeset/metrics-http-url-denylist.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-browser': patch
+---
+
+Keep `http.url` out of Web Vital metric attributes. The low-cardinality guard already dropped `url.full`, but not `http.url`, which is the pre-stable name for the same value and still what the fetch and XHR instrumentations emit, so an attribute callback returning it put a full URL including any query string onto a metric label.

--- a/packages/logfire-browser/src/browserMetrics.test.ts
+++ b/packages/logfire-browser/src/browserMetrics.test.ts
@@ -264,6 +264,7 @@ describe('browser metrics runtime', () => {
       defaultAttributes: () =>
         ({
           'browser.session.id': 'browser-session-1',
+          'http.url': 'https://example.com/products/123?token=secret',
           'logfire.page.route': '/products/:id',
           'logfire.page.url.full': 'https://example.com/products/123?token=secret',
           'logfire.page.url.path': '/products/123',

--- a/packages/logfire-browser/src/browserMetrics.ts
+++ b/packages/logfire-browser/src/browserMetrics.ts
@@ -98,6 +98,8 @@ const WEB_VITAL_METRIC_INSTRUMENTS: Record<WebVitalName, WebVitalMetricInstrumen
 
 const DISALLOWED_WEB_VITAL_METRIC_ATTRIBUTES = new Set([
   'browser.session.id',
+  // The pre-stable name for `url.full`, and still what the fetch and XHR instrumentations emit.
+  'http.url',
   'logfire.page.route',
   'logfire.page.url.full',
   'logfire.page.url.path',


### PR DESCRIPTION
`DISALLOWED_WEB_VITAL_METRIC_ATTRIBUTES` in `packages/logfire-browser/src/browserMetrics.ts` blocks `url.full` from Web Vital metric labels, but not `http.url`. Those are the same value under two semantic-convention generations, and `http.url` is the one the installed fetch and XHR instrumentations still emit, so an `attributes` or `defaultAttributes` callback that copies it through puts a full URL, query string included, onto a metric label.

The existing low-cardinality test already covers this shape: it feeds in `'url.full': 'https://example.com/products/123?token=secret'` and asserts it is dropped. I added the same value under `http.url` to that case, and it fails on current main with the token-bearing URL present in the recorded attributes.

I deliberately left `url.path` alone. That test asserts it survives, which makes sense since a templated path is low cardinality, so this only adds the full-URL alias.

Ran the repo preflight and `pnpm run check`, both green. Patch changeset for `@pydantic/logfire-browser` included.

quick disclosure: worked through this with Claude Code and read the diff myself. Freshman still learning, and I may have the semconv history wrong, so correct me if `http.url` is meant to be allowed here :)