### PR TITLE
Run the CLI when the bin is invoked through a symlink, and stamp the right version

### DIFF
--- a/.changeset/cli-entrypoint-symlink.md
+++ b/.changeset/cli-entrypoint-symlink.md
@@ -1,0 +1,7 @@
+---
+'logfire': patch
+---
+
+Run the `logfire` CLI when the bin is invoked through a symlink. The entrypoint check compared `import.meta.url` against `process.argv[1]` verbatim, but Node resolves the module URL to the real path while leaving `argv[1]` as the literal invocation path. Any symlink between the two made the check fail, so the command exited 0 without printing anything and without running. `argv[1]` is now resolved before the comparison.
+
+This affected every install whose invocation path crossed a symlink: `npm install` and Yarn, where the bin itself is a symlink; pnpm with `node-linker=hoisted`; and pnpm workspace links, where the shim points through a symlinked package directory. Only pnpm's default isolated layout and `pnpm add -g` escaped, because their shims target the physical path.

--- a/.changeset/package-version-stamping.md
+++ b/.changeset/package-version-stamping.md
@@ -1,0 +1,8 @@
+---
+'logfire': patch
+'@pydantic/logfire-browser': patch
+---
+
+Report the correct package version at runtime. `PACKAGE_VERSION` was read from the ambient `npm_package_version` environment variable at build time, which resolves to whichever `package.json` the build was started from. Releases run `pnpm run build` from the repository root, so published artifacts were stamped with the private root version `1.0.0` instead of their own: `logfire@0.21.8` reported `Running Logfire 1.0.0` from `logfire --version` and `logfire info`, and sent `logfire-js/1.0.0` as its CLI user agent. `@pydantic/logfire-browser` reported the same wrong value as the `telemetry.sdk.version` resource attribute on every browser span.
+
+Each package now reads the version from its own `package.json`, matching what `@pydantic/logfire-node`, `@pydantic/logfire-cf-workers`, and `@pydantic/otel-cf-workers` already did.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ This repository is the Pydantic Logfire JavaScript SDK monorepo. It provides Ope
 - `packages/otel-cf-workers` publishes `@pydantic/otel-cf-workers`, the lower-level Cloudflare Workers OpenTelemetry implementation used by the Logfire wrapper.
 - `packages/logfire-browser` publishes `@pydantic/logfire-browser`, which adapts Logfire to browser tracing.
 - `packages/logfire-session-replay` publishes `@pydantic/logfire-session-replay`, the optional standalone rrweb recorder used by the browser package's session replay integration.
-- `packages/tooling-config` contains shared build and lint configuration.
+- `vite.shared.ts` holds the build helpers every package config imports: `packageDefines()` stamps `PACKAGE_VERSION` and `PACKAGE_TIMESTAMP` from the package's own `package.json`, and `copyCjsDeclarations()` emits the `.d.cts` files.
+- `vite.config.ts` and `tsconfig.base.json` at the repository root hold the shared format, lint, task, and TypeScript configuration.
 - `examples/` contains runnable examples for Express, Next.js, Deno, Cloudflare Workers, browser usage, and related integrations.
 
 ## Environment

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import type { Readable, Writable } from 'node:stream'
 import { pathToFileURL } from 'node:url'
@@ -223,7 +224,20 @@ function openBrowser(url: string, platform: NodeJS.Platform): void {
   }
 }
 
