### PR TITLE
Route span tree metrics through the shared increment

### DIFF
--- a/.changeset/evals-zero-metric-parity.md
+++ b/.changeset/evals-zero-metric-parity.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop recording zero-valued eval metrics that pydantic-evals omits. Span-tree metric extraction now goes through the same increment path as `incrementEvalMetric`, so a provider reporting `gen_ai.usage.cached_tokens: 0` no longer invents a `cached_tokens: 0` metric on the case.

--- a/packages/logfire-api/src/evals/__test__/spanTree.test.ts
+++ b/packages/logfire-api/src/evals/__test__/spanTree.test.ts
@@ -92,6 +92,33 @@ describe('span tree capture + HasMatchingSpan', () => {
     expect(m?.['cost']).toBeCloseTo(0.001)
   })
 
+  it('omits usage metrics that would be recorded as zero', async () => {
+    const dataset = new Dataset<null, string>({
+      cases: [new Case<null, string>({ inputs: null, name: 'usage' })],
+      name: 'zero-usage-metrics-test',
+    })
+
+    const { result } = await withMemoryExporter(async () =>
+      dataset.evaluate(async () => {
+        const tracer = TraceAPI.getTracer('user-llm')
+        await tracer.startActiveSpan('chat', async (span) => {
+          span.setAttribute('gen_ai.request.model', 'gpt-4')
+          span.setAttribute('gen_ai.operation.name', 'chat')
+          span.setAttribute('gen_ai.usage.input_tokens', 100)
+          // Providers report zero for the token buckets a request did not use, and
+          // pydantic-evals leaves those keys out of the metrics entirely.
+          span.setAttribute('gen_ai.usage.cached_tokens', 0)
+          span.setAttribute('gen_ai.usage.details.reasoning_tokens', 0)
+          span.setAttribute('operation.cost', 0)
+          span.end()
+        })
+        return 'done'
+      })
+    )
+
+    expect(result.cases[0]?.metrics).toEqual({ input_tokens: 100, requests: 1 })
+  })
+
   it('builds deterministic trees and evaluates structural span queries', () => {
     const tree = SpanTree.fromSpans([
       fakeSpan({

--- a/packages/logfire-api/src/evals/currentTaskRun.ts
+++ b/packages/logfire-api/src/evals/currentTaskRun.ts
@@ -84,6 +84,23 @@ export function setEvalAttribute(name: string, value: unknown): void {
 }
 
 /**
+ * Add `amount` to a metric, leaving the key absent when the result is still zero.
+ *
+ * Mirrors pydantic-evals' `TaskRun.increment_metric`, which is the single place that
+ * writes metrics in the Python port and skips the write when both the current and the
+ * new value are zero. Every metric write here must go through this so a zero-valued
+ * usage attribute does not invent a metric key that Python omits.
+ */
+export function incrementMetric(metrics: Record<string, number>, name: string, amount: number): void {
+  const current = metrics[name] ?? 0
+  const next = current + amount
+  if (current === 0 && next === 0) {
+    return
+  }
+  metrics[name] = next
+}
+
+/**
  * Increment a metric on the current case. No-op outside a `Dataset.evaluate`
  * task. Mirrors pydantic-evals' `increment_eval_metric`.
  */
@@ -92,10 +109,5 @@ export function incrementEvalMetric(name: string, amount: number): void {
   if (state === undefined) {
     return
   }
-  const current = state.metrics[name] ?? 0
-  const next = current + amount
-  if (current === 0 && next === 0) {
-    return
-  }
-  state.metrics[name] = next
+  incrementMetric(state.metrics, name, amount)
 }

--- a/packages/logfire-api/src/evals/extractMetrics.ts
+++ b/packages/logfire-api/src/evals/extractMetrics.ts
@@ -11,6 +11,8 @@
 
 import type { SpanTree } from './spanTree/SpanTree'
 
+import { incrementMetric } from './currentTaskRun'
+
 export function extractMetricsFromSpanTree(tree: SpanTree, into: Record<string, number>): void {
   for (const node of tree.all()) {
     const attrs = node.attributes
@@ -18,11 +20,11 @@ export function extractMetricsFromSpanTree(tree: SpanTree, into: Record<string, 
       continue
     }
     if (attrs['gen_ai.operation.name'] === 'chat') {
-      into['requests'] = (into['requests'] ?? 0) + 1
+      incrementMetric(into, 'requests', 1)
     }
     const cost = attrs['operation.cost']
     if (typeof cost === 'number') {
-      into['cost'] = (into['cost'] ?? 0) + cost
+      incrementMetric(into, 'cost', cost)
     }
     for (const [k, v] of Object.entries(attrs)) {
       if (typeof v !== 'number') {
@@ -31,11 +33,9 @@ export function extractMetricsFromSpanTree(tree: SpanTree, into: Record<string, 
       const usagePrefix = 'gen_ai.usage.'
       const detailsPrefix = 'gen_ai.usage.details.'
       if (k.startsWith(detailsPrefix)) {
-        const key = k.slice(detailsPrefix.length)
-        into[key] = (into[key] ?? 0) + v
+        incrementMetric(into, k.slice(detailsPrefix.length), v)
       } else if (k.startsWith(usagePrefix)) {
-        const key = k.slice(usagePrefix.length)
-        into[key] = (into[key] ?? 0) + v
+        incrementMetric(into, k.slice(usagePrefix.length), v)
       }
     }
   }


### PR DESCRIPTION
## Defect

Span-tree metric extraction records metrics with value zero. pydantic-evals does not, so a JS eval report carries metric keys the Python one omits, and those keys show up as extra columns with mean 0 in the rendered report.

Providers routinely report zero for the token buckets a request did not use, so this is the common case rather than an edge case.

## Evidence

`TaskRun.increment_metric` is the single metric write in the Python port, and it refuses to create a key that would still be zero (`pydantic_evals/_task_run.py`):

```python
def increment_metric(self, name: str, amount: int | float) -> None:
    current_value = self.metrics.get(name, 0)
    incremented_value = current_value + amount
    if current_value == 0 and incremented_value == 0:
        return
    self.record_metric(name, incremented_value)
```

`extract_span_tree_metrics` calls that method, so the rule applies to span-tree metrics too.

On this side the rule is implemented, correctly, in `incrementEvalMetric` in `currentTaskRun.ts`, but `extractMetricsFromSpanTree` writes to the map directly and bypasses it. So the port split one Python function into two implementations and only one kept the guard.

Verified on `7874752`. A case whose task emits `gen_ai.usage.input_tokens: 100`, `gen_ai.usage.cached_tokens: 0`, `gen_ai.usage.details.reasoning_tokens: 0` and `operation.cost: 0` produces:

```
{ cached_tokens: 0, cost: 0, input_tokens: 100, reasoning_tokens: 0, requests: 1 }
```

Python produces `{ input_tokens: 100, requests: 1 }`.

## Fix

Give the rule one home. `incrementMetric(metrics, name, amount)` is factored out of `incrementEvalMetric`, which now calls it, and the three inline `into[key] = (into[key] ?? 0) + v` writes in `extractMetricsFromSpanTree` call it as well. That removes the duplicated arithmetic rather than adding a second copy of the guard, so a future metric writer cannot drift the same way.

`incrementMetric` is intentionally not added to `evals/index.ts`; it stays internal.

The regression test asserts the whole metrics object, so it fails both if a zero key reappears and if a real metric goes missing. Reverting either call site to the inline form fails it with `+ "cached_tokens": 0` and `+ "reasoning_tokens": 0`.

Built this with Claude Code's help and reviewed the diff myself.