### PR TITLE
Report PR AUC as not computable for single-class datasets

### DIFF
--- a/.changeset/pr-auc-single-class.md
+++ b/.changeset/pr-auc-single-class.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Report `PrecisionRecallEvaluator` as not computable when every case shares one class. With only positive cases it returned an AUC of 1, and with only negative cases an AUC of 0, so a dataset that carries no signal read as a perfect or a worthless model. `ROCAUCEvaluator` and `KolmogorovSmirnovEvaluator` already return `NaN` and no curve for the same input.

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -753,6 +753,45 @@ describe('report evaluator edge cases', () => {
     expect(trapezoidalAuc([0, 0.5, 1], [0, 1, 1])).toBe(0.75)
   })
 
+  it('reports threshold evaluators as not computable when every case shares one class', () => {
+    const singleClassCtx = (positive: boolean) => {
+      const report: EvaluationReport = {
+        analyses: [],
+        cases: [0.9, 0.8, 0.7].map((score, index) =>
+          makeReportCase({
+            assertions: { p: resultJson('p', positive) },
+            name: `c${String(index)}`,
+            scores: { s: resultJson('s', score) },
+          })
+        ),
+        failures: [],
+        name: 'single-class',
+        report_evaluator_failures: [],
+        span_id: null,
+        trace_id: null,
+      }
+      return { cases: report.cases, name: report.name, report }
+    }
+    const options = { positiveFrom: 'assertions' as const, positiveKey: 'p', scoreKey: 's' }
+    const pr = new PrecisionRecallEvaluator(options)
+    const roc = new ROCAUCEvaluator(options)
+    const ks = new KolmogorovSmirnovEvaluator(options)
+
+    // Only positives: precision is 1 at every threshold by construction, so an AUC would read as a perfect score.
+    const allPositive = singleClassCtx(true)
+    expect(Number.isNaN(pr.evaluate(allPositive)[1].value)).toBe(true)
+    expect(pr.evaluate(allPositive)[0].curves).toEqual([])
+    expect(Number.isNaN(roc.evaluate(allPositive)[1].value)).toBe(true)
+    expect(Number.isNaN(ks.evaluate(allPositive)[1].value)).toBe(true)
+
+    // Only negatives: recall has no denominator, so an AUC would read as a worthless score.
+    const allNegative = singleClassCtx(false)
+    expect(Number.isNaN(pr.evaluate(allNegative)[1].value)).toBe(true)
+    expect(pr.evaluate(allNegative)[0].curves).toEqual([])
+    expect(Number.isNaN(roc.evaluate(allNegative)[1].value)).toBe(true)
+    expect(Number.isNaN(ks.evaluate(allNegative)[1].value)).toBe(true)
+  })
+
   it('computes PR/ROC AUC at full resolution before downsampling display points', () => {
     const report: EvaluationReport = {
       analyses: [],

--- a/packages/logfire-api/src/evals/reportEvaluators/PrecisionRecallEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/PrecisionRecallEvaluator.ts
@@ -70,11 +70,27 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
     }
     const inputs = buildThresholdInputs(cases, thresholdOptions)
 
-    const thresholds = uniqueSortedThresholds(inputs.scores)
-    const points: { precision: number; recall: number; threshold: number }[] = []
-    if (inputs.scores.length > 0) {
-      points.push({ precision: 1, recall: 0, threshold: Math.max(...inputs.scores) })
+    const emptyResult: [PrecisionRecallAnalysis, ScalarAnalysis] = [
+      { curves: [], title: this.title, type: 'precision_recall' },
+      { title: `${this.title} AUC`, type: 'scalar', value: Number.NaN },
+    ]
+    if (inputs.scores.length === 0) {
+      return emptyResult
     }
+
+    // Precision-recall is undefined without both classes, so report it as not
+    // computable rather than as a score, matching ROCAUCEvaluator and
+    // KolmogorovSmirnovEvaluator.
+    const totalPositives = inputs.positives.filter(Boolean).length
+    const totalNegatives = inputs.positives.length - totalPositives
+    if (totalPositives === 0 || totalNegatives === 0) {
+      return emptyResult
+    }
+
+    const thresholds = uniqueSortedThresholds(inputs.scores)
+    const points: { precision: number; recall: number; threshold: number }[] = [
+      { precision: 1, recall: 0, threshold: Math.max(...inputs.scores) },
+    ]
     for (const t of thresholds) {
       let tp = 0
       let fp = 0
@@ -100,12 +116,12 @@ export class PrecisionRecallEvaluator extends ReportEvaluator {
     // Recall ascending → AUC under PR curve (a.k.a. average precision).
     const xs = points.map((p) => p.recall)
     const ys = points.map((p) => p.precision)
-    const auc = inputs.scores.length === 0 ? Number.NaN : trapezoidalAuc(xs, ys)
+    const auc = trapezoidalAuc(xs, ys)
     const displayPoints = downsample(points, this.nThresholds)
 
     return [
       {
-        curves: inputs.scores.length === 0 ? [] : [{ auc, name: ctx.name, points: displayPoints }],
+        curves: [{ auc, name: ctx.name, points: displayPoints }],
         title: this.title,
         type: 'precision_recall',
       },


### PR DESCRIPTION
## What is wrong

`PrecisionRecallEvaluator` sweeps thresholds without checking the label distribution. Its two sibling threshold evaluators do:

```ts
// ROCAUCEvaluator
if (totalPositives === 0 || totalNegatives === 0) {
  return emptyResult
}

// KolmogorovSmirnovEvaluator
if (allScores.length === 0 || positiveScores.length === 0 || negativeScores.length === 0) {
  return emptyResult
}
```

Precision-recall has the same requirement. Without negatives there are no false positives, so `precision` is 1 at every threshold by construction. Without positives the recall denominator is zero and the point-level guard (`tp + fn === 0 ? 0 : ...`) pins recall to 0, collapsing the curve onto `x = 0`.

## Evidence

Three cases sharing one class, run through all three evaluators on `817fca1`:

| dataset | PR AUC | ROC AUC | KS |
|---|---|---|---|
| all positive | **1** | NaN | NaN |
| all negative | **0** | NaN | NaN |

PR also emits a curve in both rows where ROC emits none.

Neither number measures discrimination, because there is nothing to discriminate. But 1 is indistinguishable from a perfect model and 0 from a worthless one, so a dataset that drifts to a single class reports a confident score instead of "not computable". The existing coverage does not catch this: `'threshold report evaluators return empty/NaN analyses ... when inputs are absent'` exercises the no-scores path, where all three already agree.

## What this does

Returns the same empty analysis and `NaN` scalar the other two already return, so the three agree on degenerate input. Mixed-class behaviour is untouched.

Kept `NaN` rather than a numeric sentinel because that is the convention the other two evaluators and the existing no-scores path already established, and it is what the `ScalarAnalysis` consumers already handle. Reporting the value while flagging it separately would need a schema change for a case that has no meaningful value to report.

The test covers both single-class branches and asserts all three evaluators together, so the three cannot drift apart again. Verified by removing the guard, which fails that test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.