### PR TITLE
Omit a blank environment binding

### DIFF
--- a/.changeset/cf-blank-environment.md
+++ b/.changeset/cf-blank-environment.md
@@ -2,4 +2,4 @@
 '@pydantic/logfire-cf-workers': patch
 ---
 
-Omit `deployment.environment.name` when the `LOGFIRE_ENVIRONMENT` binding is declared without a value, instead of recording an empty environment on every span.
+Omit `deployment.environment.name` when the resolved environment is empty, instead of recording an empty environment on every span. This covers both a `LOGFIRE_ENVIRONMENT` binding declared without a value and an explicit `environment: ''` passed to `instrumentInProcess`.

--- a/.changeset/cf-blank-environment.md
+++ b/.changeset/cf-blank-environment.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-cf-workers': patch
+---
+
+Omit `deployment.environment.name` when the `LOGFIRE_ENVIRONMENT` binding is declared without a value, instead of recording an empty environment on every span.

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -85,6 +85,31 @@ describe('User-Agent', () => {
     })
   })
 
+  it('omits the environment when the binding is declared without a value', async () => {
+    vi.resetModules()
+
+    type InProcessConfigFn = (env: Record<string, string | undefined>) => { environment?: string }
+    let capturedConfigFn: InProcessConfigFn | undefined
+
+    vi.doMock('@pydantic/otel-cf-workers', () => ({
+      instrument: (handler: unknown, configFn: InProcessConfigFn): unknown => {
+        capturedConfigFn = configFn
+        return handler
+      },
+      instrumentDO: (doClass: unknown): unknown => doClass,
+      OTLP_EXPORTER_USER_AGENT: 'otel-cf-workers/0.0.0',
+    }))
+
+    const { instrumentInProcess } = await import('./index')
+    instrumentInProcess({}, { service: { name: 'test-service' } })
+
+    const blank = capturedConfigFn?.({ LOGFIRE_ENVIRONMENT: '', LOGFIRE_TOKEN: 'test-token' })
+    expect(blank !== undefined && 'environment' in blank).toBe(false)
+
+    const set = capturedConfigFn?.({ LOGFIRE_ENVIRONMENT: 'staging', LOGFIRE_TOKEN: 'test-token' })
+    expect(set?.environment).toBe('staging')
+  })
+
   it('exportTailEventsToLogfire sends the two-product User-Agent header', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'))
     vi.stubGlobal('fetch', fetchMock)

--- a/packages/logfire-cf-workers/src/index.test.ts
+++ b/packages/logfire-cf-workers/src/index.test.ts
@@ -110,6 +110,30 @@ describe('User-Agent', () => {
     expect(set?.environment).toBe('staging')
   })
 
+  it('omits an explicitly empty environment option', async () => {
+    vi.resetModules()
+
+    type InProcessConfigFn = (env: Record<string, string | undefined>) => { environment?: string }
+    let capturedConfigFn: InProcessConfigFn | undefined
+
+    vi.doMock('@pydantic/otel-cf-workers', () => ({
+      instrument: (handler: unknown, configFn: InProcessConfigFn): unknown => {
+        capturedConfigFn = configFn
+        return handler
+      },
+      instrumentDO: (doClass: unknown): unknown => doClass,
+      OTLP_EXPORTER_USER_AGENT: 'otel-cf-workers/0.0.0',
+    }))
+
+    const { instrumentInProcess } = await import('./index')
+    // The option is spread into the returned config, so it has to be dropped at the source
+    // rather than merely skipped when the replacement is added.
+    instrumentInProcess({}, { environment: '', service: { name: 'test-service' } })
+
+    const resolved = capturedConfigFn?.({ LOGFIRE_TOKEN: 'test-token' })
+    expect(resolved !== undefined && 'environment' in resolved).toBe(false)
+  })
+
   it('exportTailEventsToLogfire sends the two-product User-Agent header', async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response('ok'))
     vi.stubGlobal('fetch', fetchMock)

--- a/packages/logfire-cf-workers/src/index.ts
+++ b/packages/logfire-cf-workers/src/index.ts
@@ -79,12 +79,14 @@ function configureScrubbing(config: InProcessConfigOptions): void {
 }
 
 function getInProcessConfig(config: InProcessConfigOptions): (env: Env) => TraceConfig {
+  // `environment` is pulled out so the spread below cannot reintroduce an empty one.
+  const { environment: configEnvironment, ...configRest } = config
   return (env: Env): TraceConfig => {
     const token = envString(env, 'LOGFIRE_TOKEN') ?? ''
     const envDeploymentEnvironment = envString(env, 'LOGFIRE_ENVIRONMENT')
 
     const baseUrl = resolveBaseUrl(env as LogfireEnv, config.baseUrl, token)
-    const resolvedEnvironment = config.environment ?? envDeploymentEnvironment
+    const resolvedEnvironment = configEnvironment ?? envDeploymentEnvironment
 
     const additionalSpanProcessors = config.additionalSpanProcessors ?? []
 
@@ -93,7 +95,7 @@ function getInProcessConfig(config: InProcessConfigOptions): (env: Env) => Trace
     }
 
     return {
-      ...config,
+      ...configRest,
       additionalSpanProcessors,
       exporter: {
         headers: { Authorization: token },

--- a/packages/logfire-cf-workers/src/index.ts
+++ b/packages/logfire-cf-workers/src/index.ts
@@ -102,7 +102,10 @@ function getInProcessConfig(config: InProcessConfigOptions): (env: Env) => Trace
       },
       idGenerator: new ULIDGenerator(),
       postProcessor: (spans: ReadableSpan[]) => postProcessAttributes(spans),
-      ...(resolvedEnvironment !== undefined ? { environment: resolvedEnvironment } : {}),
+      // A binding declared without a value arrives as an empty string, and an empty
+      // `deployment.environment.name` on every span is worse than no attribute at all. The Python
+      // SDK guards the same field with `if self.environment:`.
+      ...(resolvedEnvironment !== undefined && resolvedEnvironment !== '' ? { environment: resolvedEnvironment } : {}),
     } satisfies TraceConfig
   }
 }


