### PR TITLE
Run the CLI when the bin is invoked through a symlink

### DIFF
--- a/.changeset/cli-symlink-entry-guard.md
+++ b/.changeset/cli-symlink-entry-guard.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Run the CLI when it is invoked through the npm bin symlink. The entry-point guard compared `import.meta.url` against `process.argv[1]`, which never match when npm installs the bin as a symlink, so `npx logfire auth` exited 0 without doing anything.

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/require-await -- test stubs satisfy async signatures without awaiting. */
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { Writable } from 'node:stream'
 
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
@@ -119,6 +121,20 @@ describe('CLI entrypoint', () => {
       project_url: 'fake_project_url',
       token: 'fake_token',
     })
+  })
+
+  it('runs when the bin is invoked through a symlink', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'logfire-cli-bin-'))
+    tmpDirs.push(dir)
+    const link = join(dir, 'logfire')
+    // npm installs the bin as a symlink into node_modules/.bin, which is the shape that made the
+    // entry-point guard miss and the CLI exit 0 without printing anything.
+    symlinkSync(fileURLToPath(new URL('../../dist/cli.js', import.meta.url)), link)
+
+    const result = spawnSync(process.execPath, [link, '--help'], { encoding: 'utf8' })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout.split('\n')[0]).toBe('The CLI for Pydantic Logfire.')
   })
 
   function makeTmpDir(): string {

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import type { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
@@ -223,7 +224,11 @@ function openBrowser(url: string, platform: NodeJS.Platform): void {
   }
 }
 
-if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// npm installs the bin as a symlink into `node_modules/.bin`. Node resolves `import.meta.url`
+// to the real file while `process.argv[1]` stays the symlink, so comparing them directly never
+// matches and the CLI exits 0 without running anything.
+const entryPath = process.argv[1]
+if (entryPath !== undefined && import.meta.url === pathToFileURL(realpathSync(entryPath)).href) {
   runCli()
     .then((exitCode) => {
       process.exitCode = exitCode


### PR DESCRIPTION
Fixes #238.

## Defect

`npx logfire auth` exits 0 and prints nothing, so every documented CLI command is unreachable through the npm bin. Nothing throws, so there is no error to search for: a user follows the setup guide, gets no credentials, and later finds no data in their project.

## Evidence

The entry-point guard at `packages/logfire-api/src/cli/index.ts:226` was:

```ts
if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
```

npm installs the bin as a symlink (`node_modules/.bin/logfire -> ../logfire/dist/cli.js`). Node resolves `import.meta.url` to the real file, while `process.argv[1]` stays the symlink path, so the two are never equal and `runCli()` is never called.

Reproduced on current main (79bcac0), not only on the published 0.21.8. Symlinking a freshly built `dist/cli.js` and invoking the link prints nothing; invoking the same file by its real path prints the help.

## Fix

Resolve the symlink before comparing. The guard cannot simply be removed: `src/cli/index.test.ts` imports `runCli` from this module, so an unguarded call would run the CLI during the test suite.

The regression test symlinks the built `dist/cli.js` into a temp dir and spawns it, asserting the first line of `--help`. On the unfixed guard it fails with `expected '' to be 'The CLI for Pydantic Logfire.'`, which is the reported symptom exactly.

One tradeoff I took deliberately: `realpathSync` throws if `process.argv[1]` does not exist on disk, where the old code silently skipped `runCli()`. I did not add a try/catch, because Node refuses to start when the entry script is missing and every import path (test runner included) has a real file at `argv[1]`. Happy to wrap it if you would rather the module never throw at load.

Credit for the diagnosis goes to @strawgate in #238; I confirmed it on main and wrote the patch and test.

Built this with Claude Code's help and reviewed the diff myself.