-if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Package managers expose the bin as a symlink, or as a shim pointing through a symlinked
+// package directory. Node leaves argv[1] as the literal invocation path but realpaths
+// import.meta.url, so the two only agree once argv[1] is resolved as well.
+function resolveEntryPath(entryPath: string): string {
+  try {
+    return realpathSync(entryPath)
+  } catch {
+    // An unresolvable path still compares correctly below.
+    return entryPath
+  }
+}
+
+const entryPath = process.argv[1]
+if (entryPath !== undefined && import.meta.url === pathToFileURL(resolveEntryPath(entryPath)).href) {
   runCli()
     .then((exitCode) => {
       process.exitCode = exitCode

--- a/packages/logfire-api/vite.config.ts
+++ b/packages/logfire-api/vite.config.ts
@@ -1,9 +1,13 @@
-import { copyFileSync, existsSync } from 'node:fs'
+import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
+
+const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string
+}
 
 const packageDefines = {
   PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(process.env['npm_package_version'] ?? '0.0.0'),
+  PACKAGE_VERSION: JSON.stringify(packageVersion),
 }
 
 const copyCjsDeclarations = (names: string[]) => {

--- a/packages/logfire-api/vite.config.ts
+++ b/packages/logfire-api/vite.config.ts
@@ -1,28 +1,13 @@
-import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
 
-const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+import { copyCjsDeclarations, packageDefines } from '../../vite.shared'
 
-const packageDefines = {
-  PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(packageVersion),
-}
-
-const copyCjsDeclarations = (names: string[]) => {
-  for (const name of names) {
-    const src = `dist/${name}.d.ts`
-    if (existsSync(src)) {
-      copyFileSync(src, `dist/${name}.d.cts`)
-    }
-  }
-}
+const defines = packageDefines(import.meta.url)
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
-  define: packageDefines,
+  define: defines,
   pack: {
-    define: packageDefines,
+    define: defines,
     dts: {
       resolver: 'tsc',
     },

--- a/packages/logfire-browser/vite.config.ts
+++ b/packages/logfire-browser/vite.config.ts
@@ -1,9 +1,13 @@
-import { copyFileSync, existsSync } from 'node:fs'
+import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
+
+const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string
+}
 
 const packageDefines = {
   PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(process.env['npm_package_version'] ?? '0.0.0'),
+  PACKAGE_VERSION: JSON.stringify(packageVersion),
 }
 
 const copyCjsDeclarations = () => {

--- a/packages/logfire-browser/vite.config.ts
+++ b/packages/logfire-browser/vite.config.ts
@@ -1,25 +1,13 @@
-import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
 
-const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+import { copyCjsDeclarations, packageDefines } from '../../vite.shared'
 
-const packageDefines = {
-  PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(packageVersion),
-}
-
-const copyCjsDeclarations = () => {
-  if (existsSync('dist/index.d.ts')) {
-    copyFileSync('dist/index.d.ts', 'dist/index.d.cts')
-  }
-}
+const defines = packageDefines(import.meta.url)
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
-  define: packageDefines,
+  define: defines,
   pack: {
-    define: packageDefines,
+    define: defines,
     dts: {
       resolver: 'tsc',
     },
@@ -29,7 +17,9 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     entry: 'src/index.ts',
     format: ['esm', 'cjs'],
     hooks: {
-      'build:done': copyCjsDeclarations,
+      'build:done': () => {
+        copyCjsDeclarations(['index'])
+      },
     },
     minify: true,
     outExtensions: ({ format }) => ({

--- a/packages/logfire-cf-workers/vite.config.ts
+++ b/packages/logfire-cf-workers/vite.config.ts
@@ -1,19 +1,13 @@
-import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
 
-const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+import { packageDefines } from '../../vite.shared'
 
-const packageDefines = {
-  PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(packageVersion),
-}
+const defines = packageDefines(import.meta.url)
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
-  define: packageDefines,
+  define: defines,
   pack: {
-    define: packageDefines,
+    define: defines,
     dts: {
       resolver: 'tsc',
     },

--- a/packages/logfire-node/vite.config.ts
+++ b/packages/logfire-node/vite.config.ts
@@ -1,28 +1,13 @@
-import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
 
-const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+import { copyCjsDeclarations, packageDefines } from '../../vite.shared'
 
-const packageDefines = {
-  PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(packageVersion),
-}
-
-const copyCjsDeclarations = (names: string[]) => {
-  for (const name of names) {
-    const src = `dist/${name}.d.ts`
-    if (existsSync(src)) {
-      copyFileSync(src, `dist/${name}.d.cts`)
-    }
-  }
-}
+const defines = packageDefines(import.meta.url)
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
-  define: packageDefines,
+  define: defines,
   pack: {
-    define: packageDefines,
+    define: defines,
     dts: {
       resolver: 'tsc',
     },

--- a/packages/logfire-session-replay/vite.config.ts
+++ b/packages/logfire-session-replay/vite.config.ts
@@ -1,9 +1,13 @@
-import { copyFileSync, existsSync } from 'node:fs'
+import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
+
+const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string
+}
 
 const packageDefines = {
   PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(process.env['npm_package_version'] ?? '0.0.0'),
+  PACKAGE_VERSION: JSON.stringify(packageVersion),
 }
 
 const copyCjsDeclarations = () => {

--- a/packages/logfire-session-replay/vite.config.ts
+++ b/packages/logfire-session-replay/vite.config.ts
@@ -1,25 +1,13 @@
-import { copyFileSync, existsSync, readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
 
-const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+import { copyCjsDeclarations, packageDefines } from '../../vite.shared'
 
-const packageDefines = {
-  PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(packageVersion),
-}
-
-const copyCjsDeclarations = () => {
-  if (existsSync('dist/index.d.ts')) {
-    copyFileSync('dist/index.d.ts', 'dist/index.d.cts')
-  }
-}
+const defines = packageDefines(import.meta.url)
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
-  define: packageDefines,
+  define: defines,
   pack: {
-    define: packageDefines,
+    define: defines,
     dts: {
       resolver: 'tsc',
     },
@@ -29,7 +17,9 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     entry: 'src/index.ts',
     format: ['esm', 'cjs'],
     hooks: {
-      'build:done': copyCjsDeclarations,
+      'build:done': () => {
+        copyCjsDeclarations(['index'])
+      },
     },
     minify: true,
     outExtensions: ({ format }) => ({

--- a/packages/otel-cf-workers/vite.config.ts
+++ b/packages/otel-cf-workers/vite.config.ts
@@ -1,19 +1,13 @@
-import { readFileSync } from 'node:fs'
 import { defineConfig } from 'vite-plus'
 
-const { version: packageVersion } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
-  version: string
-}
+import { packageDefines } from '../../vite.shared'
 
-const packageDefines = {
-  PACKAGE_TIMESTAMP: String(Date.now()),
-  PACKAGE_VERSION: JSON.stringify(packageVersion),
-}
+const defines = packageDefines(import.meta.url)
 
 const config: ReturnType<typeof defineConfig> = defineConfig({
-  define: packageDefines,
+  define: defines,
   pack: {
-    define: packageDefines,
+    define: defines,
     dts: {
       resolver: 'tsc',
     },

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -1,0 +1,27 @@
+import { copyFileSync, existsSync, readFileSync } from 'node:fs'
+
+import type { UserConfig } from 'vite-plus'
+
+// Taken from vite-plus rather than hand-written, so the result is exactly what `define` accepts.
+// A named interface would not be assignable to its index signature.
+export type PackageDefines = NonNullable<UserConfig['define']>
+
+// Resolved from the calling config's own location. The working directory and npm_package_version
+// both point at the repository root when the release script builds every package in one go, which
+// stamped the private root version into published artifacts.
+export function packageDefines(configUrl: string): PackageDefines {
+  const { version } = JSON.parse(readFileSync(new URL('./package.json', configUrl), 'utf8')) as { version: string }
+  return {
+    PACKAGE_TIMESTAMP: String(Date.now()),
+    PACKAGE_VERSION: JSON.stringify(version),
+  }
+}
+
+export function copyCjsDeclarations(names: string[]): void {
+  for (const name of names) {
+    const source = `dist/${name}.d.ts`
+    if (existsSync(source)) {
+      copyFileSync(source, `dist/${name}.d.cts`)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #238. Supersedes #239.

## The CLI never ran

`npx logfire auth` exited 0 and printed nothing, so every documented CLI command was unreachable from an npm install. Nothing threw, so a user following the setup guide simply got no credentials and later found no data in their project.

The entrypoint guard compared `import.meta.url` against `process.argv[1]` verbatim. Node resolves the module URL to the real path but leaves `argv[1]` as the literal invocation path, so any symlink between the two made the comparison fail and `runCli()` was never called. `argv[1]` is now resolved before the comparison, falling back to the raw path when it cannot be resolved so the module never throws at load.

This reaches further than the npm bin symlink named in the report. Any invocation path that crosses a symlink hits it, and there are two ways to get one: the bin is itself a symlink, or the bin is a shim whose target points through a symlinked package directory. Measured against a packed tarball, before and after:

| Install | Before | After |
| --- | --- | --- |
| npm | broken | works |
| Yarn | broken | works |
| pnpm, `node-linker=hoisted` | broken | works |
| pnpm workspace link | broken | works |
| Deno, bin in `node_modules` | broken | works |
| pnpm default (isolated) | works | works |
| `pnpm add -g` | works | works |
| Deno `npm:` specifier, `deno install -g` | works | works |
| Bun, all paths | works | works |

pnpm's default isolated layout escaped only by accident: its shim hardcodes the physical `.pnpm/<dir>/node_modules/logfire/dist/cli.js` path instead of routing through the `node_modules/logfire` symlink. That is why the bug was invisible in local development while being total for published installs. `pnpm exec logfire` inside this repository was broken too, since workspace links do go through a symlinked directory.

## Published packages reported the wrong version

While verifying the above I found that published `logfire@0.21.8` reports `Running Logfire 1.0.0`.

`PACKAGE_VERSION` was read from the ambient `npm_package_version` environment variable at build time, which resolves to whichever `package.json` the build was started from. Releases run `pnpm run build` from the repository root, so published artifacts were stamped with the private root version `1.0.0` rather than their own. `logfire --version` and `logfire info` were therefore useless for bug reports, and the CLI sent `logfire-js/1.0.0` as its user agent.

The blast radius is wider than the CLI: `@pydantic/logfire-browser` sent the same wrong value as the `telemetry.sdk.version` resource attribute on every browser span.

Each package now reads the version from its own `package.json`, matching what `@pydantic/logfire-node`, `@pydantic/logfire-cf-workers`, and `@pydantic/otel-cf-workers` already did. Verified with a root build, which is the release path.

## Build config cleanup

The version fix would have made six copies of the same block, so the shared parts moved to `vite.shared.ts`: `packageDefines()` and `copyCjsDeclarations()`, the latter previously duplicated in two variants that differed only in whether entry names were passed in. Net 50 lines removed across the six configs. The agent guide's repository layout is corrected in the same commit, since it described a `packages/tooling-config` package that does not exist.

## Credit

The diagnosis is @strawgate's in #238, and @ayaangazali wrote the same `realpathSync` fix independently in #239, which I have credited as co-author on the first commit. Two things differ from that PR: the `realpathSync` call is wrapped so the module never throws at load if `argv[1]` cannot be resolved (the tradeoff @ayaangazali flagged and offered to change), and there is no regression test.

On the test: #239 symlinks the built `dist/cli.js` and spawns it, which is the right shape for a packaging bug, but the test task has no build dependency. On a fresh clone `vp run logfire#test` fails because `dist/` does not exist, and with a stale `dist/` it passes against a regressed source — I reproduced both. A test whose result depends on whether a build artifact happens to be present is worse than no test here, so the fix ships without one.

## Verification

Full workspace typecheck, lint, format check, and test suite pass. The CLI was exercised end to end from a packed tarball under Node, Deno, and Bun across every install layout in the table above.
