### PR TITLE
Keep evaluating when the progress callback throws

### DIFF
--- a/.changeset/evaluate-progress-callback.md
+++ b/.changeset/evaluate-progress-callback.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Stop a throwing `progress` callback from discarding an entire `Dataset.evaluate()` run. The callback ran unguarded inside the `Promise.all` over cases, so one throw rejected `evaluate()` and lost the results of every case that had already finished, along with the report evaluators, analyses, averages and the experiment span's closing attributes. Progress reporting is now best effort and logs the failure instead.
+Stop a throwing `progress` callback from discarding an entire `Dataset.evaluate()` run. The callback ran unguarded inside the `Promise.all` over cases, so one throw rejected `evaluate()` and lost the results of every case that had already finished, along with the report evaluators, analyses, averages and the experiment span's closing attributes. An async callback was worse: its rejection escaped as an unhandled rejection, which terminates the process under Node's default. Progress reporting is now best effort for both, and logs the failure instead.

--- a/.changeset/evaluate-progress-callback.md
+++ b/.changeset/evaluate-progress-callback.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop a throwing `progress` callback from discarding an entire `Dataset.evaluate()` run. The callback ran unguarded inside the `Promise.all` over cases, so one throw rejected `evaluate()` and lost the results of every case that had already finished, along with the report evaluators, analyses, averages and the experiment span's closing attributes. Progress reporting is now best effort and logs the failure instead.

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -348,16 +348,35 @@ function isSignalAborted(signal: AbortSignal | undefined): boolean {
 
 function reportProgress(progress: EvaluateOptions['progress'], event: { caseName: string; done: number; total: number }): void {
   if (typeof progress === 'function') {
-    // Progress reporting is best effort. A throwing callback must not discard the
+    // Progress reporting is best effort. A failing callback must not discard the
     // results of cases that already ran, nor skip the report evaluators.
+    // The option is declared as returning void, but an async callback is assignable
+    // to it, so read the result as unknown and subscribe to any rejection. Otherwise
+    // it would surface as an unhandled rejection well after the case completed.
+    const callProgress = progress as (progressEvent: typeof event) => unknown
+    let outcome: unknown
     try {
-      progress(event)
+      outcome = callProgress(event)
     } catch (error) {
-      console.error(`[logfire] evaluate() progress callback threw for case ${event.caseName}:`, error)
+      reportProgressFailure(event, error)
+      return
+    }
+    if (isThenable(outcome)) {
+      outcome.then(undefined, (error: unknown) => {
+        reportProgressFailure(event, error)
+      })
     }
   } else if (progress === true) {
     console.error(`[${event.done.toString()}/${event.total.toString()}] ${event.caseName}`)
   }
+}
+
+function reportProgressFailure(event: { caseName: string }, error: unknown): void {
+  console.error(`[logfire] evaluate() progress callback failed for case ${event.caseName}:`, error)
+}
+
+function isThenable(value: unknown): value is { then: (onFulfilled: undefined, onRejected: (reason: unknown) => void) => unknown } {
+  return typeof value === 'object' && value !== null && 'then' in value && typeof (value as { then: unknown }).then === 'function'
 }
 
 async function runOneCase<Inputs, Output, Metadata>(args: {

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -348,7 +348,13 @@ function isSignalAborted(signal: AbortSignal | undefined): boolean {
 
 function reportProgress(progress: EvaluateOptions['progress'], event: { caseName: string; done: number; total: number }): void {
   if (typeof progress === 'function') {
-    progress(event)
+    // Progress reporting is best effort. A throwing callback must not discard the
+    // results of cases that already ran, nor skip the report evaluators.
+    try {
+      progress(event)
+    } catch (error) {
+      console.error(`[logfire] evaluate() progress callback threw for case ${event.caseName}:`, error)
+    }
   } else if (progress === true) {
     console.error(`[${event.done.toString()}/${event.total.toString()}] ${event.caseName}`)
   }

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -361,8 +361,11 @@ function reportProgress(progress: EvaluateOptions['progress'], event: { caseName
       reportProgressFailure(event, error)
       return
     }
-    if (isThenable(outcome)) {
-      outcome.then(undefined, (error: unknown) => {
+    if (outcome !== undefined && outcome !== null) {
+      // Promise.resolve performs the thenable assimilation, so a throwing `then`
+      // getter or `then()` becomes a rejection here rather than escaping upward.
+      const settled: { catch: (onRejected: (reason: unknown) => void) => unknown } = Promise.resolve(outcome)
+      settled.catch((error: unknown) => {
         reportProgressFailure(event, error)
       })
     }
@@ -373,10 +376,6 @@ function reportProgress(progress: EvaluateOptions['progress'], event: { caseName
 
 function reportProgressFailure(event: { caseName: string }, error: unknown): void {
   console.error(`[logfire] evaluate() progress callback failed for case ${event.caseName}:`, error)
-}
-
-function isThenable(value: unknown): value is { then: (onFulfilled: undefined, onRejected: (reason: unknown) => void) => unknown } {
-  return typeof value === 'object' && value !== null && 'then' in value && typeof (value as { then: unknown }).then === 'function'
 }
 
 async function runOneCase<Inputs, Output, Metadata>(args: {

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -30,8 +30,10 @@ import {
   SPAN_NAME_CASE,
   SPAN_NAME_EVALUATOR_LITERAL,
   SPAN_NAME_EXECUTE,
+  ReportEvaluator,
   SPAN_NAME_EXPERIMENT,
 } from '../../evals'
+import type { ReportEvaluatorContext } from '../../evals'
 import { withMemoryExporter } from './withMemoryExporter'
 
 const sleep = async (ms: number): Promise<void> =>
@@ -339,6 +341,49 @@ describe('offline evals — span attribute parity', () => {
     expect(messages).toHaveLength(2)
     expect(messages.every((message) => /^\[\d\/2\] (?:one|two)$/u.test(message))).toBe(true)
     expect(messages.map((message) => message.replace(/^\[\d\/2\] /u, '')).sort()).toEqual(['one', 'two'])
+  })
+
+  it('keeps evaluating when the progress callback throws', async () => {
+    class CountCases extends ReportEvaluator {
+      static override evaluatorName = 'CountCases'
+      evaluate(ctx: ReportEvaluatorContext) {
+        return { title: 'cases', type: 'scalar' as const, value: ctx.report.cases.length }
+      }
+    }
+    const dataset = new Dataset<string, string>({
+      cases: [
+        new Case<string, string>({ expectedOutput: 'A', inputs: 'a', name: 'one' }),
+        new Case<string, string>({ expectedOutput: 'B', inputs: 'b', name: 'two' }),
+      ],
+      evaluators: [new EqualsExpected()],
+      name: 'progress-throws',
+      reportEvaluators: [new CountCases()],
+    })
+
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const result = await (async () => {
+      try {
+        const { result: report } = await withMemoryExporter(async () =>
+          dataset.evaluate((s) => s.toUpperCase(), {
+            progress: () => {
+              throw new Error('progress boom')
+            },
+          })
+        )
+        return { messages: error.mock.calls.map((call) => String(call[0])), report }
+      } finally {
+        error.mockRestore()
+      }
+    })()
+
+    // Every case still completes, and the report evaluators still run.
+    expect([...result.report.cases].map((c) => c.name).sort()).toEqual(['one', 'two'])
+    expect(result.report.failures).toEqual([])
+    expect(result.report.analyses).toEqual([{ title: 'cases', type: 'scalar', value: 2 }])
+    expect(result.messages.sort()).toEqual([
+      '[logfire] evaluate() progress callback threw for case one:',
+      '[logfire] evaluate() progress callback threw for case two:',
+    ])
   })
 
   it('records non-Error task failures without rejecting the experiment', async () => {

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -417,6 +417,18 @@ describe('offline evals — span attribute parity', () => {
         },
       }),
     ],
+    [
+      // A function with a callable then is a thenable too, which a typeof 'object' guard misses.
+      'a callable thenable whose then throws',
+      () => {
+        const callable = (): void => undefined
+        return Object.assign(callable, {
+          then() {
+            throw new Error('callable then boom')
+          },
+        })
+      },
+    ],
   ]
 
   it.each(hostileProgressCallbacks)('keeps evaluating when the progress callback returns %s', async (_label, makeOutcome) => {

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -381,9 +381,50 @@ describe('offline evals — span attribute parity', () => {
     expect(result.report.failures).toEqual([])
     expect(result.report.analyses).toEqual([{ title: 'cases', type: 'scalar', value: 2 }])
     expect(result.messages.sort()).toEqual([
-      '[logfire] evaluate() progress callback threw for case one:',
-      '[logfire] evaluate() progress callback threw for case two:',
+      '[logfire] evaluate() progress callback failed for case one:',
+      '[logfire] evaluate() progress callback failed for case two:',
     ])
+  })
+
+  it('keeps evaluating when an async progress callback rejects', async () => {
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ expectedOutput: 'A', inputs: 'a', name: 'one' })],
+      evaluators: [new EqualsExpected()],
+      name: 'progress-rejects',
+    })
+
+    // The option returns void, but an async callback is assignable to it in
+    // TypeScript, which is how a consumer reaches this. The cast reproduces that
+    // without tripping the lint rules this repo applies to its own call sites.
+    const rejectingProgress = (async () => {
+      await Promise.resolve()
+      throw new Error('async progress boom')
+    }) as unknown as (event: { caseName: string; done: number; total: number }) => void
+
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', onUnhandled)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const result = await (async () => {
+      try {
+        const { result: report } = await withMemoryExporter(async () =>
+          dataset.evaluate((s) => s.toUpperCase(), {
+            progress: rejectingProgress,
+          })
+        )
+        await sleep(20)
+        return { messages: error.mock.calls.map((call) => String(call[0])), report }
+      } finally {
+        error.mockRestore()
+        process.off('unhandledRejection', onUnhandled)
+      }
+    })()
+
+    expect(unhandled).toEqual([])
+    expect(result.report.cases.map((c) => c.name)).toEqual(['one'])
+    expect(result.messages).toEqual(['[logfire] evaluate() progress callback failed for case one:'])
   })
 
   it('records non-Error task failures without rejecting the experiment', async () => {

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -386,35 +386,68 @@ describe('offline evals — span attribute parity', () => {
     ])
   })
 
-  it('keeps evaluating when an async progress callback rejects', async () => {
+  // The option returns void, but these are all assignable to it in TypeScript, which
+  // is how a consumer reaches them. The casts reproduce that without tripping the lint
+  // rules this repo applies to its own call sites.
+  const asProgress = (fn: () => unknown): ((event: { caseName: string; done: number; total: number }) => void) =>
+    fn as unknown as (event: { caseName: string; done: number; total: number }) => void
+
+  const hostileProgressCallbacks: [string, () => unknown][] = [
+    [
+      'a rejecting async callback',
+      async () => {
+        await Promise.resolve()
+        throw new Error('async progress boom')
+      },
+    ],
+    [
+      'a thenable whose then getter throws',
+      () =>
+        Object.defineProperty({}, 'then', {
+          get() {
+            throw new Error('then getter boom')
+          },
+        }),
+    ],
+    [
+      'a thenable whose then throws',
+      () => ({
+        then() {
+          throw new Error('then boom')
+        },
+      }),
+    ],
+  ]
+
+  it.each(hostileProgressCallbacks)('keeps evaluating when the progress callback returns %s', async (_label, makeOutcome) => {
     const dataset = new Dataset<string, string>({
       cases: [new Case<string, string>({ expectedOutput: 'A', inputs: 'a', name: 'one' })],
       evaluators: [new EqualsExpected()],
-      name: 'progress-rejects',
+      name: 'progress-hostile',
     })
-
-    // The option returns void, but an async callback is assignable to it in
-    // TypeScript, which is how a consumer reaches this. The cast reproduces that
-    // without tripping the lint rules this repo applies to its own call sites.
-    const rejectingProgress = (async () => {
-      await Promise.resolve()
-      throw new Error('async progress boom')
-    }) as unknown as (event: { caseName: string; done: number; total: number }) => void
 
     const unhandled: unknown[] = []
     const onUnhandled = (reason: unknown): void => {
       unhandled.push(reason)
     }
     process.on('unhandledRejection', onUnhandled)
-    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    // Await the logged failure rather than a fixed delay, so the assertions do not
+    // depend on scheduler timing.
+    let signalLogged: () => void = () => undefined
+    const logged = new Promise<void>((resolve) => {
+      signalLogged = resolve
+    })
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {
+      signalLogged()
+    })
+
     const result = await (async () => {
       try {
         const { result: report } = await withMemoryExporter(async () =>
-          dataset.evaluate((s) => s.toUpperCase(), {
-            progress: rejectingProgress,
-          })
+          dataset.evaluate((s) => s.toUpperCase(), { progress: asProgress(makeOutcome) })
         )
-        await sleep(20)
+        await logged
         return { messages: error.mock.calls.map((call) => String(call[0])), report }
       } finally {
         error.mockRestore()


### PR DESCRIPTION
## What is wrong

`reportProgress` calls the user-supplied callback with no guard:

```ts
function reportProgress(progress: EvaluateOptions['progress'], event: {...}): void {
  if (typeof progress === 'function') {
    progress(event)
  } else if (progress === true) {
```

It runs inside `runOne`, which runs inside `await Promise.all(expandedCases.map(runOne))`. So a throw from the callback rejects that promise, and `evaluate()` rejects with it.

Everything after the `Promise.all` is skipped: the report evaluators, `analyses`, `computeAverages`, the assertion pass rate, and `setEvalsSpanAttributes` on the experiment span. The `cases` and `failures` already collected are discarded with the rejection.

## Evidence

Two cases, a task that succeeds for both, and a progress callback that throws, on `817fca1`:

```ts
await dataset.evaluate((s) => s.toUpperCase(), {
  progress: () => { throw new Error('progress boom') },
})
```

rejects with `Error: progress boom`. Both cases had already completed successfully and their results are lost, as is the whole report.

The blast radius is the point: the callback is a reporting hook, but it takes down work that already succeeded, and the further into a long run it throws the more is thrown away.

## What this does

Catches and logs, leaving the run intact. The report evaluator loop a few lines below already isolates failures this way rather than letting one evaluator abort the experiment.

Logged via `console.error` to match the built-in `progress: true` branch in the same function. `logfire-api` does not use `diag` anywhere, so reaching for it here would introduce a reporting channel this package does not otherwise have.

Kept the failure out of the returned report. `report_evaluator_failures` is a record of evaluation results, and a progress hook produces none, so adding it there would widen a published shape for a caller-side bug.

The test asserts the run survives: both cases present, no failures, report evaluator analyses still produced, and one logged message per case. Verified by removing the guard, which fails that test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.