### PR TITLE
Keep result map entries when the map has a value key

### DIFF
--- a/.changeset/evaluator-result-map-value-key.md
+++ b/.changeset/evaluator-result-map-value-key.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Keep every entry of an evaluator result map that happens to contain a `value` key. A map such as `{ value: 0.8, confidence: 0.9 }` was read as a single `EvaluationReason`, so it produced one result named after the evaluator and the sibling keys were dropped without warning. A result map and an `EvaluationReason` are now told apart by their keys, since `EvaluationReason` declares only `value` and optional `reason`.
+Keep every entry of an evaluator result map that happens to contain a `value` key. A map such as `{ value: 0.8, confidence: 0.9 }` was read as a single `EvaluationReason`, so it produced one result named after the evaluator and the sibling keys were dropped without warning. A result map and an `EvaluationReason` are now told apart by shape rather than by key names alone: a lone `EvaluationReason` must carry only `value` and `reason`, with a scalar `value` and a string or absent `reason`. Key names by themselves were not enough, because `{ value: 0.8, reason: 0.9 }` is a legal map of scores.

--- a/.changeset/evaluator-result-map-value-key.md
+++ b/.changeset/evaluator-result-map-value-key.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep every entry of an evaluator result map that happens to contain a `value` key. A map such as `{ value: 0.8, confidence: 0.9 }` was read as a single `EvaluationReason`, so it produced one result named after the evaluator and the sibling keys were dropped without warning. A result map and an `EvaluationReason` are now told apart by their keys, since `EvaluationReason` declares only `value` and optional `reason`.

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -198,6 +198,12 @@ describe('offline evals — span attribute parity', () => {
         return { confidence: 0.9, value: 0.8 }
       }
     }
