### PR TITLE
Expand references that follow an even backslash run

### DIFF
--- a/.changeset/composition-escaped-backslash-guard.md
+++ b/.changeset/composition-escaped-backslash-guard.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Expand references in a referenced variable's value when they follow an even backslash run. The fast-path guard in `expandReferenceSerializedValue` tested the JSON-encoded text with a single-character lookbehind, so any `@{ref}@` preceded by a literal backslash was treated as escaped. A value such as `\\@{inner}@` therefore skipped composition entirely and `inner` was left unexpanded and absent from `composedFrom`, even though the same string expands when it appears at the top level.

--- a/packages/logfire-api/src/vars/composition.test.ts
+++ b/packages/logfire-api/src/vars/composition.test.ts
@@ -174,6 +174,35 @@ describe('variable composition', () => {
     })
   })
 
+  it('applies the backslash escape rule to referenced values the same way as to top-level values', async () => {
+    // An even backslash run leaves the reference live, so it expands on both paths.
+    await expect(
+      expandReferences(JSON.stringify('@{ref}@'), resolver({ inner: resolved('X'), ref: resolved('\\\\@{inner}@') }))
+    ).resolves.toMatchObject({ serializedValue: JSON.stringify('\\X') })
+    await expect(expandReferences(JSON.stringify('\\\\@{inner}@'), resolver({ inner: resolved('X') }))).resolves.toMatchObject({
+      serializedValue: JSON.stringify('\\X'),
+    })
+
+    // An odd backslash run escapes the reference, so it stays literal.
+    await expect(
+      expandReferences(JSON.stringify('@{ref}@'), resolver({ inner: resolved('X'), ref: resolved('\\@{inner}@') }))
+    ).resolves.toMatchObject({ serializedValue: JSON.stringify('\\@{inner}@') })
+  })
+
+  it('records nested references behind an escaped backslash in composition metadata', async () => {
+    const result = await expandReferences(JSON.stringify('@{ref}@'), resolver({ inner: resolved('X'), ref: resolved('\\\\@{inner}@') }))
+
+    expect(result.composedFrom).toEqual([
+      {
+        composedFrom: [{ fatal: false, name: 'inner', reason: 'resolved', value: '"X"' }],
+        fatal: false,
+        name: 'ref',
+        reason: 'resolved',
+        value: '"\\\\X"',
+      },
+    ])
+  })
+
   it('preserves JSON encoding for rendered reference values', async () => {
     const value = 'line 1\n"quoted" \\ slash café'
     const result = await expandReferences(JSON.stringify('Value: @{text}@'), resolver({ text: resolved(value) }))

--- a/packages/logfire-api/src/vars/composition.test.ts
+++ b/packages/logfire-api/src/vars/composition.test.ts
@@ -176,17 +176,19 @@ describe('variable composition', () => {
 
   it('applies the backslash escape rule to referenced values the same way as to top-level values', async () => {
     // An even backslash run leaves the reference live, so it expands on both paths.
-    await expect(
-      expandReferences(JSON.stringify('@{ref}@'), resolver({ inner: resolved('X'), ref: resolved('\\\\@{inner}@') }))
-    ).resolves.toMatchObject({ serializedValue: JSON.stringify('\\X') })
-    await expect(expandReferences(JSON.stringify('\\\\@{inner}@'), resolver({ inner: resolved('X') }))).resolves.toMatchObject({
-      serializedValue: JSON.stringify('\\X'),
-    })
+    const throughReference = await expandReferences(
+      JSON.stringify('@{ref}@'),
+      resolver({ inner: resolved('X'), ref: resolved('\\\\@{inner}@') })
+    )
+    const atTopLevel = await expandReferences(JSON.stringify('\\\\@{inner}@'), resolver({ inner: resolved('X') }))
+
+    expect(throughReference.serializedValue).toBe(JSON.stringify('\\X'))
+    expect(atTopLevel.serializedValue).toBe(JSON.stringify('\\X'))
 
     // An odd backslash run escapes the reference, so it stays literal.
-    await expect(
-      expandReferences(JSON.stringify('@{ref}@'), resolver({ inner: resolved('X'), ref: resolved('\\@{inner}@') }))
-    ).resolves.toMatchObject({ serializedValue: JSON.stringify('\\@{inner}@') })
+    const escaped = await expandReferences(JSON.stringify('@{ref}@'), resolver({ inner: resolved('X'), ref: resolved('\\@{inner}@') }))
+
+    expect(escaped.serializedValue).toBe(JSON.stringify('\\@{inner}@'))
   })
 
   it('records nested references behind an escaped backslash in composition metadata', async () => {

--- a/packages/logfire-api/src/vars/composition.ts
+++ b/packages/logfire-api/src/vars/composition.ts
@@ -1,5 +1,5 @@
 import { VariableCompositionCycleError, VariableCompositionDepthError, VariableCompositionError } from './errors'
-import { HAS_REFERENCE, findReferencesAndErrorsInString, hasCompositionReferences, renderOnce } from './referenceSyntax'
+import { findReferencesAndErrorsInString, hasCompositionReferences, renderOnce } from './referenceSyntax'
 import type { ReferenceSyntaxError } from './referenceSyntax'
 import type { VariableResolutionReason } from './index'
 
@@ -310,7 +310,7 @@ async function expandReferenceSerializedValue(
     }
   }
 
-  if (!HAS_REFERENCE.test(serializedValue)) {
+  if (!hasReferences(parsed)) {
     return { composedFrom: [], serializedValue, value: parsed }
   }
 

--- a/packages/logfire-api/src/vars/referenceSyntax.ts
+++ b/packages/logfire-api/src/vars/referenceSyntax.ts
@@ -2,8 +2,6 @@ import Handlebars from 'handlebars'
 
 import { createSafeHandlebarsContext } from './template'
 
-export const HAS_REFERENCE: RegExp = /(?<!\\)@\{/u
-
 export interface ReferenceSyntaxError {
   message: string
   type: 'parse_error'


### PR DESCRIPTION
## What is wrong

`expandReferenceSerializedValue` guards nested composition with a regex over the **JSON-encoded** value:

```ts
export const HAS_REFERENCE: RegExp = /(?<!\\)@\{/u
...
if (!HAS_REFERENCE.test(serializedValue)) {
  return { composedFrom: [], serializedValue, value: parsed }
}
```

Escape state is a property of the decoded string, and the rest of the module agrees: `isEscapedAt()` counts backslash **parity**, so an even run does not escape the reference. The lookbehind only checks the single preceding character, and JSON doubles every backslash, so a value whose reference is preceded by an even (non-escaping) run reaches the guard looking escaped and skips composition entirely.

## Evidence

The same string expands at the top level but not when reached through a reference:

```ts
// through a reference
await expandReferences(
  JSON.stringify('@{ref}@'),
  resolver({ inner: resolved('X'), ref: resolved('\\\\@{inner}@') })
)
// serializedValue -> "\\\\@{inner}@"   (inner never expands, absent from composedFrom)

// the same value at the top level
await expandReferences(JSON.stringify('\\\\@{inner}@'), resolver({ inner: resolved('X') }))
// serializedValue -> "\\X"             (expands)
```

Mapping literal backslashes before a reference to what the guard decides:

| literal backslashes | escaped per `isEscapedAt` | guard expands |
|---|---|---|
| 0 | no | yes |
| 1 | yes | no |
| 2 | no | **no** |
| 3 | yes | no |

Only the even-and-nonzero rows are wrong, so this is the single case the change affects.

## What this does

Uses the existing `hasReferences()` helper on the already-parsed value. It walks strings, arrays and objects and calls `hasCompositionReferences()`, which is the same parity rule `isEscapedAt()` implements, so the guard and the expander now agree.

Swapping the regex for `hasCompositionReferences(serializedValue)` would be wrong in the other direction: parity applied to JSON text treats a single literal backslash as even and would break the escaped case pinned at `composition.test.ts:172`. Checking the decoded value is what keeps both branches correct.

`HAS_REFERENCE` had this one caller and is not re-exported from `vars/reference-syntax`, so it is removed rather than left as a second, disagreeing definition.

Tests cover both branches: even run expands and matches the top-level result, odd run stays literal. Verified by reverting the guard, which fails exactly these two tests and no others.

---
This change was prepared with AI assistance and reviewed by me before opening.