### PR TITLE
Add `logfire projects status` and `read-tokens create --save`

### DIFF
--- a/.changeset/cli-projects-status.md
+++ b/.changeset/cli-projects-status.md
@@ -1,0 +1,5 @@
+---
+"logfire": minor
+---
+
+Add `logfire projects status` to show what telemetry has actually reached the linked project, one row per service. It reads a read token saved by the new `logfire read-tokens create --save`, which stores the token in `.logfire/read_token.json` instead of printing it, so verifying your own setup never puts a token in a terminal, a CI log, or an agent's transcript.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -116,12 +116,13 @@ Now requests through Express and Fastify, queries to PostgreSQL, MySQL, and Redi
 
 ## Troubleshooting
 
-| Symptom                                   | Likely cause                                    | Fix                                                                                                                                     |
-| ----------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Nothing appears in the Live view          | No credentials set                              | Run `npx logfire auth`, or set `LOGFIRE_TOKEN` from **Settings > Write tokens**                                                         |
-| A short script sends nothing              | The process exited before telemetry was flushed | Call `await logfire.shutdown()` before exiting                                                                                          |
-| Automatic traces are missing              | The app loaded before instrumentation did       | Load the instrumentation file first, for example `npx tsx --import ./instrumentation.ts server.ts`, and keep `configure()` in that file |
-| A `.ts` file won't run, or `import` fails | No TypeScript runner, or a CommonJS project     | Run with `npx tsx`, which handles TypeScript and ES modules in any project                                                              |
+| Symptom                                        | Likely cause                                    | Fix                                                                                                                                     |
+| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Nothing appears in the Live view               | No credentials set                              | Run `npx logfire auth`, or set `LOGFIRE_TOKEN` from **Settings > Write tokens**                                                         |
+| Need to confirm data arrived without a browser | e.g. checking from a CI job or a coding agent   | Run `npx logfire read-tokens create --save` once, then `npx logfire projects status` to see what's arrived, per service                 |
+| A short script sends nothing                   | The process exited before telemetry was flushed | Call `await logfire.shutdown()` before exiting                                                                                          |
+| Automatic traces are missing                   | The app loaded before instrumentation did       | Load the instrumentation file first, for example `npx tsx --import ./instrumentation.ts server.ts`, and keep `configure()` in that file |
+| A `.ts` file won't run, or `import` fails      | No TypeScript runner, or a CommonJS project     | Run with `npx tsx`, which handles TypeScript and ES modules in any project                                                              |
 
 ## Next steps
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,7 +18,9 @@ Supported commands:
 - `projects list`: list projects where the current user can create write tokens.
 - `projects new [project-name]`: create a project and write local project credentials.
 - `projects use [project-name]`: create a write token for an existing project and write local project credentials.
+- `projects status`: show what telemetry has actually reached the project this directory is linked to.
 - `read-tokens --project <org>/<project> create`: create a read token and print it to stdout.
+- `read-tokens create --save`: create a read token and store it in the data directory instead of printing it.
 - `whoami`: show configured user and project information.
 - `clean`: remove local project credentials.
 - `info`: print SDK and runtime information.
@@ -78,6 +80,50 @@ Both commands write `.logfire/logfire_credentials.json` and `.logfire/.gitignore
 
 Pass `--data-dir <dir>` to write credentials somewhere other than `.logfire`.
 
+## Status
+
+To see what telemetry has actually reached the project this directory is linked to, run:
+
+```bash
+npx logfire projects status
+```
+
+```
+Project  my-org/orders
+         https://logfire-us.pydantic.dev/my-org/orders
+
+ Service         | Records | Last seen
+-----------------|---------|---------------------------------
+ orders-web      | 87      | 2026-08-19T01:01:29.717170+00:00
+ orders-worker   | 84      | 2026-08-19T01:01:29.716577+00:00
+```
+
+One row per service, so a partly-instrumented system shows up as one: if you instrumented a web app and a worker but only the web app appears, the worker is not reporting.
+
+This needs a saved read token — see below — and reports the last hour. Add `--json` for machine-readable output.
+
+## Read tokens
+
+To create a read token for a project and print it to stdout, run:
+
+```bash
+npx logfire read-tokens --project <org>/<project> create
+```
+
+### Saving a token instead of printing it
+
+To store the token in the data directory rather than printing it, use `--save`:
+
+```bash
+npx logfire read-tokens create --save
+```
+
+With no `--project`, this uses the project the current directory is linked to. The token is written to `.logfire/read_token.json`, readable only by you, in the same gitignored directory that already holds your write credentials — and it is never printed, so it cannot end up in your terminal history, a CI log, or a coding agent's transcript.
+
+`npx logfire projects status` uses this token. A saved token expires after 30 days; run the command again to replace it.
+
+> A read token can read everything in the project, which may include personal data captured in span attributes. Keep `.logfire/` out of version control — the CLI adds a `.gitignore` for you — and use `npx logfire clean` to remove stored credentials.
+
 ## Whoami and clean
 
 Show the configured user and project for the current directory:
@@ -86,7 +132,7 @@ Show the configured user and project for the current directory:
 npx logfire whoami
 ```
 
-Remove the local project credentials written by `projects use/new`:
+Remove the local project credentials written by `projects use/new`, and any saved read token:
 
 ```bash
 npx logfire clean

--- a/packages/logfire-api/src/cli/client.test.ts
+++ b/packages/logfire-api/src/cli/client.test.ts
@@ -192,6 +192,32 @@ describe('CLI client', () => {
       new LogfireCliError('Could not reach https://logfire-us.pydantic.dev: connect ECONNREFUSED')
     )
   })
+
+  it('strips control characters from query connection errors', async () => {
+    const rejectedFetch = vi.fn<typeof fetch>(async () => Promise.reject(new Error('connect\x1b[2Kfailed')))
+    await expect(queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', { fetch: rejectedFetch })).rejects.toEqual(
+      new LogfireCliError('Could not reach https://logfire-us.pydantic.dev: connect�[2Kfailed')
+    )
+
+    const unusedFetch = vi.fn<typeof fetch>()
+    await expect(queryProject('bad\x1b[2Kurl', 'read-token', 'SELECT 1', { fetch: unusedFetch })).rejects.toEqual(
+      new LogfireCliError('Could not reach bad�[2Kurl: Invalid URL')
+    )
+    expect(unusedFetch).not.toHaveBeenCalled()
+  })
+
+  it('wraps a failure while reading a non-200 response body', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      Promise.resolve({
+        status: 500,
+        text: async () => Promise.reject(new Error('terminated\x1b[2K')),
+      } as unknown as Response)
+    )
+
+    await expect(queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', { fetch: fetchImpl })).rejects.toEqual(
+      new LogfireCliError('Could not read the project response: terminated�[2K')
+    )
+  })
 })
 
 interface CapturedRequest {

--- a/packages/logfire-api/src/cli/client.test.ts
+++ b/packages/logfire-api/src/cli/client.test.ts
@@ -159,6 +159,16 @@ describe('CLI client', () => {
     )
   })
 
+  it('strips control characters from a non-200 response body before it reaches the error message', async () => {
+    // The body of a non-200 response is whatever the server (or a proxy/WAF answering on
+    // its behalf) sent, not something this CLI generated -- the same untrusted-text
+    // reasoning `printableCell` applies to a telemetry-supplied service name.
+    const fetchImpl = fetchSequence([], [new Response('evil\x1b[2Kmessage', { status: 500 })])
+    await expect(queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', { fetch: fetchImpl })).rejects.toEqual(
+      new LogfireCliError('Could not read the project: 500 evil�[2Kmessage')
+    )
+  })
+
   it.each([
     ['not json at all', 'not json at all'],
     ['{"no_data_key":[]}', '{"no_data_key":[]}'],

--- a/packages/logfire-api/src/cli/client.test.ts
+++ b/packages/logfire-api/src/cli/client.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi } from 'vite-plus/test'
 
-import { LogfireApiClient, InvalidProjectNameError, ProjectAlreadyExistsError, pollForToken, requestDeviceCode, urlFor } from './client'
+import {
+  LogfireApiClient,
+  InvalidProjectNameError,
+  ProjectAlreadyExistsError,
+  pollForToken,
+  queryProject,
+  requestDeviceCode,
+  urlFor,
+} from './client'
+import { LogfireCliError } from './errors'
 
 describe('CLI client', () => {
   it('uses Python-compatible device auth endpoints', async () => {
@@ -98,6 +107,80 @@ describe('CLI client', () => {
   it('joins endpoint URLs against base URLs with or without trailing slashes', () => {
     expect(urlFor('https://example.com', '/v1/info')).toBe('https://example.com/v1/info')
     expect(urlFor('https://example.com/', '/v1/info')).toBe('https://example.com/v1/info')
+  })
+
+  it('includes an expiry on createReadToken only when one is passed', async () => {
+    const calls: CapturedRequest[] = []
+    const client = new LogfireApiClient({
+      fetch: fetchSequence(calls, [jsonResponse({ token: 'read-token' }), jsonResponse({ token: 'read-token' })]),
+      userToken: { baseUrl: 'https://logfire-us.pydantic.dev', expiration: '2099-12-31T23:59:59Z', token: 'user-token' },
+    })
+
+    await client.createReadToken('org', 'project')
+    await client.createReadToken('org', 'project', new Date('2099-01-01T00:00:00.000Z'))
+
+    expect(calls.map((call) => call.body)).toEqual([
+      '{"description":"Created by Logfire CLI"}',
+      '{"description":"Created by Logfire CLI","expires_at":"2099-01-01T00:00:00.000Z"}',
+    ])
+  })
+
+  it('queries a project with the read token, not the class auth headers', async () => {
+    const calls: CapturedRequest[] = []
+    const fetchImpl = fetchSequence(calls, [
+      jsonResponse({ data: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 87, service_name: 'orders-web' }] }),
+    ])
+
+    await expect(
+      queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', {
+        fetch: fetchImpl,
+        limit: 10_000,
+        minTimestamp: new Date('2026-08-19T00:00:00.000Z'),
+      })
+    ).resolves.toEqual([{ last_seen: '2026-08-19T01:00:00.000Z', records: 87, service_name: 'orders-web' }])
+
+    expect(calls).toEqual([
+      {
+        authorization: 'read-token',
+        body: '{"sql":"SELECT 1","min_timestamp":"2026-08-19T00:00:00.000Z","limit":10000}',
+        method: 'POST',
+        url: 'https://logfire-us.pydantic.dev/v2/query',
+      },
+    ])
+  })
+
+  it('rejects a query with a status other than exactly 200', async () => {
+    // Not `response.ok`: a 204 is "not an error" by that test and would then fail parsing
+    // the body as JSON instead of surfacing this message. 204 is a "null body status", so
+    // the Response constructor requires `null`, not an empty string, as the body.
+    const fetchImpl = fetchSequence([], [new Response(null, { status: 204 })])
+    await expect(queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', { fetch: fetchImpl })).rejects.toEqual(
+      new LogfireCliError('Could not read the project: 204 ')
+    )
+  })
+
+  it.each([
+    ['not json at all', 'not json at all'],
+    ['{"no_data_key":[]}', '{"no_data_key":[]}'],
+    ['{"data":"not a list"}', '{"data":"not a list"}'],
+    ['{"data":["not","objects"]}', '{"data":["not","objects"]}'],
+  ])('rejects a malformed 200 response body: %s', async (_label, body) => {
+    // A 200 does not guarantee the real backend produced the body -- a proxy or WAF can
+    // intercept the request and answer with its own page.
+    const fetchImpl = fetchSequence([], [new Response(body, { status: 200 })])
+    await expect(queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', { fetch: fetchImpl })).rejects.toBeInstanceOf(
+      LogfireCliError
+    )
+  })
+
+  it('reports a network failure cleanly instead of an unhandled rejection', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      await Promise.resolve()
+      throw new Error('connect ECONNREFUSED')
+    })
+    await expect(queryProject('https://logfire-us.pydantic.dev', 'read-token', 'SELECT 1', { fetch: fetchImpl })).rejects.toEqual(
+      new LogfireCliError('Could not reach https://logfire-us.pydantic.dev: connect ECONNREFUSED')
+    )
   })
 })
 

--- a/packages/logfire-api/src/cli/client.ts
+++ b/packages/logfire-api/src/cli/client.ts
@@ -2,6 +2,7 @@ import { hostname } from 'node:os'
 
 import type { UserToken, UserTokenData } from './credentials'
 import { LogfireCliError } from './errors'
+import { sanitizeForTerminal } from './output'
 
 export const USER_AGENT: string = `logfire-js/${PACKAGE_VERSION}`
 
@@ -285,7 +286,10 @@ export async function queryProject(
   // Exactly 200, not `response.ok`: a 204 or 3xx is "not an error" by that test and would
   // then fail parsing the body as JSON instead of this message.
   if (response.status !== 200) {
-    throw new LogfireCliError(`Could not read the project: ${String(response.status)} ${await response.text()}`)
+    // Sanitized: this reaches stderr via a thrown error message, and the body is
+    // whatever the server (or a proxy/WAF answering on its behalf) sent, not something
+    // this CLI generated.
+    throw new LogfireCliError(`Could not read the project: ${String(response.status)} ${sanitizeForTerminal(await response.text())}`)
   }
 
   let payload: unknown

--- a/packages/logfire-api/src/cli/client.ts
+++ b/packages/logfire-api/src/cli/client.ts
@@ -112,10 +112,14 @@ export class LogfireApiClient {
     )
   }
 
-  async createReadToken(organization: string, projectName: string): Promise<{ token: string }> {
+  async createReadToken(organization: string, projectName: string, expiresAt?: Date): Promise<{ token: string }> {
+    const body: Record<string, string> = { description: 'Created by Logfire CLI' }
+    if (expiresAt !== undefined) {
+      body['expires_at'] = expiresAt.toISOString()
+    }
     return await this.postJson<{ token: string }>(
       `/v1/organizations/${encodeURIComponent(organization)}/projects/${encodeURIComponent(projectName)}/read-tokens`,
-      { description: 'Created by Logfire CLI' },
+      body,
       'Error creating project read token'
     )
   }
@@ -227,6 +231,77 @@ export async function getTokenInfo(
     return undefined
   }
   return (await response.json()) as TokenInfoResponse
+}
+
+export type QueryProjectRow = Record<string, unknown>
+
+export interface QueryProjectOptions {
+  fetch?: typeof fetch
+  limit?: number
+  minTimestamp?: Date
+}
+
+/**
+ * Run a SQL query against a project's telemetry, authenticated with a READ token rather
+ * than the CLI's own user session -- this is why it is a standalone function rather than
+ * a `LogfireApiClient` method, matching `getTokenInfo` above for the same reason.
+ *
+ * `baseUrl` must be the host the read token was actually minted against (recorded by
+ * `saveReadToken`), never re-derived from anywhere inside the project being queried -- see
+ * the doc comment on `saveReadToken` for why.
+ */
+export async function queryProject(
+  baseUrl: string,
+  readToken: string,
+  sql: string,
+  options: QueryProjectOptions = {}
+): Promise<QueryProjectRow[]> {
+  const fetchImpl = options.fetch ?? fetch
+  const body: Record<string, unknown> = { sql }
+  if (options.minTimestamp !== undefined) {
+    body['min_timestamp'] = options.minTimestamp.toISOString()
+  }
+  if (options.limit !== undefined) {
+    body['limit'] = options.limit
+  }
+
+  let response: Response
+  try {
+    response = await fetchImpl(urlFor(baseUrl, '/v2/query'), {
+      body: JSON.stringify(body),
+      headers: {
+        Authorization: readToken,
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+      method: 'POST',
+    })
+  } catch (error) {
+    // A DNS failure, timeout, or refused connection rejects here rather than resolving a
+    // response, and would otherwise surface as a raw, unhandled rejection.
+    throw new LogfireCliError(`Could not reach ${baseUrl}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  // Exactly 200, not `response.ok`: a 204 or 3xx is "not an error" by that test and would
+  // then fail parsing the body as JSON instead of this message.
+  if (response.status !== 200) {
+    throw new LogfireCliError(`Could not read the project: ${String(response.status)} ${await response.text()}`)
+  }
+
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    throw new LogfireCliError('Could not read the project: unexpected response shape (not JSON)')
+  }
+  const data = isRecord(payload) ? payload['data'] : undefined
+  // A 200 whose body is not JSON, or JSON shaped unlike the query response, can happen
+  // without the backend ever seeing the request -- a proxy or WAF intercepting it -- and
+  // would otherwise fail below with a raw type error instead of this message.
+  if (!Array.isArray(data) || !data.every((row) => isRecord(row))) {
+    throw new LogfireCliError('Could not read the project: unexpected response shape ("data" is not a list of objects)')
+  }
+  return data as QueryProjectRow[]
 }
 
 export function urlFor(baseUrl: string, endpoint: string): string {

--- a/packages/logfire-api/src/cli/client.ts
+++ b/packages/logfire-api/src/cli/client.ts
@@ -280,7 +280,8 @@ export async function queryProject(
   } catch (error) {
     // A DNS failure, timeout, or refused connection rejects here rather than resolving a
     // response, and would otherwise surface as a raw, unhandled rejection.
-    throw new LogfireCliError(`Could not reach ${baseUrl}: ${error instanceof Error ? error.message : String(error)}`)
+    const detail = `${baseUrl}: ${error instanceof Error ? error.message : String(error)}`
+    throw new LogfireCliError(`Could not reach ${sanitizeForTerminal(detail)}`)
   }
 
   // Exactly 200, not `response.ok`: a 204 or 3xx is "not an error" by that test and would
@@ -289,7 +290,14 @@ export async function queryProject(
     // Sanitized: this reaches stderr via a thrown error message, and the body is
     // whatever the server (or a proxy/WAF answering on its behalf) sent, not something
     // this CLI generated.
-    throw new LogfireCliError(`Could not read the project: ${String(response.status)} ${sanitizeForTerminal(await response.text())}`)
+    let responseText: string
+    try {
+      responseText = await response.text()
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      throw new LogfireCliError(`Could not read the project response: ${sanitizeForTerminal(detail)}`)
+    }
+    throw new LogfireCliError(`Could not read the project: ${String(response.status)} ${sanitizeForTerminal(responseText)}`)
   }
 
   let payload: unknown

--- a/packages/logfire-api/src/cli/commands/clean.ts
+++ b/packages/logfire-api/src/cli/commands/clean.ts
@@ -2,7 +2,7 @@ import { existsSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 import type { CliContext } from '../context'
-import { defaultDataDir, projectCredentialsPath, removeProjectCredentials } from '../credentials'
+import { defaultDataDir, projectCredentialsPath, readTokenPath, removeProjectCredentials } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { writeLine } from '../output'
 
@@ -18,7 +18,7 @@ export async function runCleanCommand(args: string[], context: CliContext): Prom
     throw new LogfireCliError(`No Logfire data found in ${dataDir}`)
   }
 
-  const files = [join(dataDir, '.gitignore'), projectCredentialsPath(dataDir)].filter((path) => existsSync(path))
+  const files = [join(dataDir, '.gitignore'), projectCredentialsPath(dataDir), readTokenPath(dataDir)].filter((path) => existsSync(path))
   const confirmed = await context.prompt.confirm(`The following files will be deleted:\n${files.join('\n')}\nAre you sure?`, false)
   if (confirmed) {
     removeProjectCredentials(dataDir)

--- a/packages/logfire-api/src/cli/commands/clean.ts
+++ b/packages/logfire-api/src/cli/commands/clean.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'node:fs'
+import { existsSync, lstatSync } from 'node:fs'
 import { join } from 'node:path'
 
 import type { CliContext } from '../context'
@@ -14,7 +14,19 @@ export async function runCleanCommand(args: string[], context: CliContext): Prom
     writeLine(context.stderr, 'No JavaScript Logfire CLI log files are created; --logs has nothing to remove.')
   }
 
-  if (!existsSync(dataDir) || !statSync(dataDir).isDirectory()) {
+  if (!existsSync(dataDir)) {
+    throw new LogfireCliError(`No Logfire data found in ${dataDir}`)
+  }
+  // `lstatSync`, not `statSync`: the data directory lives inside the user's repository, so
+  // a symlink can arrive by being committed to it. `statSync` follows symlinks, so it
+  // would report a symlinked `.logfire` as an ordinary directory, and `removeProjectCredentials`
+  // below would then list and delete through it -- exactly the risk `ensureDataDir` already
+  // guards against on the write path.
+  const dataDirStat = lstatSync(dataDir)
+  if (dataDirStat.isSymbolicLink()) {
+    throw new LogfireCliError(`${dataDir} is a symlink; refusing to clean through it.`)
+  }
+  if (!dataDirStat.isDirectory()) {
     throw new LogfireCliError(`No Logfire data found in ${dataDir}`)
   }
 

--- a/packages/logfire-api/src/cli/commands/projects.ts
+++ b/packages/logfire-api/src/cli/commands/projects.ts
@@ -1,14 +1,35 @@
 import { basename } from 'node:path'
 
 import { createAuthenticatedClient } from '../authClient'
-import type { LogfireApiClient, ProjectTokenResponse, WritableProject } from '../client'
-import { InvalidProjectNameError, ProjectAlreadyExistsError } from '../client'
+import type { LogfireApiClient, ProjectTokenResponse, QueryProjectRow, WritableProject } from '../client'
+import { InvalidProjectNameError, ProjectAlreadyExistsError, queryProject } from '../client'
 import type { CliContext, GlobalOptions } from '../context'
-import { defaultDataDir, writeProjectCredentials } from '../credentials'
+import {
+  defaultDataDir,
+  loadSavedReadToken,
+  organizationFromProjectUrl,
+  readProjectCredentials,
+  writeProjectCredentials,
+} from '../credentials'
 import { LogfireCliError } from '../errors'
 import { prettyTable, writeLine } from '../output'
 
 const PROJECT_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u
+
+// How far back `projects status` looks. Long enough to cover a setup session, short
+// enough that the answer is about what just happened rather than about last week.
+const STATUS_LOOKBACK_HOURS = 1
+
+// A ceiling on the rows this asks for, so it cannot become an enormous query. Should not
+// bind in practice -- the result is one row per service -- but this runs against someone
+// else's project and an unbounded query is not worth the surprise.
+const STATUS_MAX_ROWS = 10_000
+
+// One row per service: how much arrived and when it last did. Aggregated by the backend
+// rather than pulling rows down and counting here, and counting RECORDS rather than
+// spans -- the table holds both, and a service that only logs should not vanish from a
+// command whose whole job is "is anything arriving from this service?".
+const STATUS_SQL = 'SELECT service_name, count(*) AS records, max(start_timestamp) AS last_seen FROM records GROUP BY service_name'
 
 interface ProjectCommandOptions {
   dataDir?: string
@@ -17,10 +38,22 @@ interface ProjectCommandOptions {
   projectName?: string
 }
 
+interface StatusOptions {
+  dataDir?: string
+  json: boolean
+}
+
 export async function runProjectsCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
   const subcommand = args[0]
   if (subcommand === undefined || subcommand === '--help' || subcommand === '-h') {
     printProjectsHelp(context)
+    return
+  }
+  if (subcommand === 'status') {
+    // Deliberately does not call `createAuthenticatedClient`: `status` reads the token
+    // saved by `read-tokens create --save`, not the CLI's own user session, so it needs
+    // no login at all.
+    await projectStatus(parseStatusOptions(args.slice(1)), context)
     return
   }
 
@@ -55,9 +88,111 @@ function printProjectsHelp(context: CliContext): void {
   writeLine(context.stdout, 'usage: logfire projects <command>')
   writeLine(context.stdout)
   writeLine(context.stdout, 'Commands:')
-  writeLine(context.stdout, '  list   List projects')
-  writeLine(context.stdout, '  new    Create a new project')
-  writeLine(context.stdout, '  use    Use an existing project')
+  writeLine(context.stdout, '  list    List projects')
+  writeLine(context.stdout, '  new     Create a new project')
+  writeLine(context.stdout, '  use     Use an existing project')
+  writeLine(context.stdout, '  status  Show what telemetry has reached the current project')
+}
+
+/**
+ * Show what telemetry has reached the project this directory is linked to. Reads the
+ * token `read-tokens create --save` wrote rather than minting one: a read token is
+ * permanent and this CLI has no way to revoke it, and this command is meant to be re-run
+ * while waiting for data, so minting one per invocation would leave one behind on every
+ * poll.
+ */
+async function projectStatus(options: StatusOptions, context: CliContext): Promise<void> {
+  const dataDir = options.dataDir ?? defaultDataDir(context.cwd)
+  const credentials = readProjectCredentials(dataDir)
+  if (credentials === undefined) {
+    throw new LogfireCliError(`No Logfire credentials found in ${dataDir}\nRun \`logfire projects use PROJECT_NAME\` first.`)
+  }
+
+  const organization = organizationFromProjectUrl(credentials.project_url)
+  if (organization === undefined) {
+    throw new LogfireCliError(`Cannot tell which organization ${credentials.project_url} belongs to.`)
+  }
+
+  const saved = loadSavedReadToken(dataDir, { organization, projectName: credentials.project_name })
+  if (saved === undefined) {
+    throw new LogfireCliError(
+      `No usable read token for ${organization}/${credentials.project_name}.\n` +
+        'Run `logfire read-tokens create --save` to create one, then try again.'
+    )
+  }
+
+  const rows = await queryProject(saved.baseUrl, saved.token, STATUS_SQL, {
+    fetch: context.fetch,
+    limit: STATUS_MAX_ROWS,
+    minTimestamp: new Date(Date.now() - STATUS_LOOKBACK_HOURS * 60 * 60 * 1000),
+  })
+  const services = sortByServiceName(rows)
+
+  if (options.json) {
+    writeLine(
+      context.stdout,
+      JSON.stringify({
+        lookback_hours: STATUS_LOOKBACK_HOURS,
+        organization,
+        project_name: credentials.project_name,
+        project_url: credentials.project_url,
+        services: services.map((row) => ({
+          last_seen: row['last_seen'],
+          records: row['records'],
+          service_name: row['service_name'],
+        })),
+      })
+    )
+    return
+  }
+
+  writeLine(context.stderr, `Project  ${organization}/${credentials.project_name}`)
+  writeLine(context.stderr, `         ${credentials.project_url}`)
+  writeLine(context.stderr)
+  if (services.length === 0) {
+    // Deliberately not phrased as failure. Data takes a moment to arrive, and the common
+    // case for someone running this during setup is "not yet", not "broken".
+    writeLine(context.stderr, `No telemetry in the last ${String(STATUS_LOOKBACK_HOURS)}h.`)
+    writeLine(context.stderr, 'Run the application so it sends something, then try again.')
+    return
+  }
+  context.stderr.write(
+    prettyTable(
+      ['Service', 'Records', 'Last seen'],
+      services.map((row) => [
+        printableCell(row['service_name'], '(unnamed)'),
+        printableCell(row['records'], '0'),
+        printableCell(row['last_seen'], '-'),
+      ])
+    )
+  )
+}
+
+function sortByServiceName(rows: QueryProjectRow[]): QueryProjectRow[] {
+  return [...rows].sort((a, b) => queryValueToString(a['service_name']).localeCompare(queryValueToString(b['service_name'])))
+}
+
+// The query result columns are typed `unknown` -- they come back as parsed JSON, so a
+// plain `String(value)` risks `[object Object]` for anything that is not already a
+// primitive. Every branch here stringifies a type `String()` is actually well-defined for.
+function queryValueToString(value: unknown): string {
+  if (value === undefined || value === null) {
+    return ''
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value)
+  }
+  return JSON.stringify(value)
+}
+
+/** A telemetry-supplied value, safe to write to a terminal. `service_name` is submitted
+ * by whoever sends the data, so it can carry ANSI escapes or other control characters;
+ * written raw those could clear the screen, reposition the cursor, or forge rows in the
+ * very table an operator is reading to decide whether their setup worked. */
+function printableCell(value: unknown, fallback: string): string {
+  const text = value === undefined || value === null || value === '' ? fallback : queryValueToString(value)
+  // eslint-disable-next-line no-control-regex -- the control characters ARE the target.
+  return text.replace(/[\x00-\x1f\x7f-\x9f]/gu, '\ufffd')
 }
 
 async function listProjects(client: LogfireApiClient, context: CliContext): Promise<void> {
@@ -266,6 +401,23 @@ function parseProjectOptions(args: string[]): ProjectCommandOptions {
       throw new LogfireCliError(`Unknown option ${arg}`)
     } else if (options.projectName === undefined) {
       options.projectName = arg
+    } else {
+      throw new LogfireCliError(`Unexpected argument ${arg}`)
+    }
+  }
+  return options
+}
+
+function parseStatusOptions(args: string[]): StatusOptions {
+  const options: StatusOptions = { json: false }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index] ?? ''
+    if (arg === '--data-dir') {
+      options.dataDir = readRequiredValue(args, ++index, '--data-dir')
+    } else if (arg.startsWith('--data-dir=')) {
+      options.dataDir = arg.slice('--data-dir='.length)
+    } else if (arg === '--json') {
+      options.json = true
     } else {
       throw new LogfireCliError(`Unexpected argument ${arg}`)
     }

--- a/packages/logfire-api/src/cli/commands/projects.ts
+++ b/packages/logfire-api/src/cli/commands/projects.ts
@@ -110,13 +110,13 @@ async function projectStatus(options: StatusOptions, context: CliContext): Promi
 
   const organization = organizationFromProjectUrl(credentials.project_url)
   if (organization === undefined) {
-    throw new LogfireCliError(`Cannot tell which organization ${credentials.project_url} belongs to.`)
+    throw new LogfireCliError(`Cannot tell which organization ${sanitizeForTerminal(credentials.project_url)} belongs to.`)
   }
 
   const saved = loadSavedReadToken(dataDir, { organization, projectName: credentials.project_name })
   if (saved === undefined) {
     throw new LogfireCliError(
-      `No usable read token for ${organization}/${credentials.project_name}.\n` +
+      `No usable read token for ${sanitizeForTerminal(organization)}/${sanitizeForTerminal(credentials.project_name)}.\n` +
         'Run `logfire read-tokens create --save` to create one, then try again.'
     )
   }

--- a/packages/logfire-api/src/cli/commands/projects.ts
+++ b/packages/logfire-api/src/cli/commands/projects.ts
@@ -12,7 +12,7 @@ import {
   writeProjectCredentials,
 } from '../credentials'
 import { LogfireCliError } from '../errors'
-import { prettyTable, writeLine } from '../output'
+import { prettyTable, sanitizeForTerminal, writeLine } from '../output'
 
 const PROJECT_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u
 
@@ -146,8 +146,12 @@ async function projectStatus(options: StatusOptions, context: CliContext): Promi
     return
   }
 
