### PR TITLE
Treat a null expected_output as missing in the confusion matrix

### DIFF
--- a/.changeset/confusion-matrix-null-expected.md
+++ b/.changeset/confusion-matrix-null-expected.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Treat a null `expected_output` as missing in `ConfusionMatrixEvaluator` instead of as a class named `"null"`. A case with no expected output added a phantom row and column to the matrix, while a case with a null `output` was dropped, so the same absent value was counted on one axis and ignored on the other.

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -706,6 +706,30 @@ describe('report evaluator edge cases', () => {
     })
   })
 
+  it('ConfusionMatrixEvaluator treats a null expected_output as missing, like a null output', () => {
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [
+        makeReportCase({ expected_output: 'cat', name: 'counted', output: 'cat' }),
+        makeReportCase({ expected_output: null, name: 'null-expected', output: 'dog' }),
+        makeReportCase({ expected_output: 'dog', name: 'null-predicted', output: null }),
+      ],
+      failures: [],
+      name: 'matrix-nulls',
+      report_evaluator_failures: [],
+      span_id: null,
+      trace_id: null,
+    }
+
+    // Both null-sided cases drop out, so neither contributes a phantom "null" class.
+    expect(new ConfusionMatrixEvaluator().evaluate({ cases: report.cases, name: 'matrix-nulls', report })).toEqual({
+      class_labels: ['cat'],
+      matrix: [[1]],
+      title: 'Confusion Matrix',
+      type: 'confusion_matrix',
+    })
+  })
+
   it('threshold helpers support all sources, downsampling and empty AUC', () => {
     const cases = [
       makeReportCase({

--- a/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
@@ -132,7 +132,7 @@ function isReportCase(c: unknown): c is ReportCase {
 function extractLabel(c: ReportCase, opts: ExtractOpts): null | string {
   switch (opts.from) {
     case 'expected_output':
-      return c.expected_output === undefined ? null : safeStringify(c.expected_output)
+      return c.expected_output === undefined || c.expected_output === null ? null : safeStringify(c.expected_output)
     case 'labels': {
       if (opts.key === undefined) {
         throw new Error("'key' is required when from='labels'")


### PR DESCRIPTION
## What is wrong

`extractLabel` drops a case only when `expected_output` is `undefined`:

```ts
case 'expected_output':
  return c.expected_output === undefined ? null : safeStringify(c.expected_output)
```

A `null` therefore reaches `safeStringify`, which returns the string `"null"`, and that becomes a class label. The other branches of the same function disagree:

```ts
case 'metadata':
  if (c.metadata === undefined || c.metadata === null) { return null }
case 'output':
  return c.output === null || c.output === undefined ? null : safeStringify(c.output)
```

So does `extractPositive` in `scoreCommon.ts`, which the threshold evaluators use for the same field:

```ts
return c.expected_output === undefined || c.expected_output === null ? null : Boolean(c.expected_output)
```

`expected_output` is typed `Output`, so `null` is reachable directly, and a hosted dataset case whose JSON carries `"expected_output": null` decodes to it.

## Evidence

Three cases on `817fca1`, one clean, one with a null expected, one with a null output:

```ts
makeReportCase({ expected_output: 'cat', output: 'cat' })
makeReportCase({ expected_output: null,  output: 'dog' })
makeReportCase({ expected_output: 'dog', output: null  })
```

gives

```
class_labels: ['cat', 'dog', 'null']
```

The null-expected case adds a `"null"` row and column. The null-output case is dropped silently. The same absent value is counted on one axis and ignored on the other, and the phantom class shifts every downstream row and column index.

## What this does

Drops the case when `expected_output` is `null`, matching `output`, `metadata`, and `extractPositive`. A matrix cell needs both labels, so an absent value on either axis makes the pair meaningless.

Resolved the asymmetry in this direction rather than by promoting a null `output` to its own class: three of the four extraction paths already treat null as missing, and a `"null"` predicted class would be just as phantom as the expected one.

Verified by restoring the old condition, which fails the new test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.