### PR TITLE
Keep truncated Contains reasons valid UTF-8

### DIFF
--- a/.changeset/contains-repr-surrogate.md
+++ b/.changeset/contains-repr-surrogate.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop `Contains` leaving a lone surrogate in a truncated failure reason. The reason string was cut on UTF-16 code units at both ends, so an astral character straddling either boundary lost half of itself, and the resulting reason is not valid UTF-8 once the evaluation result is serialized.

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -181,8 +181,13 @@ describe('built-in evaluator edge cases', () => {
     const tail = `${'a'.repeat(80)}\u{1F600}${'b'.repeat(48)}`
 
     for (const value of [head, tail]) {
-      const result = new Contains({ value: 'ZZZNOTFOUND' }).evaluate(ctx(value)) as { reason?: string }
-      const reason = result.reason ?? ''
+      const result = new Contains({ value: 'ZZZNOTFOUND' }).evaluate(ctx(value)) as { reason?: string; value: boolean }
+
+      // The containment has to actually fail, otherwise there is no reason to check.
+      expect(result.value).toBe(false)
+      expect(typeof result.reason).toBe('string')
+
+      const reason = result.reason as string
       // A lone surrogate has no UTF-8 encoding, so encoding replaces it with
       // U+FFFD and the round trip stops matching.
       expect(new TextDecoder().decode(new TextEncoder().encode(reason))).toBe(reason)

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -172,4 +172,20 @@ describe('built-in evaluator edge cases', () => {
       LLMJudge_score: 0.8,
     })
   })
+
+  it('Contains does not leave a lone surrogate when truncating a reason', () => {
+    // repr is '"' + value + '"' and the string limit is 100, so the head cut lands
+    // at repr index 50, putting an emoji's halves either side of it.
+    const head = `${'a'.repeat(48)}\u{1F600}${'b'.repeat(80)}`
+    // The tail cut lands 50 units from the end, on the low half of this emoji.
+    const tail = `${'a'.repeat(80)}\u{1F600}${'b'.repeat(48)}`
+
+    for (const value of [head, tail]) {
+      const result = new Contains({ value: 'ZZZNOTFOUND' }).evaluate(ctx(value)) as { reason?: string }
+      const reason = result.reason ?? ''
+      // A lone surrogate has no UTF-8 encoding, so encoding replaces it with
+      // U+FFFD and the round trip stops matching.
+      expect(new TextDecoder().decode(new TextEncoder().encode(reason))).toBe(reason)
+    }
+  })
 })

--- a/packages/logfire-api/src/evals/builtins/Contains.ts
+++ b/packages/logfire-api/src/evals/builtins/Contains.ts
@@ -132,5 +132,19 @@ function truncatedRepr(value: unknown, maxLength: number): string {
   if (repr.length <= maxLength) {
     return repr
   }
-  return `${repr.slice(0, Math.floor(maxLength / 2))}...${repr.slice(-Math.floor(maxLength / 2))}`
+  // Slicing counts UTF-16 code units, so a cut between the halves of a surrogate
+  // pair leaves a lone surrogate, which has no UTF-8 encoding once the reason is
+  // serialized. Drop the whole character at either boundary instead.
+  const half = Math.floor(maxLength / 2)
+  const headEnd = isHighSurrogate(repr.charCodeAt(half - 1)) ? half - 1 : half
+  const tailStart = isLowSurrogate(repr.charCodeAt(repr.length - half)) ? repr.length - half + 1 : repr.length - half
+  return `${repr.slice(0, headEnd)}...${repr.slice(tailStart)}`
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff
 }


### PR DESCRIPTION
## What is wrong

`truncatedRepr` cuts the repr on UTF-16 code units, at both ends:

```ts
return `${repr.slice(0, Math.floor(maxLength / 2))}...${repr.slice(-Math.floor(maxLength / 2))}`
```

An astral character is two code units, so a boundary falling between its halves keeps only one of them. A lone surrogate has no UTF-8 encoding, and the result goes into `reason` on the `EvaluationResult`, which is serialized into span attributes.

The callers use `maxLength` of 30, 100 and 200, so the head cut lands at index 15, 50 or 100. That is well inside the visible part of ordinary output rather than far out in a long payload.

## Evidence

`Contains` against a string output on `79bcac0`, with an emoji positioned at the head boundary:

```ts
new Contains({ value: 'ZZZNOTFOUND' }).evaluate(ctx('a'.repeat(48) + '😀' + 'b'.repeat(80)))
```

The returned `reason` contains one unpaired surrogate, and `JSON.stringify` on it emits a `\ud…` escape. Encoding it as UTF-8 and decoding back does not round-trip, because the encoder substitutes `U+FFFD`.

The tail slice has the mirror problem: its start can land on the low half of a pair, dropping the high half.

## What this does

Steps past the boundary when it falls inside a pair, at whichever end is affected, so the whole character is dropped rather than half of it.

Kept it to two code-unit checks rather than iterating code points or reaching for `Intl.Segmenter`: only the two boundaries can ever split, and the result stays within `maxLength`.

The test asserts a UTF-8 round trip rather than counting surrogates, which states the property directly and avoids spreading a string. Covers both boundaries, and verified by removing the checks, which fails it and nothing else.

---
Built this with Claude Code's help and reviewed the diff myself.