### PR TITLE
Honour LOGFIRE_SEND_TO_LOGFIRE=false

### DIFF
--- a/.changeset/send-to-logfire-env-false.md
+++ b/.changeset/send-to-logfire-env-false.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Honour `LOGFIRE_SEND_TO_LOGFIRE=false`. The environment variable arrives as a string and was passed to `Boolean()`, and `Boolean('false')` is `true`, so the documented way to turn sending off left it on. Setting `sendToLogfire: false` in code was unaffected. The `true` and `false` strings are now read explicitly, case-insensitively and trimmed.
+Honour `LOGFIRE_SEND_TO_LOGFIRE=false`. The environment variable arrives as a string and was passed to `Boolean()`, and `Boolean('false')` is `true`, so the documented way to turn sending off left it on. Setting `sendToLogfire: false` in code was unaffected. `true`, `false` and `if-token-present` are now normalized once and matched explicitly, case-insensitively and trimmed, so a differently cased sentinel no longer falls through to truthiness either.

--- a/.changeset/send-to-logfire-env-false.md
+++ b/.changeset/send-to-logfire-env-false.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Honour `LOGFIRE_SEND_TO_LOGFIRE=false`. The environment variable arrives as a string and was passed to `Boolean()`, and `Boolean('false')` is `true`, so the documented way to turn sending off left it on. Setting `sendToLogfire: false` in code was unaffected. The `true` and `false` strings are now read explicitly, case-insensitively and trimmed.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -18,7 +18,7 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 | `LOGFIRE_ENVIRONMENT`         | Deployment environment resource metadata.                                |
 | `LOGFIRE_CONSOLE`             | Set to `true` to also print spans to the console. Boolean-only.          |
 | `LOGFIRE_MIN_LEVEL`           | Minimum manual Logfire level to emit.                                    |
