### PR TITLE
Run session replay acceptance in Chromium CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,21 @@ jobs:
       - name: Test
         run: vp run --filter "./packages/*" test
 
+      - name: Install Chromium
+        run: vp exec --filter @pydantic/logfire-session-replay -- playwright install --with-deps chromium
+
+      - name: Browser acceptance
+        id: browser-acceptance
+        run: vp run @pydantic/logfire-session-replay#test:browser
+
+      - name: Upload browser failure artifacts
+        if: failure() && steps.browser-acceptance.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-acceptance-results
+          path: test-results
+          retention-days: 7
+
       - name: Test release tooling
         run: node scripts/create-npm-token.test.mjs
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 packages/*/*.tgz
 coverage
 packages/*/coverage
+playwright-report
+test-results
 .env
 scratch/
 **/.turbo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,13 @@
 6. Submit a pull request.
 
 You're now set up to start contributing!
+
+## Session replay browser tests
+
+Install Chromium once, build the packages, and run the browser acceptance suite:
+
+```bash
+vp exec --filter @pydantic/logfire-session-replay -- playwright install chromium
+pnpm run build
+pnpm run test:browser
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You're now set up to start contributing!
 Install Chromium once, build the packages, and run the browser acceptance suite:
 
 ```bash
-vp exec --filter @pydantic/logfire-session-replay -- playwright install chromium
+pnpm --filter @pydantic/logfire-session-replay exec playwright install chromium
 pnpm run build
 pnpm run test:browser
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vp run --filter \"./packages/*\" build",
     "dev": "vp run --filter \"./packages/*\" --parallel dev",
     "test": "vp run --filter \"./packages/*\" test",
+    "test:browser": "vp run @pydantic/logfire-session-replay#test:browser",
     "typecheck": "vp run --filter \"./packages/*\" typecheck",
     "lint": "vp lint",
     "format": "vp fmt . --write",

