### PR TITLE
Avoid a lone surrogate in truncated console arguments

### DIFF
--- a/.changeset/replay-truncate-surrogate.md
+++ b/.changeset/replay-truncate-surrogate.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-session-replay': patch
+---
+
+Stop a truncated console argument ending in a lone surrogate. Capture cut arguments on UTF-16 code units, so an astral character straddling the limit kept only its high half, leaving text that is not valid UTF-8 once the replay event is sent. The whole character is dropped instead, and the omitted-character count stays accurate.

--- a/packages/logfire-session-replay/src/capture.test.ts
+++ b/packages/logfire-session-replay/src/capture.test.ts
@@ -53,6 +53,27 @@ describe('captureConsole', () => {
     }
   })
 
+  it('does not leave a lone surrogate when truncating an argument', () => {
+    const originalLog = console.log
+    console.log = vi.fn()
+    const emit = vi.fn()
+    const stop = captureConsole(emit)
+    try {
+      // The emoji straddles the 1024 unit boundary, so a code-unit slice would
+      // keep only its high half.
+      console.log(`${'x'.repeat(1_023)}\u{1F600}${'y'.repeat(50)}`)
+      const payload = emit.mock.calls[0]![1] as ConsolePayload
+      const arg = payload.args[0]!
+
+      expect(arg).toBe(`${'x'.repeat(1_023)}...(+52 chars)`)
+      // A lone surrogate has no UTF-8 encoding, so the round trip would not match.
+      expect(new TextDecoder().decode(new TextEncoder().encode(arg))).toBe(arg)
+    } finally {
+      stop()
+      console.log = originalLog
+    }
+  })
+
   it('restores console methods idempotently', () => {
     const realLog = console.log
     const originalLog = vi.fn()

--- a/packages/logfire-session-replay/src/capture.ts
+++ b/packages/logfire-session-replay/src/capture.ts
@@ -439,7 +439,12 @@ function truncate(text: string): string {
   if (text.length <= MAX_ARG_LENGTH) {
     return text
   }
-  return `${text.slice(0, MAX_ARG_LENGTH)}...(+${String(text.length - MAX_ARG_LENGTH)} chars)`
+  // Slicing counts UTF-16 code units, so cutting between the halves of a
+  // surrogate pair leaves a lone surrogate, which has no UTF-8 encoding once the
+  // captured argument is sent. Drop the whole character instead.
+  const lastCode = text.charCodeAt(MAX_ARG_LENGTH - 1)
+  const end = lastCode >= 0xd800 && lastCode <= 0xdbff ? MAX_ARG_LENGTH - 1 : MAX_ARG_LENGTH
+  return `${text.slice(0, end)}...(+${String(text.length - end)} chars)`
 }
 
 function getFetchMethod(input: RequestInfo | URL, init: RequestInit | undefined): string {


### PR DESCRIPTION
## What is wrong

`truncate` cuts captured console arguments on UTF-16 code units:

```ts
return `${text.slice(0, MAX_ARG_LENGTH)}...(+${String(text.length - MAX_ARG_LENGTH)} chars)`
```

An astral character is two code units, so a boundary landing between its halves keeps only the high surrogate. That has no UTF-8 encoding, and the argument is sent to the replay backend in that state.

All three callers pass user-controlled text: string arguments, error stacks, and `JSON.stringify` of objects.

## Evidence

With `MAX_ARG_LENGTH` at 1024, an emoji straddling the boundary:

```js
const s = 'x'.repeat(1023) + '😀' + 'y'.repeat(50)
s.slice(0, 1024)   // ends with an unpaired high surrogate
```

Encoding that as UTF-8 and decoding back does not round-trip, because the encoder substitutes `U+FFFD`.

## What this does

Steps back one code unit when the boundary falls inside a pair, so the whole character is dropped, and counts the omitted characters from the actual cut so `(+N chars)` stays accurate rather than reporting one fewer than it dropped.

Kept it to a single boundary check rather than iterating code points, since only the final boundary can split.

The existing truncation test is unaffected: its input is all ASCII, so the boundary is never inside a pair. The new test asserts the exact truncated string and a UTF-8 round trip, and was verified by removing the check, which fails it and nothing else.

---
Built this with Claude Code's help and reviewed the diff myself.