-  writeLine(context.stderr, `Project  ${organization}/${credentials.project_name}`)
-  writeLine(context.stderr, `         ${credentials.project_url}`)
+  // `credentials` came from a file inside the project this command runs in (see
+  // `saveReadToken`'s doc comment for the same threat model), so its fields get the same
+  // stripping as a service name -- not JSON.stringify's escaping, because this is the
+  // stderr summary, not the `--json` path above, which is already safe by construction.
+  writeLine(context.stderr, `Project  ${sanitizeForTerminal(organization)}/${sanitizeForTerminal(credentials.project_name)}`)
+  writeLine(context.stderr, `         ${sanitizeForTerminal(credentials.project_url)}`)
   writeLine(context.stderr)
   if (services.length === 0) {
     // Deliberately not phrased as failure. Data takes a moment to arrive, and the common
@@ -191,8 +195,7 @@ function queryValueToString(value: unknown): string {
  * very table an operator is reading to decide whether their setup worked. */
 function printableCell(value: unknown, fallback: string): string {
   const text = value === undefined || value === null || value === '' ? fallback : queryValueToString(value)
-  // eslint-disable-next-line no-control-regex -- the control characters ARE the target.
-  return text.replace(/[\x00-\x1f\x7f-\x9f]/gu, '\ufffd')
+  return sanitizeForTerminal(text)
 }
 
 async function listProjects(client: LogfireApiClient, context: CliContext): Promise<void> {

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -53,6 +53,14 @@ export async function runReadTokensCommand(args: string[], globalOptions: Global
   }
 
   const expiresAt = new Date(Date.now() + READ_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000)
+  // Reserve the destination BEFORE minting. A real token cannot be revoked or displayed
+  // once created, so a failure writing it -- a symlinked destination, a read-only data
+  // directory -- must happen before the mint, not leave an orphaned server-side
+  // credential behind after. The placeholder token is an empty string, which
+  // `loadSavedReadToken`'s own validation already refuses to treat as usable, so an
+  // interrupted run between this call and the real one below leaves nothing a later
+  // `projects status` could mistake for a working credential.
+  saveReadToken(dataDir, { baseUrl: client.baseUrl, expiresAt, organization, projectName: project, token: '' })
   const response = await client.createReadToken(organization, project, expiresAt)
   const path = saveReadToken(dataDir, {
     baseUrl: client.baseUrl,

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -1,6 +1,6 @@
 import { createAuthenticatedClient } from '../authClient'
 import type { CliContext, GlobalOptions } from '../context'
-import { defaultDataDir, organizationFromProjectUrl, readProjectCredentials, saveReadToken } from '../credentials'
+import { defaultDataDir, ensureDataDir, organizationFromProjectUrl, readProjectCredentials, saveReadToken } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { writeLine } from '../output'
 
@@ -53,14 +53,17 @@ export async function runReadTokensCommand(args: string[], globalOptions: Global
   }
 
   const expiresAt = new Date(Date.now() + READ_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000)
-  // Reserve the destination BEFORE minting. A real token cannot be revoked or displayed
-  // once created, so a failure writing it -- a symlinked destination, a read-only data
-  // directory -- must happen before the mint, not leave an orphaned server-side
-  // credential behind after. The placeholder token is an empty string, which
-  // `loadSavedReadToken`'s own validation already refuses to treat as usable, so an
-  // interrupted run between this call and the real one below leaves nothing a later
-  // `projects status` could mistake for a working credential.
-  saveReadToken(dataDir, { baseUrl: client.baseUrl, expiresAt, organization, projectName: project, token: '' })
+  // Reserve the destination BEFORE minting: a real token cannot be revoked or displayed
+  // once created, so a failure writing it -- a symlinked `.logfire`, a read-only data
+  // directory -- must happen before the mint, not leave an orphaned server-side credential
+  // behind after. `ensureDataDir` alone is enough; it validates the DIRECTORY without
+  // touching `read_token.json` itself, so a run that already had a valid saved token keeps
+  // it if the mint below fails, rather than losing it to an empty placeholder that then
+  // never gets overwritten. `saveReadToken`'s own `O_NOFOLLOW` on the final write still
+  // catches a symlinked `read_token.json` FILE specifically -- a narrower case this reserve
+  // step does not need to duplicate, since that failure mode can't leave a half-written
+  // orphaned credential the way a torn-down directory write could.
+  ensureDataDir(dataDir)
   const response = await client.createReadToken(organization, project, expiresAt)
   const path = saveReadToken(dataDir, {
     baseUrl: client.baseUrl,

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -127,7 +127,7 @@ function parseOrgProject(value: string): [string, string] {
 
 function readRequiredValue(args: string[], index: number, option: string): string {
   const value = args[index]
-  if (value === undefined) {
+  if (value === undefined || value.startsWith('-')) {
     throw new LogfireCliError(`Missing value for ${option}`)
   }
   return value

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -1,7 +1,14 @@
 import { createAuthenticatedClient } from '../authClient'
 import type { CliContext, GlobalOptions } from '../context'
+import { defaultDataDir, organizationFromProjectUrl, readProjectCredentials, saveReadToken } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { writeLine } from '../output'
+
+// Only tokens this CLI writes to disk get an expiry. It cannot revoke a token, so one
+// sitting in a file needs some end; a token printed for the caller to paste elsewhere
+// does not get one, because we do not know what it was wired into and silently breaking
+// it later would be worse than leaving it.
+const READ_TOKEN_TTL_DAYS = 30
 
 export async function runReadTokensCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
   if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
@@ -16,24 +23,64 @@ export async function runReadTokensCommand(args: string[], globalOptions: Global
   if (parsed.command !== 'create') {
     throw new LogfireCliError(`Unknown read-tokens command "${parsed.command}".`)
   }
-  if (parsed.organization === undefined || parsed.project === undefined) {
-    throw new LogfireCliError('Missing --project. Expected <org>/<project>.')
+
+  const dataDir = parsed.dataDir ?? defaultDataDir(context.cwd)
+  let organization = parsed.organization
+  let project = parsed.project
+  if (organization === undefined || project === undefined) {
+    // No --project, so fall back to whatever this directory is linked to. That is what
+    // makes `read-tokens create --save` work with no arguments at all, which is the case
+    // this option exists for.
+    const credentials = readProjectCredentials(dataDir)
+    if (credentials === undefined) {
+      throw new LogfireCliError(
+        `No Logfire credentials found in ${dataDir}\nPass --project <org>/<project>, or run \`logfire projects use PROJECT_NAME\` first.`
+      )
+    }
+    organization = organization ?? organizationFromProjectUrl(credentials.project_url)
+    project = project ?? credentials.project_name
+    if (organization === undefined) {
+      throw new LogfireCliError(`Cannot tell which organization ${credentials.project_url} belongs to.`)
+    }
   }
+
   const client = await createAuthenticatedClient(globalOptions, context)
-  const response = await client.createReadToken(parsed.organization, parsed.project)
-  writeLine(context.stdout, response.token)
+
+  if (!parsed.save) {
+    const response = await client.createReadToken(organization, project)
+    writeLine(context.stdout, response.token)
+    return
+  }
+
+  const expiresAt = new Date(Date.now() + READ_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000)
+  const response = await client.createReadToken(organization, project, expiresAt)
+  const path = saveReadToken(dataDir, {
+    baseUrl: client.baseUrl,
+    expiresAt,
+    organization,
+    projectName: project,
+    token: response.token,
+  })
+  // To stderr, and without the token. The whole point of `--save` is that the credential
+  // never reaches a terminal, a log, or an agent's transcript.
+  writeLine(context.stderr, `Read token for ${organization}/${project} saved to ${path}.`)
+  writeLine(context.stderr, `It expires in ${String(READ_TOKEN_TTL_DAYS)} days. \`logfire projects status\` will use it.`)
 }
 
 interface ReadTokensArgs {
   command: string | undefined
+  dataDir: string | undefined
   organization: string | undefined
   project: string | undefined
+  save: boolean
 }
 
 function parseReadTokensArgs(args: string[]): ReadTokensArgs {
   let organization: string | undefined
   let project: string | undefined
+  let dataDir: string | undefined
   let command: string | undefined
+  let save = false
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index] ?? ''
@@ -41,6 +88,12 @@ function parseReadTokensArgs(args: string[]): ReadTokensArgs {
       ;[organization, project] = parseOrgProject(readRequiredValue(args, ++index, '--project'))
     } else if (arg.startsWith('--project=')) {
       ;[organization, project] = parseOrgProject(arg.slice('--project='.length))
+    } else if (arg === '--data-dir') {
+      dataDir = readRequiredValue(args, ++index, '--data-dir')
+    } else if (arg.startsWith('--data-dir=')) {
+      dataDir = arg.slice('--data-dir='.length)
+    } else if (arg === '--save') {
+      save = true
     } else if (arg.startsWith('-')) {
       throw new LogfireCliError(`Unknown option ${arg}`)
     } else if (command === undefined) {
@@ -50,7 +103,7 @@ function parseReadTokensArgs(args: string[]): ReadTokensArgs {
     }
   }
 
-  return { command, organization, project }
+  return { command, dataDir, organization, project, save }
 }
 
 function parseOrgProject(value: string): [string, string] {
@@ -73,4 +126,7 @@ function readRequiredValue(args: string[], index: number, option: string): strin
 
 function printReadTokensHelp(context: CliContext): void {
   writeLine(context.stdout, 'usage: logfire read-tokens --project <org>/<project> create')
+  writeLine(context.stdout, '   or: logfire read-tokens create --save')
+  writeLine(context.stdout)
+  writeLine(context.stdout, '--save writes the token into the data directory instead of printing it, for `logfire projects status`.')
 }

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -1,8 +1,8 @@
 import { createAuthenticatedClient } from '../authClient'
 import type { CliContext, GlobalOptions } from '../context'
-import { defaultDataDir, ensureDataDir, organizationFromProjectUrl, readProjectCredentials, saveReadToken } from '../credentials'
+import { defaultDataDir, organizationFromProjectUrl, readProjectCredentials, reserveReadTokenSave } from '../credentials'
 import { LogfireCliError } from '../errors'
-import { writeLine } from '../output'
+import { sanitizeForTerminal, writeLine } from '../output'
 
 // Only tokens this CLI writes to disk get an expiry. It cannot revoke a token, so one
 // sitting in a file needs some end; a token printed for the caller to paste elsewhere
@@ -40,41 +40,39 @@ export async function runReadTokensCommand(args: string[], globalOptions: Global
     organization = organization ?? organizationFromProjectUrl(credentials.project_url)
     project = project ?? credentials.project_name
     if (organization === undefined) {
-      throw new LogfireCliError(`Cannot tell which organization ${credentials.project_url} belongs to.`)
+      throw new LogfireCliError(`Cannot tell which organization ${sanitizeForTerminal(credentials.project_url)} belongs to.`)
     }
   }
 
-  const client = await createAuthenticatedClient(globalOptions, context)
-
   if (!parsed.save) {
+    const client = await createAuthenticatedClient(globalOptions, context)
     const response = await client.createReadToken(organization, project)
     writeLine(context.stdout, response.token)
     return
   }
 
   const expiresAt = new Date(Date.now() + READ_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000)
-  // Reserve the destination BEFORE minting: a real token cannot be revoked or displayed
-  // once created, so a failure writing it -- a symlinked `.logfire`, a read-only data
-  // directory -- must happen before the mint, not leave an orphaned server-side credential
-  // behind after. `ensureDataDir` alone is enough; it validates the DIRECTORY without
-  // touching `read_token.json` itself, so a run that already had a valid saved token keeps
-  // it if the mint below fails, rather than losing it to an empty placeholder that then
-  // never gets overwritten. `saveReadToken`'s own `O_NOFOLLOW` on the final write still
-  // catches a symlinked `read_token.json` FILE specifically -- a narrower case this reserve
-  // step does not need to duplicate, since that failure mode can't leave a half-written
-  // orphaned credential the way a torn-down directory write could.
-  ensureDataDir(dataDir)
-  const response = await client.createReadToken(organization, project, expiresAt)
-  const path = saveReadToken(dataDir, {
-    baseUrl: client.baseUrl,
-    expiresAt,
-    organization,
-    projectName: project,
-    token: response.token,
-  })
+  const reservation = reserveReadTokenSave(dataDir)
+  let path: string
+  try {
+    const client = await createAuthenticatedClient(globalOptions, context)
+    const response = await client.createReadToken(organization, project, expiresAt)
+    path = reservation.save({
+      baseUrl: client.baseUrl,
+      expiresAt,
+      organization,
+      projectName: project,
+      token: response.token,
+    })
+  } finally {
+    reservation.abort()
+  }
   // To stderr, and without the token. The whole point of `--save` is that the credential
   // never reaches a terminal, a log, or an agent's transcript.
-  writeLine(context.stderr, `Read token for ${organization}/${project} saved to ${path}.`)
+  writeLine(
+    context.stderr,
+    `Read token for ${sanitizeForTerminal(organization)}/${sanitizeForTerminal(project)} saved to ${sanitizeForTerminal(path)}.`
+  )
   writeLine(context.stderr, `It expires in ${String(READ_TOKEN_TTL_DAYS)} days. \`logfire projects status\` will use it.`)
 }
 

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -233,7 +233,8 @@ token = "ignored"
     execFileSync('git', ['init', '--quiet'], { cwd: dir })
     execFileSync('git', ['add', '--force', path], { cwd: dir })
 
-    expect(() =>
+    let error: unknown
+    try {
       saveReadToken(dir, {
         baseUrl: 'https://logfire-us.pydantic.dev',
         expiresAt: new Date(),
@@ -241,7 +242,13 @@ token = "ignored"
         projectName: 'orders',
         token: 'read-token',
       })
-    ).toThrow(LogfireCliError)
+    } catch (caught: unknown) {
+      error = caught
+    }
+    expect(error).toBeInstanceOf(LogfireCliError)
+    expect((error as LogfireCliError).message).toBe(
+      `${path} is already tracked by git, so .gitignore does not protect it. Writing the token there risks it reaching a commit. Untrack it first (\`git rm --cached ${path}\`) or remove it, then try again.`
+    )
     expect(readFileSync(path, 'utf8')).toBe('{}')
   })
 

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -164,6 +164,30 @@ token = "ignored"
     })
   })
 
+  it('does not load a saved token through a symlink', () => {
+    const dir = makeTmpDir()
+    const target = join(dir, 'target.json')
+    writeFileSync(
+      target,
+      JSON.stringify({ base_url: 'http://127.0.0.1', organization: 'test-org', project_name: 'orders', token: 'read-token' })
+    )
+    symlinkSync(target, readTokenPath(dir))
+
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'orders' })).toBeUndefined()
+  })
+
+  it('does not load a git-tracked saved token', () => {
+    const dir = makeTmpDir()
+    writeFileSync(
+      readTokenPath(dir),
+      JSON.stringify({ base_url: 'http://127.0.0.1', organization: 'test-org', project_name: 'orders', token: 'read-token' })
+    )
+    execFileSync('git', ['init', '--quiet'], { cwd: dir })
+    execFileSync('git', ['add', '--force', 'read_token.json'], { cwd: dir })
+
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'orders' })).toBeUndefined()
+  })
+
   it.each([
     [{ organization: 'other-org' }, 'issued for a different organization'],
     [{ project_name: 'other-project' }, 'issued for a different project'],
@@ -216,6 +240,16 @@ token = "ignored"
       })
     ).toThrow(LogfireCliError)
     expect(readFileSync(victim, 'utf8')).toBe('important')
