### PR TITLE
Export every trace payload in a tail batch

### DIFF
--- a/.changeset/tail-export-all-trace-entries.md
+++ b/.changeset/tail-export-all-trace-entries.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-cf-workers': patch
+---
+
+Export every trace payload in a tail batch. `exportTailEventsToLogfire` stopped at the first entry carrying `resourceSpans`, so a tail worker receiving a batch of producing invocations forwarded only one of them and dropped the rest with no warning. The payloads are now merged into a single OTLP request, which takes `resourceSpans` as a repeated field.

--- a/packages/logfire-cf-workers/src/exportTailEventsToLogfire.ts
+++ b/packages/logfire-cf-workers/src/exportTailEventsToLogfire.ts
@@ -18,14 +18,20 @@ export async function exportTailEventsToLogfire(
     return undefined
   }
   const url = resolveBaseUrl(env, undefined, token)
-  const traceEntry = findTraceEntry(events)
-  if (traceEntry === null) {
+  const traceEntries = findTraceEntries(events)
+  if (traceEntries.length === 0) {
     return undefined
   }
+  // A tail batch carries one payload per producing invocation, and OTLP takes
+  // resourceSpans as a repeated field, so merge them into a single request.
+  const resourceSpans = traceEntries.flatMap((entry) => {
+    const spans = entry['resourceSpans']
+    return Array.isArray(spans) ? (spans as unknown[]) : []
+  })
 
   try {
     return await fetch(`${url}/v1/traces`, {
-      body: JSON.stringify(traceEntry),
+      body: JSON.stringify({ resourceSpans }),
       headers: {
         Authorization: token,
         'Content-Type': 'application/json',
@@ -39,19 +45,20 @@ export async function exportTailEventsToLogfire(
   }
 }
 
-function findTraceEntry(events: TraceItem[]): Record<string, unknown> | null {
+function findTraceEntries(events: TraceItem[]): Record<string, unknown>[] {
+  const entries: Record<string, unknown>[] = []
   for (const event of events) {
     for (const log of event.logs) {
       if (Array.isArray(log.message)) {
         for (const entry of log.message) {
           if (isTraceEntry(entry)) {
-            return entry
+            entries.push(entry)
           }
         }
       }
     }
   }
-  return null
+  return entries
 }
 
 function isTraceEntry(entry: unknown): entry is Record<string, unknown> {

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -111,4 +111,23 @@ describe('User-Agent', () => {
       method: 'POST',
     })
   })
+
+  it('exportTailEventsToLogfire exports every trace entry in the batch', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    vi.resetModules()
+    const { exportTailEventsToLogfire } = await import('./exportTailEventsToLogfire')
+
+    // A tail batch carries one payload per producing invocation, and a single
+    // invocation can flush more than once.
+    const events = [
+      { logs: [{ message: [{ resourceSpans: ['first'] }] }, { message: [{ resourceSpans: ['second'] }] }] },
+      { logs: [{ message: [{ resourceSpans: ['third'] }] }] },
+    ]
+    await exportTailEventsToLogfire(events, { LOGFIRE_TOKEN: 'test-token' })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(fetchMock.mock.lastCall?.[1]?.body).toBe(JSON.stringify({ resourceSpans: ['first', 'second', 'third'] }))
+  })
 })


### PR DESCRIPTION
## What is wrong

`exportTailEventsToLogfire` stops at the first payload it finds:

```ts
function findTraceEntry(events: TraceItem[]): Record<string, unknown> | null {
  for (const event of events) {
    for (const log of event.logs) {
      if (Array.isArray(log.message)) {
        for (const entry of log.message) {
          if (isTraceEntry(entry)) {
            return entry
          }
        }
      }
    }
  }
  return null
}
```

Its input is a batch. A tail worker is handed one `TraceItem` per producing invocation, and `TailWorkerExporter` emits a payload per flush:

```ts
const exportMessage = this.cleanNullValues(response)
console.log(exportMessage)
```

So a batch normally carries several payloads, and every one after the first is discarded. Nothing warns and nothing fails: the export returns a 200 for the payload it did send, so the loss is invisible from both ends.

## Evidence

Three payloads across two batched invocations, one of which flushed twice, on `79bcac0`:

```ts
const events = [
  { logs: [{ message: [{ resourceSpans: ['first'] }] }, { message: [{ resourceSpans: ['second'] }] }] },
  { logs: [{ message: [{ resourceSpans: ['third'] }] }] },
]
```

posts `{"resourceSpans":["first"]}`. Two of the three traces never leave the worker. The proportion lost scales with how busy the producing worker is, so it is worst exactly when the traces matter most.

## What this does

Collects every entry and merges their `resourceSpans` into one request. OTLP already models `resourceSpans` as a repeated field, so this stays a single POST and the `Promise<Response | undefined>` return is unchanged, rather than becoming N requests with N results to reconcile.

Behaviour for a batch with one payload is byte-identical, which the existing User-Agent test pins. Verified by restoring the early return, which fails the new test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.