### PR TITLE
Drop the stringified data point from Analytics Engine query text

### DIFF
--- a/.changeset/ae-query-text-object.md
+++ b/.changeset/ae-query-text-object.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/otel-cf-workers': patch
+---
+
+Stop writing `writeDataPoint [object Object]` to `db.query.text` on Analytics Engine spans. A data point write has no query text, and its contents are already summarised by the `db.cf.ae.*` attributes.

--- a/packages/otel-cf-workers/src/instrumentation/analytics-engine.ts
+++ b/packages/otel-cf-workers/src/instrumentation/analytics-engine.ts
@@ -1,6 +1,6 @@
 import type { Attributes, Exception, SpanOptions } from '@opentelemetry/api'
 import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
-import { ATTR_DB_NAMESPACE, ATTR_DB_OPERATION_NAME, ATTR_DB_QUERY_TEXT, ATTR_DB_SYSTEM_NAME } from '@opentelemetry/semantic-conventions'
+import { ATTR_DB_NAMESPACE, ATTR_DB_OPERATION_NAME, ATTR_DB_SYSTEM_NAME } from '@opentelemetry/semantic-conventions'
 import { wrap } from '../wrap.js'
 
 type ExtraAttributeFn = (argArray: any[], result: any) => Attributes
@@ -44,7 +44,6 @@ function instrumentAEFn(fn: Function, name: string, operation: string) {
           const extraAttrsFn = AEAttributes[operation]
           const extraAttrs = extraAttrsFn ? extraAttrsFn(argArray, result) : {}
           span.setAttributes(extraAttrs)
-          span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${argArray[0]}`)
           return result
         } catch (error) {
           span.recordException(error as Exception)

--- a/packages/otel-cf-workers/test/instrumentation/analytics-engine.test.ts
+++ b/packages/otel-cf-workers/test/instrumentation/analytics-engine.test.ts
@@ -63,6 +63,23 @@ describe('Analytics Engine instrumentation', () => {
     expect(spans[0]?.attributes['db.cf.ae.indexes']).toBe(1)
   })
 
+  it('records only the data point summary, not a stringified data point', async () => {
+    const instrument = instrumentAsync('my-dataset')
+    await expect(instrument.writeDataPoint({ blobs: ['b'], doubles: [1], indexes: ['idx'] })).resolves.toBe(undefined)
+
+    const spans = exporter.getFinishedSpans()
+    expect(spans[0]?.attributes).toEqual({
+      binding_type: 'AnalyticsEngine',
+      'db.cf.ae.blobs': 1,
+      'db.cf.ae.doubles': 1,
+      'db.cf.ae.index': 'idx',
+      'db.cf.ae.indexes': 1,
+      'db.namespace': 'my-dataset',
+      'db.operation.name': 'writeDataPoint',
+      'db.system.name': 'Cloudflare Analytics Engine',
+    })
+  })
+
   it('ends the span and records the error when the write rejects', async () => {
     const error = new Error('write failed')
     ;(dataset.writeDataPoint as ReturnType<typeof vitest.fn<() => Promise<void>>>).mockRejectedValue(error)


### PR DESCRIPTION
## Defect

Every Analytics Engine span carries `db.query.text: "writeDataPoint [object Object]"`. `writeDataPoint` is the only method on `AnalyticsEngineDataset`, so this is on 100% of AE spans, not an edge case.

## Evidence

`instrumentAEFn` built the query text by interpolating the first argument:

```ts
span.setAttribute(ATTR_DB_QUERY_TEXT, `${operation} ${argArray[0]}`)
```

For KV and Durable Object storage that argument is a key string, so the same line reads sensibly there. For Analytics Engine it is an `AnalyticsEngineDataPoint` object, and a template literal stringifies it to `[object Object]`.

Verified on current main with the file's existing `InMemorySpanExporter` harness. `writeDataPoint({ blobs: ['b'], doubles: [1], indexes: ['idx'] })` produced exactly `writeDataPoint [object Object]`.

## Fix

Remove the attribute rather than reformat it. A data point write has no query text to report, `db.operation.name` already carries `writeDataPoint`, and the data point's contents are already summarised by `db.cf.ae.indexes`, `db.cf.ae.index`, `db.cf.ae.doubles` and `db.cf.ae.blobs`. Setting `db.query.text` to the bare operation name would only duplicate `db.operation.name`.

The new test asserts the span's complete attribute set, so it fails if the placeholder returns and also if an unexpected attribute appears. Restoring the old line fails it with `+ "db.query.text": "writeDataPoint [object Object]"`.

If you would rather AE spans keep a `db.query.text` for consistency with KV and DO storage, say so and I will set it to the operation name instead.

Built this with Claude Code's help and reviewed the diff myself.