### PR TITLE
Unref the SSE reconnect backoff timer

### DIFF
--- a/.changeset/sse-backoff-timer-unref.md
+++ b/.changeset/sse-backoff-timer-unref.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop a pending SSE reconnect backoff from holding a Node process open. The remote variable provider unrefs its polling and debounce timers, but the reconnect backoff used a plain `setTimeout`. That backoff doubles up to a minute while the stream is unreachable, so after `shutdown()` the process could stay alive until it elapsed.

--- a/packages/logfire-api/src/vars/index.ts
+++ b/packages/logfire-api/src/vars/index.ts
@@ -3046,7 +3046,13 @@ function ignoreBackgroundError(): void {
 
 async function delay(ms: number): Promise<void> {
   await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms)
+    const timer = setTimeout(resolve, ms)
+    // Match the polling and debounce timers: the reconnect backoff grows to a
+    // minute, and a pending one must not hold a Node process open after shutdown.
+    const maybeTimer = timer as { unref?: () => void }
+    if (typeof maybeTimer.unref === 'function') {
+      maybeTimer.unref()
+    }
   })
 }
 

--- a/packages/logfire-api/src/vars/remote.test.ts
+++ b/packages/logfire-api/src/vars/remote.test.ts
@@ -494,4 +494,39 @@ describe('LogfireRemoteVariableProvider -- SSE and polling reliability', () => {
 
     provider.shutdown()
   })
+
+  // -------------------------------------------------------------------------
+  // Reconnect backoff must not hold the process open
+  // -------------------------------------------------------------------------
+  it('unrefs the SSE reconnect backoff timer', async () => {
+    vi.useRealTimers()
+    const handles: { unref: ReturnType<typeof vi.fn<() => void>> }[] = []
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((_fn: never, _ms: never) => {
+      const handle = { unref: vi.fn<() => void>() }
+      handles.push(handle)
+      return handle as never
+    }) as never)
+
+    const provider = new LogfireRemoteVariableProvider({
+      apiKey: 'test-key',
+      baseUrl: 'https://example.com',
+      fetch: vi.fn<typeof fetch>(async () => {
+        await Promise.resolve()
+        throw new Error('sse unavailable')
+      }),
+      polling: false,
+      sse: true,
+    })
+
+    provider.start()
+    // Let the failed connection reach the backoff, which is the only timer here
+    // because polling is disabled.
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    provider.shutdown()
+
+    expect(handles).toHaveLength(1)
+    expect(handles[0]?.unref.mock.calls.length).toBe(1)
+  })
 })


### PR DESCRIPTION
## What is wrong

`LogfireRemoteVariableProvider` unrefs every background timer it creates, except one. The polling timer:

```ts
const maybeTimer = this.pollingTimer as { unref?: () => void }
if (typeof maybeTimer.unref === 'function') {
  maybeTimer.unref()
}
```

and the debounce timer does the same. The SSE reconnect backoff does not:

```ts
async function delay(ms: number): Promise<void> {
  await new Promise<void>((resolve) => {
    setTimeout(resolve, ms)
  })
}
```

`delay` has exactly two callers, both the reconnect backoff in `runSseLoop`, and that backoff doubles up to 60s while the stream is unreachable. `shutdown()` is synchronous and does not await the loop, so it cannot cancel a delay that is already pending.

## Evidence

With polling disabled so the backoff is the only timer, on `4145e0e`, stubbing `setTimeout` to record handles and calling `start()` with a failing SSE endpoint:

```
timers created: 1
unref calls:    0
```

The loop itself exits correctly on the next `while (!this.shutdownRequested)` check, so this is not a leaked loop. It is a leaked timer: a Node process that has called `shutdown()` can stay alive until the backoff elapses, up to a minute, and the worse the endpoint is behaving the longer the wait.

## What this does

Applies the same guarded unref the other two timers already use, inside `delay`. The `typeof` guard keeps it a no-op where `unref` does not exist, which matters because this file is in the runtime-agnostic package.

Left the backoff itself uncancellable rather than threading an abort signal through `delay`. The loop already exits on its own and nothing waits for it, so the only observable problem was the process hold, and an abort signal would be a larger change for no additional user-visible gain. Happy to do that instead if you would rather `shutdown()` tear the loop down promptly.

Verified by removing the unref, which fails the new test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.