### PR TITLE
Treat an invalid Date as an unsupported dataset value

### DIFF
--- a/.changeset/dataset-invalid-date.md
+++ b/.changeset/dataset-invalid-date.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Report an invalid `Date` in a pushed evaluation dataset as a `DatasetSerializationError` instead of a bare `RangeError`. `normalizeHostedJsonValue` called `toISOString()` on any `Date`, which throws `RangeError: Invalid time value` for an unparseable one, losing the field, case and path that every other unsupported value reports and bypassing the `serializeValue` hook that can convert it.

--- a/.changeset/dataset-invalid-date.md
+++ b/.changeset/dataset-invalid-date.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Report an invalid `Date` in a pushed evaluation dataset as a `DatasetSerializationError` instead of a bare `RangeError`. `normalizeHostedJsonValue` called `toISOString()` on any `Date`, which throws `RangeError: Invalid time value` for an unparseable one, losing the field, case and path that every other unsupported value reports and bypassing the `serializeValue` hook that can convert it.
+Report an invalid `Date` in a pushed evaluation dataset as a `DatasetConfigurationError` instead of a bare `RangeError`. `normalizeHostedJsonValue` called `toISOString()` on any `Date`, which throws `RangeError: Invalid time value` for an unparseable one, losing the field, case and path that every other unsupported value reports and bypassing the `serializeValue` hook that can convert it.

--- a/packages/logfire-api/src/datasets.evaluation.test.ts
+++ b/packages/logfire-api/src/datasets.evaluation.test.ts
@@ -430,6 +430,40 @@ describe('hosted evaluation datasets bridge', () => {
     ).rejects.toThrow('serializeValue returned the same unsupported bigint value')
   })
 
+  it('rejects invalid Dates with a path-aware message and lets serializeValue convert them', async () => {
+    const calls: CapturedRequest[] = []
+    const client = new LogfireAPIClient({
+      apiKey: 'lf-api-key',
+      baseUrl: 'https://example.com',
+      fetch: fetchSequence(calls, [jsonResponse(hostedMetadata), jsonResponse([{ id: 'case-1' }]), jsonResponse(hostedMetadata)]),
+    })
+
+    await expect(
+      client.pushEvaluationDataset(
+        new Dataset({
+          cases: [new Case({ inputs: { seenAt: new Date('not-a-date') }, name: 'bad-date' })],
+          name: 'bad-json',
+        })
+      )
+    ).rejects.toThrow('$.cases[0].inputs.seenAt contains unsupported invalid Dates')
+
+    await client.pushEvaluationDataset(
+      new Dataset({
+        cases: [new Case({ inputs: { seenAt: new Date('not-a-date') }, name: 'bad-date' })],
+        name: 'serialized-date',
+      }),
+      {
+        serializeValue(value) {
+          return value instanceof Date && Number.isNaN(value.getTime()) ? null : undefined
+        },
+      }
+    )
+
+    expect(calls[1]?.body).toEqual({
+      cases: [{ evaluators: [], inputs: { seenAt: null }, name: 'bad-date' }],
+    })
+  })
+
   it('rejects unsupported pushed values with path-aware messages', async () => {
     const client = new LogfireAPIClient({
       apiKey: 'lf-api-key',

--- a/packages/logfire-api/src/datasets.evaluation.test.ts
+++ b/packages/logfire-api/src/datasets.evaluation.test.ts
@@ -438,14 +438,22 @@ describe('hosted evaluation datasets bridge', () => {
       fetch: fetchSequence(calls, [jsonResponse(hostedMetadata), jsonResponse([{ id: 'case-1' }]), jsonResponse(hostedMetadata)]),
     })
 
-    await expect(
-      client.pushEvaluationDataset(
+    const error: unknown = await client
+      .pushEvaluationDataset(
         new Dataset({
           cases: [new Case({ inputs: { seenAt: new Date('not-a-date') }, name: 'bad-date' })],
           name: 'bad-json',
         })
       )
-    ).rejects.toThrow('$.cases[0].inputs.seenAt contains unsupported invalid Dates')
+      .then(
+        () => undefined,
+        (reason: unknown) => reason
+      )
+
+    expect(error).toBeInstanceOf(DatasetConfigurationError)
+    expect((error as Error).message).toBe(
+      'pushEvaluationDataset inputs for case "bad-date" at $.cases[0].inputs.seenAt contains unsupported invalid Dates; pass serializeValue to convert it'
+    )
 
     await client.pushEvaluationDataset(
       new Dataset({

--- a/packages/logfire-api/src/datasets/json.ts
+++ b/packages/logfire-api/src/datasets/json.ts
@@ -29,6 +29,9 @@ function normalizeValue(
     return normalizeUnsupportedValue(value, context, serializeValue, ancestors, serializedValues, 'non-finite numbers')
   }
   if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      return normalizeUnsupportedValue(value, context, serializeValue, ancestors, serializedValues, 'invalid Dates')
+    }
     return value.toISOString()
   }
   if (Array.isArray(value)) {


### PR DESCRIPTION
## What is wrong

`normalizeHostedJsonValue` converts any `Date` unconditionally:

```ts
if (value instanceof Date) {
  return value.toISOString()
}
```

`toISOString()` throws `RangeError: Invalid time value` when the `Date` does not hold a valid time value, which is what `new Date(str)` yields for any string it cannot parse.

Every other value this module cannot represent goes through `normalizeUnsupportedValue`, which raises a `DatasetSerializationError` naming the field, case and path, and gives the caller `serializeValue` as an escape hatch. An invalid `Date` skips all of that.

## Evidence

On `817fca1`, pushing a case whose input holds an unparseable date:

```ts
new Case({ inputs: { seenAt: new Date('not-a-date') }, name: 'bad-date' })
```

throws:

```
RangeError: Invalid time value
```

Compare a `Set` in the same position, which already reports where the problem is:

```
pushEvaluationDataset inputs for case "bad-set" at $.cases[0].inputs.tags contains unsupported Set value; pass serializeValue to convert it
```

So a dataset push fails with an error that is the wrong type, names no field or path, and cannot be worked around by the documented hook. `new Date(...)` over user-supplied or upstream data is the ordinary way to reach this.

## What this does

Checks the time value and routes an invalid `Date` through `normalizeUnsupportedValue`, matching how non-finite numbers are already handled a few lines above:

```ts
if (Number.isNaN(value.getTime())) {
  return normalizeUnsupportedValue(value, context, serializeValue, ancestors, serializedValues, 'invalid Dates')
}
```

Valid `Date` values still serialize to ISO strings, unchanged. Reusing the shared path also picks up the existing `serializedValues` guard, so a `serializeValue` that hands the same invalid `Date` back reports that rather than recursing.

The test covers both branches: the error message with its path when no hook is supplied, and the converted value when one is. Verified by removing the guard, which fails exactly that test and no others.

---
This change was prepared with AI assistance and reviewed by me before opening.