### PR TITLE
Check Set members and Map keys in Contains

### DIFF
--- a/.changeset/contains-set-map.md
+++ b/.changeset/contains-set-map.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Check Set members and Map keys in the `Contains` evaluator. A task returning a `Set` or `Map` produced a failing assertion whose reason read `Output {}`, because both fell through to the object branch and were checked for property names.

--- a/.changeset/contains-set-map.md
+++ b/.changeset/contains-set-map.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Check Set members and Map keys in the `Contains` evaluator. A task returning a `Set` or `Map` produced a failing assertion whose reason read `Output {}`, because both fell through to the object branch and were checked for property names.
+Check Set members and Map entries in the `Contains` evaluator. A task returning a `Set` or `Map` produced a failing assertion whose reason read `Output {}`, because both fell through to the object branch and were checked for property names. A record value is now paired against a `Map` key by key, matching how pydantic-evals pairs it against a dict.

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -105,6 +105,9 @@ describe('built-in evaluator edge cases', () => {
     expect(new Contains({ value: 'a' }).evaluate(ctx(new Set(['a', 'b'])))).toEqual({ value: true })
     expect(new Contains({ value: { id: 1 } }).evaluate(ctx(new Set([{ id: 1 }])))).toEqual({ value: true })
     expect(new Contains({ value: 'k' }).evaluate(ctx(new Map([['k', 1]])))).toEqual({ value: true })
+    // Native membership is SameValueZero, so NaN matches; `deepEqual` compares with `===`.
+    expect(new Contains({ value: Number.NaN }).evaluate(ctx(new Set([Number.NaN])))).toEqual({ value: true })
+    expect(new Contains({ value: Number.NaN }).evaluate(ctx(new Map([[Number.NaN, 1]])))).toEqual({ value: true })
 
     // The reason has to name the contents; `JSON.stringify` renders a Set or Map as `{}`.
     expect(new Contains({ value: 'missing' }).evaluate(ctx(new Set(['a'])))).toEqual({

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -120,6 +120,43 @@ describe('built-in evaluator edge cases', () => {
     })
   })
 
+  it('Contains pairs a record against Map entries the way Python pairs it against a dict', () => {
+    expect(new Contains({ value: { k: 1 } }).evaluate(ctx(new Map<unknown, unknown>([['k', 1]])))).toEqual({ value: true })
+    expect(new Contains({ value: {} }).evaluate(ctx(new Map<unknown, unknown>([['k', 1]])))).toEqual({ value: true })
+    expect(
+      new Contains({ value: { a: 1 } }).evaluate(
+        ctx(
+          new Map<unknown, unknown>([
+            ['a', 1],
+            ['b', 2],
+          ])
+        )
+      )
+    ).toEqual({ value: true })
+    expect(new Contains({ value: { k: 2 } }).evaluate(ctx(new Map<unknown, unknown>([['k', 1]])))).toEqual({
+      reason: 'Output has different value for key "k": 1 != 2',
+      value: false,
+    })
+    expect(new Contains({ value: { z: 1 } }).evaluate(ctx(new Map<unknown, unknown>([['k', 1]])))).toEqual({
+      reason: 'Output does not contain expected key "z"',
+      value: false,
+    })
+
+    // A Map can hold the record itself as a key, which a dict cannot, so the key check still
+    // runs when the pairing fails. This is the only case that reaches the structural key loop:
+    // the NaN cases above are answered by `has`.
+    expect(new Contains({ value: { id: 1 } }).evaluate(ctx(new Map<unknown, unknown>([[{ id: 1 }, 'v']])))).toEqual({
+      value: true,
+    })
+
+    // Only a real record pairs. A Date has no own enumerable keys, so pairing it would be
+    // vacuously true; it stays a key query.
+    expect(new Contains({ value: new Date(0) }).evaluate(ctx(new Map<unknown, unknown>([['k', 1]])))).toEqual({
+      reason: 'Output ["k"] does not contain provided value as a key',
+      value: false,
+    })
+  })
+
   it('Equals and EqualsExpected preserve custom result names and empty-output behavior', () => {
     const eq = new Equals({ evaluationName: 'exact', value: { nested: ['x'] } })
     expect(eq.getResultName()).toBe('exact')

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -100,6 +100,23 @@ describe('built-in evaluator edge cases', () => {
     expect(evaluator.evaluate(ctx(new Date('2020-01-01'), { expectedOutput: new Date('2020-01-01') }))).toBe(true)
   })
 
+  it('Contains checks Set members and Map keys', () => {
+    // A task returns these in process, so they are not constrained by the dataset file format.
+    expect(new Contains({ value: 'a' }).evaluate(ctx(new Set(['a', 'b'])))).toEqual({ value: true })
+    expect(new Contains({ value: { id: 1 } }).evaluate(ctx(new Set([{ id: 1 }])))).toEqual({ value: true })
+    expect(new Contains({ value: 'k' }).evaluate(ctx(new Map([['k', 1]])))).toEqual({ value: true })
+
+    // The reason has to name the contents; `JSON.stringify` renders a Set or Map as `{}`.
+    expect(new Contains({ value: 'missing' }).evaluate(ctx(new Set(['a'])))).toEqual({
+      reason: 'Output ["a"] does not contain provided value',
+      value: false,
+    })
+    expect(new Contains({ value: 'missing' }).evaluate(ctx(new Map([['k', 1]])))).toEqual({
+      reason: 'Output ["k"] does not contain provided value as a key',
+      value: false,
+    })
+  })
+
   it('Equals and EqualsExpected preserve custom result names and empty-output behavior', () => {
     const eq = new Equals({ evaluationName: 'exact', value: { nested: ['x'] } })
     expect(eq.getResultName()).toBe('exact')

--- a/packages/logfire-api/src/evals/builtins/Contains.ts
+++ b/packages/logfire-api/src/evals/builtins/Contains.ts
@@ -106,15 +106,19 @@ export class Contains extends Evaluator {
       return { reason: `Output ${truncatedRepr([...output], 200)} does not contain provided value`, value: false }
     }
     if (output instanceof Map) {
-      if (output.has(this.value)) {
-        return { value: true }
-      }
-      for (const key of output.keys()) {
-        if (deepEqual(key, this.value)) {
+      if (isPlainObject(this.value)) {
+        // Python compares key/value pairs when both sides are dicts (`common.py:113-130`), and a
+        // Map is the closest analogue of a dict, so a record asks about pairs, not about a key.
+        const pairingFailure = missingEntry(output, this.value)
+        if (pairingFailure === undefined) {
           return { value: true }
         }
+        // A Map, unlike a dict, can also hold the record itself as a key.
+        return this.hasKey(output) ? { value: true } : pairingFailure
       }
-      return { reason: `Output ${truncatedRepr([...output.keys()], 200)} does not contain provided value as a key`, value: false }
+      return this.hasKey(output)
+        ? { value: true }
+        : { reason: `Output ${truncatedRepr([...output.keys()], 200)} does not contain provided value as a key`, value: false }
     }
     if (output !== null && typeof output === 'object') {
       const obj = output as Record<string, unknown>
@@ -139,8 +143,47 @@ export class Contains extends Evaluator {
     }
     return { reason: 'Containment check failed: output is not iterable', value: false }
   }
+
+  private hasKey(output: Map<unknown, unknown>): boolean {
+    // `has` is SameValueZero, so it matches NaN, which `deepEqual`'s `===` cannot.
+    if (output.has(this.value)) {
+      return true
+    }
+    for (const key of output.keys()) {
+      if (deepEqual(key, this.value)) {
+        return true
+      }
+    }
+    return false
+  }
 }
 registerEvaluator(Contains)
+
+// Python takes the pairing path only for a real dict. A Date or a Set has no own enumerable
+// keys, so accepting one here would make every pairing vacuously true.
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false
+  }
+  const prototype: unknown = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function missingEntry(output: Map<unknown, unknown>, value: Record<string, unknown>): EvaluationReason | undefined {
+  for (const [key, expected] of Object.entries(value)) {
+    if (!output.has(key)) {
+      return { reason: `Output does not contain expected key ${truncatedRepr(key, 30)}`, value: false }
+    }
+    const actual = output.get(key)
+    if (!deepEqual(actual, expected)) {
+      return {
+        reason: `Output has different value for key ${truncatedRepr(key, 30)}: ${truncatedRepr(actual, 100)} != ${truncatedRepr(expected, 100)}`,
+        value: false,
+      }
+    }
+  }
+  return undefined
+}
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value)

--- a/packages/logfire-api/src/evals/builtins/Contains.ts
+++ b/packages/logfire-api/src/evals/builtins/Contains.ts
@@ -93,6 +93,11 @@ export class Contains extends Evaluator {
     // it has none of. Python compares against set members and dict keys, so do the same before
     // falling through. Both report their contents, since `JSON.stringify` renders either as `{}`.
     if (output instanceof Set) {
+      // `has` is SameValueZero, so it matches NaN and is the semantics a Set caller expects.
+      // `deepEqual` compares with `===` and cannot see NaN as equal to itself.
+      if (output.has(this.value)) {
+        return { value: true }
+      }
       for (const item of output) {
         if (deepEqual(item, this.value)) {
           return { value: true }
@@ -101,6 +106,9 @@ export class Contains extends Evaluator {
       return { reason: `Output ${truncatedRepr([...output], 200)} does not contain provided value`, value: false }
     }
     if (output instanceof Map) {
+      if (output.has(this.value)) {
+        return { value: true }
+      }
       for (const key of output.keys()) {
         if (deepEqual(key, this.value)) {
           return { value: true }

--- a/packages/logfire-api/src/evals/builtins/Contains.ts
+++ b/packages/logfire-api/src/evals/builtins/Contains.ts
@@ -89,6 +89,25 @@ export class Contains extends Evaluator {
       }
       return { reason: `Output ${truncatedRepr(output, 200)} does not contain provided value`, value: false }
     }
+    // A Set or a Map reaches the object branch below and gets checked for property names, which
+    // it has none of. Python compares against set members and dict keys, so do the same before
+    // falling through. Both report their contents, since `JSON.stringify` renders either as `{}`.
+    if (output instanceof Set) {
+      for (const item of output) {
+        if (deepEqual(item, this.value)) {
+          return { value: true }
+        }
+      }
+      return { reason: `Output ${truncatedRepr([...output], 200)} does not contain provided value`, value: false }
+    }
+    if (output instanceof Map) {
+      for (const key of output.keys()) {
+        if (deepEqual(key, this.value)) {
+          return { value: true }
+        }
+      }
+      return { reason: `Output ${truncatedRepr([...output.keys()], 200)} does not contain provided value as a key`, value: false }
+    }
     if (output !== null && typeof output === 'object') {
       const obj = output as Record<string, unknown>
       if (isPlainRecord(this.value)) {


### PR DESCRIPTION
## Defect

A task returning a `Set` or a `Map` always fails `Contains`, and the reason gives the user nothing to work with:

```
Contains({ value: 'a' })  against  new Set(['a', 'b'])
  -> { value: false, reason: 'Output {} does not contain provided value as a key' }
```

The assertion is wrong, and `Output {}` is not diagnosable.

## Evidence

Both fall through to the object branch, which checks property names:

```ts
if (output !== null && typeof output === 'object') {
  const obj = output as Record<string, unknown>
  ...
  return key in obj ? { value: true } : { reason: `Output ${truncatedRepr(obj, 200)} ...` }
}
```

A `Set` has no enumerable own properties, so the check always misses, and `truncatedRepr` uses `JSON.stringify`, which renders both a `Set` and a `Map` as `{}`.

pydantic-evals reaches set membership here. Its dict branch only triggers for a dict or a model-like value, so a set takes the generic `elif self.value not in ctx.output`, and `'a' in {'a', 'b'}` is true.

These types are reachable on exactly this path. `ctx.output` is whatever the task returned in process, so it is not constrained by the dataset file format the way `value` is.

Reproduced on `787e7be`.

## Fix

Check Set members and Map keys before the object branch, using the same `deepEqual` the array branch uses so `Contains({value: {id: 1}})` matches a structurally equal member. Map is treated as key membership, matching what the object branch does for a non-dict value, since a Map's keys are the mapping's addressable side.

Both failure reasons now render the contents rather than `{}`.

Deliberately not extended to dict-style key and value comparison for a Map against an object `value`. The wire format cannot produce that pairing, and Python's equivalent only applies to dicts and model-like values, so building it would be speculative.

Reverting the two branches fails the new test with `Output {} does not contain provided value as a key`.

Built this with Claude Code's help and reviewed the diff myself.