### PR TITLE
List each evaluator once in the dataset JSON schema

### DIFF
--- a/.changeset/dedupe-schema-evaluators.md
+++ b/.changeset/dedupe-schema-evaluators.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+List each evaluator once in the dataset JSON schema. An evaluator that was both registered and passed through `customEvaluators` produced two identical `oneOf` branches, and `oneOf` requires exactly one match, so a dataset file naming that evaluator failed to validate against its own schema.

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -165,6 +165,25 @@ describe('EvaluatorSpec encoding', () => {
     expect(text).toContain('"NullSchemaEvaluator"')
     expect(text).toContain('"properties":{"NullSchemaEvaluator":{}}')
   })
+
+  it('lists an evaluator once when it is both registered and passed as custom', () => {
+    class BothWaysEvaluator extends Evaluator {
+      static override evaluatorName = 'BothWaysEvaluator'
+      evaluate(): boolean {
+        return true
+      }
+    }
+    registerEvaluator(BothWaysEvaluator as never)
+
+    const schema = buildDatasetJsonSchema({ customEvaluators: [BothWaysEvaluator as never] }) as {
+      properties: { evaluators: { items: { oneOf: { const?: string }[] } } }
+    }
+    const branches = schema.properties.evaluators.items.oneOf.filter((branch) => branch.const === 'BothWaysEvaluator')
+
+    // oneOf requires exactly one match, so a duplicate branch makes a file naming
+    // this evaluator invalid.
+    expect(branches).toHaveLength(1)
+  })
 })
 
 describe('Dataset YAML round-trip', () => {

--- a/packages/logfire-api/src/evals/serialization/jsonSchema.ts
+++ b/packages/logfire-api/src/evals/serialization/jsonSchema.ts
@@ -11,7 +11,7 @@
 
 import type { EvaluatorClass, ReportEvaluatorClass } from '../types'
 
-import { listRegisteredEvaluators, listRegisteredReportEvaluators } from '../registry'
+import { evaluatorRegistryKey, listRegisteredEvaluators, listRegisteredReportEvaluators } from '../registry'
 
 interface JsonSchemaOptions {
   customEvaluators?: readonly EvaluatorClass[]
@@ -29,8 +29,8 @@ interface HasSchemaDescriptor {
 }
 
 export function buildDatasetJsonSchema(opts: JsonSchemaOptions = {}): JsonSchema {
-  const evaluators = [...listRegisteredEvaluators(), ...(opts.customEvaluators ?? [])]
-  const reportEvaluators = [...listRegisteredReportEvaluators(), ...(opts.customReportEvaluators ?? [])]
+  const evaluators = dedupeByRegistryKey([...listRegisteredEvaluators(), ...(opts.customEvaluators ?? [])])
+  const reportEvaluators = dedupeByRegistryKey([...listRegisteredReportEvaluators(), ...(opts.customReportEvaluators ?? [])])
 
   const evaluatorOneOf = buildEvaluatorOneOf(evaluators)
   const reportOneOf = buildEvaluatorOneOf(reportEvaluators)
@@ -63,6 +63,19 @@ export function buildDatasetJsonSchema(opts: JsonSchemaOptions = {}): JsonSchema
     title: 'PydanticEvalsDataset',
     type: 'object',
   }
+}
+
+/**
+ * A class passed as a custom evaluator is often registered as well. Emitting it
+ * twice would put two identical branches in `oneOf`, which requires exactly one
+ * match, so a file naming that evaluator would fail to validate.
+ */
+function dedupeByRegistryKey<T extends { evaluatorName?: string; name: string }>(classes: readonly T[]): T[] {
+  const byKey = new Map<string, T>()
+  for (const cls of classes) {
+    byKey.set(evaluatorRegistryKey(cls), cls)
+  }
+  return [...byKey.values()]
 }
 
 function buildEvaluatorOneOf(classes: readonly (EvaluatorClass | ReportEvaluatorClass)[]): JsonSchema {


### PR DESCRIPTION
## What is wrong

`buildDatasetJsonSchema` concatenates the registry with the caller's list:

```ts
const evaluators = [...listRegisteredEvaluators(), ...(opts.customEvaluators ?? [])]
```

`buildEvaluatorOneOf` then emits a branch per entry, so a class appearing in both lists gets two identical branches. `oneOf` requires exactly one subschema to match, so two identical branches make the value invalid rather than redundant.

Both lists holding the same class is the normal case rather than a mistake: a custom evaluator has to be registered for `Dataset.fromFile` to construct it from YAML, and `customEvaluators` is what puts it in the schema.

## Evidence

Registering an evaluator and also passing it in, on `79bcac0`:

```ts
registerEvaluator(BothWaysEvaluator)
const schema = buildDatasetJsonSchema({ customEvaluators: [BothWaysEvaluator] })
```

gives two `{ const: 'BothWaysEvaluator', type: 'string' }` branches, plus two copies of the object form. A dataset file containing

```yaml
evaluators:
  - BothWaysEvaluator
```

then fails to validate against the schema generated for it, which shows up as a red squiggle in the editor the schema exists to serve.

## What this does

Deduplicates on the registry key before building the branches. That is the same identity `decodeEvaluator` uses to look the class up, so the schema and the decoder agree on what counts as the same evaluator. Later entries win, which means an explicitly passed class takes precedence over a registered one of the same name.

Existing behaviour for classes that appear in only one list is unchanged. Verified by removing the deduplication, which fails the new test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.