### PR DESCRIPTION
## Defect

A `LOGFIRE_ENVIRONMENT` binding declared without a value reaches the resource as `deployment.environment.name: ""`, so every span from the Worker carries an empty environment rather than none. Declaring a binding with no value is ordinary in a `wrangler.toml` or a CI-provided secret that has not been set yet.

## Evidence

`envString` returns the raw string, and the config guard only rejects `undefined`:

```ts
const envDeploymentEnvironment = envString(env, 'LOGFIRE_ENVIRONMENT')
const resolvedEnvironment = config.environment ?? envDeploymentEnvironment
...
...(resolvedEnvironment !== undefined ? { environment: resolvedEnvironment } : {}),
```

The Python SDK guards the same field on truthiness, so a blank value leaves the attribute off (`_internal/config.py`):

```python
if self.environment:
    dedicated_attributes[RESOURCE_ATTRIBUTES_DEPLOYMENT_ENVIRONMENT_NAME] = self.environment
```

Reproduced on `eb3a272` through the existing config-capture harness in `index.test.ts`: resolving with `LOGFIRE_ENVIRONMENT: ''` produced a config carrying `environment: ''`.

## Fix

Reject the empty string alongside `undefined` at that guard. Doing it there rather than inside `envString` also covers `instrumentInProcess(handler, { environment: '' })`, which reaches the same line.

The test asserts both directions, so it fails if a blank starts being recorded again or if a real environment stops being passed through.

Scoped to this package on purpose. `otel-cf-workers` has the same `!== undefined` guard when it builds the resource, which matters if that package is used directly rather than through this wrapper, but its `createResource` is module-private behind a one-shot `initialised` flag and I could not test a change there without reworking that. Happy to follow up if you want it covered.

Built this with Claude Code's help and reviewed the diff myself.