+    class NumericReasonKey extends Evaluator {
+      static override evaluatorName = 'NumericReasonKey'
+      evaluate(): Record<string, number> {
+        return { reason: 0.9, value: 0.8 }
+      }
+    }
     class ReasonEvaluator extends Evaluator {
       static override evaluatorName = 'ReasonEvaluator'
       evaluate(): { reason: string; value: number } {
@@ -207,7 +213,7 @@ describe('offline evals — span attribute parity', () => {
 
     const dataset = new Dataset<string, string>({
       cases: [new Case<string, string>({ inputs: 'x', name: 'case' })],
-      evaluators: [new MapWithValueKey(), new ReasonEvaluator()],
+      evaluators: [new MapWithValueKey(), new NumericReasonKey(), new ReasonEvaluator()],
       name: 'result-map-shapes',
     })
 
@@ -215,11 +221,17 @@ describe('offline evals — span attribute parity', () => {
     const scores = result.cases[0]!.scores
 
     // Extra keys mean it is a map, so every entry survives under its own name.
-    expect(Object.keys(scores).sort()).toEqual(['ReasonEvaluator', 'confidence', 'value'])
+    expect(Object.keys(scores).sort()).toEqual(['ReasonEvaluator', 'confidence', 'reason', 'value', 'value_2'])
     expect(scores['value']?.value).toBe(0.8)
     expect(scores['confidence']?.value).toBe(0.9)
 
-    // Only value and reason means it is a reason, so it stays one result named for the evaluator.
+    // Keys value and reason alone are not enough: a numeric reason is a score, not a reason,
+    // so this is a map too and neither entry is lost or written to the string reason field.
+    expect(scores['reason']?.value).toBe(0.9)
+    expect(scores['value_2']?.value).toBe(0.8)
+    expect(scores['reason']?.reason).toBe(null)
+
+    // A scalar value with a string reason is a reason, so it stays one result named for the evaluator.
     expect(scores['ReasonEvaluator']?.value).toBe(0.5)
     expect(scores['ReasonEvaluator']?.reason).toBe('looks right')
   })

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -191,6 +191,39 @@ describe('offline evals — span attribute parity', () => {
     expect(result.cases[0]?.assertions['duplicate_2']?.value).toBe(false)
   })
 
+  it('treats a result map containing a value key as a map, not as a single reason', async () => {
+    class MapWithValueKey extends Evaluator {
+      static override evaluatorName = 'MapWithValueKey'
+      evaluate(): Record<string, number> {
+        return { confidence: 0.9, value: 0.8 }
+      }
+    }
+    class ReasonEvaluator extends Evaluator {
+      static override evaluatorName = 'ReasonEvaluator'
+      evaluate(): { reason: string; value: number } {
+        return { reason: 'looks right', value: 0.5 }
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'case' })],
+      evaluators: [new MapWithValueKey(), new ReasonEvaluator()],
+      name: 'result-map-shapes',
+    })
+
+    const { result } = await withMemoryExporter(async () => dataset.evaluate((input) => input))
+    const scores = result.cases[0]!.scores
+
+    // Extra keys mean it is a map, so every entry survives under its own name.
+    expect(Object.keys(scores).sort()).toEqual(['ReasonEvaluator', 'confidence', 'value'])
+    expect(scores['value']?.value).toBe(0.8)
+    expect(scores['confidence']?.value).toBe(0.9)
+
+    // Only value and reason means it is a reason, so it stays one result named for the evaluator.
+    expect(scores['ReasonEvaluator']?.value).toBe(0.5)
+    expect(scores['ReasonEvaluator']?.reason).toBe('looks right')
+  })
+
   it('runs evaluators for a case concurrently', async () => {
     let fastStarted = false
     class SlowEvaluator extends Evaluator {

--- a/packages/logfire-api/src/evals/evaluatorResults.ts
+++ b/packages/logfire-api/src/evals/evaluatorResults.ts
@@ -12,6 +12,15 @@ export function evaluationResultsFromOutput(
   return Object.entries(raw).map(([name, value]) => buildEvaluationResultJson(name, value, source, evaluatorVersion))
 }
 
+/**
+ * A result map and an `EvaluationReason` are both plain objects, so they can only be
+ * told apart by their keys. `EvaluationReason` declares exactly `value` and optional
+ * `reason`, so anything carrying other keys is a result map.
+ */
+function isSoleEvaluationReason(value: unknown): value is EvaluationReason {
+  return isEvaluationReason(value) && Object.keys(value).every((key) => key === 'reason' || key === 'value')
+}
+
 export function buildEvaluationResultJson(
   name: string,
   value: boolean | EvaluationReason | number | string,
@@ -59,5 +68,5 @@ export function isEvaluationReason(value: unknown): value is EvaluationReason {
 }
 
 function isEvaluationScalar(value: EvaluatorOutput): value is boolean | EvaluationReason | number | string {
-  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string' || isEvaluationReason(value)
+  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string' || isSoleEvaluationReason(value)
 }

--- a/packages/logfire-api/src/evals/evaluatorResults.ts
+++ b/packages/logfire-api/src/evals/evaluatorResults.ts
@@ -14,11 +14,21 @@ export function evaluationResultsFromOutput(
 
 /**
  * A result map and an `EvaluationReason` are both plain objects, so they can only be
- * told apart by their keys. `EvaluationReason` declares exactly `value` and optional
- * `reason`, so anything carrying other keys is a result map.
+ * told apart by their shape. `EvaluationReason` declares exactly a scalar `value` and
+ * an optional string `reason`, so anything else is a result map. Key names alone are
+ * not enough: `{ value: 0.8, reason: 0.9 }` is a legal map of scores.
  */
 function isSoleEvaluationReason(value: unknown): value is EvaluationReason {
-  return isEvaluationReason(value) && Object.keys(value).every((key) => key === 'reason' || key === 'value')
+  if (!isEvaluationReason(value)) {
+    return false
+  }
+  return Object.entries(value).every(
+    ([key, entry]) => (key === 'value' && isScalar(entry)) || (key === 'reason' && (typeof entry === 'string' || entry === undefined))
+  )
+}
+
+function isScalar(value: unknown): value is boolean | number | string {
+  return typeof value === 'boolean' || typeof value === 'number' || typeof value === 'string'
 }
 
 export function buildEvaluationResultJson(


### PR DESCRIPTION
## What is wrong

`EvaluatorOutput` allows either a scalar, an `EvaluationReason`, or a result map:

```ts
export type EvaluatorOutput = boolean | EvaluationReason | number | Record<string, boolean | EvaluationReason | number | string> | string
export interface EvaluationReason { reason?: string; value: boolean | number | string }
```

Both of the object forms are plain objects, so `evaluationResultsFromOutput` has to tell them apart at runtime. It does so by testing for a `value` key alone:

```ts
export function isEvaluationReason(value: unknown): value is EvaluationReason {
  return typeof value === 'object' && value !== null && 'value' in value && !Array.isArray(value)
}
```

A result map whose keys include `value` matches that test, so it is read as a single `EvaluationReason` and every sibling key is discarded.

## Evidence

An evaluator returning a legal `Record<string, number>` on `817fca1`:

```ts
evaluate(): Record<string, number> {
  return { confidence: 0.9, value: 0.8 }
}
```

produces

```
scores: { MapWithValueKey: { name: 'MapWithValueKey', value: 0.8, reason: null } }
```

One score instead of two. `confidence` is gone, with no failure recorded and nothing on the span, so the case reads as fully evaluated. `value` is an ordinary name for a metric, which is what makes this reachable rather than theoretical.

## What this does

Discriminates on the key set instead of on a single key. `EvaluationReason` declares exactly `value` and optional `reason`, so an object carrying any other key is a result map:

```ts
function isSoleEvaluationReason(value: unknown): value is EvaluationReason {
  return isEvaluationReason(value) && Object.keys(value).every((key) => key === 'reason' || key === 'value')
}
```

Applied only to the top-level discrimination. The exported `isEvaluationReason` and the per-entry coercion in `buildEvaluationResultJson` are unchanged on purpose: tightening there would make an entry like `{ value: 1, extra: 2 }` fall through with the whole object in the `value` field, which the platform strict-parses, so it trades a dropped key for an invalid wire shape.

`{ value, reason }` and `{ value }` still resolve to a single result, and a map whose entries are reasons, such as `{ judge_score: { reason, value } }`, is unaffected. The test covers both branches. Verified by restoring the old check, which fails it and nothing else.

---
Built this with Claude Code's help and reviewed the diff myself.