### PR TITLE
Match structured attributes in span queries

### DIFF
--- a/.changeset/span-query-json-attributes.md
+++ b/.changeset/span-query-json-attributes.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Match structured attributes in span queries. `hasAttributes` compared the span attribute with `===`, so a query for an object or an array never matched: OTel carries an object as the JSON string `serializeAttributes` wrote, and an array as a real array, and neither is `===` a fresh query value. `HasMatchingSpan` and `SpanTree.any`/`find`/`first` now compare structurally and decode a JSON string attribute first, the way pydantic-evals does.

--- a/packages/logfire-api/src/evals/__test__/spanTree.test.ts
+++ b/packages/logfire-api/src/evals/__test__/spanTree.test.ts
@@ -179,6 +179,31 @@ describe('span tree capture + HasMatchingSpan', () => {
     expect(tree.any({ maxDescendantCount: 2, nameEquals: 'root-op' })).toBe(false)
   })
 
+  it('matches attributes that OTel could only carry as an array or a JSON string', () => {
+    const tree = SpanTree.fromSpans([
+      fakeSpan({
+        attributes: { count: '1', 'logfire.tags': ['a', 'b'], plain: 'text', user: '{"id":1,"name":"ada"}' },
+        name: 'op',
+        spanId: 'op',
+      }),
+    ])
+
+    // `serializeAttributes` writes an object attribute as JSON, so the query object has to be
+    // compared against the decoded value.
+    expect(tree.any({ hasAttributes: { user: { id: 1, name: 'ada' } } })).toBe(true)
+    expect(tree.any({ hasAttributes: { user: { id: 2, name: 'ada' } } })).toBe(false)
+    expect(tree.any({ hasAttributes: { user: '{"id":1,"name":"ada"}' } })).toBe(true)
+    // A sequence attribute stays a real array on the span.
+    expect(tree.any({ hasAttributes: { 'logfire.tags': ['a', 'b'] } })).toBe(true)
+    expect(tree.any({ hasAttributes: { 'logfire.tags': ['a'] } })).toBe(false)
+    expect(tree.any({ hasAttributes: { plain: 'text' } })).toBe(true)
+    expect(tree.any({ hasAttributes: { plain: { id: 1 } } })).toBe(false)
+    expect(tree.any({ hasAttributes: { missing: { id: 1 } } })).toBe(false)
+    // Decoding is only for structured queries; a string attribute is not a number.
+    expect(tree.any({ hasAttributes: { count: 1 } })).toBe(false)
+    expect(tree.any({ hasAttributes: { count: '1' } })).toBe(true)
+  })
+
   it('serializes HasMatchingSpan queries with snake_case field names', () => {
     expect(new HasMatchingSpan({ query: { maxDuration: 0.1, someChildHas: { nameEquals: 'child' } } }).toJSON()).toEqual({
       query: {

--- a/packages/logfire-api/src/evals/spanTree/SpanTree.ts
+++ b/packages/logfire-api/src/evals/spanTree/SpanTree.ts
@@ -8,6 +8,8 @@
 
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
 
+import { deepEqual } from '../builtins/Equals'
+
 export class SpanTreeRecordingError extends Error {
   constructor(
     message = 'Span-tree recording was not available. Pass `getEvalsSpanProcessor()` to your TracerProvider, or call `logfire.configure()` so the evals processor is installed automatically.'
@@ -121,6 +123,26 @@ function nsFromHrTime(hr: [number, number]): number {
   return hr[0] * 1_000_000_000 + hr[1]
 }
 
+/**
+ * An OTel attribute value is a primitive or a sequence of them, so an object or an array reaches
+ * the span as either a real array or the JSON string that `serializeAttributes` wrote. Comparing
+ * with `===` matched neither, so every query for a structured attribute failed. Python decodes the
+ * stored string before comparing, so do the same here.
+ */
+function attributeMatches(stored: unknown, expected: unknown): boolean {
+  if (deepEqual(stored, expected)) {
+    return true
+  }
+  if (typeof stored !== 'string' || expected === null || typeof expected !== 'object') {
+    return false
+  }
+  try {
+    return deepEqual(JSON.parse(stored), expected)
+  } catch {
+    return false
+  }
+}
+
 function matchesQuery(node: SpanNode, q: SpanQuery): boolean {
   const or = queryValue(q, 'or_', 'or_') as SpanQuery[] | undefined
   if (or !== undefined && or.length > 0) {
@@ -167,7 +189,7 @@ function matchesQuery(node: SpanNode, q: SpanQuery): boolean {
   const hasAttributes = queryValue(q, 'has_attributes', 'hasAttributes') as Record<string, unknown> | undefined
   if (hasAttributes !== undefined) {
     for (const [k, v] of Object.entries(hasAttributes)) {
-      if (node.attributes[k] !== v) {
+      if (!attributeMatches(node.attributes[k], v)) {
         return false
       }
     }


### PR DESCRIPTION
`hasAttributes` compares the span attribute with `===`:

```ts
if (node.attributes[k] !== v) {
  return false
}
```

An OTel attribute value can only be a primitive or a sequence of them, so a structured value never arrives as the object the query holds. An object attribute reaches the span as the JSON string `serializeAttributes` wrote, and an array attribute arrives as a real array that is not `===` a fresh one. Both queries therefore always fail.

On `118b480`, with a span carrying `{'logfire.tags': ['a', 'b'], user: '{"id":1}'}`:

```ts
tree.any({ hasAttributes: { 'logfire.tags': ['a', 'b'] } })  // false
tree.any({ hasAttributes: { user: { id: 1 } } })             // false
tree.any({ hasAttributes: { user: '{"id":1}' } })            // true
```

Only the third works, and it makes the caller hand-write the serializer's output. pydantic-evals handles both cases in `_attribute_matches` (`otel/span_tree.py:259`): value equality first, then `json.loads(stored) == expected` when the query value is a dict or a list, with the comment that "instrumentation libraries like Logfire store dict and list values as JSON strings". This port kept the query keys but not that decoding step.

The fix routes the comparison through a helper that compares structurally, then retries against the decoded string. Decoding only runs when the query value is an object or an array, which is what keeps a string attribute `'1'` from matching the number `1`.

`deepEqual` is reused rather than reimplemented; it already backs the `Equals` evaluator in the same package.

Each branch is mutation-checked: swapping `deepEqual` back to `===` fails the array assertion, dropping the JSON retry fails the object assertion, and dropping the query-value type guard fails the string-versus-number assertion. 576 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
