### PR TITLE
Accept the documented boolean env spellings

### DIFF
--- a/.changeset/env-boolean-spellings.md
+++ b/.changeset/env-boolean-spellings.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Accept the boolean environment variable spellings the Python SDK accepts. `LOGFIRE_DISTRIBUTED_TRACING=TRUE` previously matched neither branch and disabled distributed tracing, and `LOGFIRE_CONSOLE` only recognised a lowercase, untrimmed `true`.

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -289,6 +289,15 @@ describe('logfire config', () => {
     expect(logfireConfig.console).toBe(true)
   })
 
+  it('accepts the boolean env spellings the Python SDK accepts', () => {
+    // `_check_bool` in the Python SDK lowercases and takes 1/true/t, so these have to work here.
+    for (const value of ['TRUE', ' true ', '1', 't']) {
+      process.env['LOGFIRE_CONSOLE'] = value
+      configure()
+      expect(logfireConfig.console).toBe(true)
+    }
+  })
+
   it('does not parse LOGFIRE_CONSOLE as object-style console config', () => {
     process.env['LOGFIRE_CONSOLE'] = '{"enabled":true}'
 
@@ -530,6 +539,21 @@ describe('logfire config', () => {
       process.env['LOGFIRE_DISTRIBUTED_TRACING'] = 'false'
       configure({ distributedTracing: true, sendToLogfire: false })
       expect(logfireConfig.distributedTracing).toBe(true)
+    })
+
+    it('does not disable distributed tracing for an uppercase LOGFIRE_DISTRIBUTED_TRACING', () => {
+      // The worst spelling to get wrong: TRUE previously matched neither branch and turned the
+      // feature off, which is the opposite of what setting it asks for.
+      for (const value of ['TRUE', ' true ', '1', 't']) {
+        process.env['LOGFIRE_DISTRIBUTED_TRACING'] = value
+        configure({ sendToLogfire: false })
+        expect(logfireConfig.distributedTracing).toBe(true)
+      }
+      for (const value of ['FALSE', '0', 'f']) {
+        process.env['LOGFIRE_DISTRIBUTED_TRACING'] = value
+        configure({ sendToLogfire: false })
+        expect(logfireConfig.distributedTracing).toBe(false)
+      }
     })
 
     it('LOGFIRE_DISTRIBUTED_TRACING=false disables distributed tracing when the option is omitted', () => {

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -187,6 +187,16 @@ const DEFAULT_AUTO_INSTRUMENTATION_CONFIG: InstrumentationConfigMap = {
   },
 }
 
+/**
+ * Recognise the boolean spellings the Python SDK accepts. `_check_bool` in `config_params.py`
+ * lowercases and takes `1`/`true`/`t`, so `LOGFIRE_DISTRIBUTED_TRACING=TRUE` has to mean the same
+ * thing here. Anything unrecognised stays falsy, as it was before.
+ */
+function parseBooleanEnv(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  return normalized === '1' || normalized === 't' || normalized === 'true'
+}
+
 function readNonEmptyEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const value = env[key]
   return value === undefined || value.trim() === '' ? undefined : value
@@ -272,7 +282,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
 
   const env = process.env
   const envMinLevel = env['LOGFIRE_MIN_LEVEL']
-  const console = 'console' in cnf ? cnf.console : env['LOGFIRE_CONSOLE'] === 'true'
+  const console = 'console' in cnf ? cnf.console : parseBooleanEnv(env['LOGFIRE_CONSOLE'])
   const shouldReadLocalCredentials =
     cnf.token === undefined && readNonEmptyEnv(env, 'LOGFIRE_TOKEN') === undefined && cnf.sendToLogfire !== false
 
@@ -455,7 +465,7 @@ function resolveDistributedTracing(option: LogfireConfigOptions['distributedTrac
   }
   const envDistributedTracing = readNonEmptyEnv(process.env, 'LOGFIRE_DISTRIBUTED_TRACING')
   if (envDistributedTracing !== undefined) {
-    return envDistributedTracing === 'true'
+    return parseBooleanEnv(envDistributedTracing)
   }
   return true
 }


### PR DESCRIPTION
## Defect

`LOGFIRE_DISTRIBUTED_TRACING=TRUE` turns distributed tracing **off**. The value matches neither branch, so the code falls through to `false`, which is the opposite of what setting the variable asks for and it happens silently.

`LOGFIRE_CONSOLE` has the same shape with a milder outcome: only an exact lowercase, untrimmed `true` is recognised, so `TRUE`, `1`, `t` and `" true "` all leave console output off.

## Evidence

```ts
// LOGFIRE_CONSOLE
const console = 'console' in cnf ? cnf.console : env['LOGFIRE_CONSOLE'] === 'true'

// LOGFIRE_DISTRIBUTED_TRACING
if (envDistributedTracing !== undefined) {
  return envDistributedTracing === 'true'
}
```

The Python SDK accepts more spellings for every `tp=bool` parameter, and both of these are declared that way in `config_params.py`. `_check_bool` is the shared parser:

```python
if value.lower() in ('1', 'true', 't'):
    return True
if value.lower() in ('0', 'false', 'f'):
    return False
```

This SDK already agrees with that convention elsewhere: `resolveSendToLogfire` normalises with `configured.trim().toLowerCase()`, and its comment says every documented value has to be recognised the same way. These two env vars are the ones that were missed.

## Fix

One `parseBooleanEnv` helper, used at both sites, matching `_check_bool`'s accepted spellings.

Unrecognised values stay falsy, exactly as before, so nothing that behaves one way today changes. Python raises on an unrecognised boolean instead, which is a larger behaviour change than this PR should make, so it keeps the existing silent fallback and the existing test for `LOGFIRE_CONSOLE={"enabled":true}` still passes unchanged.

Defaults are untouched. `LOGFIRE_CONSOLE` still defaults off and distributed tracing still defaults on.

Each call site is mutation-verified on its own: reverting either one back to `=== 'true'` fails its own test and only its own.

Built this with Claude Code's help and reviewed the diff myself.