### PR TITLE
Validate the reference depth limit composition enforces

### DIFF
--- a/.changeset/vars-depth-limit-parity.md
+++ b/.changeset/vars-depth-limit-parity.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Report a variable reference graph that exceeds the composition depth limit during `variablesValidate`. Validation allowed one hop more than composition can expand, so a 21-link chain was reported as valid and then failed at resolve time with `Variable composition exceeded maximum depth of 20`.

--- a/packages/logfire-api/src/vars/index.ts
+++ b/packages/logfire-api/src/vars/index.ts
@@ -2008,7 +2008,9 @@ function collectReferenceDiagnosticsFromSource(
   referenceCycles: Set<string>,
   depth: number
 ): void {
-  if (depth > MAX_COMPOSITION_DEPTH) {
+  // `expandNamedReference` refuses at `depth >= MAX_COMPOSITION_DEPTH`, so validating with `>`
+  // would accept one hop more than composition can expand and report the config as valid.
+  if (depth >= MAX_COMPOSITION_DEPTH) {
     referenceErrors.add(
       `Variable '${rootVariable}' reference graph exceeded maximum depth of ${String(MAX_COMPOSITION_DEPTH)} via ${referencePath.join(' -> ')}`
     )
@@ -2087,7 +2089,7 @@ function collectTemplateFieldIssuesFromSource(
   issues: TemplateFieldIssue[],
   depth: number
 ): void {
-  if (depth > MAX_COMPOSITION_DEPTH) {
+  if (depth >= MAX_COMPOSITION_DEPTH) {
     return
   }
 

--- a/packages/logfire-api/src/vars/runtimeComposition.test.ts
+++ b/packages/logfire-api/src/vars/runtimeComposition.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { configureVariables, defineVar, getVariableProvider, variablesClear, variablesValidate } from './index'
+import { configureVariables, defineTemplateVar, defineVar, getVariableProvider, variablesClear, variablesValidate } from './index'
 import type { VariableCodec, VariablesConfig } from './index'
 
 const config = (variables: VariablesConfig['variables']): VariablesConfig => ({ variables })
@@ -194,17 +194,50 @@ describe('variable runtime composition parity', () => {
       }
       return variables
     }
-    const depthErrors = async (links: number): Promise<string[]> => {
+    const referenceErrors = async (links: number): Promise<string[]> => {
       variablesClear()
       configureVariables({ config: config(chain(links)), instrument: false })
       const report = await variablesValidate([defineVar('v0', { default: 'x' })])
-      return report.referenceErrors.filter((error) => error.includes('maximum depth'))
+      return report.referenceErrors
     }
 
     // 20 links is what `expandNamedReference` will expand, so validation must accept it.
-    expect(await depthErrors(20)).toEqual([])
+    expect(await referenceErrors(20)).toEqual([])
     // 21 is one more than composition can expand, so validation has to say so rather than
     // reporting the config as valid and failing later at resolve time.
-    expect(await depthErrors(21)).toHaveLength(1)
+    expect(await referenceErrors(21)).toEqual([
+      `Variable 'v0' reference graph exceeded maximum depth of 20 via ${Array.from({ length: 21 }, (_unused, index) => `v${String(index)}`).join(' -> ')}`,
+    ])
+  })
+  it('stops the template-field walk where composition stops', async () => {
+    // Same chain, but the deepest link carries a template path the root schema does not declare.
+    const templateChain = (links: number): VariablesConfig['variables'] => {
+      const variables: VariablesConfig['variables'] = {}
+      for (let i = 0; i < links; i++) {
+        const value = i === links - 1 ? 'Hello {{missing}}' : `@{v${String(i + 1)}}@`
+        variables[`v${String(i)}`] = {
+          labels: { prod: { serialized_value: JSON.stringify(value), version: 1 } },
+          name: `v${String(i)}`,
+          overrides: [],
+          rollout: { labels: { prod: 1 } },
+        }
+      }
+      return variables
+    }
+    const fieldNames = async (links: number): Promise<string[]> => {
+      variablesClear()
+      configureVariables({ config: config(templateChain(links)), instrument: false })
+      const root = defineTemplateVar<string, { name: string }>('v0', {
+        default: 'Hello {{name}}',
+        templateInputsSchema: { properties: { name: { type: 'string' } }, type: 'object' },
+      })
+      const report = await variablesValidate([root])
+      return report.templateFieldIssues.map((issue) => issue.fieldName)
+    }
+
+    // Reachable, so the unknown template path is reported.
+    expect(await fieldNames(20)).toEqual(['missing'])
+    // One hop past what composition will expand, so there is nothing to report about it.
+    expect(await fieldNames(21)).toEqual([])
   })
 })

--- a/packages/logfire-api/src/vars/runtimeComposition.test.ts
+++ b/packages/logfire-api/src/vars/runtimeComposition.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { configureVariables, defineVar, getVariableProvider, variablesClear } from './index'
+import { configureVariables, defineVar, getVariableProvider, variablesClear, variablesValidate } from './index'
 import type { VariableCodec, VariablesConfig } from './index'
 
 const config = (variables: VariablesConfig['variables']): VariablesConfig => ({ variables })
@@ -180,5 +180,31 @@ describe('variable runtime composition parity', () => {
     expect(resolved.exception).toBeInstanceOf(Error)
     expect(calls).toBe(1)
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('code default raised'))
+  })
+  it('validates the reference depth limit that composition enforces', async () => {
+    const chain = (n: number): VariablesConfig['variables'] => {
+      const variables: VariablesConfig['variables'] = {}
+      for (let i = 0; i < n; i++) {
+        variables[`v${String(i)}`] = {
+          labels: { prod: { serialized_value: JSON.stringify(i === n - 1 ? 'end' : `@{v${String(i + 1)}}@`), version: 1 } },
+          name: `v${String(i)}`,
+          overrides: [],
+          rollout: { labels: { prod: 1 } },
+        }
+      }
+      return variables
+    }
+    const depthErrors = async (links: number): Promise<string[]> => {
+      variablesClear()
+      configureVariables({ config: config(chain(links)), instrument: false })
+      const report = await variablesValidate([defineVar('v0', { default: 'x' })])
+      return report.referenceErrors.filter((error) => error.includes('maximum depth'))
+    }
+
+    // 20 links is what `expandNamedReference` will expand, so validation must accept it.
+    expect(await depthErrors(20)).toEqual([])
+    // 21 is one more than composition can expand, so validation has to say so rather than
+    // reporting the config as valid and failing later at resolve time.
+    expect(await depthErrors(21)).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Defect

`variablesValidate` accepts a variable reference chain that composition then refuses to expand. The config is reported valid, and the failure surfaces later at resolve time as `Variable composition exceeded maximum depth of 20`.

Both sides quote the same number, so the two messages cannot be reconciled by reading them.

## Evidence

The two walks compare the same constant differently. Composition, in `expandNamedReference`:

```ts
if (depth >= MAX_COMPOSITION_DEPTH) {
```

Validation, in `collectReferenceDiagnosticsFromSource` and `collectTemplateFieldIssuesFromSource`:

```ts
if (depth > MAX_COMPOSITION_DEPTH) {
```

Both start at `0` and add one per hop, so validation walked exactly one link further than composition will.

Reproduced on `787e7be` with a chain `v0 -> v1 -> ... -> end`:

| links | `expandReferences` | `variablesValidate` |
| --- | --- | --- |
| 20 | expands | no depth error |
| 21 | `maximum depth` error | **no depth error** |

## Fix

Compare with `>=` on the validation side so it stops where composition stops. Composition is the authority here: it is what runs, and it is the stricter of the two, so moving validation to meet it turns a resolve-time surprise into a validation error.

The same change applies to the template-field walk, which shares the constant and the traversal. It stops one level earlier now, which is correct, because issues below a depth composition will not expand are unreachable.

The new test asserts both sides of the boundary, 20 accepted and 21 reported, so it fails if either walk drifts again. Reverting the comparison fails it with `expected [] to have a length of 1`.

Built this with Claude Code's help and reviewed the diff myself.