### PR TITLE
Keep an own __proto__ key when normalizing pushed values

### DIFF
--- a/.changeset/dataset-proto-key.md
+++ b/.changeset/dataset-proto-key.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep an own `__proto__` key when normalizing values for `pushEvaluationDataset`. Assigning into a plain object invoked the `__proto__` setter instead of creating a property, so a JSON-parsed case value carrying that key had it silently dropped from the pushed dataset.

--- a/packages/logfire-api/src/datasets.evaluation.test.ts
+++ b/packages/logfire-api/src/datasets.evaluation.test.ts
@@ -324,6 +324,30 @@ describe('hosted evaluation datasets bridge', () => {
     })
   })
 
+  it('keeps an own __proto__ key from a JSON-parsed case value', async () => {
+    const calls: CapturedRequest[] = []
+    const client = new LogfireAPIClient({
+      apiKey: 'lf-api-key',
+      baseUrl: 'https://example.com',
+      fetch: fetchSequence(calls, [jsonResponse(hostedMetadata), jsonResponse([{ id: 'case-1' }]), jsonResponse(hostedMetadata)]),
+    })
+
+    // A hosted export or a dataset file reaches us through JSON.parse, which does create an own
+    // `__proto__` property rather than setting the prototype the way an object literal would.
+    const inputs = JSON.parse('{"a":1,"__proto__":{"nested":true}}') as Record<string, unknown>
+
+    await client.pushEvaluationDataset(
+      new Dataset({
+        cases: [new Case({ inputs, name: 'proto-key' })],
+        name: 'proto-normalized',
+      })
+    )
+
+    const pushed = (calls[1]?.body as { cases: { inputs: Record<string, unknown> }[] }).cases[0]?.inputs
+    expect(Object.keys(pushed as object).sort()).toEqual(['__proto__', 'a'])
+    expect((pushed as Record<string, unknown>)['__proto__']).toEqual({ nested: true })
+  })
+
   it('serializes shared unsupported values without treating sibling references as cycles', async () => {
     const calls: CapturedRequest[] = []
     const client = new LogfireAPIClient({

--- a/packages/logfire-api/src/datasets/json.ts
+++ b/packages/logfire-api/src/datasets/json.ts
@@ -53,11 +53,16 @@ function normalizeValue(
     }
     ancestors.add(value)
     try {
-      const result: Record<string, unknown> = {}
-      for (const [key, item] of Object.entries(value)) {
-        result[key] = normalizeValue(item, { ...context, path: objectPath(context.path, key) }, serializeValue, ancestors, serializedValues)
-      }
-      return result
+      // Assigning into a plain object would invoke the `__proto__` setter rather than create an
+      // own property, so a JSON-parsed value carrying an own `__proto__` key would lose it here
+      // without any error. `Object.fromEntries` defines own properties, as `vars/template.ts`
+      // already does for the same reason.
+      return Object.fromEntries(
+        Object.entries(value).map(([key, item]) => [
+          key,
+          normalizeValue(item, { ...context, path: objectPath(context.path, key) }, serializeValue, ancestors, serializedValues),
+        ])
+      )
     } finally {
       ancestors.delete(value)
     }


### PR DESCRIPTION
## Defect

`pushEvaluationDataset` silently drops an own `__proto__` key from a case value. The field is gone from the pushed dataset with no error, in a normalizer where every other awkward input raises a path-aware `DatasetSerializationError`.

## Evidence

The object branch of `normalizeValue` copied entries by assignment:

```ts
const result: Record<string, unknown> = {}
for (const [key, item] of Object.entries(value)) {
  result[key] = normalizeValue(...)
}
```

`result['__proto__'] = x` invokes the inherited `__proto__` setter rather than defining a property, so the key never lands on `result`.

An own `__proto__` key is reachable on exactly the path this function serves. An object literal cannot produce one, but `JSON.parse` does, and case values arrive from hosted exports and dataset files:

```
JSON.parse('{"a":1,"__proto__":{"nested":true}}')  ->  own keys ['a', '__proto__']
```

Reproduced on `8effa79`: pushing a case whose `inputs` is that parsed value sends `{a: 1}`.

## Fix

Build the normalized object with `Object.fromEntries`, which defines own properties. `vars/template.ts` and `vars/composition.ts` already map objects this way, so this matches the existing convention rather than introducing one, and it drops the mutable accumulator.

Reverting to the assignment loop fails the new test with `expected [ 'a' ] to deeply equal [ '__proto__', 'a' ]`.

Built this with Claude Code's help and reviewed the diff myself.