### PR TITLE
Compare Date, RegExp, Set and Map contents in deepEqual

### DIFF
--- a/.changeset/equals-opaque-objects.md
+++ b/.changeset/equals-opaque-objects.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Compare the contents of Dates, RegExps, Sets and Maps in the `Equals` and `EqualsExpected` evaluators. `deepEqual` only compared own enumerable keys, and those types keep their contents in internal slots, so any two of them matched each other and a wrong `Date` passed as equal to the expected one.

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -54,6 +54,39 @@ describe('built-in evaluator edge cases', () => {
     expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false)
   })
 
+  it('deepEqual compares the contents of Dates, RegExps, Sets and Maps', () => {
+    // A task returns these in process, so they are not constrained by the dataset file format.
+    expect(deepEqual(new Date('2020-01-01'), new Date('1990-01-01'))).toBe(false)
+    expect(deepEqual(new Date('2020-01-01'), new Date('2020-01-01'))).toBe(true)
+    expect(deepEqual(new Date(0), new Map())).toBe(false)
+    expect(deepEqual(new Date(0), { getTime: 0 })).toBe(false)
+    expect(deepEqual(/a/gu, /b/gu)).toBe(false)
+    expect(deepEqual(/a/gu, /a/gu)).toBe(true)
+    expect(deepEqual(/a/gu, /a/u)).toBe(false)
+    expect(deepEqual(new Set([1]), new Set([2]))).toBe(false)
+    expect(deepEqual(new Set([1]), new Set([1, 2]))).toBe(false)
+    expect(deepEqual(new Set([1, 'a']), new Set([1, 'a']))).toBe(true)
+    expect(deepEqual(new Map([['a', 1]]), new Map([['a', 2]]))).toBe(false)
+    expect(deepEqual(new Map([['a', 1]]), new Map([['b', 1]]))).toBe(false)
+    expect(
+      deepEqual(
+        new Map([['a', 1]]),
+        new Map([
+          ['a', 1],
+          ['b', 2],
+        ])
+      )
+    ).toBe(false)
+    expect(deepEqual(new Map([['a', undefined]]), new Map([['b', undefined]]))).toBe(false)
+    expect(deepEqual(new Map([['a', { n: 1 }]]), new Map([['a', { n: 1 }]]))).toBe(true)
+  })
+
+  it('EqualsExpected reports a wrong Date as a failure', () => {
+    const evaluator = new EqualsExpected()
+    expect(evaluator.evaluate(ctx(new Date('2020-01-01'), { expectedOutput: new Date('1990-01-01') }))).toBe(false)
+    expect(evaluator.evaluate(ctx(new Date('2020-01-01'), { expectedOutput: new Date('2020-01-01') }))).toBe(true)
+  })
+
   it('Equals and EqualsExpected preserve custom result names and empty-output behavior', () => {
     const eq = new Equals({ evaluationName: 'exact', value: { nested: ['x'] } })
     expect(eq.getResultName()).toBe('exact')

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -81,6 +81,19 @@ describe('built-in evaluator edge cases', () => {
     expect(deepEqual(new Map([['a', { n: 1 }]]), new Map([['a', { n: 1 }]]))).toBe(true)
   })
 
+  it('deepEqual rejects an object that only claims a built-in tag', () => {
+    // `Symbol.toStringTag` is writable, so the tag alone cannot be trusted: calling the built-in's
+    // method on such a value would throw out of the evaluator instead of returning a result.
+    for (const tag of ['Date', 'RegExp', 'Set', 'Map']) {
+      const left = { [Symbol.toStringTag]: tag }
+      const right = { [Symbol.toStringTag]: tag }
+      expect(deepEqual(left, right)).toBe(false)
+      expect(deepEqual(left, left)).toBe(true)
+    }
+    expect(deepEqual({ [Symbol.toStringTag]: 'Date' }, new Date(0))).toBe(false)
+    expect(deepEqual(new Set([1]), { [Symbol.toStringTag]: 'Set' })).toBe(false)
+  })
+
   it('EqualsExpected reports a wrong Date as a failure', () => {
     const evaluator = new EqualsExpected()
     expect(evaluator.evaluate(ctx(new Date('2020-01-01'), { expectedOutput: new Date('1990-01-01') }))).toBe(false)

--- a/packages/logfire-api/src/evals/builtins/Equals.ts
+++ b/packages/logfire-api/src/evals/builtins/Equals.ts
@@ -74,6 +74,25 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   if (Array.isArray(b)) {
     return false
   }
+  // Everything below compares own enumerable keys, and a Date, RegExp, Set or Map keeps its
+  // contents in internal slots instead. Any two of them have no keys at all, so they compared
+  // equal to each other, a Date to a Map included.
+  const tag = Object.prototype.toString.call(a)
+  if (tag !== Object.prototype.toString.call(b)) {
+    return false
+  }
+  if (tag === '[object Date]') {
+    return (a as Date).getTime() === (b as Date).getTime()
+  }
+  if (tag === '[object RegExp]') {
+    return (a as RegExp).source === (b as RegExp).source && (a as RegExp).flags === (b as RegExp).flags
+  }
+  if (tag === '[object Set]') {
+    return setsEqual(a as Set<unknown>, b as Set<unknown>)
+  }
+  if (tag === '[object Map]') {
+    return mapsEqual(a as Map<unknown, unknown>, b as Map<unknown, unknown>)
+  }
   const ka = Object.keys(a as Record<string, unknown>)
   const kb = Object.keys(b as Record<string, unknown>)
   if (ka.length !== kb.length) {
@@ -81,6 +100,32 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   }
   for (const k of ka) {
     if (!deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Members are matched with `has`, so membership is SameValueZero, the semantics a Set caller expects. */
+function setsEqual(a: Set<unknown>, b: Set<unknown>): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const item of a) {
+    if (!b.has(item)) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Keys are matched with `has` for the same reason; values still compare structurally. */
+function mapsEqual(a: Map<unknown, unknown>, b: Map<unknown, unknown>): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const [key, value] of a) {
+    if (!b.has(key) || !deepEqual(value, b.get(key))) {
       return false
     }
   }

--- a/packages/logfire-api/src/evals/builtins/Equals.ts
+++ b/packages/logfire-api/src/evals/builtins/Equals.ts
@@ -81,17 +81,20 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   if (tag !== Object.prototype.toString.call(b)) {
     return false
   }
+  // `Symbol.toStringTag` is writable, so a plain object can claim any of these tags. Each branch
+  // checks the prototype as well, which makes a spoofed value unequal rather than a TypeError
+  // thrown out of the evaluator by a method the object does not have.
   if (tag === '[object Date]') {
-    return (a as Date).getTime() === (b as Date).getTime()
+    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime()
   }
   if (tag === '[object RegExp]') {
-    return (a as RegExp).source === (b as RegExp).source && (a as RegExp).flags === (b as RegExp).flags
+    return a instanceof RegExp && b instanceof RegExp && a.source === b.source && a.flags === b.flags
   }
   if (tag === '[object Set]') {
-    return setsEqual(a as Set<unknown>, b as Set<unknown>)
+    return a instanceof Set && b instanceof Set && setsEqual(a, b)
   }
   if (tag === '[object Map]') {
-    return mapsEqual(a as Map<unknown, unknown>, b as Map<unknown, unknown>)
+    return a instanceof Map && b instanceof Map && mapsEqual(a, b)
   }
   const ka = Object.keys(a as Record<string, unknown>)
   const kb = Object.keys(b as Record<string, unknown>)


### PR DESCRIPTION
`deepEqual` in `evals/builtins/Equals.ts` reaches its object branch and compares own enumerable keys. A `Date`, `RegExp`, `Set` or `Map` keeps its contents in internal slots, so `Object.keys()` returns nothing for either side and any two of them compare equal.

On `118b480`:

```js
deepEqual(new Date('2020-01-01'), new Date('1990-01-01'))  // true
deepEqual(new Set([1]), new Set([2]))                      // true
deepEqual(new Map([['a', 1]]), new Map())                  // true
deepEqual(/a/, /b/)                                        // true
deepEqual(new Date(0), new Map())                          // true
```

`Equals` and `EqualsExpected` both run on `deepEqual`, and `EqualsExpected` is a default evaluator, so a task returning the wrong `Date` scores as a pass. That is the bad direction for an eval framework: the assertion goes green for a value it never looked at. Python compares these by value (`datetime(2020, 1, 1) == datetime(1990, 1, 1)` is `False`), so this is the port diverging rather than a deliberate JS choice.

The fix compares the class tag first, so two different exotic types can no longer match, then reads the contents each type actually carries: timestamp for `Date`, source and flags for `RegExp`, size and members for `Set`, size and per-key values for `Map`. Plain objects and class instances keep the existing key comparison.

`Set` members and `Map` keys are matched with `has`, which is SameValueZero. That is what a caller who put the value in the collection expects, it makes `NaN` match itself, and it avoids inventing a structural-identity rule for members that JavaScript has no hashing for. `Map` values still compare structurally.

Each branch was verified by mutation: dropping the tag check, the `Date` timestamp, the `RegExp` flags, either `size` check, the `Set` membership test, the `Map` key test, or the `Map` value test each fails one of the new assertions. 577 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