+  })
+
+  it('fails closed when the git index cannot be checked', () => {
+    const dir = makeTmpDir()
+    writeFileSync(join(dir, '.git'), 'not a git directory')
+
+    expect(() => reserveReadTokenSave(dir)).toThrow(
+      new LogfireCliError(`${readTokenPath(dir)} could not be checked against the git index; refusing to save a read token there.`)
+    )
+    expect(readdirSync(dir)).toEqual(['.git'])
   })
 
   it('refuses to write through a symlinked data directory', () => {

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,12 +8,18 @@ import {
   UserTokenCollection,
   formatUserToken,
   isExpired,
+  loadSavedReadToken,
+  organizationFromProjectUrl,
   parseUserTokensToml,
   projectCredentialsPath,
   readProjectCredentials,
+  readTokenPath,
+  removeProjectCredentials,
+  saveReadToken,
   stringifyUserTokensToml,
   writeProjectCredentials,
 } from './credentials'
+import { LogfireCliError } from './errors'
 
 describe('CLI credentials', () => {
   const tmpDirs: string[] = []
@@ -96,6 +102,165 @@ token = "ignored"
     })
 
     expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('node_modules\n')
+  })
+
+  it('saves and loads a read token, scoped to the org and project that issued it', () => {
+    const dir = makeTmpDir()
+    const expiresAt = new Date('2099-12-31T23:59:59.000Z')
+
+    const path = saveReadToken(dir, {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiresAt,
+      organization: 'test-org',
+      projectName: 'orders',
+      token: 'read-token',
+    })
+
+    expect(path).toBe(readTokenPath(dir))
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({
+      base_url: 'https://logfire-us.pydantic.dev',
+      expires_at: '2099-12-31T23:59:59.000Z',
+      organization: 'test-org',
+      project_name: 'orders',
+      token: 'read-token',
+    })
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'orders' })).toEqual({
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      token: 'read-token',
+    })
+    // A different project must not see it -- `projects use` repoints the directory, and a
+    // token left from the previous project would otherwise be sent for the new one.
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'other-project' })).toBeUndefined()
+  })
+
+  it('treats a missing expiry as unbounded, not invalid', () => {
+    const dir = makeTmpDir()
+    writeFileSync(
+      readTokenPath(dir),
+      JSON.stringify({ base_url: 'https://logfire-us.pydantic.dev', organization: 'test-org', project_name: 'orders', token: 'read-token' })
+    )
+
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'orders' })).toEqual({
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      token: 'read-token',
+    })
+  })
+
+  it.each([
+    [{ organization: 'other-org' }, 'issued for a different organization'],
+    [{ project_name: 'other-project' }, 'issued for a different project'],
+    [{ expires_at: '2000-01-01T00:00:00Z' }, 'already expired'],
+    [{ expires_at: 'not-a-timestamp' }, 'unparseable expiry'],
+    [{ token: '' }, 'empty token'],
+    [{ token: undefined }, 'no token key'],
+    [{ base_url: undefined }, 'no base_url key'],
+  ])('rejects a saved token that is unusable: %j (%s)', (override, _reason) => {
+    const dir = makeTmpDir()
+    const base = {
+      base_url: 'https://logfire-us.pydantic.dev',
+      expires_at: '2099-12-31T23:59:59Z',
+      organization: 'test-org',
+      project_name: 'orders',
+      token: 'read-token',
+    }
+    writeFileSync(readTokenPath(dir), JSON.stringify({ ...base, ...override }))
+
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'orders' })).toBeUndefined()
+  })
+
+  it('writes the saved token readable only by its owner', () => {
+    const dir = makeTmpDir()
+    saveReadToken(dir, {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiresAt: new Date(),
+      organization: 'test-org',
+      projectName: 'orders',
+      token: 'read-token',
+    })
+
+    expect(statSync(readTokenPath(dir)).mode & 0o777).toBe(0o600)
+  })
+
+  it('refuses to follow a symlink at the saved-token destination', () => {
+    const dir = makeTmpDir()
+    const victim = join(dir, 'victim.txt')
+    writeFileSync(victim, 'important')
+    symlinkSync(victim, readTokenPath(dir))
+
+    expect(() =>
+      saveReadToken(dir, {
+        baseUrl: 'https://logfire-us.pydantic.dev',
+        expiresAt: new Date(),
+        organization: 'test-org',
+        projectName: 'orders',
+        token: 'read-token',
+      })
+    ).toThrow(LogfireCliError)
+    expect(readFileSync(victim, 'utf8')).toBe('important')
+  })
+
+  it('narrows an existing permissive file before writing, not after', () => {
+    const dir = makeTmpDir()
+    writeFileSync(readTokenPath(dir), '{}')
+    chmodSync(readTokenPath(dir), 0o644)
+
+    saveReadToken(dir, {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiresAt: new Date(),
+      organization: 'test-org',
+      projectName: 'orders',
+      token: 'read-token',
+    })
+
+    // The mode passed to `openSync` only applies when it CREATES the file, so a file that
+    // already existed keeps its old permissions unless something explicitly narrows them.
+    expect(statSync(readTokenPath(dir)).mode & 0o777).toBe(0o600)
+  })
+
+  it('removes the saved read token as part of removing project credentials', () => {
+    const dir = makeTmpDir()
+    writeProjectCredentials(dir, {
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'orders',
+      project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+      token: 'write-token',
+    })
+    saveReadToken(dir, {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiresAt: new Date(),
+      organization: 'test-org',
+      projectName: 'orders',
+      token: 'read-token',
+    })
+
+    removeProjectCredentials(dir)
+
+    expect(readProjectCredentials(dir)).toBeUndefined()
+    expect(loadSavedReadToken(dir, { organization: 'test-org', projectName: 'orders' })).toBeUndefined()
+  })
+
+  it('seeds .gitignore when saveReadToken creates the data directory itself', () => {
+    // `saveReadToken` calls the same `ensureDataDir` as `writeProjectCredentials`, but
+    // exercised on its own: `read-tokens create --save` can run before `projects use` has
+    // ever created the directory (an explicit `--project` needs no linked directory at
+    // all), so this path has to seed `.gitignore` too, not only the project-credentials one.
+    const dir = join(makeTmpDir(), 'nested', '.logfire')
+    saveReadToken(dir, {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      expiresAt: new Date(),
+      organization: 'test-org',
+      projectName: 'orders',
+      token: 'read-token',
+    })
+
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('*')
+  })
+
+  it('derives the organization from a project URL', () => {
+    expect(organizationFromProjectUrl('https://logfire-us.pydantic.dev/test-org/orders')).toBe('test-org')
+    expect(organizationFromProjectUrl('https://logfire-us.pydantic.dev/test-org/orders/')).toBe('test-org')
+    expect(organizationFromProjectUrl('https://logfire-us.pydantic.dev/orders')).toBeUndefined()
+    expect(organizationFromProjectUrl('not a url')).toBeUndefined()
   })
 
   function makeTmpDir(): string {

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -203,8 +204,8 @@ token = "ignored"
   it('refuses to write through a symlinked data directory', () => {
     // `O_NOFOLLOW` on the final `openSync` call only protects `read_token.json` itself --
     // a committed `.logfire` that is ITSELF a symlink (to a tracked directory, or one CI
-    // collects artifacts from) would sail past that check entirely, since `dataDir`'s
-    // existence is checked with `statSync`, which follows symlinks.
+    // collects artifacts from) would sail past that check entirely, so `ensureDataDir`
+    // uses `lstatSync` and rejects the symlinked directory before any write.
     const parent = makeTmpDir()
     const victim = makeTmpDir()
     const dataDir = join(parent, '.logfire')
@@ -220,6 +221,28 @@ token = "ignored"
       })
     ).toThrow(LogfireCliError)
     expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
+  })
+
+  it('refuses to save a read token through an already git-tracked file', () => {
+    // `.gitignore` does not protect a path already tracked -- committed before this
+    // feature existed, or by mistake. Writing a live, permanent credential into it would
+    // put that credential in the next `git commit -am`.
+    const dir = makeTmpDir()
+    const path = readTokenPath(dir)
+    writeFileSync(path, '{}')
+    execFileSync('git', ['init', '--quiet'], { cwd: dir })
+    execFileSync('git', ['add', '--force', path], { cwd: dir })
+
+    expect(() =>
+      saveReadToken(dir, {
+        baseUrl: 'https://logfire-us.pydantic.dev',
+        expiresAt: new Date(),
+        organization: 'test-org',
+        projectName: 'orders',
+        token: 'read-token',
+      })
+    ).toThrow(LogfireCliError)
+    expect(readFileSync(path, 'utf8')).toBe('{}')
   })
 
   it('narrows an existing permissive file before writing, not after', () => {

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -16,6 +16,7 @@ import {
   readProjectCredentials,
   readTokenPath,
   removeProjectCredentials,
+  reserveReadTokenSave,
   saveReadToken,
   stringifyUserTokensToml,
   writeProjectCredentials,
@@ -103,6 +104,22 @@ token = "ignored"
     })
 
     expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('node_modules\n')
+  })
+
+  it("adds the saved token to an existing data directory's ignore rules", () => {
+    const dir = makeTmpDir()
+    writeFileSync(join(dir, '.gitignore'), 'logfire_credentials.json\n')
+    execFileSync('git', ['init', '--quiet'], { cwd: dir })
+
+    saveReadToken(dir, {
+      baseUrl: 'https://logfire-us.pydantic.dev',
+      organization: 'test-org',
+      projectName: 'orders',
+      token: 'read-token',
+    })
+
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('logfire_credentials.json\nread_token.json\n')
+    expect(() => execFileSync('git', ['check-ignore', '--quiet', 'read_token.json'], { cwd: dir })).not.toThrow()
   })
 
   it('saves and loads a read token, scoped to the org and project that issued it', () => {
@@ -268,6 +285,18 @@ token = "ignored"
     // The mode passed to `openSync` only applies when it CREATES the file, so a file that
     // already existed keeps its old permissions unless something explicitly narrows them.
     expect(statSync(readTokenPath(dir)).mode & 0o777).toBe(0o600)
+  })
+
+  it('aborting a save reservation preserves the existing token and removes the staged file', () => {
+    const dir = makeTmpDir()
+    const path = readTokenPath(dir)
+    writeFileSync(path, 'existing-token')
+
+    const reservation = reserveReadTokenSave(dir)
+    reservation.abort()
+
+    expect(readFileSync(path, 'utf8')).toBe('existing-token')
+    expect(readdirSync(dir).sort()).toEqual(['.gitignore', 'read_token.json'])
   })
 
   it('removes the saved read token as part of removing project credentials', () => {

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -118,7 +118,7 @@ token = "ignored"
       token: 'read-token',
     })
 
