### PR TITLE
Reject a non-finite evaluator score

### DIFF
--- a/.changeset/evals-nonfinite-scalar.md
+++ b/.changeset/evals-nonfinite-scalar.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Report an evaluator failure when a case evaluator returns `NaN` or `Infinity` instead of recording it as a score. A single non-finite score made the mean for that key `NaN` across the whole experiment, and pydantic-evals rejects these values outright.

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -673,4 +673,26 @@ describe('offline evals — span attribute parity', () => {
       expect(c.evaluator_failures).toMatchObject([{ error_message: 'Evaluator error', error_type: 'Error', name: 'FailingEvaluator' }])
     }
   })
+
+  it('reports an evaluator failure instead of a non-finite score', async () => {
+    class NanScore extends Evaluator {
+      static override evaluatorName = 'NanScore'
+      evaluate(): number {
+        return 0 / 0
+      }
+    }
+
+    const dataset = new Dataset<null, string>({
+      cases: [new Case<null, string>({ inputs: null, name: 'a' })],
+      evaluators: [new NanScore()],
+      name: 'non-finite',
+    })
+
+    const { result } = await withMemoryExporter(async () => dataset.evaluate(() => 'x'))
+
+    expect(result.cases[0]?.scores).toEqual({})
+    expect(result.cases[0]?.evaluator_failures.map((f) => [f.name, f.error_message])).toEqual([
+      ['NanScore', 'Evaluator returned a non-finite value for NanScore: NaN'],
+    ])
+  })
 })

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -674,6 +674,30 @@ describe('offline evals — span attribute parity', () => {
     }
   })
 
+  it('reports an evaluator failure when any entry of a result map is non-finite', async () => {
+    class MixedScores extends Evaluator {
+      static override evaluatorName = 'MixedScores'
+      evaluate(): Record<string, number> {
+        return { finite: 1, unbounded: Number.POSITIVE_INFINITY }
+      }
+    }
+
+    const dataset = new Dataset<null, string>({
+      cases: [new Case<null, string>({ inputs: null, name: 'a' })],
+      evaluators: [new MixedScores()],
+      name: 'non-finite-map',
+    })
+
+    const { result } = await withMemoryExporter(async () => dataset.evaluate(() => 'x'))
+
+    // The whole evaluator fails, so the valid sibling entry is not recorded either. Python
+    // validates the entire output up front and discards it the same way.
+    expect(result.cases[0]?.scores).toEqual({})
+    expect(result.cases[0]?.evaluator_failures.map((f) => [f.name, f.error_message])).toEqual([
+      ['MixedScores', 'Evaluator returned a non-finite value for unbounded: Infinity'],
+    ])
+  })
+
   it('reports an evaluator failure instead of a non-finite score', async () => {
     class NanScore extends Evaluator {
       static override evaluatorName = 'NanScore'

--- a/packages/logfire-api/src/evals/evaluatorResults.ts
+++ b/packages/logfire-api/src/evals/evaluatorResults.ts
@@ -39,6 +39,13 @@ export function buildEvaluationResultJson(
 ): EvaluationResultJson {
   const reason = isEvaluationReason(value) ? (value.reason ?? null) : null
   const scalar = isEvaluationReason(value) ? value.value : value
+  if (typeof scalar === 'number' && !Number.isFinite(scalar)) {
+    // `EvaluationScalar` is `bool | int | Annotated[float, Field(allow_inf_nan=False)] | str`, so
+    // pydantic-evals rejects these and reports an evaluator failure. Both callers here run inside
+    // a try that does the same, and a non-finite score would otherwise make every aggregate over
+    // that key NaN.
+    throw new Error(`Evaluator returned a non-finite value for ${name}: ${String(scalar)}`)
+  }
   const out: EvaluationResultJson = {
     name,
     reason,


### PR DESCRIPTION
## Defect

A case evaluator returning `NaN` or `Infinity` is recorded as a score. One such case makes the mean for that key `NaN` for the whole experiment, so a single degenerate evaluator silently destroys a whole column of the report rather than reporting itself as broken.

## Evidence

pydantic-evals rejects these values in the type itself (`evaluators/evaluator.py`):

```python
EvaluationScalar = bool | int | Annotated[float, Field(allow_inf_nan=False)] | str
```

`run_evaluator` validates the output against that adapter and turns a violation into an `EvaluatorFailure`, so in Python the evaluator is reported as failing and no score is written.

On this side nothing checks finiteness. `isScalar` accepts any `number`, and `reporting.ts` then accumulates it:

```ts
if (typeof r.value === 'number') {
  acc.count += 1
  acc.sum += r.value
}
```

`sum` becomes `NaN`, so `mean` is `NaN` for every case under that key. `JSON.stringify(NaN)` is `null`, so the serialized report carries a null where a number is expected.

Reproduced on `8effa79` with an evaluator returning `0 / 0`: both cases recorded `scores.NanScore = NaN`.

## Fix

Validate in `buildEvaluationResultJson`, which is the single point both the scalar path and the result-map path funnel through, and which `runEvaluators` and `online.ts` each already call inside a `try` that builds an `EvaluatorFailureRecord`. So the throw lands in the same place Python's `ValidationError` does, and the failure is reported per evaluator without aborting the experiment.

Deliberately not narrowing `isScalar` instead: `isEvaluationScalar` returning false for `NaN` would send the value to `Object.entries(NaN)`, which yields `[]`, so the evaluator would silently produce no result at all. That is worse than the bug.

The report evaluators that intentionally return `NaN` for single-class inputs are untouched. They emit `ReportAnalysis` values and never pass through this builder, and their tests still pass.

Reverting the guard fails the new test with `expected { Object (NanScore) } to deeply equal {}`.

Built this with Claude Code's help and reviewed the diff myself.