### PR TITLE
Leave blank resource options off the resource

### DIFF
--- a/.changeset/resource-blank-attributes.md
+++ b/.changeset/resource-blank-attributes.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Leave a blank first-class resource option off the resource instead of recording an empty value. `LOGFIRE_ENVIRONMENT=` reached the resource as `deployment.environment.name: ""` on every span, where the Python SDK omits the attribute.

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -1094,6 +1094,21 @@ describe('sdk lifecycle helpers', () => {
     })
   })
 
+  it('leaves a blank first-class resource option off rather than stamping an empty value', () => {
+    // `LOGFIRE_ENVIRONMENT=` in a compose file or CI matrix reaches here as an empty string.
+    // Python guards each of these with `if self.environment:`, so the attribute is simply absent.
+    Object.assign(logfireConfig, {
+      deploymentEnvironment: '',
+      serviceVersion: '',
+    })
+
+    start()
+
+    const attributes = getLatestResourceAttributes()
+    expect('deployment.environment.name' in attributes).toBe(false)
+    expect('service.version' in attributes).toBe(false)
+  })
+
   it('keeps first-class resource options ahead of generic resource attributes', () => {
     Object.assign(logfireConfig, {
       deploymentEnvironment: 'production',

--- a/packages/logfire-node/src/utils.ts
+++ b/packages/logfire-node/src/utils.ts
@@ -10,5 +10,8 @@ export function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Om
 }
 
 export function removeEmptyKeys<T extends Record<string, unknown>>(dict: T): T {
-  return Object.fromEntries(Object.entries(dict).filter(([, value]) => value !== undefined && value !== null)) as T
+  // An empty string is as absent as null here: the Python SDK guards each of these resource
+  // fields with `if self.environment:` and friends, so a blank value has to leave the attribute
+  // off rather than stamp an empty one on every span.
+  return Object.fromEntries(Object.entries(dict).filter(([, value]) => value !== undefined && value !== null && value !== '')) as T
 }


### PR DESCRIPTION
## Defect

A blank `LOGFIRE_ENVIRONMENT` stamps `deployment.environment.name: ""` on the resource, so every span, metric and log carries an empty environment instead of none. Declaring the variable without a value is ordinary in a compose file or a CI matrix.

`serviceVersion` and the `codeSource` fields behave the same way when set to an empty string.

## Evidence

The resource is built through a helper whose name says it drops these, but it only drops nullish values:

```ts
export function removeEmptyKeys<T extends Record<string, unknown>>(dict: T): T {
  return Object.fromEntries(Object.entries(dict).filter(([, value]) => value !== undefined && value !== null)) as T
}
```

The Python SDK guards each of these fields on truthiness, so a blank value leaves the attribute off (`_internal/config.py`):

```python
if self.service_version:
    dedicated_attributes['service.version'] = self.service_version
if self.environment:
    dedicated_attributes[RESOURCE_ATTRIBUTES_DEPLOYMENT_ENVIRONMENT_NAME] = self.environment
```

This is also inconsistent inside the same object literal: `serviceName` and `serviceVersion` arrive via `readNonEmptyEnv`, which already turns a blank env var into `undefined`, while `deploymentEnvironment` is read straight from `env['LOGFIRE_ENVIRONMENT']` two lines away.

## Fix

Filter empty strings too, which is what the helper's name claims and what Python does for every field in that literal. One line, one call site.

I fixed the helper rather than the `LOGFIRE_ENVIRONMENT` read, because the read is only one way in: `configure({ environment: '' })` reaches the same place, and so do `serviceVersion` and `codeSource.rootPath`.

Dropping a blank `service.name` is a small improvement on its own: the OTel SDK then applies its `unknown_service` default, which is what the comment above this block says should happen.

Reverting the added check fails the new test.

Built this with Claude Code's help and reviewed the diff myself.