### PR TITLE
Do not rethrow when probing a returned value for then

### DIFF
--- a/.changeset/instrument-thenable-getter.md
+++ b/.changeset/instrument-thenable-getter.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop `instrument` with `recordReturn` rethrowing when the returned value has a throwing `then` getter. Detecting a thenable reads `then`, which runs caller code, so a successful call could surface to the caller as a thrown error and be recorded on the span as a failure. The probe now treats a throwing getter as not thenable.

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -1254,6 +1254,25 @@ describe('instrument', () => {
     )
   })
 
+  test('recordReturn true does not rethrow when the returned value has a throwing then getter', () => {
+    const wrapped = instrument(
+      () => {
+        const result = { ok: true }
+        // A lazy proxy or ORM model can throw on an unknown property read.
+        Object.defineProperty(result, 'then', {
+          get() {
+            throw new Error('then getter boom')
+          },
+        })
+        return result
+      },
+      { recordReturn: true }
+    )
+
+    // Probing for a thenable must not turn a successful call into a failure.
+    expect(wrapped()).toEqual({ ok: true })
+  })
+
   test('recordReturn true preserves complex input schema when recording complex return values', () => {
     function processPayload(_payload: { value: string }) {
       return { status: 'ok' }

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -1273,6 +1273,27 @@ describe('instrument', () => {
     expect(wrapped()).toEqual({ ok: true })
   })
 
+  test('recordReturn true reads the then property once when the getter is stateful', async () => {
+    let reads = 0
+    const wrapped = instrument(
+      () => ({
+        // A stateful getter can hand back a function on the first read and throw
+        // on the next, so probing and calling must not be two separate reads.
+        get then() {
+          reads += 1
+          if (reads > 1) {
+            throw new Error('then getter boom')
+          }
+          return (onFulfilled: (value: { ok: boolean }) => unknown) => onFulfilled({ ok: true })
+        },
+      }),
+      { recordReturn: true }
+    )
+
+    expect(await wrapped()).toEqual({ ok: true })
+    expect(reads).toBe(1)
+  })
+
   test('recordReturn true preserves complex input schema when recording complex return values', () => {
     function processPayload(_payload: { value: string }) {
       return { status: 'ok' }

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -334,9 +334,16 @@ function isHrTime(value: unknown): value is HrTime {
 }
 
 function isThenable<T>(value: T): value is T & PromiseLike<Awaited<T>> {
-  return (
-    (typeof value === 'object' || typeof value === 'function') && value !== null && typeof (value as { then?: unknown }).then === 'function'
-  )
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+    return false
+  }
+  try {
+    return typeof (value as { then?: unknown }).then === 'function'
+  } catch {
+    // Reading `then` runs a getter, which belongs to the caller. Instrumentation
+    // must not turn a returned value into a thrown error.
+    return false
+  }
 }
 
 function getFunctionName(fn: InstrumentableFunction): string {

--- a/packages/logfire-api/src/index.ts
+++ b/packages/logfire-api/src/index.ts
@@ -333,17 +333,26 @@ function isHrTime(value: unknown): value is HrTime {
   return Array.isArray(value) && value.length === 2 && typeof value[0] === 'number' && typeof value[1] === 'number'
 }
 
-function isThenable<T>(value: T): value is T & PromiseLike<Awaited<T>> {
+type ThenMethod = (onFulfilled: (value: never) => unknown) => unknown
+
+/**
+ * Returns the value's `then` method, or undefined when it has none.
+ *
+ * Reading `then` runs a getter belonging to the caller, so the read is guarded and
+ * the method is returned rather than re-read: a stateful getter can hand back a
+ * function once and throw on the next read.
+ */
+function getThenMethod(value: unknown): ThenMethod | undefined {
   if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
-    return false
+    return undefined
   }
+  let then: unknown
   try {
-    return typeof (value as { then?: unknown }).then === 'function'
+    then = (value as { then?: unknown }).then
   } catch {
-    // Reading `then` runs a getter, which belongs to the caller. Instrumentation
-    // must not turn a returned value into a thrown error.
-    return false
+    return undefined
   }
+  return typeof then === 'function' ? (then as ThenMethod) : undefined
 }
 
 function getFunctionName(fn: InstrumentableFunction): string {
@@ -691,8 +700,9 @@ function instrumentWithSettings<F extends InstrumentableFunction>(
         if (options.recordReturn !== true) {
           return result
         }
-        if (isThenable(result)) {
-          return result.then((value: Awaited<ReturnType<F>>) => {
+        const thenMethod = getThenMethod(result)
+        if (thenMethod !== undefined) {
+          return thenMethod.call(result, (value: Awaited<ReturnType<F>>) => {
             recordReturnAttributes(activeSpan, spanSerializationAttributes ?? {}, value)
             return value
           }) as ReturnType<F>


### PR DESCRIPTION
## What is wrong

`isThenable` decides whether to await an instrumented function's result by reading `then`:

```ts
function isThenable<T>(value: T): value is T & PromiseLike<Awaited<T>> {
  return (
    (typeof value === 'object' || typeof value === 'function') && value !== null && typeof (value as { then?: unknown }).then === 'function'
  )
}
```

Reading a property runs a getter, and that getter belongs to the caller's value. If it throws, the throw happens inside the instrumented callback, so `spanWithSettings` records an exception and rethrows.

The function had already returned successfully. Instrumentation turns that into a failure for the caller and reports a failure that never happened.

## Evidence

With `recordReturn: true`, on `79bcac0`:

```ts
const wrapped = instrument(() => {
  const result = { ok: true }
  Object.defineProperty(result, 'then', { get() { throw new Error('then getter boom') } })
  return result
}, { recordReturn: true })

wrapped()   // throws: then getter boom
```

The value is returned, then discarded and replaced by a throw. A lazy proxy or an ORM model that throws on an unknown property read hits this without anything adversarial going on.

## What this does

Treats a throwing getter as not thenable, so the value takes the synchronous path and is recorded like any other return value.

Kept the probe rather than switching to `Promise.resolve`, which is what I would reach for elsewhere: here the point is to distinguish thenables from plain values, and resolving everything would turn synchronous instrumented functions into asynchronous ones.

`recordReturn` is off by default, so this only affects callers who opted in. Verified by removing the guard, which fails the new test and no others.

---
Built this with Claude Code's help and reviewed the diff myself.