### PR TITLE
Avoid splitting a surrogate pair when truncating

### DIFF
--- a/.changeset/truncate-surrogate-pair.md
+++ b/.changeset/truncate-surrogate-pair.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop `truncateString` splitting a surrogate pair. Truncation cut on UTF-16 code units, so a message value or baggage value long enough to be truncated with an astral character straddling the boundary kept only the high half, leaving a lone surrogate that is not valid UTF-8 once the attribute is serialized. The whole character is dropped instead.

--- a/packages/logfire-api/src/formatter.test.ts
+++ b/packages/logfire-api/src/formatter.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vite-plus/test'
 
 import { NoopScrubber } from './AttributeScrubber'
-import { logfireFormatWithExtras } from './formatter'
+import { logfireFormatWithExtras, truncateString } from './formatter'
 
 function format(template: string, record: Record<string, unknown>): string {
   return logfireFormatWithExtras(template, record, NoopScrubber).formattedMessage
@@ -74,5 +74,22 @@ describe('message template nested field access', () => {
 
   test('a literal attribute key containing brackets keeps resolving', () => {
     expect(format('first item is {a[0]}', { 'a[0]': 'zero' })).toBe('first item is zero')
+  })
+})
+
+describe('truncateString', () => {
+  test('does not split a surrogate pair at the cut', () => {
+    // The emoji straddles the cut, so a code-unit slice would keep only its high half.
+    const value = `${'a'.repeat(96)}\u{1F600}${'b'.repeat(20)}`
+    const truncated = truncateString(value, 100)
+
+    expect(truncated).toBe(`${'a'.repeat(96)}...`)
+    expect(truncated.split('').some((char) => char >= '\uD800' && char <= '\uDFFF')).toBe(false)
+    expect(JSON.stringify(truncated).includes('\\ud')).toBe(false)
+  })
+
+  test('cuts at the limit when the boundary is not a surrogate', () => {
+    expect(truncateString('a'.repeat(120), 100)).toBe(`${'a'.repeat(97)}...`)
+    expect(truncateString('short', 100)).toBe('short')
   })
 })

--- a/packages/logfire-api/src/formatter.ts
+++ b/packages/logfire-api/src/formatter.ts
@@ -265,6 +265,14 @@ export function truncateString(str: string, maxLength: number): string {
     return str
   }
 
-  // Truncate and add ellipsis
-  return str.substring(0, maxLength - 3) + '...'
+  // `substring` counts UTF-16 code units, so cutting between the halves of a
+  // surrogate pair leaves a lone surrogate that is not valid UTF-8 once the
+  // attribute is serialized. Drop the whole character instead.
+  let end = maxLength - 3
+  const lastCode = str.charCodeAt(end - 1)
+  if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+    end -= 1
+  }
+
+  return str.substring(0, end) + '...'
 }


### PR DESCRIPTION
## What is wrong

`truncateString` cuts with `substring`, which counts UTF-16 code units:

```ts
return str.substring(0, maxLength - 3) + '...'
```

An astral character is two code units, so a cut landing between its halves keeps only the high surrogate. A lone surrogate has no UTF-8 encoding, so it survives as an escape through `JSON.stringify` and is rejected or replaced by strict consumers downstream.

Three call sites feed it user-controlled text: formatted message values twice at `MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT` (2000), and baggage values at `MAX_BAGGAGE_VALUE_LENGTH` (1000).

## Evidence

On `79bcac0`, a 2000-plus character value with an emoji straddling the boundary:

```js
const s = 'a'.repeat(1996) + '😀' + 'tail'
truncateString(s, 2000)
```

ends `...aaaa\ud83d...`, an unpaired high surrogate. `JSON.stringify` on the result emits `"\ud83d"` verbatim.

It needs a value past the limit with an astral character at one specific offset, so it is rare per message rather than rare in aggregate: at telemetry volume, emoji in user content will land there.

## What this does

Steps back one code unit when the last kept unit is a high surrogate, dropping the whole character rather than half of it. The truncated result stays within `maxLength`.

Chose the surrogate check over iterating code points or reaching for `Intl.Segmenter`: only the final boundary can be split, so a single check does the job, and this file is in the runtime-agnostic package where a smaller surface is worth keeping.

Non-surrogate boundaries and the under-limit early return are unchanged, both covered by the tests. Verified by removing the check, which fails the surrogate test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.