--- a/packages/logfire-browser/test-fixtures/privacy-defaults/main.ts
+++ b/packages/logfire-browser/test-fixtures/privacy-defaults/main.ts
@@ -46,6 +46,7 @@ const cleanup = logfire.configure({
       : {}),
     flushIntervalMs: 60_000,
     ignoreUrlPatterns: [/\/receipts(?:\/|$)/u],
+    minSessionDurationMs: 0,
     load: async () => {
       const replayModule = await import('lf-privacy-recorder')
       return {

--- a/packages/logfire-session-replay/browser-tests/playwright.config.ts
+++ b/packages/logfire-session-replay/browser-tests/playwright.config.ts
@@ -1,0 +1,40 @@
+import { resolve } from 'node:path'
+
+import { defineConfig } from '@playwright/test'
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..')
+const fixtureServers = [
+  {
+    command: 'pnpm exec vp dev --config packages/logfire-session-replay/test-fixtures/delivery/vite.config.ts',
+    url: 'http://127.0.0.1:4177/',
+  },
+  {
+    command: 'pnpm exec vp dev --config packages/logfire-browser/test-fixtures/privacy-defaults/vite.config.ts',
+    url: 'http://127.0.0.1:4178/',
+  },
+]
+
+export default defineConfig({
+  expect: {
+    timeout: 10_000,
+  },
+  forbidOnly: process.env['CI'] !== undefined,
+  fullyParallel: false,
+  outputDir: resolve(repositoryRoot, 'test-results'),
+  reporter: process.env['CI'] === undefined ? 'line' : [['github'], ['line']],
+  testDir: '.',
+  testMatch: 'session-replay.pw.ts',
+  timeout: 30_000,
+  use: {
+    browserName: 'chromium',
+    trace: 'retain-on-failure',
+  },
+  webServer: fixtureServers.map(({ command, url }) => ({
+    command,
+    cwd: repositoryRoot,
+    reuseExistingServer: false,
+    timeout: 30_000,
+    url,
+  })),
+  workers: 1,
+})

--- a/packages/logfire-session-replay/browser-tests/session-replay.pw.ts
+++ b/packages/logfire-session-replay/browser-tests/session-replay.pw.ts
@@ -1,0 +1,116 @@
+import { execFile as execFileCallback } from 'node:child_process'
+import { resolve } from 'node:path'
+import { gunzipSync } from 'node:zlib'
+
+import { expect, test } from '@playwright/test'
+import type { TestInfo } from '@playwright/test'
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..')
+const deliveryVerifier = resolve(repositoryRoot, 'packages/logfire-session-replay/test-fixtures/delivery/verify.mjs')
+const privacyVerifier = resolve(repositoryRoot, 'packages/logfire-browser/test-fixtures/privacy-defaults/verify.mjs')
+
+declare global {
+  interface Window {
+    logfireReplayPlayback: {
+      load(events: unknown[]): Promise<void>
+    }
+  }
+}
+
+test.describe('session replay delivery in Chromium', () => {
+  for (const scenario of ['csp', 'retry-after', 'utf8'] as const) {
+    test(scenario, async ({ page }, testInfo) => {
+      await page.goto(`http://127.0.0.1:4177/${scenario}/`)
+      await expect(page.locator('#status')).toHaveText(/^(?:complete|failed)$/u)
+      await expect(page.locator('#status')).toHaveText('complete')
+      await runVerifier(deliveryVerifier, scenario, testInfo)
+    })
+  }
+
+  test('unload chunks remain ordered and playable', async ({ page, request }, testInfo) => {
+    await page.goto('http://127.0.0.1:4177/unload/')
+    await expect(page.locator('#status')).toHaveText('ready')
+    await page.locator('#leave').click()
+    await expect(page).toHaveURL('http://127.0.0.1:4177/after-unload.html')
+    await expect(page.locator('#status')).toHaveText('navigation complete')
+
+    await runVerifier(deliveryVerifier, 'unload', testInfo)
+    const response = await request.get('http://127.0.0.1:4177/fixture/status?scenario=unload')
+    expect(response.ok()).toBe(true)
+    const events = replayEvents(await response.text())
+
+    await page.goto('http://127.0.0.1:4177/playback.html')
+    await page.evaluate(async (recordedEvents) => window.logfireReplayPlayback.load(recordedEvents), events)
+    const replayedText = await page.frameLocator('iframe').locator('#payload').textContent()
+    expect(replayedText?.slice(0, 18)).toBe('unload-marker-two:')
+    expect(replayedText?.length).toBe(26_018)
+  })
+})
+
+test.describe('session replay privacy', () => {
+  for (const scenario of ['default', 'opt-in'] as const) {
+    test(scenario, async ({ page }, testInfo) => {
+      const secret = `${scenario}-page-secret`
+      await page.goto(`http://127.0.0.1:4178/${scenario}/?page_secret=${secret}#${scenario}-fragment-secret`)
+      await expect(page.locator('#status')).toHaveText(/^(?:complete|failed)$/u)
+      await expect(page.locator('#status')).toHaveText('complete')
+      await runVerifier(privacyVerifier, scenario, testInfo)
+    })
+  }
+})
+
+async function runVerifier(path: string, scenario: string, testInfo: TestInfo): Promise<void> {
+  const { stderr, stdout } = await new Promise<{ stderr: string; stdout: string }>((resolve, reject) => {
+    execFileCallback(process.execPath, [path, scenario], { cwd: repositoryRoot, encoding: 'utf8' }, (error, stdout, stderr) => {
+      if (error !== null) {
+        reject(new Error(error.message, { cause: error }))
+        return
+      }
+      resolve({ stderr, stdout })
+    })
+  })
+  await testInfo.attach(`${scenario}-verification`, {
+    body: Buffer.from(`${stdout}${stderr}`),
+    contentType: 'text/plain',
+  })
+}
+
+function replayEvents(serializedEvidence: string): unknown[] {
+  const evidence = parseRecord(serializedEvidence, 'delivery evidence')
+  const receipts = evidence['receipts']
+  if (!Array.isArray(receipts)) {
+    throw new Error('delivery evidence has no receipts')
+  }
+  return receipts
+    .map((value) => {
+      if (!isRecord(value) || typeof value['body'] !== 'string' || typeof value['seq'] !== 'number') {
+        throw new Error('delivery evidence contains an invalid receipt')
+      }
+      return { body: value['body'], seq: value['seq'] }
+    })
+    .sort((left, right) => left.seq - right.seq)
+    .flatMap(({ body }) => {
+      const envelope = parseRecord(gunzipSync(Buffer.from(body, 'base64')).toString('utf8'), 'replay envelope')
+      const events = envelope['events']
+      if (!Array.isArray(events)) {
+        throw new Error('replay envelope has no events')
+      }
+      const values: unknown[] = []
+      for (const event of events) {
+        values.push(event)
+      }
+      return values
+    })
+}
+
+function parseRecord(serialized: string, name: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(serialized)
+  if (!isRecord(value)) {
+    throw new Error(`${name} is not an object`)
+  }
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/logfire-session-replay/browser-tests/session-replay.pw.ts
+++ b/packages/logfire-session-replay/browser-tests/session-replay.pw.ts
@@ -45,6 +45,19 @@ test.describe('session replay delivery in Chromium', () => {
     expect(replayedText?.slice(0, 18)).toBe('unload-marker-two:')
     expect(replayedText?.length).toBe(26_018)
   })
+
+  test('navigation drops a replay shorter than five seconds', async ({ page, request }) => {
+    await page.goto('http://127.0.0.1:4177/short/')
+    await expect(page.locator('#status')).toHaveText('ready')
+    await page.locator('#leave').click()
+    await expect(page).toHaveURL('http://127.0.0.1:4177/after-unload.html')
+    await page.waitForTimeout(500)
+
+    const response = await request.get('http://127.0.0.1:4177/fixture/status?scenario=short')
+    expect(response.ok()).toBe(true)
+    const evidence = parseRecord(await response.text(), 'short-session evidence')
+    expect(evidence['receipts']).toEqual([])
+  })
 })
 
 test.describe('session replay privacy', () => {

--- a/packages/logfire-session-replay/browser-tests/tsconfig.json
+++ b/packages/logfire-session-replay/browser-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["*.ts", "../test-fixtures/delivery/*.ts"],
+  "compilerOptions": {
+    "declaration": false,
+    "isolatedDeclarations": false,
+    "types": ["node"]
+  }
+}

--- a/packages/logfire-session-replay/package.json
+++ b/packages/logfire-session-replay/package.json
@@ -46,16 +46,20 @@
     "build": "vp pack",
     "lint": "vp lint",
     "preview": "vp preview",
-    "typecheck": "tsc",
+    "typecheck": "tsc && tsc --project browser-tests/tsconfig.json",
     "prepack": "cp ../../LICENSE .",
     "postpublish": "rm LICENSE",
-    "test": "vp test"
+    "test": "vp test",
+    "test:browser": "playwright test --config browser-tests/playwright.config.ts"
   },
   "dependencies": {
     "@rrweb/record": "catalog:",
     "fflate": "catalog:"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
+    "@rrweb/replay": "2.1.1",
+    "@types/node": "^22.5.1",
     "jsdom": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/logfire-session-replay/test-fixtures/delivery/main.ts
+++ b/packages/logfire-session-replay/test-fixtures/delivery/main.ts
@@ -55,14 +55,14 @@ async function run(): Promise<void> {
   if (scenario === 'unload') {
     await prepareUnload()
     state.phase = 'ready'
-    setStatus('ready')
     await saveState()
+    setStatus('ready')
     return
   }
   if (scenario === 'short') {
     state.phase = 'ready'
-    setStatus('ready')
     await saveState()
+    setStatus('ready')
     return
   }
   if (scenario === 'csp') {
@@ -81,8 +81,8 @@ async function run(): Promise<void> {
   }
 
   state.phase = 'complete'
-  setStatus('complete')
   await saveState()
+  setStatus('complete')
 }
 
 async function prepareUnload(): Promise<void> {

--- a/packages/logfire-session-replay/test-fixtures/delivery/main.ts
+++ b/packages/logfire-session-replay/test-fixtures/delivery/main.ts
@@ -42,6 +42,7 @@ async function run(): Promise<void> {
     getSessionId: () => `delivery-${scenario}`,
     headers: () => ({ 'X-Replay-Marker': scenario }),
     ignoreUrlPatterns: [/\/fixture\//u, /\/replay\//u],
+    maskAllText: false,
     maxBufferBytes: 1_000_000,
     onError: (error: unknown) => {
       state.errors.push(error instanceof Error ? error.message : String(error))
@@ -66,8 +67,8 @@ async function run(): Promise<void> {
   } else if (scenario === 'retry-after') {
     await replay.flush()
   } else {
-    await fetch('/application/fetch', { method: 'POST', body: 'é🚀' })
-    await sendXhr('/application/xhr', 'é🚀')
+    await fetch(`/application/fetch?scenario=${scenario}`, { method: 'POST', body: 'é🚀' })
+    await sendXhr(`/application/xhr?scenario=${scenario}`, 'é🚀')
     await delay(50)
     await replay.flush()
   }

--- a/packages/logfire-session-replay/test-fixtures/delivery/main.ts
+++ b/packages/logfire-session-replay/test-fixtures/delivery/main.ts
@@ -1,7 +1,7 @@
 import { startSessionReplay } from 'lf-replay-delivery'
 import type { SessionReplay } from '@pydantic/logfire-session-replay'
 
-type Scenario = 'csp' | 'retry-after' | 'unload' | 'utf8'
+type Scenario = 'csp' | 'retry-after' | 'short' | 'unload' | 'utf8'
 type Phase = 'starting' | 'ready' | 'complete' | 'failed'
 
 interface DeliveryState {
@@ -44,6 +44,7 @@ async function run(): Promise<void> {
     ignoreUrlPatterns: [/\/fixture\//u, /\/replay\//u],
     maskAllText: false,
     maxBufferBytes: 1_000_000,
+    minSessionDurationMs: scenario === 'short' ? 5_000 : 0,
     onError: (error: unknown) => {
       state.errors.push(error instanceof Error ? error.message : String(error))
     },
@@ -53,6 +54,12 @@ async function run(): Promise<void> {
 
   if (scenario === 'unload') {
     await prepareUnload()
+    state.phase = 'ready'
+    setStatus('ready')
+    await saveState()
+    return
+  }
+  if (scenario === 'short') {
     state.phase = 'ready'
     setStatus('ready')
     await saveState()
@@ -140,6 +147,9 @@ function scenarioFromPath(pathname: string): Scenario {
   }
   if (pathname.startsWith('/retry-after/')) {
     return 'retry-after'
+  }
+  if (pathname.startsWith('/short/')) {
+    return 'short'
   }
   if (pathname.startsWith('/utf8/')) {
     return 'utf8'

--- a/packages/logfire-session-replay/test-fixtures/delivery/playback.html
+++ b/packages/logfire-session-replay/test-fixtures/delivery/playback.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logfire replay playback acceptance</title>
+  </head>
+  <body>
+    <main>
+      <h1>Logfire replay playback acceptance</h1>
+      <div id="replay"></div>
+    </main>
+    <script type="module" src="/playback.ts"></script>
+  </body>
+</html>

--- a/packages/logfire-session-replay/test-fixtures/delivery/playback.ts
+++ b/packages/logfire-session-replay/test-fixtures/delivery/playback.ts
@@ -1,0 +1,36 @@
+import { Replayer } from '@rrweb/replay'
+
+type ReplayEvents = ConstructorParameters<typeof Replayer>[0]
+
+const root = document.querySelector<HTMLElement>('#replay')
+if (root === null) {
+  throw new Error('missing replay root')
+}
+
+Reflect.set(window, 'logfireReplayPlayback', {
+  async load(events: ReplayEvents): Promise<void> {
+    const replayer = new Replayer(events, {
+      mouseTail: false,
+      root,
+      showWarning: false,
+      skipInactive: true,
+      speed: 1_000,
+    })
+    const finished = new Promise<void>((resolve) => {
+      replayer.on('finish', () => {
+        resolve()
+      })
+    })
+    replayer.play()
+    await finished
+    await nextFrame()
+  },
+})
+
+async function nextFrame(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      resolve()
+    })
+  })
+}

--- a/packages/logfire-session-replay/test-fixtures/delivery/recorder.d.ts
+++ b/packages/logfire-session-replay/test-fixtures/delivery/recorder.d.ts
@@ -1,3 +1,4 @@
+// Vite replaces this module with the built recorder after rewriting its browser dependencies.
 declare module 'lf-replay-delivery' {
   export { startSessionReplay } from '@pydantic/logfire-session-replay'
 }

--- a/packages/logfire-session-replay/test-fixtures/delivery/verify.mjs
+++ b/packages/logfire-session-replay/test-fixtures/delivery/verify.mjs
@@ -7,13 +7,7 @@ if (!['unload', 'csp', 'retry-after', 'utf8'].includes(scenario)) {
 }
 
 try {
-  const response = await fetch(`http://127.0.0.1:4177/fixture/status?scenario=${scenario}`)
-  assert(response.ok, `status request failed: ${String(response.status)}`)
-  const evidence = await response.json()
-  const decoded = evidence.receipts.map((receipt) => ({
-    ...receipt,
-    envelope: JSON.parse(gunzipSync(Buffer.from(receipt.body, 'base64')).toString('utf8')),
-  }))
+  const { decoded, evidence } = await pollForEvidence(Date.now() + 10_000)
   if (scenario !== 'unload') {
     assert(evidence.state?.phase === 'complete', `fixture failed: ${String(evidence.state?.error ?? evidence.state?.phase)}`)
   }
@@ -36,6 +30,28 @@ try {
   if (scenario === 'unload') {
     await fetch('http://127.0.0.1:4177/fixture/release?scenario=unload', { method: 'POST' })
   }
+}
+
+async function pollForEvidence(deadline) {
+  const response = await fetch(`http://127.0.0.1:4177/fixture/status?scenario=${scenario}`)
+  assert(response.ok, `status request failed: ${String(response.status)}`)
+  const evidence = await response.json()
+  const decoded = evidence.receipts.map((receipt) => ({
+    ...receipt,
+    envelope: JSON.parse(gunzipSync(Buffer.from(receipt.body, 'base64')).toString('utf8')),
+  }))
+  if (scenario !== 'unload' || unloadMarkersPresent(decoded) || Date.now() >= deadline) {
+    return { decoded, evidence }
+  }
+  await new Promise((resolve) => {
+    setTimeout(resolve, 50)
+  })
+  return pollForEvidence(deadline)
+}
+
+function unloadMarkersPresent(decoded) {
+  const bodies = decoded.map((receipt) => JSON.stringify(receipt.envelope))
+  return bodies.some((body) => body.includes('unload-marker-one')) && bodies.some((body) => body.includes('unload-marker-two'))
 }
 
 function verifyUnload(evidence, decoded) {

--- a/packages/logfire-session-replay/test-fixtures/delivery/vite.config.ts
+++ b/packages/logfire-session-replay/test-fixtures/delivery/vite.config.ts
@@ -7,10 +7,10 @@ import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite-plus'
 
 interface ReplayReceipt {
-  authorization?: string
+  authorization: string | undefined
   body: string
   byteLength: number
-  marker?: string
+  marker: string | undefined
   receivedAt: number
   seq: number
   url: string
@@ -66,7 +66,7 @@ export default defineConfig({
             next()
             return
           }
-          const scenario = url.searchParams.get('scenario') ?? scenarioFromReplayPath(url.pathname)
+          const scenario = url.searchParams.get('scenario') ?? scenarioFromReplayPath(url.pathname) ?? 'unknown'
           if (request.method === 'POST' && url.pathname === '/fixture/reset') {
             receipts.set(scenario, [])
             applicationReceipts.set(scenario, [])
@@ -168,8 +168,8 @@ function readBody(request: NodeJS.ReadableStream, done: (body: Buffer) => void):
   })
 }
 
-function scenarioFromReplayPath(pathname: string): string {
-  return /^\/replay\/([^/]+)(?:\/|$)/u.exec(pathname)?.[1] ?? 'unknown'
+function scenarioFromReplayPath(pathname: string): string | undefined {
+  return /^\/replay\/([^/]+)(?:\/|$)/u.exec(pathname)?.[1]
 }
 
 function headerValue(value: string | string[] | undefined): string | undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,7 +324,7 @@ importers:
         version: link:../../packages/logfire-api
       next:
         specifier: ^16.3.0
-        version: 16.3.0(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@22.19.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -385,7 +385,7 @@ importers:
         version: link:../../packages/logfire-api
       next:
         specifier: ^16.3.0
-        version: 16.3.0(@opentelemetry/api@1.9.1)(@types/node@20.19.28)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@20.19.28)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -609,6 +609,15 @@ importers:
         specifier: 'catalog:'
         version: 0.8.3
     devDependencies:
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
+      '@rrweb/replay':
+        specifier: 2.1.1
+        version: 2.1.1
+      '@types/node':
+        specifier: ^22.5.1
+        version: 22.19.5
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1
@@ -2376,6 +2385,11 @@ packages:
     resolution: {integrity: sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@pnpm/deps.graph-sequencer@1100.0.1':
     resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
     engines: {node: '>=22.13'}
@@ -2424,6 +2438,9 @@ packages:
 
   '@rrweb/record@2.1.1':
     resolution: {integrity: sha512-c2u175R+daC37PhbjaQV0migxtIXsLuD0mRgRstj/x/CRmLGctRlDi373/4miIUclleq4eZIQXAglH9opclFRQ==}
+
+  '@rrweb/replay@2.1.1':
+    resolution: {integrity: sha512-jq64eyJvrh/ioBS1MpDrs/Lj+7QY2TW4xGxp4g4LJKdltSkqMjMbUmhTDcpzaEDZt66S0gasGcgqCulsksSXnw==}
 
   '@rrweb/types@2.1.1':
     resolution: {integrity: sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ==}
@@ -3013,6 +3030,11 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3408,6 +3430,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -5601,6 +5633,10 @@ snapshots:
 
   '@oxlint/plugins@1.68.0': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@polka/url@1.0.0-next.29': {}
@@ -5643,6 +5679,11 @@ snapshots:
     dependencies:
       '@rrweb/types': 2.1.1
       '@rrweb/utils': 2.1.1
+      rrweb: 2.1.1
+
+  '@rrweb/replay@2.1.1':
+    dependencies:
+      '@rrweb/types': 2.1.1
       rrweb: 2.1.1
 
   '@rrweb/types@2.1.1': {}
@@ -6268,6 +6309,9 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6530,7 +6574,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@20.19.28)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@20.19.28)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -6550,13 +6594,14 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.62.1
       sharp: 0.35.3(@types/node@20.19.28)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
 
-  next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.3.0(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@22.19.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -6576,6 +6621,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.62.1
       sharp: 0.35.3(@types/node@22.19.5)
     transitivePeerDependencies:
       - '@babel/core'
@@ -6691,6 +6737,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@7.0.0: {}
 


### PR DESCRIPTION
Stacked on #259.

## Summary

- automate delivery and privacy fixtures in real Chromium
- verify short navigations do not upload replays below the five-second minimum
- replay ordered lifecycle chunks with `@rrweb/replay` and assert the reconstructed final DOM
- upload Playwright traces when browser acceptance fails

## Validation

- build, lint, typecheck, and 1,103 package tests
- `pnpm run test:browser` (7 Chromium scenarios)