### PR TITLE
Avoid a lone surrogate in truncated report cells

### DIFF
--- a/.changeset/render-truncate-surrogate.md
+++ b/.changeset/render-truncate-surrogate.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop `renderReport` leaving a lone surrogate in a truncated cell. Inputs and outputs were cut on UTF-16 code units at 30, so an astral character straddling that boundary kept only its high half, and the returned report string is no longer valid UTF-8.

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -938,6 +938,25 @@ describe('renderReport', () => {
     expect(text).toContain('ok=✓')
   })
 
+  it('does not leave a lone surrogate when truncating a rendered input', () => {
+    // The repr is '"' + value + '"' and the limit is 30, so the cut lands on the
+    // emoji's high half.
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [makeReportCase({ inputs: `${'a'.repeat(27)}\u{1F600}${'b'.repeat(20)}`, name: 'one' })],
+      failures: [],
+      name: 'demo',
+      report_evaluator_failures: [],
+      span_id: 's',
+      trace_id: 't',
+    }
+
+    const text = renderReport(report, { includeInput: true })
+
+    // A lone surrogate has no UTF-8 encoding, so the round trip would not match.
+    expect(new TextDecoder().decode(new TextEncoder().encode(text))).toBe(text)
+  })
+
   it('renders optional inputs, outputs, failures, analyses and scalar formatting', () => {
     const report: EvaluationReport = {
       analyses: [{ title: 'Quality', type: 'scalar', value: 0.95 }],

--- a/packages/logfire-api/src/evals/render.ts
+++ b/packages/logfire-api/src/evals/render.ts
@@ -93,7 +93,11 @@ function truncate(s: string, max: number): string {
   if (s.length <= max) {
     return s
   }
-  return `${s.slice(0, max - 1)}…`
+  // Slicing counts UTF-16 code units, so a cut between the halves of a surrogate
+  // pair leaves a lone surrogate in the rendered report.
+  const end = max - 1
+  const lastCode = s.charCodeAt(end - 1)
+  return `${s.slice(0, lastCode >= 0xd800 && lastCode <= 0xdbff ? end - 1 : end)}…`
 }
 
 function formatTable(headers: string[], rows: string[][]): string[] {


### PR DESCRIPTION
## What is wrong

`renderReport` truncates the input and output cells on UTF-16 code units:

```ts
function truncate(s: string, max: number): string {
  if (s.length <= max) {
    return s
  }
  return `${s.slice(0, max - 1)}…`
}
```

Both callers pass `max` of 30, so the cut lands at index 29 of a `JSON.stringify` repr. An astral character straddling it keeps only its high surrogate, and the string `renderReport` returns is then not valid UTF-8.

## Evidence

On `79bcac0`, an input whose emoji sits on the boundary:

```ts
renderReport(reportWith(`${'a'.repeat(27)}😀${'b'.repeat(20)}`), { includeInput: true })
```

The rendered text carries an unpaired high surrogate. Encoding it as UTF-8 and decoding back does not round-trip, because the encoder substitutes `U+FFFD`.

Being clear about severity: this is lower impact than the same cut on an exported attribute, since the usual destination is a terminal, where it shows as a replacement glyph. It still matters because `renderReport` is exported and returns the string to the caller, so it can be written anywhere, including back through `logfire.info`.

## What this does

Drops the whole character when the boundary falls inside a pair, matching the single-boundary check used for the other truncations. A 30 unit limit means this boundary sits well inside ordinary values rather than far out in a long payload.

The test asserts a UTF-8 round trip on the rendered report, and was verified by restoring the old cut, which fails it and nothing else.

---
Built this with Claude Code's help and reviewed the diff myself.