### PR TITLE
Omit the explanation attribute when a failure has no message

### DIFF
--- a/.changeset/failure-empty-explanation.md
+++ b/.changeset/failure-empty-explanation.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Omit `gen_ai.evaluation.explanation` on an evaluator failure that carries no message, instead of emitting an empty string. pydantic-evals leaves the attribute off in that case, so a failure from `throw new Error()` no longer records an explanation that is not one.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -368,6 +368,8 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(logs).toHaveLength(1)
     expect(logs[0]?.body).toBe('evaluation: MissingFailureFields failed')
     expect(logs[0]?.attributes[ERROR_TYPE]).toBe('pydantic_evals.EvaluatorFailure')
+    // Python leaves the attribute off entirely rather than sending an empty one.
+    expect(GEN_AI_EXPLANATION in (logs[0]?.attributes ?? {})).toBe(false)
   })
 
   it('converts online evaluator failures without calling onError', async () => {

--- a/packages/logfire-api/src/evals/otelEmit.ts
+++ b/packages/logfire-api/src/evals/otelEmit.ts
@@ -75,7 +75,11 @@ export function emitEvaluatorFailure(failure: EvaluatorFailureRecord, opts: Emit
     [GEN_AI_EVAL_NAME]: failure.name,
     [GEN_AI_EVAL_TARGET]: opts.target,
     [GEN_AI_EVALUATOR_SOURCE]: JSON.stringify(failure.source),
-    [GEN_AI_EXPLANATION]: errorMessage,
+  }
+  // `_emit_failure` omits the attribute for an empty message rather than sending one, so a
+  // failure without a message has no explanation instead of an empty one.
+  if (errorMessage !== '') {
+    attrs[GEN_AI_EXPLANATION] = errorMessage
   }
   if (failure.evaluator_version !== undefined) {
     attrs[GEN_AI_EVALUATOR_VERSION] = failure.evaluator_version


### PR DESCRIPTION
## Defect

An evaluator failure with no message emits `gen_ai.evaluation.explanation: ""`. pydantic-evals omits the attribute entirely, so the same failure carries an explanation on this side that is not one, and a query filtering on the attribute's presence matches it.

## Evidence

`_emit_failure` guards the assignment (`_otel_emit.py`):

```python
attrs[_ATTR_ERROR_TYPE] = failure.error_type or 'pydantic_evals.EvaluatorFailure'
if failure.error_message:
    attrs[_ATTR_EXPLANATION] = failure.error_message
```

`emitEvaluatorFailure` set it unconditionally from `failure.error_message || ''`.

The empty case is reachable rather than theoretical: `buildEvaluatorFailureRecord` uses `err.message`, and `new Error()` has an empty message. The body already handled it correctly, producing `evaluation: NAME failed` without the trailing message, so only the attribute was out of step.

Reproduced on `787e7be`: emitting a failure with `error_message: ''` produced the attribute with value `""`.

## Fix

Guard the assignment the same way. This is the same shape as #245, where a value pydantic-evals declines to record was being recorded here.

The result path is untouched and already matches: both sides check `reason` against null, so an empty-string reason is still recorded there.

This extends the existing `emits Python-compatible evaluator failure fallbacks when message/type are missing` test, which already covered this exact input but only asserted the body and error type. Reverting the guard fails it.

Built this with Claude Code's help and reviewed the diff myself.