### PR TITLE
Encode a single list argument in the long form

### DIFF
--- a/.changeset/spec-list-positional-arg.md
+++ b/.changeset/spec-list-positional-arg.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Encode an evaluator whose only argument is a list in the long form. `new Equals({ value: [1, 2] })` serialized to `{Equals: [1, 2]}`, which reads back as the multi-positional form and rebuilt the evaluator with the wrong arguments.

--- a/.changeset/spec-list-positional-arg.md
+++ b/.changeset/spec-list-positional-arg.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Encode an evaluator whose only argument is a list in the long form. `new Equals({ value: [1, 2] })` serialized to `{Equals: [1, 2]}`, which reads back as the multi-positional form and rebuilt the evaluator with the wrong arguments.
+Encode an evaluator whose only argument is a list in the long form. `new Equals({ value: [1, 2] })` previously serialized to the short form `{Equals: [1, 2]}`, which reads back as two positional arguments and rebuilt the evaluator with the wrong ones. It now serializes to `{Equals: {value: [1, 2]}}`. Existing files that already contain the short form are unaffected by this change and still decode as positional arguments.

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -55,6 +55,18 @@ describe('EvaluatorSpec encoding', () => {
     expect(decodeSpec({ Equals: 1 })).toEqual({ arguments: [1], name: 'Equals' })
   })
 
+  it('round-trips an evaluator whose only argument is a list', () => {
+    // The short form `{Equals: [1, 2]}` would decode as the multi-positional form, so a list
+    // argument has to encode long even though it is a single argument.
+    const encoded = encodeEvaluatorSpec(new Equals({ value: [1, 2] }))
+
+    expect(encoded).toEqual({ Equals: { value: [1, 2] } })
+    expect(decodeSpec(encoded)).toEqual({ arguments: { value: [1, 2] }, name: 'Equals' })
+
+    const decoded = decodeEvaluator(encoded, new Map([['Equals', Equals]]), new Map([['Equals', 'value']]))
+    expect((decoded as Equals).value).toEqual([1, 2])
+  })
+
   it('decodeSpec parses kwargs long form', () => {
     expect(decodeSpec({ Contains: { value: 'foo' } })).toEqual({ arguments: { value: 'foo' }, name: 'Contains' })
   })

--- a/packages/logfire-api/src/evals/serialization/spec.ts
+++ b/packages/logfire-api/src/evals/serialization/spec.ts
@@ -47,9 +47,11 @@ export function encodeEvaluatorSpec(evaluator: Evaluator | ReportEvaluator): Enc
   if (keys.length === 1) {
     const onlyKey = keys[0]!
     const onlyVal = args[onlyKey]
-    // Short form ONLY safe when value is NOT a string-keyed dict (otherwise round-trip
-    // is ambiguous with the long form). Matches `pydantic_ai/_spec.py:36–46`.
-    if (!isStringKeyedDict(onlyVal)) {
+    // Short form ONLY safe when the value is neither a string-keyed dict nor a list. A dict
+    // would come back as kwargs (`pydantic_ai/_spec.py:36-46`), and a list would come back as
+    // the multi-positional form that `decodeSpec` supports, so both are ambiguous encodings of
+    // a single argument and have to use the long form.
+    if (!isStringKeyedDict(onlyVal) && !Array.isArray(onlyVal)) {
       return { [name]: onlyVal }
     }
   }


### PR DESCRIPTION
## Defect

An evaluator whose only argument is a list does not survive serialization. It comes back constructed with the wrong arguments, and nothing raises.

```
new Equals({ value: [1, 2] })
  -> encodeEvaluatorSpec -> { Equals: [1, 2] }
  -> decodeSpec          -> { name: 'Equals', arguments: [1, 2] }
  -> constructEvaluator  -> new Equals(1, 2)
```

`Equals` takes an options object, so it receives `1` as its options and the assertion the dataset asked for is silently gone. The one-element case is worse than a crash: `{ value: [1] }` round-trips to `value: 1`, so a case asserting the output equals `[1]` quietly starts asserting it equals `1`.

## Evidence

`encodeEvaluatorSpec` already refuses the short form when the single argument is a string-keyed dict, because that would read back as kwargs:

```ts
// Short form ONLY safe when value is NOT a string-keyed dict (otherwise round-trip
// is ambiguous with the long form).
if (!isStringKeyedDict(onlyVal)) {
  return { [name]: onlyVal }
}
```

A list is ambiguous for the same reason, against a different form. `decodeSpec` treats an array value as the multi-positional form, which `serialization.test.ts:98` pins deliberately with `{ PairEvaluator: ['x', 2] }`. So `{Equals: [1, 2]}` is a valid encoding of two positional arguments, and the encoder must not emit it to mean one list argument.

Reproduced on `7874752`: `encodeEvaluatorSpec(new Equals({ value: [1, 2] }))` returns `{ Equals: [1, 2] }` and `decodeSpec` returns `arguments: [1, 2]`.

## Fix

Extend the existing ambiguity guard to lists, so a single list argument encodes long as `{Equals: {value: [1, 2]}}` and decodes back through the kwargs path.

I fixed the encoder rather than the decoder on purpose. Making `decodeSpec` read an array as one positional argument would match `_SerializedNamedSpec._args`, whose `arguments` is a one-element tuple with no multi-positional form at all, but it would also break the `PairEvaluator` behaviour this repo tests on purpose. That looked like the obvious fix until the test said otherwise, so the extension stays and the ambiguous encoding goes.

Reverting the guard fails the new test with `expected { Equals: [ 1, 2 ] } to deeply equal { Equals: { value: [ 1, 2 ] } }`.

Built this with Claude Code's help and reviewed the diff myself.