### PR TITLE
Remove the processor check that cannot return true

### DIFF
--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -59,7 +59,7 @@ import { Semaphore } from './Semaphore'
 import { buildDatasetJsonSchema, datasetFromObject, datasetToObject, parseYaml, stringifyYaml } from './serialization'
 import type { FromOptions, JsonSchema, ToOptions } from './serialization'
 import type { SpanTree } from './spanTree'
-import { buildSpanTree, getEvalsSpanProcessor, isProcessorInstalledOnGlobal, SpanTreeRecordingError } from './spanTree'
+import { buildSpanTree, getEvalsSpanProcessor, SpanTreeRecordingError } from './spanTree'
 
 export interface DatasetOptions<Inputs, Output, Metadata = unknown> {
   cases?: readonly Case<Inputs, Output, Metadata>[]
@@ -474,7 +474,7 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
     // Build span tree and auto-extract metrics
     const capturedSpans = evalsProcessor.drainBucket(exporterContextId)
     let spanTree: SpanTree
-    if (capturedSpans.length === 0 && !isProcessorInstalledOnGlobal()) {
+    if (capturedSpans.length === 0) {
       spanTree = buildSpanTree([], new SpanTreeRecordingError())
     } else {
       spanTree = buildSpanTree(capturedSpans, null)

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -24,7 +24,7 @@ import { emitEvaluationResult, emitEvaluatorFailure, spanReferenceFromSpan } fro
 import type { SpanReference } from './otelEmit'
 import { Semaphore } from './Semaphore'
 import type { SpanTree } from './spanTree'
-import { buildSpanTree, getEvalsSpanProcessor, isProcessorInstalledOnGlobal, SpanTreeRecordingError } from './spanTree'
+import { buildSpanTree, getEvalsSpanProcessor, SpanTreeRecordingError } from './spanTree'
 
 export type SamplingMode = 'correlated' | 'independent'
 
@@ -307,10 +307,7 @@ export function withOnlineEvaluation<F extends (...args: never[]) => Promise<unk
     }
 
     const capturedSpans = evalsProcessor.drainBucket(exporterContextId)
-    const spanTree =
-      capturedSpans.length === 0 && !isProcessorInstalledOnGlobal()
-        ? buildSpanTree([], new SpanTreeRecordingError())
-        : buildSpanTree(capturedSpans, null)
+    const spanTree = capturedSpans.length === 0 ? buildSpanTree([], new SpanTreeRecordingError()) : buildSpanTree(capturedSpans, null)
     const metrics: Record<string, number> = {}
     extractMetricsFromSpanTree(spanTree, metrics)
 

--- a/packages/logfire-api/src/evals/spanTree/exporter.ts
+++ b/packages/logfire-api/src/evals/spanTree/exporter.ts
@@ -13,7 +13,7 @@
 import type { Context } from '@opentelemetry/api'
 import type { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-import { context as ContextAPI, createContextKey, trace as TraceAPI } from '@opentelemetry/api'
+import { context as ContextAPI, createContextKey } from '@opentelemetry/api'
 
 import type { SpanTreeRecordingError } from './SpanTree'
 import { SpanTree } from './SpanTree'
@@ -103,14 +103,4 @@ export function buildSpanTree(spans: ReadableSpan[], recordingError: null | Span
     return SpanTree.fromError(recordingError)
   }
   return SpanTree.fromSpans(spans)
-}
-
-/**
- * Best-effort detection of whether the active TracerProvider can record spans.
- * If the provider is not the default no-op/proxy provider, assume callers wired
- * the evals processor or another recording provider.
- */
-export function isProcessorInstalledOnGlobal(): boolean {
-  const tp = TraceAPI.getTracerProvider()
-  return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
 }

--- a/packages/logfire-api/src/evals/spanTree/index.ts
+++ b/packages/logfire-api/src/evals/spanTree/index.ts
@@ -1,2 +1,2 @@
-export { buildSpanTree, EvalsSpanProcessor, getEvalsSpanProcessor, isProcessorInstalledOnGlobal } from './exporter'
+export { buildSpanTree, EvalsSpanProcessor, getEvalsSpanProcessor } from './exporter'
 export { SpanNode, type SpanQuery, spanQueryToSnakeCase, SpanTree, SpanTreeRecordingError } from './SpanTree'


### PR DESCRIPTION
Closes #228, taking option 2 from that issue. Happy to switch to option 1 instead if you would rather the detection actually work.

## What is wrong

`isProcessorInstalledOnGlobal` decides recording is available by excluding the proxy provider:

```ts
const tp = TraceAPI.getTracerProvider()
return typeof tp === 'object' && tp.constructor.name !== 'NoopTracerProvider' && tp.constructor.name !== 'ProxyTracerProvider'
```

`@opentelemetry/api@1.9.1` registers the proxy as the global and gives it the real provider as a delegate:

```js
setGlobalTracerProvider(provider) {
  const success = registerGlobal(API_NAME, this._proxyTracerProvider, DiagAPI.instance());
  if (success) { this._proxyTracerProvider.setDelegate(provider); }
}
getTracerProvider() { return getGlobal(API_NAME) || this._proxyTracerProvider; }
```

So `getTracerProvider()` returns a `ProxyTracerProvider` whether or not anything was registered, the second exclusion always matches, and the function always returns `false`. Confirmed by registering a `BasicTracerProvider` carrying the evals processor and reading it back: `false` before and after, `constructor.name` `'ProxyTracerProvider'` both times.

## What this does

Both call sites read it the same way:

```
Dataset.ts:477   if (capturedSpans.length === 0 && !isProcessorInstalledOnGlobal()) {
online.ts:311    capturedSpans.length === 0 && !isProcessorInstalledOnGlobal()
```

`!false` is always true, so both already reduced to `capturedSpans.length === 0`. This drops the term and the function, leaving that condition explicit.

No behaviour change, which is why there is no test and no changeset: the removed term could not affect either branch, and the helper is internal to `evals/spanTree`, not part of the `logfire/evals` export list. The existing suite passes unchanged.

Worth noting for option 1 if you go that way: `constructor.name` is a poor signal here regardless. The repo already treats it as unreliable, defaulting `errorFingerprinting` to false in the browser because "minified code produces unstable fingerprints", and `canonicalizeError` builds from `error.constructor.name`.

---
Built this with Claude Code's help and reviewed the diff myself.