### PR TITLE
Respect block scope when validating template inputs

### DIFF
--- a/.changeset/template-block-scope.md
+++ b/.changeset/template-block-scope.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Stop reporting item fields inside an `each` or `with` block as missing template inputs. `variablesValidate` collected bare paths from a block body and checked them against the root `templateInputsSchema`, so `{{#each items}}{{name}}{{/each}}` was flagged for `name` even though the template renders correctly.

--- a/packages/logfire-api/src/vars/referenceSyntax.ts
+++ b/packages/logfire-api/src/vars/referenceSyntax.ts
@@ -62,7 +62,8 @@ interface Placeholder {
   value: string
 }
 
-const CONTEXT_SHIFTING_HELPERS: ReadonlySet<string> = new Set(['each', 'with'])
+/** Block helpers that run their program body against a different context. */
+export const CONTEXT_SHIFTING_HELPERS: ReadonlySet<string> = new Set(['each', 'with'])
 const IGNORED_PATHS: ReadonlySet<string> = new Set(['', '.', 'else', 'this'])
 
 function adaptCompositionTemplate(template: string, additionalCollisionValues: string[]): AdaptedTemplate {

--- a/packages/logfire-api/src/vars/templateValidation.test.ts
+++ b/packages/logfire-api/src/vars/templateValidation.test.ts
@@ -28,8 +28,30 @@ describe('variable template validation', () => {
     configureVariables(false)
   })
 
+  it('does not report item fields inside an each block as missing template inputs', () => {
+    const schema = {
+      properties: { items: { items: { properties: { name: { type: 'string' } }, type: 'object' }, type: 'array' } },
+      type: 'object',
+    }
+
+    expect(validateTemplateInputs(JSON.stringify('{{#each items}}{{name}}{{/each}}'), schema, 'v', undefined)).toEqual([])
+    // The inverse block runs against the enclosing context, so an unknown path there is still reported.
+    expect(
+      validateTemplateInputs(JSON.stringify('{{#each items}}{{name}}{{else}}{{missing}}{{/each}}'), schema, 'v', undefined).map(
+        (issue) => issue.path
+      )
+    ).toEqual(['missing'])
+  })
+
   it('extracts common Handlebars paths from templates', () => {
     expect(extractTemplatePaths('Hello {{user.name}} {{#if beta}}yes{{/if}}')).toEqual(['user.name', 'beta'])
+    // `each` and `with` shift the context, so a bare path in the program body belongs to the item,
+    // not to the template inputs. The inverse block still runs against the enclosing context.
+    expect(extractTemplatePaths('{{#each items}}{{name}}{{/each}}')).toEqual(['items'])
+    expect(extractTemplatePaths('{{#with brand}}{{tagline}}{{/with}}')).toEqual(['brand'])
+    expect(extractTemplatePaths('{{#each items}}{{name}}{{else}}{{fallback}}{{/each}}')).toEqual(['items', 'fallback'])
+    // A parent-scoped path is still dropped by shouldValidatePath, unchanged by the depth model.
+    expect(extractTemplatePaths('{{#each items}}{{../heading}}{{/each}}')).toEqual(['items'])
   })
 
   it('allows template paths covered by object-valued additionalProperties', () => {

--- a/packages/logfire-api/src/vars/templateValidation.ts
+++ b/packages/logfire-api/src/vars/templateValidation.ts
@@ -2,6 +2,7 @@ import Handlebars from 'handlebars'
 
 import type { ComposedReference } from './composition'
 import type { JsonSchema } from './index'
+import { CONTEXT_SHIFTING_HELPERS } from './referenceSyntax'
 
 export interface ReferenceValidationIssue {
   label?: string
@@ -112,11 +113,11 @@ export function extractTemplatePaths(template: string): string[] {
   }
   const paths: string[] = []
   const seen = new Set<string>()
-  collectPathsFromAst(ast, paths, seen)
+  collectPathsFromAst(ast, paths, seen, 0)
   return paths
 }
 
-function collectPathsFromAst(node: unknown, paths: string[], seen: Set<string>): void {
+function collectPathsFromAst(node: unknown, paths: string[], seen: Set<string>, shiftedDepth: number): void {
   if (!isRecord(node)) {
     return
   }
@@ -125,48 +126,62 @@ function collectPathsFromAst(node: unknown, paths: string[], seen: Set<string>):
   if (type === 'MustacheStatement' || type === 'SubExpression') {
     const params = Array.isArray(node['params']) ? node['params'] : []
     if (params.length === 0) {
-      addPathNode(node['path'], paths, seen)
+      addPathNode(node['path'], paths, seen, shiftedDepth)
     } else {
       for (const param of params) {
-        addPathNode(param, paths, seen)
+        addPathNode(param, paths, seen, shiftedDepth)
       }
     }
-    collectHashPaths(node['hash'], paths, seen)
+    collectHashPaths(node['hash'], paths, seen, shiftedDepth)
   } else if (type === 'BlockStatement') {
     const params = Array.isArray(node['params']) ? node['params'] : []
     for (const param of params) {
-      addPathNode(param, paths, seen)
+      addPathNode(param, paths, seen, shiftedDepth)
     }
-    collectHashPaths(node['hash'], paths, seen)
+    collectHashPaths(node['hash'], paths, seen, shiftedDepth)
+
+    // `each` and `with` run their program body against a different context, so a bare path in
+    // there is a property of that context and not of the template inputs. The inverse block runs
+    // against the enclosing context, so it keeps the current depth. Same model as
+    // `collectBlockReferences` in referenceSyntax.ts.
+    const helperName = isRecord(node['path']) && typeof node['path']['original'] === 'string' ? node['path']['original'] : undefined
+    const childShiftedDepth = helperName !== undefined && CONTEXT_SHIFTING_HELPERS.has(helperName) ? shiftedDepth + 1 : shiftedDepth
+    collectPathsFromAst(node['program'], paths, seen, childShiftedDepth)
+    collectPathsFromAst(node['inverse'], paths, seen, shiftedDepth)
+    return
   }
 
   for (const value of Object.values(node)) {
     if (Array.isArray(value)) {
       for (const item of value) {
-        collectPathsFromAst(item, paths, seen)
+        collectPathsFromAst(item, paths, seen, shiftedDepth)
       }
     } else if (isRecord(value)) {
-      collectPathsFromAst(value, paths, seen)
+      collectPathsFromAst(value, paths, seen, shiftedDepth)
     }
   }
 }
 
-function collectHashPaths(hash: unknown, paths: string[], seen: Set<string>): void {
+function collectHashPaths(hash: unknown, paths: string[], seen: Set<string>, shiftedDepth: number): void {
   if (!isRecord(hash) || !Array.isArray(hash['pairs'])) {
     return
   }
   for (const pair of hash['pairs']) {
     if (isRecord(pair)) {
-      addPathNode(pair['value'], paths, seen)
+      addPathNode(pair['value'], paths, seen, shiftedDepth)
     }
   }
 }
 
-function addPathNode(node: unknown, paths: string[], seen: Set<string>): void {
+function addPathNode(node: unknown, paths: string[], seen: Set<string>, shiftedDepth: number): void {
   if (!isRecord(node) || node['type'] !== 'PathExpression') {
     if (isRecord(node) && node['type'] === 'SubExpression') {
-      collectPathsFromAst(node, paths, seen)
+      collectPathsFromAst(node, paths, seen, shiftedDepth)
     }
+    return
+  }
+  const depth = typeof node['depth'] === 'number' ? node['depth'] : 0
+  if (depth < shiftedDepth) {
     return
   }
   const original = node['original']


### PR DESCRIPTION
## Defect

`variablesValidate` reports a template input issue for a template that renders correctly. A bare path inside an `each` or `with` block is a property of the block's context, but validation checks it against the root `templateInputsSchema`.

```
schema:   { items: { type: 'array', items: { properties: { name: {...} } } } }
template: {{#each items}}{{name}}{{/each}}
issue:    Template path 'name' is not present in template_inputs_schema
```

Reproduced on `eb3a272`.

## Evidence

`collectPathsFromAst` walks every child node at one flat scope, so `{{name}}` in the block body is collected exactly as if it sat at the top level. `shouldValidatePath` already drops `this` and `../` paths, which are the explicit ways to write scope, but a bare path inside a context-shifting block gets no such treatment.

`referenceSyntax.ts` in the same package already models this correctly for the `@{}@` composition syntax. `collectBlockReferences` carries a `shiftedDepth`, increments it for the helpers in `CONTEXT_SHIFTING_HELPERS`, and drops a path whose own `depth` is below it:

```ts
const childShiftedDepth = CONTEXT_SHIFTING_HELPERS.has(helperName) ? shiftedDepth + 1 : shiftedDepth
collectReferencesFromAst(block['program'], references, childShiftedDepth)
collectReferencesFromAst(block['inverse'], references, shiftedDepth)
```

So the two walkers in this package disagree about block scope, and the template-input one is the one that is wrong.

## Fix

Give the template walker the same depth model, and export `CONTEXT_SHIFTING_HELPERS` so the list of helpers has one home rather than two copies that can drift.

The inverse block keeps the enclosing depth, matching Handlebars: `{{else}}` inside `{{#each}}` runs against the parent, so an unknown path there is still reported. The new test asserts that, not just the positive case.

Both halves are mutation-verified independently: removing the depth check and shifting the inverse each fail the tests. The existing `{{#if}}` case is unaffected, since `if` does not shift context.

One thing deliberately left alone: a `../` path is still dropped by `shouldValidatePath` even when the depth model could now resolve it to the root. That is a missing check rather than a false report, it predates this change, and it is a separate question.

Built this with Claude Code's help and reviewed the diff myself.