### PR TITLE
Treat a null expected_output as missing in EqualsExpected

### DIFF
--- a/.changeset/equals-expected-null.md
+++ b/.changeset/equals-expected-null.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Treat a null `expected_output` as missing in `EqualsExpected`. A dataset case written with `expected_output: null` produced a failing assertion instead of no assertion, which is what pydantic-evals records and what #219 already settled for the confusion matrix.

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -64,6 +64,8 @@ describe('built-in evaluator edge cases', () => {
     const expected = new EqualsExpected({ evaluationName: 'expected-match' })
     expect(expected.toJSON()).toEqual({ evaluation_name: 'expected-match' })
     expect(expected.evaluate(ctx('x'))).toEqual({})
+    // A dataset file spells a missing expected output as `null`, which Python skips on.
+    expect(expected.evaluate(ctx('x', { expectedOutput: null }))).toEqual({})
     expect(expected.evaluate(ctx('x', { expectedOutput: 'x' }))).toBe(true)
   })
 

--- a/packages/logfire-api/src/evals/builtins/EqualsExpected.ts
+++ b/packages/logfire-api/src/evals/builtins/EqualsExpected.ts
@@ -30,7 +30,9 @@ export class EqualsExpected extends Evaluator {
   }
 
   evaluate(ctx: EvaluatorContext): EvaluatorOutput {
-    if (ctx.expectedOutput === undefined) {
+    // Python has one absent value and skips on `expected_output is None`. JSON and YAML give
+    // us `null` for that, so both spellings have to mean "no expected output".
+    if (ctx.expectedOutput === undefined || ctx.expectedOutput === null) {
       return {}
     }
     return deepEqual(ctx.output, ctx.expectedOutput)


### PR DESCRIPTION
## Defect

A dataset case written with `expected_output: null` gets a **failing** `EqualsExpected` assertion instead of no assertion.

## Evidence

`EqualsExpected.evaluate` skips only on `undefined`:

```ts
if (ctx.expectedOutput === undefined) {
  return {}
}
```

Python has one absent value and skips on it (`evaluators/common.py`):

```python
def evaluate(self, ctx) -> bool | dict[str, bool]:
    if ctx.expected_output is None:
        return {}  # Only compare if expected output is provided
    return ctx.output == ctx.expected_output
```

JSON and YAML spell that absent value as `null`, and `datasetFromObject` passes it straight through, since `expected_output !== undefined` is true for `null`. So the skip never fires for a file-loaded case.

Reproduced on `7874752`. Loading `{cases: [{inputs: 'a', expected_output: null, name: 'explicit-null'}], evaluators: ['EqualsExpected']}` and evaluating gives:

```
{ EqualsExpected: { value: false, reason: null, ... } }
```

Python records no assertion at all for that case.

## Fix

Treat `null` and `undefined` the same, which is what #219 already settled for `ConfusionMatrixEvaluator.extractLabel` and what `extractPositive` in `scoreCommon` does for the threshold evaluators. This was the last site still checking `undefined` alone.

The existing assertions in that test keep their meaning: an absent expected output still returns `{}`, and a real one still compares. Reverting the added `|| null` check fails the new assertion with `expected false to deeply equal {}`.

Built this with Claude Code's help and reviewed the diff myself.