-    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('logfire_credentials.json\nread_token.json\n')
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('logfire_credentials.json\nread_token.json*\n')
     expect(() => execFileSync('git', ['check-ignore', '--quiet', 'read_token.json'], { cwd: dir })).not.toThrow()
   })
 
@@ -331,6 +331,20 @@ token = "ignored"
 
     expect(readFileSync(path, 'utf8')).toBe('existing-token')
     expect(readdirSync(dir).sort()).toEqual(['.gitignore', 'read_token.json'])
+  })
+
+  it('allows only one active save reservation', () => {
+    const dir = makeTmpDir()
+    const first = reserveReadTokenSave(dir)
+
+    expect(() => reserveReadTokenSave(dir)).toThrow(
+      new LogfireCliError(
+        `Another read-token save is already in progress for ${readTokenPath(dir)}. If no other command is running, remove ${join(dir, 'read_token.json.lock')} and try again.`
+      )
+    )
+
+    first.abort()
+    expect(readdirSync(dir)).toEqual(['.gitignore'])
   })
 
   it('removes the saved read token as part of removing project credentials', () => {

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -197,6 +197,28 @@ token = "ignored"
       })
     ).toThrow(LogfireCliError)
     expect(readFileSync(victim, 'utf8')).toBe('important')
+  })
+
+  it('refuses to write through a symlinked data directory', () => {
+    // `O_NOFOLLOW` on the final `openSync` call only protects `read_token.json` itself --
+    // a committed `.logfire` that is ITSELF a symlink (to a tracked directory, or one CI
+    // collects artifacts from) would sail past that check entirely, since `dataDir`'s
+    // existence is checked with `statSync`, which follows symlinks.
+    const parent = makeTmpDir()
+    const victim = makeTmpDir()
+    const dataDir = join(parent, '.logfire')
+    symlinkSync(victim, dataDir)
+
+    expect(() =>
+      saveReadToken(dataDir, {
+        baseUrl: 'https://logfire-us.pydantic.dev',
+        expiresAt: new Date(),
+        organization: 'test-org',
+        projectName: 'orders',
+        token: 'read-token',
+      })
+    ).toThrow(LogfireCliError)
+    expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
   })
 
   it('narrows an existing permissive file before writing, not after', () => {

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -151,6 +151,7 @@ token = "ignored"
     [{ project_name: 'other-project' }, 'issued for a different project'],
     [{ expires_at: '2000-01-01T00:00:00Z' }, 'already expired'],
     [{ expires_at: 'not-a-timestamp' }, 'unparseable expiry'],
+    [{ expires_at: null }, 'expiry present but not a string -- must not be treated as absent'],
     [{ token: '' }, 'empty token'],
     [{ token: undefined }, 'no token key'],
     [{ base_url: undefined }, 'no base_url key'],

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -3,11 +3,11 @@ import {
   constants,
   existsSync,
   fchmodSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
   writeSync,
 } from 'node:fs'
@@ -383,7 +383,18 @@ function ensureDataDir(dataDir: string): void {
   // Match Python's `ensure_data_dir_exists`: only seed `.gitignore` when creating the
   // directory, so an existing dir's ignore rules are never clobbered.
   if (existsSync(dataDir)) {
-    if (!statSync(dataDir).isDirectory()) {
+    // `lstatSync`, not `statSync`: the data directory lives inside the user's repository,
+    // so a symlink can arrive by being committed to it, the same way a symlinked
+    // `read_token.json` can -- `writeFileSecurely`'s `O_NOFOLLOW` only protects that final
+    // path component, not `dataDir` itself. `statSync` follows symlinks, so it would
+    // report a symlinked `.logfire` pointing at a tracked or artifact-collected directory
+    // as a perfectly ordinary directory, and every write meant for the ignored data
+    // directory would silently land wherever the symlink actually points.
+    const stat = lstatSync(dataDir)
+    if (stat.isSymbolicLink()) {
+      throw new LogfireCliError(`${dataDir} is a symlink; refusing to write Logfire data through it.`)
+    }
+    if (!stat.isDirectory()) {
       throw new LogfireCliError(`Data directory ${dataDir} exists but is not a directory`)
     }
     return

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -302,13 +302,13 @@ export function readTokenPath(dataDir: string): string {
  * `.gitignore` only stops an UNTRACKED file from being added; it does nothing for a path
  * already in the index -- committed before this feature existed, or by mistake -- so
  * writing a real, permanent credential through such a path would make the next `git
- * commit -am` publish it. `execFileSync` throws both when the file is genuinely untracked
- * (`git ls-files` exits non-zero) and when git itself is unavailable or the check times
- * out, and `false` is the right answer for both: "definitely not tracked" and "cannot
- * tell, so do not block a working setup over an environment quirk unrelated to the file's
- * own tracked status" land on the same safe outcome here.
+ * commit -am` publish it. Operational failures must fail closed: only Git's documented
+ * no-match exit means the path is untracked.
  */
 function isGitTracked(path: string): boolean {
+  if (!hasGitMetadata(dirname(path))) {
+    return false
+  }
   try {
     execFileSync('git', ['ls-files', '--error-unmatch', '--', basename(path)], {
       cwd: dirname(path),
@@ -316,9 +316,30 @@ function isGitTracked(path: string): boolean {
       timeout: 5000,
     })
     return true
-  } catch {
-    return false
+  } catch (error) {
+    if (hasExitStatus(error, 1)) {
+      return false
+    }
+    throw error
   }
+}
+
+function hasGitMetadata(path: string): boolean {
+  let current = path
+  for (;;) {
+    if (existsSync(join(current, '.git'))) {
+      return true
+    }
+    const parent = dirname(current)
+    if (parent === current) {
+      return false
+    }
+    current = parent
+  }
+}
+
+function hasExitStatus(error: unknown, status: number): boolean {
+  return typeof error === 'object' && error !== null && 'status' in error && error.status === status
 }
 
 /**
@@ -328,10 +349,16 @@ function isGitTracked(path: string): boolean {
 export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation {
   ensureDataDir(dataDir)
   const path = readTokenPath(dataDir)
-  if (isGitTracked(path)) {
-    throw new LogfireCliError(
-      `${path} is already tracked by git, so .gitignore does not protect it. Writing the token there risks it reaching a commit. Untrack it first (\`git rm --cached ${path}\`) or remove it, then try again.`
-    )
+  try {
+    if (isGitTracked(path)) {
+      throw new LogfireCliError(
+        `${path} is already tracked by git, so .gitignore does not protect it. Writing the token there risks it reaching a commit. Untrack it first (\`git rm --cached ${path}\`) or remove it, then try again.`
+      )
+    }
+  } catch (error) {
+    throw error instanceof LogfireCliError
+      ? error
+      : new LogfireCliError(`${path} could not be checked against the git index; refusing to save a read token there.`)
   }
 
   try {
@@ -440,12 +467,11 @@ export function saveReadToken(dataDir: string, options: SaveReadTokenOptions): s
  */
 export function loadSavedReadToken(dataDir: string, options: LoadSavedReadTokenOptions): SavedReadToken | undefined {
   const path = readTokenPath(dataDir)
-  if (!existsSync(path)) {
-    return undefined
-  }
-
   let raw: unknown
   try {
+    if (!lstatSync(path).isFile() || isGitTracked(path)) {
+      return undefined
+    }
     raw = JSON.parse(readFileSync(path, 'utf8')) as unknown
   } catch {
     return undefined

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import {
   closeSync,
   constants,
@@ -8,9 +9,9 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
-  writeSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -61,6 +62,11 @@ export interface SaveReadTokenOptions {
 export interface LoadSavedReadTokenOptions {
   organization: string
   projectName: string
+}
+
+export interface ReadTokenSaveReservation {
+  abort(): void
+  save(options: SaveReadTokenOptions): string
 }
 
 export function defaultAuthFilePath(homeDir: string = homedir()): string {
@@ -291,21 +297,6 @@ export function readTokenPath(dataDir: string): string {
 }
 
 /**
- * Save a read token for reuse by `projects status`, instead of creating one on every
- * invocation. Read tokens are permanent and this CLI has no way to revoke one, so a
- * command meant to be re-run while waiting for data would otherwise leave a live
- * credential behind on every poll.
- *
- * `baseUrl` must be the host the CREATE request actually used (`client.baseUrl` after
- * `createAuthenticatedClient`), never re-derived from `logfire_credentials.json` at query
- * time: that file lives inside the project this command runs in, so a tampered repository
- * could point it at an attacker's server and this command would hand over the read token
- * in the next request's Authorization header. Deriving the host from the token's own
- * region prefix instead (as an earlier version of the Python CLI did) closes that hole but
- * silently breaks self-hosted deployments, whose base URL cannot be recovered from the
- * token -- only from where it was actually minted.
- */
-/**
  * Whether `path` is tracked by the git repository it sits in, if any.
  *
  * `.gitignore` only stops an UNTRACKED file from being added; it does nothing for a path
@@ -330,7 +321,11 @@ function isGitTracked(path: string): boolean {
   }
 }
 
-export function saveReadToken(dataDir: string, options: SaveReadTokenOptions): string {
+/**
+ * Validate and reserve the saved-token destination before minting a token. The staged
+ * file stays empty until `save`, so aborting a failed mint preserves any existing token.
+ */
+export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation {
   ensureDataDir(dataDir)
   const path = readTokenPath(dataDir)
   if (isGitTracked(path)) {
@@ -338,17 +333,99 @@ export function saveReadToken(dataDir: string, options: SaveReadTokenOptions): s
       `${path} is already tracked by git, so .gitignore does not protect it. Writing the token there risks it reaching a commit. Untrack it first (\`git rm --cached ${path}\`) or remove it, then try again.`
     )
   }
-  const payload: Record<string, string> = {
-    base_url: options.baseUrl,
-    organization: options.organization,
-    project_name: options.projectName,
-    token: options.token,
+
+  try {
+    ensureReadTokenIgnored(dataDir)
+    if (existsSync(path)) {
+      const stat = lstatSync(path)
+      if (stat.isSymbolicLink()) {
+        throw new LogfireCliError(`${path} is a symlink; refusing to write a Logfire read token through it.`)
+      }
+      if (!stat.isFile()) {
+        throw new LogfireCliError(`${path} exists but is not a regular file.`)
+      }
+    }
+  } catch (error) {
+    throw error instanceof LogfireCliError ? error : writeReadTokenError(path, error)
   }
-  if (options.expiresAt !== undefined) {
-    payload['expires_at'] = options.expiresAt.toISOString()
+
+  const temporaryPath = join(dataDir, `.${READ_TOKEN_FILENAME}.${randomUUID()}.tmp`)
+  let fd: number | undefined
+  const cleanupTemporaryFile = (): Error | undefined => {
+    let cleanupError: Error | undefined
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch (error) {
+        cleanupError = error instanceof Error ? error : new Error(String(error))
+      }
+      fd = undefined
+    }
+    try {
+      rmSync(temporaryPath, { force: true })
+    } catch (error) {
+      cleanupError ??= error instanceof Error ? error : new Error(String(error))
+    }
+    return cleanupError
   }
-  writeFileSecurely(path, `${JSON.stringify(payload, null, 2)}\n`)
-  return path
+
+  try {
+    fd = openSync(temporaryPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600)
+    fchmodSync(fd, 0o600)
+  } catch (error) {
+    throw writeReadTokenError(path, cleanupTemporaryFile() ?? error)
+  }
+
+  let active = true
+  const abort = (): void => {
+    if (!active) {
+      return
+    }
+    active = false
+    const error = cleanupTemporaryFile()
+    if (error !== undefined) {
+      throw writeReadTokenError(path, error)
+    }
+  }
+
+  return {
+    abort,
+    save(options) {
+      if (!active || fd === undefined) {
+        throw new LogfireCliError(`Could not write ${path}: the save reservation is no longer active.`)
+      }
+      try {
+        writeFileSync(fd, serializeReadToken(options))
+        closeSync(fd)
+        fd = undefined
+        renameSync(temporaryPath, path)
+        active = false
+        return path
+      } catch (error) {
+        let finalError = error
+        try {
+          abort()
+        } catch (cleanupError) {
+          finalError = cleanupError
+        }
+        throw finalError instanceof LogfireCliError ? finalError : writeReadTokenError(path, finalError)
+      }
+    },
+  }
+}
+
+/**
+ * Save a read token for reuse by `projects status`, instead of creating one on every
+ * invocation. `baseUrl` must be the host the create request actually used, because a
+ * self-hosted deployment cannot be reconstructed from the token.
+ */
+export function saveReadToken(dataDir: string, options: SaveReadTokenOptions): string {
+  const reservation = reserveReadTokenSave(dataDir)
+  try {
+    return reservation.save(options)
+  } finally {
+    reservation.abort()
+  }
 }
 
 /**
@@ -444,36 +521,43 @@ export function ensureDataDir(dataDir: string): void {
   writeFileSync(join(dataDir, '.gitignore'), '*')
 }
 
-/**
- * Write a file readable only by its owner, refusing to follow a symlink at the
- * destination. The data directory lives inside the user's repository, so a symlink can
- * arrive by being committed to it; following one would apply `O_TRUNC` and a permissions
- * change to whatever it points at instead of the intended file.
- *
- * The mode passed to `openSync` only applies when it CREATES the file, so an existing
- * file keeps whatever permissions it had -- `fchmodSync` runs before any bytes are
- * written, not after, so the content is never briefly sitting in a world-readable file.
- */
-function writeFileSecurely(path: string, contents: string): void {
-  // `O_NOFOLLOW` is not available on every platform (notably Windows, where creating a
-  // symlink needs a privilege most processes do not have); Node still exposes the
-  // constant as `undefined` there rather than throwing, so this falls back to 0. The
-  // `@types/node` type says `number`, not `number | undefined` -- that type is wrong on
-  // those platforms, not this fallback.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see above; the type is wrong on Windows.
-  const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0)
-  let fd: number
-  try {
-    fd = openSync(path, flags, 0o600)
-  } catch (error) {
-    throw new LogfireCliError(`Could not write ${path}: ${error instanceof Error ? error.message : String(error)}`)
+function ensureReadTokenIgnored(dataDir: string): void {
+  const path = join(dataDir, '.gitignore')
+  let contents = ''
+  if (existsSync(path)) {
+    if (lstatSync(path).isSymbolicLink()) {
+      throw new LogfireCliError(`${path} is a symlink; refusing to update ignore rules through it.`)
+    }
+    contents = readFileSync(path, 'utf8')
   }
-  try {
-    fchmodSync(fd, 0o600)
-    writeSync(fd, contents)
-  } finally {
-    closeSync(fd)
+
+  const rules = contents
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#'))
+  const lastRule = rules.at(-1)
+  if (lastRule === '*' || lastRule === READ_TOKEN_FILENAME || lastRule === `/${READ_TOKEN_FILENAME}`) {
+    return
   }
+  const separator = contents === '' || contents.endsWith('\n') ? '' : '\n'
+  writeFileSync(path, `${contents}${separator}${READ_TOKEN_FILENAME}\n`)
+}
+
+function serializeReadToken(options: SaveReadTokenOptions): string {
+  const payload: Record<string, string> = {
+    base_url: options.baseUrl,
+    organization: options.organization,
+    project_name: options.projectName,
+    token: options.token,
+  }
+  if (options.expiresAt !== undefined) {
+    payload['expires_at'] = options.expiresAt.toISOString()
+  }
+  return `${JSON.stringify(payload, null, 2)}\n`
+}
+
+function writeReadTokenError(path: string, error: unknown): LogfireCliError {
+  return new LogfireCliError(`Could not write ${path}: ${error instanceof Error ? error.message : String(error)}`)
 }
 
 function quoteTomlString(value: string): string {

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -1,4 +1,16 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -9,6 +21,12 @@ import { LogfireCliError } from './errors'
 export const DEFAULT_LOGFIRE_HOME = '.logfire'
 export const USER_TOKEN_FILENAME = 'default.toml'
 export const PROJECT_CREDENTIALS_FILENAME = 'logfire_credentials.json'
+// Matches the Python CLI's filename exactly (not a new key on `logfire_credentials.json`):
+// `readProjectCredentials` throws on an unrecognized field, so bolting one on would break
+// exactly like Python's `LogfireCredentials(**data)` would have on an older reader. Same
+// filename on both sides is also what lets a project set up by one SDK's CLI be read by
+// the other.
+export const READ_TOKEN_FILENAME = 'read_token.json'
 
 export interface UserTokenData {
   token: string
@@ -26,6 +44,24 @@ export interface ProjectCredentials {
   logfire_api_url: string
 }
 
+export interface SavedReadToken {
+  baseUrl: string
+  token: string
+}
+
+export interface SaveReadTokenOptions {
+  baseUrl: string
+  expiresAt?: Date
+  organization: string
+  projectName: string
+  token: string
+}
+
+export interface LoadSavedReadTokenOptions {
+  organization: string
+  projectName: string
+}
+
 export function defaultAuthFilePath(homeDir: string = homedir()): string {
   return join(homeDir, DEFAULT_LOGFIRE_HOME, USER_TOKEN_FILENAME)
 }
@@ -36,6 +72,22 @@ export function defaultDataDir(cwd: string = process.cwd()): string {
 
 export function projectCredentialsPath(dataDir: string): string {
   return join(dataDir, PROJECT_CREDENTIALS_FILENAME)
+}
+
+/**
+ * The organization a project URL belongs to, or `undefined` if it does not look like one.
+ * `ProjectCredentials` stores the project URL but not the organization, and the
+ * read-token endpoint needs both. Project URLs end in `<organization>/<project>`, so the
+ * organization is the second-to-last path segment.
+ */
+export function organizationFromProjectUrl(projectUrl: string): string | undefined {
+  let parts: string[]
+  try {
+    parts = new URL(projectUrl).pathname.split('/').filter((part) => part !== '')
+  } catch {
+    return undefined
+  }
+  return parts.length >= 2 ? parts[parts.length - 2] : undefined
 }
 
 export function isExpired(expiration: string): boolean {
@@ -229,7 +281,90 @@ export function writeProjectCredentials(dataDir: string, credentials: ProjectCre
 
 export function removeProjectCredentials(dataDir: string): void {
   rmSync(projectCredentialsPath(dataDir), { force: true })
+  rmSync(readTokenPath(dataDir), { force: true })
   rmSync(join(dataDir, '.gitignore'), { force: true })
+}
+
+export function readTokenPath(dataDir: string): string {
+  return join(dataDir, READ_TOKEN_FILENAME)
+}
+
+/**
+ * Save a read token for reuse by `projects status`, instead of creating one on every
+ * invocation. Read tokens are permanent and this CLI has no way to revoke one, so a
+ * command meant to be re-run while waiting for data would otherwise leave a live
+ * credential behind on every poll.
+ *
+ * `baseUrl` must be the host the CREATE request actually used (`client.baseUrl` after
+ * `createAuthenticatedClient`), never re-derived from `logfire_credentials.json` at query
+ * time: that file lives inside the project this command runs in, so a tampered repository
+ * could point it at an attacker's server and this command would hand over the read token
+ * in the next request's Authorization header. Deriving the host from the token's own
+ * region prefix instead (as an earlier version of the Python CLI did) closes that hole but
+ * silently breaks self-hosted deployments, whose base URL cannot be recovered from the
+ * token -- only from where it was actually minted.
+ */
+export function saveReadToken(dataDir: string, options: SaveReadTokenOptions): string {
+  ensureDataDir(dataDir)
+  const path = readTokenPath(dataDir)
+  const payload: Record<string, string> = {
+    base_url: options.baseUrl,
+    organization: options.organization,
+    project_name: options.projectName,
+    token: options.token,
+  }
+  if (options.expiresAt !== undefined) {
+    payload['expires_at'] = options.expiresAt.toISOString()
+  }
+  writeFileSecurely(path, `${JSON.stringify(payload, null, 2)}\n`)
+  return path
+}
+
+/**
+ * A saved read token for THIS project, if there is one and it is still usable. Returns
+ * `undefined` rather than throwing for every failure mode -- missing, unreadable, corrupt,
+ * expired, or belonging to a different project -- so the caller can give one message
+ * naming the command to run instead of several ways to fail.
+ *
+ * The project check matters: `projects use` repoints the directory, and a token left over
+ * from the previous project would otherwise be sent for the new one and produce a
+ * confusing 401 or, worse, another project's data.
+ */
+export function loadSavedReadToken(dataDir: string, options: LoadSavedReadTokenOptions): SavedReadToken | undefined {
+  const path = readTokenPath(dataDir)
+  if (!existsSync(path)) {
+    return undefined
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8')) as unknown
+  } catch {
+    return undefined
+  }
+  if (!isRecord(raw)) {
+    return undefined
+  }
+
+  const token = readString(raw, 'token')
+  const baseUrl = readString(raw, 'base_url')
+  if (token === undefined || baseUrl === undefined) {
+    return undefined
+  }
+  if (raw['organization'] !== options.organization || raw['project_name'] !== options.projectName) {
+    return undefined
+  }
+
+  const expiresAt = raw['expires_at']
+  // No `expires_at` means unbounded, not invalid: this CLI always writes one, so a file
+  // without it was written by a different version or edited by hand. Refusing it would
+  // break a working setup over a field we added -- the expiry exists to bound a leak, not
+  // to gate the happy path.
+  if (typeof expiresAt === 'string' && isExpired(expiresAt)) {
+    return undefined
+  }
+
+  return { baseUrl, token }
 }
 
 function readUserTokensFile(path: string): Map<string, UserToken> {
@@ -255,6 +390,38 @@ function ensureDataDir(dataDir: string): void {
   }
   mkdirSync(dataDir, { recursive: true })
   writeFileSync(join(dataDir, '.gitignore'), '*')
+}
+
+/**
+ * Write a file readable only by its owner, refusing to follow a symlink at the
+ * destination. The data directory lives inside the user's repository, so a symlink can
+ * arrive by being committed to it; following one would apply `O_TRUNC` and a permissions
+ * change to whatever it points at instead of the intended file.
+ *
+ * The mode passed to `openSync` only applies when it CREATES the file, so an existing
+ * file keeps whatever permissions it had -- `fchmodSync` runs before any bytes are
+ * written, not after, so the content is never briefly sitting in a world-readable file.
+ */
+function writeFileSecurely(path: string, contents: string): void {
+  // `O_NOFOLLOW` is not available on every platform (notably Windows, where creating a
+  // symlink needs a privilege most processes do not have); Node still exposes the
+  // constant as `undefined` there rather than throwing, so this falls back to 0. The
+  // `@types/node` type says `number`, not `number | undefined` -- that type is wrong on
+  // those platforms, not this fallback.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see above; the type is wrong on Windows.
+  const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | (constants.O_NOFOLLOW ?? 0)
+  let fd: number
+  try {
+    fd = openSync(path, flags, 0o600)
+  } catch (error) {
+    throw new LogfireCliError(`Could not write ${path}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  try {
+    fchmodSync(fd, 0o600)
+    writeSync(fd, contents)
+  } finally {
+    closeSync(fd)
+  }
 }
 
 function quoteTomlString(value: string): string {

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -29,6 +29,7 @@ export const PROJECT_CREDENTIALS_FILENAME = 'logfire_credentials.json'
 // filename on both sides is also what lets a project set up by one SDK's CLI be read by
 // the other.
 export const READ_TOKEN_FILENAME = 'read_token.json'
+const READ_TOKEN_IGNORE_PATTERN = `${READ_TOKEN_FILENAME}*`
 
 export interface UserTokenData {
   token: string
@@ -349,6 +350,7 @@ function hasExitStatus(error: unknown, status: number): boolean {
 export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation {
   ensureDataDir(dataDir)
   const path = readTokenPath(dataDir)
+  const lockPath = join(dataDir, `${READ_TOKEN_FILENAME}.lock`)
   try {
     if (isGitTracked(path)) {
       throw new LogfireCliError(
@@ -376,9 +378,11 @@ export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation 
     throw error instanceof LogfireCliError ? error : writeReadTokenError(path, error)
   }
 
-  const temporaryPath = join(dataDir, `.${READ_TOKEN_FILENAME}.${randomUUID()}.tmp`)
+  const temporaryPath = join(dataDir, `${READ_TOKEN_FILENAME}.${randomUUID()}.tmp`)
   let fd: number | undefined
-  const cleanupTemporaryFile = (): Error | undefined => {
+  let lockFd: number | undefined
+  let ownsLock = false
+  const cleanupReservationFiles = (): Error | undefined => {
     let cleanupError: Error | undefined
     if (fd !== undefined) {
       try {
@@ -388,19 +392,44 @@ export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation 
       }
       fd = undefined
     }
+    if (lockFd !== undefined) {
+      try {
+        closeSync(lockFd)
+      } catch (error) {
+        cleanupError ??= error instanceof Error ? error : new Error(String(error))
+      }
+      lockFd = undefined
+    }
     try {
       rmSync(temporaryPath, { force: true })
     } catch (error) {
       cleanupError ??= error instanceof Error ? error : new Error(String(error))
     }
+    if (ownsLock) {
+      try {
+        rmSync(lockPath, { force: true })
+        ownsLock = false
+      } catch (error) {
+        cleanupError ??= error instanceof Error ? error : new Error(String(error))
+      }
+    }
     return cleanupError
   }
 
   try {
+    lockFd = openSync(lockPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600)
+    ownsLock = true
+    fchmodSync(lockFd, 0o600)
     fd = openSync(temporaryPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600)
     fchmodSync(fd, 0o600)
   } catch (error) {
-    throw writeReadTokenError(path, cleanupTemporaryFile() ?? error)
+    const cleanupError = cleanupReservationFiles()
+    if (hasErrorCode(error, 'EEXIST')) {
+      throw new LogfireCliError(
+        `Another read-token save is already in progress for ${path}. If no other command is running, remove ${lockPath} and try again.`
+      )
+    }
+    throw writeReadTokenError(path, cleanupError ?? error)
   }
 
   let active = true
@@ -409,7 +438,7 @@ export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation 
       return
     }
     active = false
-    const error = cleanupTemporaryFile()
+    const error = cleanupReservationFiles()
     if (error !== undefined) {
       throw writeReadTokenError(path, error)
     }
@@ -426,6 +455,10 @@ export function reserveReadTokenSave(dataDir: string): ReadTokenSaveReservation 
         closeSync(fd)
         fd = undefined
         renameSync(temporaryPath, path)
+        const cleanupError = cleanupReservationFiles()
+        if (cleanupError !== undefined) {
+          throw cleanupError
+        }
         active = false
         return path
       } catch (error) {
@@ -562,11 +595,15 @@ function ensureReadTokenIgnored(dataDir: string): void {
     .map((line) => line.trim())
     .filter((line) => line !== '' && !line.startsWith('#'))
   const lastRule = rules.at(-1)
-  if (lastRule === '*' || lastRule === READ_TOKEN_FILENAME || lastRule === `/${READ_TOKEN_FILENAME}`) {
+  if (lastRule === '*' || lastRule === READ_TOKEN_IGNORE_PATTERN || lastRule === `/${READ_TOKEN_IGNORE_PATTERN}`) {
     return
   }
   const separator = contents === '' || contents.endsWith('\n') ? '' : '\n'
-  writeFileSync(path, `${contents}${separator}${READ_TOKEN_FILENAME}\n`)
+  writeFileSync(path, `${contents}${separator}${READ_TOKEN_IGNORE_PATTERN}\n`)
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code
 }
 
 function serializeReadToken(options: SaveReadTokenOptions): string {

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import {
   closeSync,
   constants,
@@ -12,7 +13,7 @@ import {
   writeSync,
 } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { LOGFIRE_REGIONS, PYDANTIC_LOGFIRE_TOKEN_PATTERN } from '../tokenBaseUrl'
 import type { Prompt } from './interactivePrompt'
@@ -304,9 +305,39 @@ export function readTokenPath(dataDir: string): string {
  * silently breaks self-hosted deployments, whose base URL cannot be recovered from the
  * token -- only from where it was actually minted.
  */
+/**
+ * Whether `path` is tracked by the git repository it sits in, if any.
+ *
+ * `.gitignore` only stops an UNTRACKED file from being added; it does nothing for a path
+ * already in the index -- committed before this feature existed, or by mistake -- so
+ * writing a real, permanent credential through such a path would make the next `git
+ * commit -am` publish it. `execFileSync` throws both when the file is genuinely untracked
+ * (`git ls-files` exits non-zero) and when git itself is unavailable or the check times
+ * out, and `false` is the right answer for both: "definitely not tracked" and "cannot
+ * tell, so do not block a working setup over an environment quirk unrelated to the file's
+ * own tracked status" land on the same safe outcome here.
+ */
+function isGitTracked(path: string): boolean {
+  try {
+    execFileSync('git', ['ls-files', '--error-unmatch', '--', basename(path)], {
+      cwd: dirname(path),
+      stdio: 'ignore',
+      timeout: 5000,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function saveReadToken(dataDir: string, options: SaveReadTokenOptions): string {
   ensureDataDir(dataDir)
   const path = readTokenPath(dataDir)
+  if (isGitTracked(path)) {
+    throw new LogfireCliError(
+      `${path} is already tracked by git, so .gitignore does not protect it. Writing the token there risks it reaching a commit. Untrack it first (\`git rm --cached ${path}\`) or remove it, then try again.`
+    )
+  }
   const payload: Record<string, string> = {
     base_url: options.baseUrl,
     organization: options.organization,

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -356,12 +356,22 @@ export function loadSavedReadToken(dataDir: string, options: LoadSavedReadTokenO
   }
 
   const expiresAt = raw['expires_at']
-  // No `expires_at` means unbounded, not invalid: this CLI always writes one, so a file
-  // without it was written by a different version or edited by hand. Refusing it would
-  // break a working setup over a field we added -- the expiry exists to bound a leak, not
-  // to gate the happy path.
-  if (typeof expiresAt === 'string' && isExpired(expiresAt)) {
-    return undefined
+  // Absent (`undefined`) means unbounded, not invalid: this CLI always writes the key, so
+  // a file without it was written by a different version or edited by hand. Refusing it
+  // would break a working setup over a field we added -- the expiry exists to bound a
+  // leak, not to gate the happy path. PRESENT but not a string is different: this file
+  // always writes a string, so `null`/a number/etc. did not come from a normal run, and
+  // treating it the same as absent -- which a bare `typeof expiresAt === 'string'` check
+  // does, since it is also false for a present `null` -- would let a tampered file defeat
+  // the TTL entirely instead of merely losing it. `JSON.parse` keeps a `null` present key
+  // distinct from a missing one (`undefined`), so this can tell them apart.
+  if (expiresAt !== undefined) {
+    if (typeof expiresAt !== 'string') {
+      return undefined
+    }
+    if (isExpired(expiresAt)) {
+      return undefined
+    }
   }
 
   return { baseUrl, token }
@@ -379,7 +389,7 @@ function writeUserTokensFile(path: string, tokens: ReadonlyMap<string, UserToken
   writeFileSync(path, stringifyUserTokensToml(tokens))
 }
 
-function ensureDataDir(dataDir: string): void {
+export function ensureDataDir(dataDir: string): void {
   // Match Python's `ensure_data_dir_exists`: only seed `.gitignore` when creating the
   // directory, so an existing dir's ignore rules are never clobbered.
   if (existsSync(dataDir)) {

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -784,12 +784,20 @@ function jsonResponse(data: unknown, status = 200): Response {
  * the case -- which is what caught the original bug (`npx logfire auth` hanging on a
  * piped multi-line answer) in the first place. */
 async function withTimeout<T>(fn: () => Promise<T>, ms = 2000): Promise<T> {
-  return await Promise.race([
-    fn(),
-    new Promise<T>((_resolve, reject) => {
-      setTimeout(() => {
-        reject(new Error(`Timed out after ${String(ms)}ms -- a prompt call likely hung`))
-      }, ms)
-    }),
-  ])
+  // `Promise.race` settles as soon as `fn()` does, but the losing `setTimeout` keeps
+  // running regardless -- left uncleared, it holds the event loop open for the rest of
+  // `ms` after every fast test and can fire into a promise nothing is awaiting anymore.
+  let timer: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`Timed out after ${String(ms)}ms -- a prompt call likely hung`))
+        }, ms)
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
 }

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -249,6 +249,49 @@ describe('CLI entrypoint', () => {
     expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
   })
 
+  it('read-tokens create --save keeps an existing valid token if the mint itself fails', async () => {
+    // The reserve step only validates the DIRECTORY (`ensureDataDir`), never writing a
+    // placeholder into `read_token.json` itself -- an earlier version reserved by writing
+    // an empty-string placeholder there first, which meant a mint failure after a
+    // successful reserve left the user WORSE off than before the command ran: an
+    // already-working saved token got overwritten with an unusable placeholder and never
+    // restored. Proven here by a mint that fails over the network after the directory
+    // reserve succeeds, while a real, valid token already sits on disk. A non-2xx HTTP
+    // response, not a rejected fetch: `postJson` only wraps THAT case in a clean
+    // `LogfireCliError` today, and exercising the other (a network exception escaping
+    // uncaught) would pin down a real but separate gap this test is not about.
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    const existingToken = JSON.stringify({
+      base_url: 'https://logfire-us.pydantic.dev',
+      expires_at: '2099-12-31T23:59:59.000Z',
+      organization: 'test-org',
+      project_name: 'orders',
+      token: 'still-good-read-token',
+    })
+    writeFileSync(join(cwd, '.logfire/read_token.json'), existingToken)
+
+    const fetchImpl = fetchSequence([new Response('server error', { status: 500 })])
+
+    await expect(
+      runCli(['read-tokens', 'create', '--project', 'test-org/orders', '--save'], {
+        cwd,
+        fetch: fetchImpl,
+        homeDir,
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+
+    expect(readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')).toBe(existingToken)
+  })
+
   it('read-tokens create without --save prints the token and writes no file', async () => {
     const cwd = makeTmpDir()
     const homeDir = makeTmpDir()
@@ -378,6 +421,21 @@ describe('CLI entrypoint', () => {
 
     expect(confirmMessage).toContain('read_token.json')
     expect(existsSync(join(cwd, '.logfire/read_token.json'))).toBe(false)
+  })
+
+  it('clean refuses to follow a symlinked data directory', async () => {
+    // `.logfire` lives inside the user's repository, so a symlink can arrive by being
+    // committed to it. Following one would list and delete through it -- reading a
+    // directory the user never meant to touch, and telling them their real
+    // `read_token.json` was cleaned when it never existed at that path at all.
+    const cwd = makeTmpDir()
+    const victim = makeTmpDir()
+    writeFileSync(join(victim, 'read_token.json'), 'important')
+    symlinkSync(victim, join(cwd, '.logfire'))
+
+    await expect(runCli(['clean'], { cwd, homeDir: makeTmpDir(), stderr: new MemoryOutput(), stdout: new MemoryOutput() })).resolves.toBe(1)
+
+    expect(existsSync(join(victim, 'read_token.json'))).toBe(true)
   })
 
   it('projects status without a saved token says what to run, without calling the API', async () => {

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -2,7 +2,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { Writable } from 'node:stream'
+import { PassThrough, Writable } from 'node:stream'
 
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
 
@@ -85,6 +85,51 @@ describe('CLI entrypoint', () => {
       '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
     )
     expect(stderr.text()).toContain('Successfully authenticated!')
+  })
+
+  it('authenticates through the REAL prompt from one piped multi-line answer, region and Enter together', async () => {
+    // No `prompt` override: this drives `auth` through the actual `createPrompt`, not a
+    // fake, so it is the one test in this file that would have caught the original bug --
+    // a real agent, following the shipped prompt's literal `npx logfire auth`, found that
+    // `printf '1\n\n' | npx logfire auth` hung forever on the second (Enter) prompt.
+    await withTimeout(async () => {
+      const homeDir = makeTmpDir()
+      const stderr = new MemoryOutput()
+      const openBrowser = vi.fn<(_url: string) => void>()
+      const fetchImpl = fetchSequence([
+        jsonResponse({ device_code: 'DC', frontend_auth_url: 'https://example.com/auth' }),
+        jsonResponse({ expiration: '2099-12-31T23:59:59Z', token: 'user-token' }),
+      ])
+      const stdin = new PassThrough()
+      stdin.end('1\n\n')
+
+      await expect(runCli(['auth'], { fetch: fetchImpl, homeDir, openBrowser, stderr, stdin, stdout: new MemoryOutput() })).resolves.toBe(0)
+
+      expect(readFileSync(join(homeDir, '.logfire/default.toml'), 'utf8')).toBe(
+        '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+      )
+    })
+  })
+
+  it('names the region commands instead of hanging when stdin has nothing to read', async () => {
+    // Mirrors pydantic/logfire#2275's own non-interactive test: no `--region`, and stdin
+    // closed immediately (matching `< /dev/null`, or the pipe Claude Code's own Bash tool
+    // gives a spawned command) -- the region choice has no default to fall back to, so
+    // this is the one case that has to fail, and it must fail by saying what to run.
+    await withTimeout(async () => {
+      const stderr = new MemoryOutput()
+      const fetchImpl = vi.fn<typeof fetch>()
+      const stdin = new PassThrough()
+      stdin.end('')
+
+      await expect(runCli(['auth'], { fetch: fetchImpl, homeDir: makeTmpDir(), stderr, stdin, stdout: new MemoryOutput() })).resolves.toBe(
+        1
+      )
+
+      expect(fetchImpl).not.toHaveBeenCalled()
+      expect(stderr.text()).toContain('logfire --region us auth')
+      expect(stderr.text()).toContain('logfire --region eu auth')
+    })
   })
 
   it('configures an existing project and writes local credentials', async () => {
@@ -560,4 +605,20 @@ function jsonResponse(data: unknown, status = 200): Response {
     headers: { 'content-type': 'application/json' },
     status,
   })
+}
+
+/** For tests that drive the REAL prompt (no `prompt` override): a hang there would
+ * otherwise fail as a generic test-runner timeout with no indication of which promise
+ * never settled. A short, generous race turns that into an assertion failure that names
+ * the case -- which is what caught the original bug (`npx logfire auth` hanging on a
+ * piped multi-line answer) in the first place. */
+async function withTimeout<T>(fn: () => Promise<T>, ms = 2000): Promise<T> {
+  return await Promise.race([
+    fn(),
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Timed out after ${String(ms)}ms -- a prompt call likely hung`))
+      }, ms)
+    }),
+  ])
 }

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -121,6 +121,401 @@ describe('CLI entrypoint', () => {
     })
   })
 
+  it('read-tokens create --save writes the file and prints nothing, falling back to the linked project', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: 'orders',
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+
+    const stdout = new MemoryOutput()
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['read-tokens', 'create', '--save'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ token: 'saved-read-token' })]),
+        homeDir,
+        stderr,
+        stdout,
+      })
+    ).resolves.toBe(0)
+
+    expect(stdout.text()).toBe('')
+    expect(stderr.text()).not.toContain('saved-read-token')
+    expect(stderr.text()).toContain('test-org/orders')
+
+    const saved = JSON.parse(readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')) as Record<string, unknown>
+    expect(saved['token']).toBe('saved-read-token')
+    expect(saved['organization']).toBe('test-org')
+    expect(saved['project_name']).toBe('orders')
+    expect(saved['base_url']).toBe('https://logfire-us.pydantic.dev')
+  })
+
+  it('read-tokens create without --save prints the token and writes no file', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+
+    const stdout = new MemoryOutput()
+    await expect(
+      runCli(['read-tokens', '--project', 'test-org/orders', 'create'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ token: 'printed-token' })]),
+        homeDir,
+        stderr: new MemoryOutput(),
+        stdout,
+      })
+    ).resolves.toBe(0)
+
+    expect(stdout.text()).toBe('printed-token\n')
+    expect(() => readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')).toThrow('ENOENT')
+  })
+
+  it('read-tokens create --save with an explicit --project needs no linked directory', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    // Deliberately no `.logfire/logfire_credentials.json` in cwd: --project bypasses the
+    // linked-directory fallback entirely.
+
+    await expect(
+      runCli(['read-tokens', '--project', 'other-org/other-project', 'create', '--save'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ token: 'explicit-project-token' })]),
+        homeDir,
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    const saved = JSON.parse(readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')) as Record<string, unknown>
+    expect(saved['organization']).toBe('other-org')
+    expect(saved['project_name']).toBe('other-project')
+  })
+
+  it('read-tokens create --save run twice replaces the stale token, not merges with it', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: 'orders',
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+    // A long, stale token: dropping symlink-safe truncation would leave trailing bytes
+    // from this behind, and a same-length fresh token would not expose that.
+    writeFileSync(
+      join(cwd, '.logfire/read_token.json'),
+      JSON.stringify({
+        base_url: 'https://logfire-us.pydantic.dev',
+        organization: 'test-org',
+        project_name: 'orders',
+        token: `stale-token-${'x'.repeat(200)}`,
+      })
+    )
+
+    await expect(
+      runCli(['read-tokens', 'create', '--save'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ token: 'fresh-token' })]),
+        homeDir,
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    const saved = JSON.parse(readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')) as Record<string, unknown>
+    expect(saved['token']).toBe('fresh-token')
+  })
+
+  it('projects status without a saved token says what to run, without calling the API', async () => {
+    const cwd = makeTmpDir()
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: 'orders',
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+
+    const stderr = new MemoryOutput()
+    const fetchImpl = vi.fn<typeof fetch>()
+    await expect(runCli(['projects', 'status'], { cwd, fetch: fetchImpl, stderr, stdout: new MemoryOutput() })).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(stderr.text()).toContain('read-tokens create --save')
+  })
+
+  it('projects status renders one row per service and never displays the read token', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status'], {
+        cwd,
+        fetch: fetchSequence([
+          jsonResponse({
+            data: [
+              { last_seen: '2026-08-19T01:00:00.000Z', records: 87, service_name: 'orders-web' },
+              { last_seen: '2026-08-19T01:00:05.000Z', records: 84, service_name: 'orders-worker' },
+            ],
+          }),
+        ]),
+        stderr,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    const text = stderr.text()
+    expect(text).toContain('test-org/orders')
+    expect(text).toContain('orders-web')
+    expect(text).toContain('orders-worker')
+    expect(text).toContain('87')
+    expect(text).not.toContain('fake-read-token')
+  })
+
+  it('projects status --json puts the same data on stdout', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+
+    const stdout = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status', '--json'], {
+        cwd,
+        fetch: fetchSequence([
+          jsonResponse({ data: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 87, service_name: 'orders-web' }] }),
+        ]),
+        stderr: new MemoryOutput(),
+        stdout,
+      })
+    ).resolves.toBe(0)
+
+    expect(JSON.parse(stdout.text())).toEqual({
+      lookback_hours: 1,
+      organization: 'test-org',
+      project_name: 'orders',
+      project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+      services: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 87, service_name: 'orders-web' }],
+    })
+  })
+
+  it('projects status reports "not yet" rather than failure when nothing has arrived', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status'], { cwd, fetch: fetchSequence([jsonResponse({ data: [] })]), stderr, stdout: new MemoryOutput() })
+    ).resolves.toBe(0)
+
+    expect(stderr.text()).toContain('No telemetry in the last 1h')
+  })
+
+  it('ignores a malicious logfire_api_url and queries the host the token was saved with', async () => {
+    // `logfire_credentials.json` lives inside the project this command runs in, so a
+    // tampered repository can set `logfire_api_url` to anything. If that value controlled
+    // where the read token were sent, checking out an untrusted repo and running `projects
+    // status` in it would hand the token straight to an attacker.
+    const cwd = makeTmpDir()
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://attacker.example.com',
+        project_name: 'orders',
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+    writeFileSync(
+      join(cwd, '.logfire/read_token.json'),
+      JSON.stringify({
+        base_url: 'https://logfire-us.pydantic.dev',
+        organization: 'test-org',
+        project_name: 'orders',
+        token: 'fake-read-token',
+      })
+    )
+
+    const requestedHosts: string[] = []
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      requestedHosts.push(new URL(input instanceof Request ? input.url : input.toString()).host)
+      return jsonResponse({ data: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 1, service_name: 'orders-web' }] })
+    })
+
+    await expect(
+      runCli(['projects', 'status'], { cwd, fetch: fetchImpl, stderr: new MemoryOutput(), stdout: new MemoryOutput() })
+    ).resolves.toBe(0)
+
+    expect(requestedHosts).toEqual(['logfire-us.pydantic.dev'])
+  })
+
+  it('queries a self-hosted deployment using the saved base URL, not a region guess', async () => {
+    // An earlier design derived the query host from the token's own region prefix, which
+    // closed the exfiltration path above but would have silently misrouted a self-hosted
+    // deployment: its base URL cannot be recovered from the token, only from where it was
+    // actually minted.
+    const cwd = makeTmpDir()
+    linkProject(cwd, {
+      baseUrl: 'https://logfire.example.com',
+      readToken: 'fake-read-token',
+      projectUrl: 'https://logfire.example.com/test-org/orders',
+    })
+
+    const requestedHosts: string[] = []
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      requestedHosts.push(new URL(input instanceof Request ? input.url : input.toString()).host)
+      return jsonResponse({ data: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 1, service_name: 'orders-web' }] })
+    })
+
+    await expect(
+      runCli(['projects', 'status'], { cwd, fetch: fetchImpl, stderr: new MemoryOutput(), stdout: new MemoryOutput() })
+    ).resolves.toBe(0)
+
+    expect(requestedHosts).toEqual(['logfire.example.com'])
+  })
+
+  it('reports a network failure cleanly instead of an unhandled rejection', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      await Promise.resolve()
+      throw new Error('connect ECONNREFUSED')
+    })
+
+    const stderr = new MemoryOutput()
+    await expect(runCli(['projects', 'status'], { cwd, fetch: fetchImpl, stderr, stdout: new MemoryOutput() })).resolves.toBe(1)
+    expect(stderr.text()).toContain('Could not reach https://logfire-us.pydantic.dev')
+  })
+
+  it('rejects a non-200 response cleanly', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status'], {
+        cwd,
+        fetch: fetchSequence([new Response(null, { status: 204 })]),
+        stderr,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+    expect(stderr.text()).toContain('Could not read the project: 204')
+  })
+
+  it('rejects a malformed 200 response body cleanly', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status'], {
+        cwd,
+        fetch: fetchSequence([new Response('not json', { status: 200 })]),
+        stderr,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+    expect(stderr.text()).toContain('unexpected response shape')
+  })
+
+  it('strips control characters from a service name before writing to the terminal', async () => {
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+    const evilName = 'evil\x1b[2Korders-web\x9btest'
+
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ data: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 1, service_name: evilName }] })]),
+        stderr,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    const text = stderr.text()
+    expect(text).not.toContain('\x1b')
+    expect(text).not.toContain('\x9b')
+  })
+
+  it('does not need control-character stripping in --json mode: JSON.stringify already escapes them', async () => {
+    // Pins that nobody "fixes" this by routing --json through the same stripping the
+    // table uses, which would mangle legitimate unicode service names for no reason: a
+    // JSON string escapes control characters (as `\u001b`, not a literal ESC byte) by
+    // construction, so the raw value is safe here without help.
+    const cwd = makeTmpDir()
+    linkProject(cwd, { baseUrl: 'https://logfire-us.pydantic.dev', readToken: 'fake-read-token' })
+    const evilName = 'evil\x1b[2Korders-web'
+
+    const stdout = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status', '--json'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ data: [{ last_seen: '2026-08-19T01:00:00.000Z', records: 1, service_name: evilName }] })]),
+        stderr: new MemoryOutput(),
+        stdout,
+      })
+    ).resolves.toBe(0)
+
+    const raw = stdout.text()
+    expect(raw).not.toContain('\x1b')
+    expect(raw).toContain('\\u001b')
+    expect((JSON.parse(raw) as { services: { service_name: string }[] }).services[0]?.service_name).toBe(evilName)
+  })
+
+  function linkProject(cwd: string, options: { baseUrl: string; projectUrl?: string; readToken: string }): void {
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: options.baseUrl,
+        project_name: 'orders',
+        project_url: options.projectUrl ?? `${options.baseUrl}/test-org/orders`,
+        token: 'fake-write-token',
+      })
+    )
+    writeFileSync(
+      join(cwd, '.logfire/read_token.json'),
+      JSON.stringify({ base_url: options.baseUrl, organization: 'test-org', project_name: 'orders', token: options.readToken })
+    )
+  }
+
   function makeTmpDir(): string {
     const dir = mkdtempSync(join(tmpdir(), 'logfire-cli-entry-'))
     tmpDirs.push(dir)

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await -- test stubs satisfy async signatures without awaiting. */
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Writable } from 'node:stream'
@@ -208,6 +208,47 @@ describe('CLI entrypoint', () => {
     expect(saved['base_url']).toBe('https://logfire-us.pydantic.dev')
   })
 
+  it('read-tokens create --save never mints a token if the destination cannot be reserved first', async () => {
+    // A read token cannot be revoked or displayed once created. If the destination is
+    // checked only AFTER minting, a symlinked `.logfire` (or a read-only data directory)
+    // leaves a real, orphaned server-side credential behind with no way to see or undo
+    // it. Reserving the destination first means that failure happens before the mint
+    // ever has a chance to run at all -- proven here by asserting `fetch` (the mint's
+    // only network call in this flow) is never even invoked.
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    // A symlinked data directory, with an explicit --project so `readProjectCredentials`
+    // is never consulted -- otherwise ITS OWN "no credentials found" failure (reading
+    // through the same symlink to a directory with nothing in it) would exit 1 and skip
+    // `fetch` regardless of ordering, and the test would pass without the fix it exists to
+    // pin down.
+    const victim = makeTmpDir()
+    symlinkSync(victim, join(cwd, '.logfire'))
+
+    // A real response, not a bare `vi.fn()`: if the mint DID run before the reserve
+    // check, an un-stubbed fetch would throw its own `TypeError` reading `.ok` off
+    // `undefined`, which fails this test for the wrong reason -- masking the ordering bug
+    // as a crash instead of a clean "fetch was called when it should not have been".
+    const fetchImpl = fetchSequence([jsonResponse({ token: 'newly-minted-token' })])
+    await expect(
+      runCli(['read-tokens', 'create', '--project', 'test-org/orders', '--save'], {
+        cwd,
+        fetch: fetchImpl,
+        homeDir,
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
+  })
+
   it('read-tokens create without --save prints the token and writes no file', async () => {
     const cwd = makeTmpDir()
     const homeDir = makeTmpDir()
@@ -300,6 +341,43 @@ describe('CLI entrypoint', () => {
 
     const saved = JSON.parse(readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')) as Record<string, unknown>
     expect(saved['token']).toBe('fresh-token')
+  })
+
+  it('clean lists the saved read token in the confirmation prompt, and removes it on confirm', async () => {
+    // Approving deletion should not silently remove a credential the prompt never
+    // mentioned -- the read token is deleted by `removeProjectCredentials` just like the
+    // write-token credentials file, so it has to be named alongside it.
+    const cwd = makeTmpDir()
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: 'orders',
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+    writeFileSync(
+      join(cwd, '.logfire/read_token.json'),
+      JSON.stringify({ base_url: 'https://logfire-us.pydantic.dev', organization: 'test-org', project_name: 'orders', token: 'read-token' })
+    )
+
+    let confirmMessage = ''
+    const prompt: Prompt = {
+      ...promptWithDefaults(),
+      confirm: async (message) => {
+        confirmMessage = message
+        return true
+      },
+    }
+
+    await expect(
+      runCli(['clean'], { cwd, homeDir: makeTmpDir(), prompt, stderr: new MemoryOutput(), stdout: new MemoryOutput() })
+    ).resolves.toBe(0)
+
+    expect(confirmMessage).toContain('read_token.json')
+    expect(existsSync(join(cwd, '.logfire/read_token.json'))).toBe(false)
   })
 
   it('projects status without a saved token says what to run, without calling the API', async () => {
@@ -542,6 +620,41 @@ describe('CLI entrypoint', () => {
     expect(raw).not.toContain('\x1b')
     expect(raw).toContain('\\u001b')
     expect((JSON.parse(raw) as { services: { service_name: string }[] }).services[0]?.service_name).toBe(evilName)
+  })
+
+  it('strips control characters from the project name in the status header', async () => {
+    // `organization`/`project_name`/`project_url` come from `logfire_credentials.json`,
+    // a file inside the project this command runs in -- the same threat model
+    // `saveReadToken`'s own doc comment already applies to `base_url`, and the same
+    // untrusted-text reasoning as a telemetry-supplied service name.
+    const cwd = makeTmpDir()
+    const evilName = 'orders\x1b[2Kevil'
+    mkdirSync(join(cwd, '.logfire'), { recursive: true })
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: evilName,
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+    writeFileSync(
+      join(cwd, '.logfire/read_token.json'),
+      JSON.stringify({
+        base_url: 'https://logfire-us.pydantic.dev',
+        organization: 'test-org',
+        project_name: evilName,
+        token: 'fake-read-token',
+      })
+    )
+
+    const stderr = new MemoryOutput()
+    await expect(
+      runCli(['projects', 'status'], { cwd, fetch: fetchSequence([jsonResponse({ data: [] })]), stderr, stdout: new MemoryOutput() })
+    ).resolves.toBe(0)
+
+    expect(stderr.text()).not.toContain('\x1b')
   })
 
   function linkProject(cwd: string, options: { baseUrl: string; projectUrl?: string; readToken: string }): void {

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -311,6 +311,25 @@ describe('CLI entrypoint', () => {
     expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
   })
 
+  it('read-tokens create rejects a missing --data-dir value before minting', async () => {
+    const fetchImpl = fetchSequence([jsonResponse({ token: 'newly-minted-token' })])
+    const stdout = new MemoryOutput()
+    const stderr = new MemoryOutput()
+
+    await expect(
+      runCli(['read-tokens', 'create', '--data-dir', '--save', '--project', 'test-org/orders'], {
+        fetch: fetchImpl,
+        homeDir: makeTmpDir(),
+        stderr,
+        stdout,
+      })
+    ).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(stdout.text()).toBe('')
+    expect(stderr.text()).toBe('Missing value for --data-dir\n')
+  })
+
   it('read-tokens create --save never mints through a symlinked token file', async () => {
     const cwd = makeTmpDir()
     const victim = join(makeTmpDir(), 'victim.txt')

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await -- test stubs satisfy async signatures without awaiting. */
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Writable } from 'node:stream'
@@ -166,6 +167,33 @@ describe('CLI entrypoint', () => {
     })
   })
 
+  it('does not create a project by accepting prompt defaults at stdin EOF', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    const stdin = new PassThrough()
+    stdin.end('')
+    const fetchImpl = fetchSequence([jsonResponse([{ organization_name: 'test-org' }])])
+
+    await expect(
+      runCli(['--region', 'us', 'projects', 'new'], {
+        cwd,
+        fetch: fetchImpl,
+        homeDir,
+        stderr: new MemoryOutput(),
+        stdin,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(existsSync(join(cwd, '.logfire/logfire_credentials.json'))).toBe(false)
+  })
+
   it('read-tokens create --save writes the file and prints nothing, falling back to the linked project', async () => {
     const cwd = makeTmpDir()
     const homeDir = makeTmpDir()
@@ -206,6 +234,40 @@ describe('CLI entrypoint', () => {
     expect(saved['organization']).toBe('test-org')
     expect(saved['project_name']).toBe('orders')
     expect(saved['base_url']).toBe('https://logfire-us.pydantic.dev')
+  })
+
+  it('strips control characters from saved-token confirmation output', async () => {
+    const cwd = makeTmpDir()
+    const homeDir = makeTmpDir()
+    mkdirSync(join(homeDir, '.logfire'))
+    writeFileSync(
+      join(homeDir, '.logfire/default.toml'),
+      '[tokens."https://logfire-us.pydantic.dev"]\ntoken = "user-token"\nexpiration = "2099-12-31T23:59:59Z"\n'
+    )
+    mkdirSync(join(cwd, '.logfire'))
+    writeFileSync(
+      join(cwd, '.logfire/logfire_credentials.json'),
+      JSON.stringify({
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: 'orders\x1b[2K',
+        project_url: 'https://logfire-us.pydantic.dev/test-org/orders',
+        token: 'fake-write-token',
+      })
+    )
+    const stderr = new MemoryOutput()
+
+    await expect(
+      runCli(['read-tokens', 'create', '--save'], {
+        cwd,
+        fetch: fetchSequence([jsonResponse({ token: 'saved-read-token' })]),
+        homeDir,
+        stderr,
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(0)
+
+    expect(stderr.text()).not.toContain('\x1b')
+    expect(stderr.text()).toContain('orders�[2K')
   })
 
   it('read-tokens create --save never mints a token if the destination cannot be reserved first', async () => {
@@ -249,6 +311,51 @@ describe('CLI entrypoint', () => {
     expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
   })
 
+  it('read-tokens create --save never mints through a symlinked token file', async () => {
+    const cwd = makeTmpDir()
+    const victim = join(makeTmpDir(), 'victim.txt')
+    mkdirSync(join(cwd, '.logfire'))
+    writeFileSync(victim, 'important')
+    symlinkSync(victim, join(cwd, '.logfire/read_token.json'))
+
+    const fetchImpl = fetchSequence([jsonResponse({ token: 'newly-minted-token' })])
+    await expect(
+      runCli(['read-tokens', 'create', '--project', 'test-org/orders', '--save'], {
+        cwd,
+        fetch: fetchImpl,
+        homeDir: makeTmpDir(),
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(readFileSync(victim, 'utf8')).toBe('important')
+  })
+
+  it('read-tokens create --save never mints into an already tracked token file', async () => {
+    const cwd = makeTmpDir()
+    const dataDir = join(cwd, '.logfire')
+    mkdirSync(dataDir)
+    writeFileSync(join(dataDir, 'read_token.json'), '{}')
+    execFileSync('git', ['init', '--quiet'], { cwd })
+    execFileSync('git', ['add', '--force', '.logfire/read_token.json'], { cwd })
+
+    const fetchImpl = fetchSequence([jsonResponse({ token: 'newly-minted-token' })])
+    await expect(
+      runCli(['read-tokens', 'create', '--project', 'test-org/orders', '--save'], {
+        cwd,
+        fetch: fetchImpl,
+        homeDir: makeTmpDir(),
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+    ).resolves.toBe(1)
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(readFileSync(join(dataDir, 'read_token.json'), 'utf8')).toBe('{}')
+  })
+
   it('read-tokens create --save keeps an existing valid token if the mint itself fails', async () => {
     // The reserve step only validates the DIRECTORY (`ensureDataDir`), never writing a
     // placeholder into `read_token.json` itself -- an earlier version reserved by writing
@@ -290,6 +397,7 @@ describe('CLI entrypoint', () => {
     ).resolves.toBe(1)
 
     expect(readFileSync(join(cwd, '.logfire/read_token.json'), 'utf8')).toBe(existingToken)
+    expect(readdirSync(join(cwd, '.logfire')).filter((name) => name.endsWith('.tmp'))).toEqual([])
   })
 
   it('read-tokens create without --save prints the token and writes no file', async () => {

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -63,6 +63,11 @@ export async function runCli(argv: string[] = process.argv.slice(2), options: Cl
       return error.exitCode
     }
     throw error
+  } finally {
+    // A real TTY, unlike a pipe or a redirected file, never reaches EOF on its own -- so
+    // without this, an interactive terminal session would keep the process alive after
+    // the command above had nothing left to do.
+    context.prompt.dispose?.()
   }
 }
 

--- a/packages/logfire-api/src/cli/interactivePrompt.test.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.test.ts
@@ -1,0 +1,160 @@
+import { PassThrough, Writable } from 'node:stream'
+
+import { describe, expect, it } from 'vite-plus/test'
+
+import { createPrompt, NoAnswerAvailableError } from './interactivePrompt'
+
+describe('CLI interactive prompt', () => {
+  it('reads a real answer and validates it against the choice list', async () => {
+    const { prompt } = makePrompt('2\n')
+
+    await expect(prompt.choice('Pick one', ['1', '2', '3'])).resolves.toBe('2')
+  })
+
+  it('reprompts on an answer outside the choice list, then accepts a valid one', async () => {
+    const { prompt } = makePrompt('9\n2\n')
+
+    await expect(prompt.choice('Pick one', ['1', '2', '3'])).resolves.toBe('2')
+  })
+
+  it('reads two sequential prompts from one piped multi-line write without losing the second answer', async () => {
+    // The exact bug this suite exists to catch: a real agent, following the shipped
+    // prompt's literal `npx logfire auth`, found that a naive `printf '1\n\n' | ...`
+    // answer silently dropped the second line and hung forever -- with BOTH the
+    // promise-based and callback-based readline APIs, on a fresh interface per call AND
+    // a persistent one. Only reading through the readline interface's async-iterator
+    // protocol (what `createPrompt` uses) drains what already arrived in one chunk. A
+    // fresh `createInterface` per call, or repeated `question()` calls on a persistent
+    // one, both reproduce the hang -- so this test is only meaningful against the real
+    // `createPrompt` implementation, not a mock of it.
+    await withTimeout(async () => {
+      const { prompt } = makePrompt('1\n\n')
+
+      const region = await prompt.choice('Select a region', ['1', '2'])
+      expect(region).toBe('1')
+      // `waitForEnter` reads the second, empty line from the SAME buffered write.
+      await expect(prompt.waitForEnter('Press Enter')).resolves.toBeUndefined()
+    })
+  })
+
+  it('reads three sequential answers from one piped multi-line write', async () => {
+    await withTimeout(async () => {
+      const { prompt } = makePrompt('yes\nProject Name\nn\n')
+
+      await expect(prompt.confirm('Create it?')).resolves.toBe(true)
+      await expect(prompt.text('Name', 'default')).resolves.toBe('Project Name')
+      await expect(prompt.confirm('Again?')).resolves.toBe(false)
+    })
+  })
+
+  describe('when there is nothing left to read (stdin closed, no TTY)', () => {
+    it('choice falls back to its default instead of hanging', async () => {
+      await withTimeout(async () => {
+        const { prompt } = makePrompt('')
+        await expect(prompt.choice('Pick one', ['1', '2'], '1')).resolves.toBe('1')
+      })
+    })
+
+    it('choice with no default throws NoAnswerAvailableError instead of hanging', async () => {
+      await withTimeout(async () => {
+        const { prompt } = makePrompt('')
+        await expect(prompt.choice('Pick one', ['1', '2'])).rejects.toBeInstanceOf(NoAnswerAvailableError)
+      })
+    })
+
+    it('confirm falls back to its default instead of hanging', async () => {
+      await withTimeout(async () => {
+        const { prompt: promptYes } = makePrompt('')
+        await expect(promptYes.confirm('Continue?', true)).resolves.toBe(true)
+        const { prompt: promptNo } = makePrompt('')
+        await expect(promptNo.confirm('Continue?', false)).resolves.toBe(false)
+      })
+    })
+
+    it('text falls back to its default instead of hanging', async () => {
+      await withTimeout(async () => {
+        const { prompt } = makePrompt('')
+        await expect(prompt.text('Name', 'fallback')).resolves.toBe('fallback')
+      })
+    })
+
+    it('text with no default resolves to an empty string instead of hanging', async () => {
+      await withTimeout(async () => {
+        const { prompt } = makePrompt('')
+        await expect(prompt.text('Name')).resolves.toBe('')
+      })
+    })
+
+    it('waitForEnter resolves instead of hanging, with no default to fall back to', async () => {
+      await withTimeout(async () => {
+        const { prompt } = makePrompt('')
+        await expect(prompt.waitForEnter('Press Enter')).resolves.toBeUndefined()
+      })
+    })
+  })
+
+  describe('dispose', () => {
+    it('is a no-op when no prompt was ever asked', () => {
+      const { prompt } = makePrompt('')
+      expect(() => prompt.dispose?.()).not.toThrow()
+    })
+
+    it('is safe to call more than once', async () => {
+      const { prompt } = makePrompt('1\n')
+      await prompt.choice('Pick one', ['1', '2'])
+      expect(() => {
+        prompt.dispose?.()
+        prompt.dispose?.()
+      }).not.toThrow()
+    })
+
+    it('releases a never-ending input stream (the real-TTY case) so the process is not held open', async () => {
+      // A piped/redirected input reaches EOF on its own once drained, which is what lets
+      // every other test in this file finish without calling `dispose()` at all. A real
+      // terminal never does -- there is no EOF, ever -- so `dispose()` closing the
+      // interface is the only thing that lets the process exit afterward. Modelled here
+      // with a stream that is deliberately never `.end()`-ed; if `dispose()` did not
+      // release it, this test would hang and the suite's own timeout would fail it.
+      await withTimeout(async () => {
+        const input = new PassThrough()
+        input.write('1\n')
+        const output = new DiscardingWritable()
+        const prompt = createPrompt({ input, output })
+
+        await expect(prompt.choice('Pick one', ['1', '2'])).resolves.toBe('1')
+        prompt.dispose?.()
+        input.destroy()
+      })
+    })
+  })
+})
+
+/** A `Prompt` over an input that has already ended -- the answers, if any, are already
+ * fully written. Matches how a real agent's tool call pipes a fixed string to a command's
+ * stdin, and how a closed/redirected-from-`/dev/null` stdin looks to the process. */
+function makePrompt(inputData: string): { prompt: ReturnType<typeof createPrompt> } {
+  const input = new PassThrough()
+  input.end(inputData)
+  return { prompt: createPrompt({ input, output: new DiscardingWritable() }) }
+}
+
+class DiscardingWritable extends Writable {
+  override _write(_chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    callback()
+  }
+}
+
+/** Every case in this file asserts "resolves", not "resolves within N ms" -- a real hang
+ * would otherwise fail as a test-runner timeout with no indication of which promise never
+ * settled. Wrapping in a short, generous timeout turns that into an assertion failure
+ * that names the case, which is what caught the original bug in the first place. */
+async function withTimeout<T>(fn: () => Promise<T>, ms = 2000): Promise<T> {
+  return await Promise.race([
+    fn(),
+    new Promise<T>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Timed out after ${String(ms)}ms -- a prompt call likely hung`))
+      }, ms)
+    }),
+  ])
+}

--- a/packages/logfire-api/src/cli/interactivePrompt.test.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.test.ts
@@ -2,6 +2,7 @@ import { PassThrough, Writable } from 'node:stream'
 
 import { describe, expect, it } from 'vite-plus/test'
 
+import { LogfireCliError } from './errors'
 import { createPrompt, NoAnswerAvailableError } from './interactivePrompt'
 
 describe('CLI interactive prompt', () => {
@@ -59,6 +60,22 @@ describe('CLI interactive prompt', () => {
       await withTimeout(async () => {
         const { prompt } = makePrompt('')
         await expect(prompt.choice('Pick one', ['1', '2'])).rejects.toBeInstanceOf(NoAnswerAvailableError)
+      })
+    })
+
+    it('NoAnswerAvailableError is a LogfireCliError with a real message, not a bare Error', async () => {
+      // `runCli()`'s top-level catch only special-cases `LogfireCliError` -- anything else
+      // escapes as a raw, unhandled stack trace, which is exactly the failure mode this
+      // whole file exists to remove. A caller with nothing more specific to say than
+      // `promptForRegion` has (it names the exact commands to run) can therefore just NOT
+      // catch this at all and still get a clean exit code and an actionable message,
+      // rather than a blank one.
+      await withTimeout(async () => {
+        const { prompt } = makePrompt('')
+        const error: unknown = await prompt.choice('Pick one', ['1', '2']).catch((caught: unknown) => caught)
+        expect(error).toBeInstanceOf(LogfireCliError)
+        expect((error as LogfireCliError).message).not.toBe('')
+        expect((error as LogfireCliError).exitCode).toBe(1)
       })
     })
 

--- a/packages/logfire-api/src/cli/interactivePrompt.test.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.test.ts
@@ -74,7 +74,9 @@ describe('CLI interactive prompt', () => {
         const { prompt } = makePrompt('')
         const error: unknown = await prompt.choice('Pick one', ['1', '2']).catch((caught: unknown) => caught)
         expect(error).toBeInstanceOf(LogfireCliError)
-        expect((error as LogfireCliError).message).not.toBe('')
+        expect((error as LogfireCliError).message).toBe(
+          'No answer available: not running in a terminal and nothing left to read from stdin.'
+        )
         expect((error as LogfireCliError).exitCode).toBe(1)
       })
     })
@@ -166,12 +168,20 @@ class DiscardingWritable extends Writable {
  * settled. Wrapping in a short, generous timeout turns that into an assertion failure
  * that names the case, which is what caught the original bug in the first place. */
 async function withTimeout<T>(fn: () => Promise<T>, ms = 2000): Promise<T> {
-  return await Promise.race([
-    fn(),
-    new Promise<T>((_resolve, reject) => {
-      setTimeout(() => {
-        reject(new Error(`Timed out after ${String(ms)}ms -- a prompt call likely hung`))
-      }, ms)
-    }),
-  ])
+  // `Promise.race` settles as soon as `fn()` does, but the losing `setTimeout` keeps
+  // running regardless -- left uncleared, it holds the event loop open for the rest of
+  // `ms` after every fast test and can fire into a promise nothing is awaiting anymore.
+  let timer: NodeJS.Timeout | undefined
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`Timed out after ${String(ms)}ms -- a prompt call likely hung`))
+        }, ms)
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
 }

--- a/packages/logfire-api/src/cli/interactivePrompt.test.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.test.ts
@@ -48,11 +48,19 @@ describe('CLI interactive prompt', () => {
     })
   })
 
+  it('accepts displayed defaults only from explicit blank answers', async () => {
+    const { prompt } = makePrompt('\n\n\n')
+
+    await expect(prompt.choice('Pick one', ['1', '2'], '1')).resolves.toBe('1')
+    await expect(prompt.confirm('Continue?', true)).resolves.toBe(true)
+    await expect(prompt.text('Name', 'fallback')).resolves.toBe('fallback')
+  })
+
   describe('when there is nothing left to read (stdin closed, no TTY)', () => {
-    it('choice falls back to its default instead of hanging', async () => {
+    it('choice rejects EOF instead of accepting its default without an answer', async () => {
       await withTimeout(async () => {
         const { prompt } = makePrompt('')
-        await expect(prompt.choice('Pick one', ['1', '2'], '1')).resolves.toBe('1')
+        await expect(prompt.choice('Pick one', ['1', '2'], '1')).rejects.toBeInstanceOf(NoAnswerAvailableError)
       })
     })
 
@@ -81,26 +89,26 @@ describe('CLI interactive prompt', () => {
       })
     })
 
-    it('confirm falls back to its default instead of hanging', async () => {
+    it('confirm rejects EOF instead of authorizing its default without an answer', async () => {
       await withTimeout(async () => {
         const { prompt: promptYes } = makePrompt('')
-        await expect(promptYes.confirm('Continue?', true)).resolves.toBe(true)
+        await expect(promptYes.confirm('Continue?', true)).rejects.toBeInstanceOf(NoAnswerAvailableError)
         const { prompt: promptNo } = makePrompt('')
-        await expect(promptNo.confirm('Continue?', false)).resolves.toBe(false)
+        await expect(promptNo.confirm('Continue?', false)).rejects.toBeInstanceOf(NoAnswerAvailableError)
       })
     })
 
-    it('text falls back to its default instead of hanging', async () => {
+    it('text rejects EOF instead of supplying its default without an answer', async () => {
       await withTimeout(async () => {
         const { prompt } = makePrompt('')
-        await expect(prompt.text('Name', 'fallback')).resolves.toBe('fallback')
+        await expect(prompt.text('Name', 'fallback')).rejects.toBeInstanceOf(NoAnswerAvailableError)
       })
     })
 
-    it('text with no default resolves to an empty string instead of hanging', async () => {
+    it('text with no default rejects EOF instead of supplying an empty answer', async () => {
       await withTimeout(async () => {
         const { prompt } = makePrompt('')
-        await expect(prompt.text('Name')).resolves.toBe('')
+        await expect(prompt.text('Name')).rejects.toBeInstanceOf(NoAnswerAvailableError)
       })
     })
 

--- a/packages/logfire-api/src/cli/interactivePrompt.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.ts
@@ -5,8 +5,9 @@ import type { Readable, Writable } from 'node:stream'
 import { LogfireCliError } from './errors'
 
 /**
- * Thrown by `ask()` when there is nothing left to read and the caller passed no default
- * to fall back to. Extends `LogfireCliError`, not `Error`: `runCli()`'s top-level catch
+ * Thrown by a prompt when there is nothing left to read. EOF must not authorize a
+ * default action; an explicit blank line still selects the displayed default. Extends
+ * `LogfireCliError`, not `Error`: `runCli()`'s top-level catch
  * already turns any `LogfireCliError` into a clean message and exit code, so a caller with
  * nothing more specific to say can simply not catch this at all and still avoid the raw,
  * unhandled stack trace this whole file exists to get rid of. A caller that CAN say
@@ -81,11 +82,6 @@ export function createPrompt({ input, output }: PromptStreams): Prompt {
         // eslint-disable-next-line no-await-in-loop -- prompts are inherently sequential.
         const raw = await ask(`${message}${suffix}: `)
         if (raw === undefined) {
-          // A default answers for us; with none, looping on input that will never
-          // arrive is worse than failing loudly and saying so.
-          if (defaultChoice !== undefined) {
-            return defaultChoice
-          }
           throw new NoAnswerAvailableError()
         }
         const value = raw.trim() || defaultChoice
@@ -101,7 +97,7 @@ export function createPrompt({ input, output }: PromptStreams): Prompt {
         // eslint-disable-next-line no-await-in-loop -- prompts are inherently sequential.
         const raw = await ask(`${message}${suffix}`)
         if (raw === undefined) {
-          return defaultYes
+          throw new NoAnswerAvailableError()
         }
         const value = raw.trim().toLowerCase()
         if (value === '') {
@@ -119,7 +115,7 @@ export function createPrompt({ input, output }: PromptStreams): Prompt {
       const suffix = defaultValue !== undefined ? ` [${defaultValue}]` : ''
       const raw = await ask(`${message}${suffix}: `)
       if (raw === undefined) {
-        return defaultValue ?? ''
+        throw new NoAnswerAvailableError()
       }
       const trimmed = raw.trim()
       return trimmed === '' ? (defaultValue ?? '') : trimmed

--- a/packages/logfire-api/src/cli/interactivePrompt.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.ts
@@ -2,13 +2,23 @@ import { createInterface } from 'node:readline'
 
 import type { Readable, Writable } from 'node:stream'
 
+import { LogfireCliError } from './errors'
+
 /**
  * Thrown by `ask()` when there is nothing left to read and the caller passed no default
- * to fall back to. A caller that can say something more specific than "no answer" --
- * `promptForRegion` names the exact commands to run instead -- catches this and re-throws
- * its own `LogfireCliError`; one that cannot just lets it propagate.
+ * to fall back to. Extends `LogfireCliError`, not `Error`: `runCli()`'s top-level catch
+ * already turns any `LogfireCliError` into a clean message and exit code, so a caller with
+ * nothing more specific to say can simply not catch this at all and still avoid the raw,
+ * unhandled stack trace this whole file exists to get rid of. A caller that CAN say
+ * something more specific -- `promptForRegion` names the exact commands to run instead --
+ * catches it and throws its own `LogfireCliError` in its place.
  */
-export class NoAnswerAvailableError extends Error {}
+export class NoAnswerAvailableError extends LogfireCliError {
+  constructor() {
+    super('No answer available: not running in a terminal and nothing left to read from stdin.')
+    this.name = 'NoAnswerAvailableError'
+  }
+}
 
 export interface Prompt {
   choice(message: string, choices: readonly string[], defaultChoice?: string): Promise<string>

--- a/packages/logfire-api/src/cli/interactivePrompt.ts
+++ b/packages/logfire-api/src/cli/interactivePrompt.ts
@@ -1,12 +1,29 @@
-import { createInterface } from 'node:readline/promises'
+import { createInterface } from 'node:readline'
 
 import type { Readable, Writable } from 'node:stream'
+
+/**
+ * Thrown by `ask()` when there is nothing left to read and the caller passed no default
+ * to fall back to. A caller that can say something more specific than "no answer" --
+ * `promptForRegion` names the exact commands to run instead -- catches this and re-throws
+ * its own `LogfireCliError`; one that cannot just lets it propagate.
+ */
+export class NoAnswerAvailableError extends Error {}
 
 export interface Prompt {
   choice(message: string, choices: readonly string[], defaultChoice?: string): Promise<string>
   confirm(message: string, defaultYes?: boolean): Promise<boolean>
   text(message: string, defaultValue?: string): Promise<string>
   waitForEnter(message: string): Promise<void>
+  /**
+   * Release the readline interface, if one was ever created. A no-op if no prompt was
+   * ever asked, and safe to call more than once. Exists because a real TTY, unlike a
+   * pipe or a redirected file, never reaches EOF on its own -- without this, an
+   * interactive terminal session would keep the CLI process alive indefinitely after its
+   * last command had nothing left to do, where piped input happened to release it by
+   * running out on its own.
+   */
+  dispose?(): void
 }
 
 export interface PromptStreams {
@@ -15,13 +32,35 @@ export interface PromptStreams {
 }
 
 export function createPrompt({ input, output }: PromptStreams): Prompt {
-  async function ask(question: string): Promise<string> {
-    const rl = createInterface({ input, output, terminal: false })
-    try {
-      return await rl.question(question)
-    } finally {
-      rl.close()
+  // ONE interface for the process's whole lifetime, created lazily so a command that
+  // never prompts (`whoami`, `projects list`) never touches stdin at all. Read through
+  // the async-iterator protocol, not repeated `question()` calls: verified against a real
+  // container that `question()` -- promise-based AND callback-based, on a fresh interface
+  // per call or a persistent one -- silently drops whatever answer arrives after the
+  // first when several lines land in the same chunk (`printf '1\n2\n' | ...` hangs
+  // forever on the second read). The async iterator is the one interface that correctly
+  // drains what is already buffered. This is exactly the race the shipped prompt's own
+  // literal `npx logfire auth` sequence hits: a real agent had to hand-build a paced named
+  // pipe to work around it before this fix existed.
+  let rl: ReturnType<typeof createInterface> | undefined
+  // `AsyncIterator<string>`'s default `TReturn` is `any` (so is Node's own
+  // `NodeJS.AsyncIterator`, which `rl[Symbol.asyncIterator]()` actually returns) --
+  // pinned to `undefined` here so the destructure below is typed, not `any`.
+  let lines: AsyncIterator<string, undefined> | undefined
+
+  async function ask(question: string): Promise<string | undefined> {
+    if (lines === undefined) {
+      rl = createInterface({ input, output, terminal: false })
+      lines = rl[Symbol.asyncIterator]()
     }
+    output.write(question)
+    // Deliberately not `input.isTTY`/`process.stdin.isTTY`. That answers "is a terminal
+    // attached", which is a different question -- a pipe is not a tty and is perfectly
+    // answerable, and piping the answers in is how scripts have always driven this
+    // command. Gating on isTTY would turn that into a hard failure. EOF from the
+    // iterator (`done: true`) is the only signal that means "nothing is coming".
+    const { value, done } = await lines.next()
+    return done === true ? undefined : value
   }
 
   return {
@@ -30,7 +69,16 @@ export function createPrompt({ input, output }: PromptStreams): Prompt {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- reprompt until a valid choice is entered.
       while (true) {
         // eslint-disable-next-line no-await-in-loop -- prompts are inherently sequential.
-        const value = (await ask(`${message}${suffix}: `)).trim() || defaultChoice
+        const raw = await ask(`${message}${suffix}: `)
+        if (raw === undefined) {
+          // A default answers for us; with none, looping on input that will never
+          // arrive is worse than failing loudly and saying so.
+          if (defaultChoice !== undefined) {
+            return defaultChoice
+          }
+          throw new NoAnswerAvailableError()
+        }
+        const value = raw.trim() || defaultChoice
         if (value !== undefined && choices.includes(value)) {
           return value
         }
@@ -41,7 +89,11 @@ export function createPrompt({ input, output }: PromptStreams): Prompt {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- reprompt until a yes/no answer is entered.
       while (true) {
         // eslint-disable-next-line no-await-in-loop -- prompts are inherently sequential.
-        const value = (await ask(`${message}${suffix}`)).trim().toLowerCase()
+        const raw = await ask(`${message}${suffix}`)
+        if (raw === undefined) {
+          return defaultYes
+        }
+        const value = raw.trim().toLowerCase()
         if (value === '') {
           return defaultYes
         }
@@ -55,10 +107,22 @@ export function createPrompt({ input, output }: PromptStreams): Prompt {
     },
     async text(message, defaultValue) {
       const suffix = defaultValue !== undefined ? ` [${defaultValue}]` : ''
-      return ((await ask(`${message}${suffix}: `)).trim() || defaultValue) ?? ''
+      const raw = await ask(`${message}${suffix}: `)
+      if (raw === undefined) {
+        return defaultValue ?? ''
+      }
+      const trimmed = raw.trim()
+      return trimmed === '' ? (defaultValue ?? '') : trimmed
     },
     async waitForEnter(message) {
+      // No branch on the result: a real Enter and "nothing left to read" mean the same
+      // thing here -- continue. There is no default to fall back to and nothing to
+      // validate, only a beat to give a person before a browser window appears, and
+      // there is no beat to give when there is no one to press the key.
       await ask(`${message}\n`)
+    },
+    dispose() {
+      rl?.close()
     },
   }
 }

--- a/packages/logfire-api/src/cli/output.ts
+++ b/packages/logfire-api/src/cli/output.ts
@@ -11,6 +11,18 @@ export function writeLine(output: WritableOutput, message = ''): void {
   output.write(`${message}\n`)
 }
 
+/**
+ * Strip control characters from text before it reaches a terminal. Telemetry fields, a
+ * saved credentials file inside the user's repo, and a server's own response body are all
+ * text this CLI did not author -- written raw, escape sequences in any of them could clear
+ * the screen, reposition the cursor, or forge rows in whatever table or message the
+ * operator is actually reading to decide whether their setup worked.
+ */
+export function sanitizeForTerminal(text: string): string {
+  // eslint-disable-next-line no-control-regex -- the control characters ARE the target.
+  return text.replace(/[\x00-\x1f\x7f-\x9f]/gu, '�')
+}
+
 export function prettyTable(header: string[], rows: string[][]): string {
   const indent = (cells: string[]): string[] => [` ${cells[0] ?? ''}`, ...cells.slice(1)]
   const tableRows = [indent(header), ...rows.map(indent)]

--- a/packages/logfire-api/src/cli/regions.test.ts
+++ b/packages/logfire-api/src/cli/regions.test.ts
@@ -42,7 +42,8 @@ describe('CLI regions', () => {
       // path only fires if that contract is ever violated -- guards against a future
       // regression there, not something a real prompt implementation can trigger today.
       const prompt = fakePrompt({ choice: async () => '99' })
-      await expect(promptForRegion(prompt)).rejects.toThrow('Invalid Logfire region selection.')
+      const error: unknown = await promptForRegion(prompt).catch((caught: unknown) => caught)
+      expect((error as Error).message).toBe('Invalid Logfire region selection.')
     })
 
     it('names the exact command to run for each region when there is no answer to read', async () => {
@@ -55,7 +56,8 @@ describe('CLI regions', () => {
         },
       })
 
-      await expect(promptForRegion(prompt)).rejects.toThrow(
+      const error: unknown = await promptForRegion(prompt).catch((caught: unknown) => caught)
+      expect((error as Error).message).toBe(
         [
           'Logfire is available in multiple data regions and no region was selected.',
           'Re-run in an interactive terminal to choose, or pass one:',
@@ -67,13 +69,14 @@ describe('CLI regions', () => {
     })
 
     it('lets an unrelated error from choice() propagate unchanged', async () => {
+      const originalError = new Error('the terminal caught fire')
       const prompt = fakePrompt({
         choice: async () => {
-          throw new Error('the terminal caught fire')
+          throw originalError
         },
       })
 
-      await expect(promptForRegion(prompt)).rejects.toThrow('the terminal caught fire')
+      await expect(promptForRegion(prompt)).rejects.toBe(originalError)
     })
   })
 })

--- a/packages/logfire-api/src/cli/regions.test.ts
+++ b/packages/logfire-api/src/cli/regions.test.ts
@@ -1,7 +1,10 @@
+/* eslint-disable @typescript-eslint/require-await -- test stubs satisfy async signatures without awaiting. */
 import { describe, expect, it } from 'vite-plus/test'
 
 import { getBaseUrlFromToken } from '../tokenBaseUrl'
-import { isCliRegion, resolveSelectedBaseUrl } from './regions'
+import { NoAnswerAvailableError } from './interactivePrompt'
+import type { Prompt } from './interactivePrompt'
+import { isCliRegion, promptForRegion, resolveSelectedBaseUrl } from './regions'
 
 describe('CLI regions', () => {
   it('accepts public regions and rejects inherited object properties', () => {
@@ -27,4 +30,60 @@ describe('CLI regions', () => {
     expect(getBaseUrlFromToken('pylf_v1_eu_abc123')).toBe('https://logfire-eu.pydantic.dev')
     expect(getBaseUrlFromToken(undefined)).toBe('https://logfire-us.pydantic.dev')
   })
+
+  describe('promptForRegion', () => {
+    it('resolves the base URL for the chosen region', async () => {
+      const prompt = fakePrompt({ choice: async () => '2' })
+      await expect(promptForRegion(prompt)).resolves.toBe('https://logfire-eu.pydantic.dev')
+    })
+
+    it('rejects a selection outside the numbered list', async () => {
+      // `choice()` itself only ever returns a value from the list it was given, so this
+      // path only fires if that contract is ever violated -- guards against a future
+      // regression there, not something a real prompt implementation can trigger today.
+      const prompt = fakePrompt({ choice: async () => '99' })
+      await expect(promptForRegion(prompt)).rejects.toThrow('Invalid Logfire region selection.')
+    })
+
+    it('names the exact command to run for each region when there is no answer to read', async () => {
+      // Mirrors pydantic/logfire#2275 ("let `logfire auth` complete without a TTY"): which
+      // region holds your data is not the CLI's to guess, so this stays a hard stop -- but
+      // one that says exactly what to run instead of hanging on a prompt nobody can answer.
+      const prompt = fakePrompt({
+        choice: async () => {
+          throw new NoAnswerAvailableError()
+        },
+      })
+
+      await expect(promptForRegion(prompt)).rejects.toThrow(
+        [
+          'Logfire is available in multiple data regions and no region was selected.',
+          'Re-run in an interactive terminal to choose, or pass one:',
+          '',
+          '  logfire --region us auth',
+          '  logfire --region eu auth',
+        ].join('\n')
+      )
+    })
+
+    it('lets an unrelated error from choice() propagate unchanged', async () => {
+      const prompt = fakePrompt({
+        choice: async () => {
+          throw new Error('the terminal caught fire')
+        },
+      })
+
+      await expect(promptForRegion(prompt)).rejects.toThrow('the terminal caught fire')
+    })
+  })
 })
+
+function fakePrompt(overrides: Partial<Prompt>): Prompt {
+  return {
+    choice: async (_message, choices, defaultChoice) => defaultChoice ?? choices[0] ?? '',
+    confirm: async (_message, defaultYes = true) => defaultYes,
+    text: async (_message, defaultValue) => defaultValue ?? '',
+    waitForEnter: async () => undefined,
+    ...overrides,
+  }
+}

--- a/packages/logfire-api/src/cli/regions.ts
+++ b/packages/logfire-api/src/cli/regions.ts
@@ -1,5 +1,6 @@
 import { LOGFIRE_PUBLIC_REGIONS, removeTrailingSlash } from '../tokenBaseUrl'
 import { LogfireCliError } from './errors'
+import { NoAnswerAvailableError } from './interactivePrompt'
 import type { Prompt } from './interactivePrompt'
 
 export type CliRegion = keyof typeof LOGFIRE_PUBLIC_REGIONS
@@ -26,10 +27,28 @@ export async function promptForRegion(prompt: Prompt): Promise<string> {
   const choicesText = entries
     .map(([region, data], index) => `${String(index + 1)}. ${region.toUpperCase()} (GCP region: ${data.gcpRegion})`)
     .join('\n')
-  const selected = await prompt.choice(
-    `Logfire is available in multiple data regions. Please select one:\n${choicesText}\nSelected region`,
-    choices
-  )
+  let selected: string
+  try {
+    selected = await prompt.choice(
+      `Logfire is available in multiple data regions. Please select one:\n${choicesText}\nSelected region`,
+      choices
+    )
+  } catch (error) {
+    if (!(error instanceof NoAnswerAvailableError)) {
+      throw error
+    }
+    // Which region holds your data is not ours to guess, so it stays a required choice --
+    // but it is answerable ahead of time, and saying so beats hanging on a prompt nobody
+    // can reply to. Each suggestion is its own runnable line, because `--region us|eu` is
+    // a shell pipeline if you paste it.
+    const lines = [
+      'Logfire is available in multiple data regions and no region was selected.',
+      'Re-run in an interactive terminal to choose, or pass one:',
+      '',
+      ...entries.map(([region]) => `  logfire --region ${region} auth`),
+    ]
+    throw new LogfireCliError(lines.join('\n'))
+  }
   const selectedRegion = entries[Number(selected) - 1]?.[1]
   if (selectedRegion === undefined) {
     throw new LogfireCliError('Invalid Logfire region selection.')


### PR DESCRIPTION
## Summary

- `logfire projects status` shows what telemetry has actually reached the project this directory is linked to, one row per service — a partly-instrumented system shows up as one, where "no errors on startup" cannot.
- `logfire read-tokens create --save` stores the read token in `.logfire/read_token.json` instead of printing it, so `projects status` can verify a setup without a credential ever reaching a terminal, a CI log, or a coding agent's transcript.
- Ports the Python `logfire` CLI's feature of the same name, including its security-relevant design: the query is sent to the host the token was minted against (recorded at save time from the client's own base URL, never from a URL read out of the project being queried), the saved token file is written with `O_NOFOLLOW` and narrowed to `0600` before any bytes land, and telemetry-supplied service names are stripped of control characters before reaching a terminal.

## Test plan

- [x] `pnpm run check` (build, format, lint, typecheck, unit tests across all packages) passes
- [x] New tests cover: SSRF prevention (a tampered `logfire_credentials.json` cannot redirect the query), self-hosted routing (base URL isn't guessed from the token's region prefix), symlink refusal, file permissions, expired/foreign-project token rejection, non-200 and malformed-body responses, network failures, and control-character stripping (verified both in the table and that `--json` doesn't need separate stripping, since `JSON.stringify` already escapes them)
- [x] Added a changeset (`logfire` package, minor bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)