-| `LOGFIRE_SEND_TO_LOGFIRE`     | Set sending behavior. `if-token-present` sends only when a token exists. |
+| `LOGFIRE_SEND_TO_LOGFIRE`     | Set sending behavior. `true`, `false`, or `if-token-present`.            |
 | `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
 | `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`.                                      |
 | `LOGFIRE_BASE_URL`            | Override the Logfire API base URL.                                       |
@@ -32,6 +32,12 @@ For service metadata, precedence is code configuration, then `LOGFIRE_*`, then
 `LOGFIRE_MIN_LEVEL` accepts `trace`, `debug`, `info`, `notice`, `warning`,
 `error`, or `fatal`. Values are matched case-insensitively. Numeric strings are
 not accepted. Invalid values warn with `console.warn` and are ignored.
+
+`LOGFIRE_SEND_TO_LOGFIRE` accepts `true`, `false`, or `if-token-present`, which
+sends only when a token is present and is the default. Values are matched
+case-insensitively and surrounding whitespace is ignored. The Python SDK
+spellings `1`, `0`, `t`, and `f` are not recognised here, and any other value
+enables sending.
 
 `LOGFIRE_CONSOLE=true` enables Node console output with the default console
 minimum level of `info`. Object-style console options such as

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -34,10 +34,10 @@ For service metadata, precedence is code configuration, then `LOGFIRE_*`, then
 not accepted. Invalid values warn with `console.warn` and are ignored.
 
 `LOGFIRE_SEND_TO_LOGFIRE` accepts `true`, `false`, or `if-token-present`, which
-sends only when a token is present and is the default. Values are matched
+sends only when a token is present and is the default. All three are matched
 case-insensitively and surrounding whitespace is ignored. The Python SDK
-spellings `1`, `0`, `t`, and `f` are not recognised here, and any other value
-enables sending.
+spellings `1`, `0`, `t`, and `f` are not recognised here: an empty or blank
+value disables sending, and any other unrecognised value enables it.
 
 `LOGFIRE_CONSOLE=true` enables Node console output with the default console
 minimum level of `info`. Object-style console options such as

--- a/packages/logfire-api/src/logfireApiConfig.test.ts
+++ b/packages/logfire-api/src/logfireApiConfig.test.ts
@@ -48,6 +48,16 @@ test('reads LOGFIRE_SEND_TO_LOGFIRE=false as disabled', () => {
   expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'if-token-present' }, undefined, token)).toBe(true)
   expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'if-token-present' }, undefined, undefined)).toBe(false)
 
+  // The sentinel is normalized the same way, so a differently cased or padded
+  // spelling still requires a token rather than falling through to truthiness.
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'IF-TOKEN-PRESENT' }, undefined, undefined)).toBe(false)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: ' if-token-present ' }, undefined, undefined)).toBe(false)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'IF-TOKEN-PRESENT' }, undefined, token)).toBe(true)
+
+  // An empty or blank value is not a documented spelling and disables sending.
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: '' }, undefined, token)).toBe(false)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: '   ' }, undefined, token)).toBe(false)
+
   // An explicit option still wins over the environment.
   expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'false' }, true, token)).toBe(true)
   expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'true' }, false, token)).toBe(false)

--- a/packages/logfire-api/src/logfireApiConfig.test.ts
+++ b/packages/logfire-api/src/logfireApiConfig.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vite-plus/test'
 
-import { resolveBaseUrl } from './logfireApiConfig'
+import { resolveBaseUrl, resolveSendToLogfire } from './logfireApiConfig'
 
 test('returns the passed url', () => {
   const baseUrl = resolveBaseUrl({}, 'https://example.com', 'token')
@@ -34,4 +34,21 @@ test('resolves the base url from API keys with organization IDs', () => {
 test('resolves staging base urls from the token', () => {
   expect(resolveBaseUrl({}, undefined, 'pylf_v1_stagingus_1234567890')).toBe('https://logfire-us.pydantic.info')
   expect(resolveBaseUrl({}, undefined, 'pylf_v1_stagingeu_1234567890')).toBe('https://logfire-eu.pydantic.info')
+})
+
+test('reads LOGFIRE_SEND_TO_LOGFIRE=false as disabled', () => {
+  const token = 'pylf_v1_us_1234567890'
+
+  // The env var is a string, so plain truthiness would keep sending on 'false'.
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'false' }, undefined, token)).toBe(false)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'FALSE' }, undefined, token)).toBe(false)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: ' false ' }, undefined, token)).toBe(false)
+
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'true' }, undefined, undefined)).toBe(true)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'if-token-present' }, undefined, token)).toBe(true)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'if-token-present' }, undefined, undefined)).toBe(false)
+
+  // An explicit option still wins over the environment.
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'false' }, true, token)).toBe(true)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'true' }, false, token)).toBe(false)
 })

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -151,6 +151,17 @@ export function resolveSendToLogfire(env: Env, option: SendToLogfire, token: str
       return false
     }
   } else {
+    // The env var arrives as a string, and `Boolean('false')` is true, so the
+    // documented values have to be read before falling back to truthiness.
+    if (typeof sendToLogfireConfig === 'string') {
+      const normalized = sendToLogfireConfig.trim().toLowerCase()
+      if (normalized === 'false') {
+        return false
+      }
+      if (normalized === 'true') {
+        return true
+      }
+    }
     return Boolean(sendToLogfireConfig)
   }
 }

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -142,28 +142,22 @@ function resolveScrubber(scrubbing: LogfireApiConfigOptions['scrubbing']) {
 }
 
 export function resolveSendToLogfire(env: Env, option: SendToLogfire, token: string | undefined): boolean {
-  const sendToLogfireConfig = option ?? env['LOGFIRE_SEND_TO_LOGFIRE'] ?? 'if-token-present'
+  const configured = option ?? env['LOGFIRE_SEND_TO_LOGFIRE'] ?? 'if-token-present'
+  // The env var arrives as a string, so normalize once before matching: every
+  // documented value has to be recognised the same way, and `Boolean('false')`
+  // is true, so truthiness alone cannot be the only test.
+  const sendToLogfireConfig = typeof configured === 'string' ? configured.trim().toLowerCase() : configured
 
   if (sendToLogfireConfig === 'if-token-present') {
-    if (token !== undefined && token !== '') {
-      return true
-    } else {
-      return false
-    }
-  } else {
-    // The env var arrives as a string, and `Boolean('false')` is true, so the
-    // documented values have to be read before falling back to truthiness.
-    if (typeof sendToLogfireConfig === 'string') {
-      const normalized = sendToLogfireConfig.trim().toLowerCase()
-      if (normalized === 'false') {
-        return false
-      }
-      if (normalized === 'true') {
-        return true
-      }
-    }
-    return Boolean(sendToLogfireConfig)
+    return token !== undefined && token !== ''
   }
+  if (sendToLogfireConfig === 'false') {
+    return false
+  }
+  if (sendToLogfireConfig === 'true') {
+    return true
+  }
+  return Boolean(sendToLogfireConfig)
 }
 
 export function resolveBaseUrl(env: Env, passedUrl: string | undefined, token: string): string {


### PR DESCRIPTION
## What is wrong

`resolveSendToLogfire` handles `'if-token-present'` and then falls through to truthiness:

```ts
const sendToLogfireConfig = option ?? env['LOGFIRE_SEND_TO_LOGFIRE'] ?? 'if-token-present'

if (sendToLogfireConfig === 'if-token-present') {
  ...
} else {
  return Boolean(sendToLogfireConfig)
}
```

An environment variable is always a string, and `Boolean('false')` is `true`. `SendToLogfire` is `'if-token-present' | boolean | undefined`, so `false` is a documented value, and `docs/reference/environment-variables.md` lists the variable as setting sending behaviour.

## Evidence

On `817fca1`, with a token present:

| input | result |
|---|---|
| `LOGFIRE_SEND_TO_LOGFIRE=false` | **true** |
| `LOGFIRE_SEND_TO_LOGFIRE=true` | true |
| `sendToLogfire: false` in code | false |

So the environment opt-out never takes effect and it fails open, continuing to send. The code path works because that `false` reaches `Boolean()` as a real boolean rather than a string, which is why the two disagree.

The existing tests only ever pass `sendToLogfire: false` through `configure()`, so the string form was never exercised.

## What this does

Reads the documented `'true'` and `'false'` strings explicitly before the truthiness fallback, trimmed and case-insensitive.

Scoped deliberately to those two. Other strings such as `'0'` and `'no'` still resolve to `true` exactly as they do today: they are not in the type, and widening the accepted set is a parity question against the Python SDK rather than a bug fix. Happy to broaden it in this PR if you would rather match Python's set.

`'if-token-present'` and the code path are untouched, and the test covers both those and the precedence of an explicit option over the environment. Verified by removing the string handling, which fails that test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.