### PR TITLE
Omit the prefix from KV list query text when there is none

### DIFF
--- a/.changeset/kv-list-query-text.md
+++ b/.changeset/kv-list-query-text.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+Stop writing the literal text `list undefined` to `db.query.text` on KV list spans that have no prefix.

--- a/packages/otel-cf-workers/src/instrumentation/kv.ts
+++ b/packages/otel-cf-workers/src/instrumentation/kv.ts
@@ -91,7 +91,9 @@ function instrumentKVFn(fn: Function, name: string, operation: string) {
           if (operation === 'list') {
             const opts: KVNamespaceListOptions = argArray[0] || {}
             const { prefix } = opts
-            span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${prefix || undefined}`)
+            // `undefined` stringifies inside a template literal, so interpolating an absent prefix
+            // produced the literal text "list undefined" rather than omitting it.
+            span.setAttribute(ATTR_DB_QUERY_TEXT, prefix ? `${operation} ${prefix}` : operation)
           } else {
             span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${argArray[0]}`)
             span.setAttribute('db.cf.kv.key', argArray[0])

--- a/packages/otel-cf-workers/test/instrumentation/kv.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/kv.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@cloudflare/workers-types" />
+
 import type { Span, Tracer } from '@opentelemetry/api'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
 import { describe, expect, it, vitest } from 'vitest'
@@ -30,6 +32,28 @@ describe('KV attributes', () => {
         'db.cf.kv.list_response_cursor': 'response-cursor',
       }
     )
+  })
+
+  it('omits the prefix from the list query text when there is none', async () => {
+    const attributes: Record<string, unknown> = {}
+    const span = createSpan()
+    span.setAttribute = ((key: string, value: unknown) => {
+      attributes[key] = value
+    }) as unknown as typeof span.setAttribute
+    const getTracer = vitest.spyOn(trace, 'getTracer').mockReturnValue(mockTracer(span as unknown as Span))
+    const kv = {
+      list: vitest.fn<() => Promise<unknown>>(async () => Promise.resolve({ keys: [], list_complete: true })),
+    } as unknown as KVNamespace
+
+    try {
+      await instrumentKV(kv, 'CACHE').list()
+      expect(attributes['db.query.text']).toBe('list')
+
+      await instrumentKV(kv, 'CACHE').list({ prefix: 'user:' })
+      expect(attributes['db.query.text']).toBe('list user:')
+    } finally {
+      getTracer.mockRestore()
+    }
   })
 
   it('records errors and ends spans when KV operations reject', async () => {


### PR DESCRIPTION
## Defect

Every `kv.list()` call that does not pass a prefix writes the literal text `list undefined` to `db.query.text` on the KV span. That is the default list call, so it is the common case rather than an edge case.

## Evidence

`instrumentKVFn` built the query text by interpolation:

```ts
const opts: KVNamespaceListOptions = argArray[0] || {}
const { prefix } = opts
span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${prefix || undefined}`)
```

The `|| undefined` idiom means "omit this" everywhere else in the file, because `setAttributes` drops undefined values. Inside a template literal it does the opposite: `undefined` stringifies, so the attribute is always present and reads `list undefined` when no prefix was given.

Verified against the file's own `createSpan` / `mockTracer` harness on current main. `instrumentKV(kv, 'CACHE').list()` set `db.query.text` to `list undefined`.

## Fix

Interpolate only when there is a prefix. The attribute stays present either way, so list spans remain consistent with every other KV operation, which always sets it. Truthiness is kept rather than an explicit `undefined` check, to match how `prefix` and the surrounding cursor and limit attributes are already treated.

The new test asserts both branches. On the old line it fails with `expected 'list undefined' to be 'list'`.

One unrelated line is included because it is required, not by choice: `kv.test.ts` was the only one of the eight test files in that directory without the `/// <reference types="@cloudflare/workers-types" />` header, so the pre-commit lint could not resolve `KVNamespace` in it and rejected the commit. Adding the header matches the other seven.

Built this with Claude Code's help and reviewed the diff myself.