### PR TITLE
Generate a dataset schema that matches the evaluator forms

### DIFF
--- a/.changeset/dataset-schema-short-form.md
+++ b/.changeset/dataset-schema-short-form.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Generate a dataset JSON Schema that matches the evaluator forms the loader accepts. The schema only described `{Name: {kwargs}}`, so the short form `{Equals: 1}` that `Dataset.toText`/`toObject` writes failed validation in an editor, while a bare `Equals` validated even though constructing it with no arguments throws.

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -22,6 +22,13 @@ import {
   stringifyYaml,
 } from '../../evals'
 
+function evaluatorBranches(schema: Record<string, unknown>, name: string): Record<string, unknown>[] {
+  const properties = schema['properties'] as { evaluators: { items: { anyOf: Record<string, unknown>[] } } }
+  return properties.evaluators.items.anyOf.filter(
+    (branch) => branch['const'] === name || Object.hasOwn((branch['properties'] ?? {}) as object, name)
+  )
+}
+
 const sleep = async (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms)
@@ -178,6 +185,43 @@ describe('EvaluatorSpec encoding', () => {
     expect(text).toContain('"properties":{"NullSchemaEvaluator":{}}')
   })
 
+  it('accepts the short evaluator form that the serializer writes', () => {
+    const dataset = new Dataset({ cases: [new Case({ evaluators: [new Equals({ value: 1 })], inputs: 'x' })], name: 'd' })
+    expect(dataset.toObject()['cases']).toEqual([{ evaluators: [{ Equals: 1 }], inputs: 'x' }])
+
+    // The first branch is the one that form validates against; the second is the kwargs form.
+    expect(evaluatorBranches(dataset.jsonSchema(), 'Equals')).toEqual([
+      { additionalProperties: false, properties: { Equals: {} }, required: ['Equals'], type: 'object' },
+      {
+        additionalProperties: false,
+        properties: {
+          Equals: {
+            additionalProperties: false,
+            properties: { evaluation_name: { type: 'string' }, value: {} },
+            required: ['value'],
+            type: 'object',
+          },
+        },
+        required: ['Equals'],
+        type: 'object',
+      },
+    ])
+  })
+
+  it('offers the bare name only for an evaluator that needs no arguments', () => {
+    const schema = buildDatasetJsonSchema()
+    // `new Equals()` throws, so a file naming it with no arguments must not validate.
+    expect(evaluatorBranches(schema, 'Equals').map((branch) => branch['const'])).toEqual([undefined, undefined])
+    expect(evaluatorBranches(schema, 'EqualsExpected')[0]).toEqual({ const: 'EqualsExpected', type: 'string' })
+    // MaxDuration takes one required number, so the short form carries that number's schema.
+    expect(evaluatorBranches(schema, 'MaxDuration')[0]).toEqual({
+      additionalProperties: false,
+      properties: { MaxDuration: { type: 'number' } },
+      required: ['MaxDuration'],
+      type: 'object',
+    })
+  })
+
   it('lists an evaluator once when it is both registered and passed as custom', () => {
     class BothWaysEvaluator extends Evaluator {
       static override evaluatorName = 'BothWaysEvaluator'
@@ -188,12 +232,10 @@ describe('EvaluatorSpec encoding', () => {
     registerEvaluator(BothWaysEvaluator as never)
 
     const schema = buildDatasetJsonSchema({ customEvaluators: [BothWaysEvaluator as never] }) as {
-      properties: { evaluators: { items: { oneOf: { const?: string }[] } } }
+      properties: { evaluators: { items: { anyOf: { const?: string }[] } } }
     }
-    const branches = schema.properties.evaluators.items.oneOf.filter((branch) => branch.const === 'BothWaysEvaluator')
+    const branches = schema.properties.evaluators.items.anyOf.filter((branch) => branch.const === 'BothWaysEvaluator')
 
-    // oneOf requires exactly one match, so a duplicate branch makes a file naming
-    // this evaluator invalid.
     expect(branches).toHaveLength(1)
   })
 })

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -222,6 +222,53 @@ describe('EvaluatorSpec encoding', () => {
     })
   })
 
+  it('offers a short branch for a single-parameter evaluator the encoder writes short', () => {
+    const encoded = encodeEvaluatorSpec(new EqualsExpected({ evaluation_name: 'x' }))
+    expect(encoded).toEqual({ EqualsExpected: 'x' })
+
+    const schema = buildDatasetJsonSchema()
+    const shortBranch = evaluatorBranches(schema, 'EqualsExpected').find(
+      (branch) => ((branch['properties'] ?? {}) as Record<string, unknown>)['EqualsExpected'] !== undefined
+    )
+
+    expect(shortBranch).toEqual({
+      additionalProperties: false,
+      properties: { EqualsExpected: { type: 'string' } },
+      required: ['EqualsExpected'],
+      type: 'object',
+    })
+  })
+
+  it('honours primaryArgKeys for a custom evaluator, as decoding already does', () => {
+    class TwoArgEvaluator extends Evaluator {
+      static override evaluatorName = 'TwoArgEvaluator'
+      static jsonSchema(): Record<string, unknown> {
+        return {
+          properties: { other: { type: 'number' }, subject: { type: 'string' } },
+          required: ['subject'],
+          type: 'object',
+        }
+      }
+      evaluate(): boolean {
+        return true
+      }
+    }
+
+    const withoutKey = buildDatasetJsonSchema({ customEvaluators: [TwoArgEvaluator as never] })
+    const withKey = buildDatasetJsonSchema({
+      customEvaluators: [TwoArgEvaluator as never],
+      primaryArgKeys: { TwoArgEvaluator: 'subject' },
+    })
+
+    const shortOf = (schema: Record<string, unknown>): unknown =>
+      evaluatorBranches(schema, 'TwoArgEvaluator')
+        .map((branch) => ((branch['properties'] ?? {}) as Record<string, unknown>)['TwoArgEvaluator'])
+        .find((value) => JSON.stringify(value) === JSON.stringify({ type: 'string' }))
+
+    expect(shortOf(withoutKey)).toBeUndefined()
+    expect(shortOf(withKey)).toEqual({ type: 'string' })
+  })
+
   it('lists an evaluator once when it is both registered and passed as custom', () => {
     class BothWaysEvaluator extends Evaluator {
       static override evaluatorName = 'BothWaysEvaluator'

--- a/packages/logfire-api/src/evals/serialization/jsonSchema.ts
+++ b/packages/logfire-api/src/evals/serialization/jsonSchema.ts
@@ -1,10 +1,10 @@
 /**
  * JSON Schema generation for dataset files.
  *
- * Produces a schema where `evaluators` is a discriminated union of one entry
- * per registered evaluator (plus the bare-name string), so IDEs with YAML
- * language servers offer completion + validation against `pydantic-evals`-style
- * dataset files.
+ * Produces a schema where `evaluators` is a union of the forms `decodeEvaluator` accepts for
+ * each registered evaluator: the bare name when it needs no arguments, `{Name: value}` for a
+ * lone argument, and `{Name: {kwargs}}`. IDEs with YAML language servers use it for completion
+ * and validation of `pydantic-evals`-style dataset files.
  *
  * Mirrors pydantic-evals' `Dataset.model_json_schema_with_evaluators`.
  */
@@ -12,6 +12,7 @@
 import type { EvaluatorClass, ReportEvaluatorClass } from '../types'
 
 import { evaluatorRegistryKey, listRegisteredEvaluators, listRegisteredReportEvaluators } from '../registry'
+import { BUILTIN_PRIMARY_ARG_KEYS } from './builtinsPrimaryArgs'
 
 interface JsonSchemaOptions {
   customEvaluators?: readonly EvaluatorClass[]
@@ -32,8 +33,8 @@ export function buildDatasetJsonSchema(opts: JsonSchemaOptions = {}): JsonSchema
   const evaluators = dedupeByRegistryKey([...listRegisteredEvaluators(), ...(opts.customEvaluators ?? [])])
   const reportEvaluators = dedupeByRegistryKey([...listRegisteredReportEvaluators(), ...(opts.customReportEvaluators ?? [])])
 
-  const evaluatorOneOf = buildEvaluatorOneOf(evaluators)
-  const reportOneOf = buildEvaluatorOneOf(reportEvaluators)
+  const evaluatorAnyOf = buildEvaluatorAnyOf(evaluators)
+  const reportAnyOf = buildEvaluatorAnyOf(reportEvaluators)
 
   return {
     $schema: 'https://json-schema.org/draft-07/schema#',
@@ -44,7 +45,7 @@ export function buildDatasetJsonSchema(opts: JsonSchemaOptions = {}): JsonSchema
         items: {
           additionalProperties: false,
           properties: {
-            evaluators: { items: evaluatorOneOf, type: 'array' },
+            evaluators: { items: evaluatorAnyOf, type: 'array' },
             expected_output: {},
             inputs: {},
             metadata: {},
@@ -55,9 +56,9 @@ export function buildDatasetJsonSchema(opts: JsonSchemaOptions = {}): JsonSchema
         },
         type: 'array',
       },
-      evaluators: { items: evaluatorOneOf, type: 'array' },
+      evaluators: { items: evaluatorAnyOf, type: 'array' },
       name: { type: 'string' },
-      report_evaluators: { items: reportOneOf, type: 'array' },
+      report_evaluators: { items: reportAnyOf, type: 'array' },
     },
     required: ['name', 'cases'],
     title: 'PydanticEvalsDataset',
@@ -78,31 +79,50 @@ function dedupeByRegistryKey<T extends { evaluatorName?: string; name: string }>
   return [...byKey.values()]
 }
 
-function buildEvaluatorOneOf(classes: readonly (EvaluatorClass | ReportEvaluatorClass)[]): JsonSchema {
-  const oneOf: JsonSchema[] = []
+function buildEvaluatorAnyOf(classes: readonly (EvaluatorClass | ReportEvaluatorClass)[]): JsonSchema {
+  // `anyOf`, not `oneOf`: an evaluator whose single argument is untyped matches both its short
+  // and its long branch, and `oneOf` demands exactly one match. Python's schema is a union,
+  // which pydantic also renders as `anyOf`.
+  const anyOf: JsonSchema[] = []
   for (const cls of classes) {
     const name = cls.evaluatorName ?? cls.name
-    oneOf.push({ const: name, type: 'string' })
     const schemaProvider = cls as unknown as HasSchemaDescriptor
-    if (typeof schemaProvider.jsonSchema === 'function') {
-      const argSchema = schemaProvider.jsonSchema()
-      if (argSchema !== null) {
-        oneOf.push({
-          additionalProperties: false,
-          properties: { [name]: argSchema },
-          required: [name],
-          type: 'object',
-        })
-        continue
-      }
+    const argSchema = typeof schemaProvider.jsonSchema === 'function' ? schemaProvider.jsonSchema() : null
+    if (argSchema === null) {
+      // No schema provider; allow the bare name, a single positional value, or a kwargs object.
+      anyOf.push({ const: name, type: 'string' })
+      anyOf.push(namedBranch(name, {}))
+      continue
     }
-    // No schema provider; allow either single positional value or kwargs object.
-    oneOf.push({
-      additionalProperties: false,
-      properties: { [name]: {} },
-      required: [name],
-      type: 'object',
-    })
+    const properties = isRecord(argSchema['properties']) ? argSchema['properties'] : {}
+    const required = Array.isArray(argSchema['required']) ? (argSchema['required'] as string[]) : []
+    // The bare name constructs the evaluator with no arguments, so it is only valid when the
+    // evaluator has none that are required.
+    if (required.length === 0) {
+      anyOf.push({ const: name, type: 'string' })
+    }
+    // `{Name: value}` is what `encodeEvaluatorSpec` writes for a lone argument. Only the
+    // evaluators with a primary-argument key can be built back from it, since that key is what
+    // turns the bare value into the constructor's options object.
+    const shortArgKey = BUILTIN_PRIMARY_ARG_KEYS[name]
+    if (shortArgKey !== undefined) {
+      const shortSchema = properties[shortArgKey]
+      anyOf.push(namedBranch(name, isRecord(shortSchema) ? shortSchema : {}))
+    }
+    anyOf.push(namedBranch(name, argSchema))
   }
-  return { oneOf }
+  return { anyOf }
+}
+
+function namedBranch(name: string, valueSchema: Record<string, unknown>): JsonSchema {
+  return {
+    additionalProperties: false,
+    properties: { [name]: valueSchema },
+    required: [name],
+    type: 'object',
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/packages/logfire-api/src/evals/serialization/jsonSchema.ts
+++ b/packages/logfire-api/src/evals/serialization/jsonSchema.ts
@@ -17,6 +17,12 @@ import { BUILTIN_PRIMARY_ARG_KEYS } from './builtinsPrimaryArgs'
 interface JsonSchemaOptions {
   customEvaluators?: readonly EvaluatorClass[]
   customReportEvaluators?: readonly ReportEvaluatorClass[]
+  /**
+   * Primary-argument key per evaluator name, merged over the builtin map. Mirrors the option
+   * `FromOptions` already accepts, so a custom evaluator that decodes from `{Name: value}` can
+   * also validate against a generated schema.
+   */
+  primaryArgKeys?: Readonly<Record<string, string>> | ReadonlyMap<string, string>
 }
 
 export interface JsonSchema {
@@ -33,8 +39,9 @@ export function buildDatasetJsonSchema(opts: JsonSchemaOptions = {}): JsonSchema
   const evaluators = dedupeByRegistryKey([...listRegisteredEvaluators(), ...(opts.customEvaluators ?? [])])
   const reportEvaluators = dedupeByRegistryKey([...listRegisteredReportEvaluators(), ...(opts.customReportEvaluators ?? [])])
 
-  const evaluatorAnyOf = buildEvaluatorAnyOf(evaluators)
-  const reportAnyOf = buildEvaluatorAnyOf(reportEvaluators)
+  const primaryArgKeys = mergePrimaryArgKeys(opts.primaryArgKeys)
+  const evaluatorAnyOf = buildEvaluatorAnyOf(evaluators, primaryArgKeys)
+  const reportAnyOf = buildEvaluatorAnyOf(reportEvaluators, primaryArgKeys)
 
   return {
     $schema: 'https://json-schema.org/draft-07/schema#',
@@ -79,7 +86,21 @@ function dedupeByRegistryKey<T extends { evaluatorName?: string; name: string }>
   return [...byKey.values()]
 }
 
-function buildEvaluatorAnyOf(classes: readonly (EvaluatorClass | ReportEvaluatorClass)[]): JsonSchema {
+function mergePrimaryArgKeys(overrides: JsonSchemaOptions['primaryArgKeys']): ReadonlyMap<string, string> {
+  const merged = new Map(Object.entries(BUILTIN_PRIMARY_ARG_KEYS))
+  if (overrides !== undefined) {
+    const entries: Iterable<readonly [string, string]> = overrides instanceof Map ? overrides.entries() : Object.entries(overrides)
+    for (const [name, key] of entries) {
+      merged.set(name, key)
+    }
+  }
+  return merged
+}
+
+function buildEvaluatorAnyOf(
+  classes: readonly (EvaluatorClass | ReportEvaluatorClass)[],
+  primaryArgKeys: ReadonlyMap<string, string>
+): JsonSchema {
   // `anyOf`, not `oneOf`: an evaluator whose single argument is untyped matches both its short
   // and its long branch, and `oneOf` demands exactly one match. Python's schema is a union,
   // which pydantic also renders as `anyOf`.
@@ -101,10 +122,13 @@ function buildEvaluatorAnyOf(classes: readonly (EvaluatorClass | ReportEvaluator
     if (required.length === 0) {
       anyOf.push({ const: name, type: 'string' })
     }
-    // `{Name: value}` is what `encodeEvaluatorSpec` writes for a lone argument. Only the
-    // evaluators with a primary-argument key can be built back from it, since that key is what
-    // turns the bare value into the constructor's options object.
-    const shortArgKey = BUILTIN_PRIMARY_ARG_KEYS[name]
+    // `{Name: value}` is what `encodeEvaluatorSpec` writes for a lone argument, and it writes it
+    // for ANY evaluator whose `toJSON()` has exactly one key. Keying this off the builtin map
+    // alone left single-parameter evaluators such as `EqualsExpected` without a short branch, so
+    // the library emitted a file its own schema rejected. Fall back to parameter count, which is
+    // what Python keys on (`_spec.py:320-338`).
+    const onlyProperty = Object.keys(properties).length === 1 ? Object.keys(properties)[0] : undefined
+    const shortArgKey = primaryArgKeys.get(name) ?? onlyProperty
     if (shortArgKey !== undefined) {
       const shortSchema = properties[shortArgKey]
       anyOf.push(namedBranch(name, isRecord(shortSchema) ? shortSchema : {}))


### PR DESCRIPTION
`Dataset.toText`/`toObject` write the short evaluator form, and `buildDatasetJsonSchema` does not describe it, so a dataset file this library produces fails validation against the schema this library produces.

On `118b480`:

```js
new Dataset({ cases: [new Case({ inputs: 'x', evaluators: [new Equals({ value: 1 })] })], name: 'd' }).toObject()
// cases[0].evaluators -> [{"Equals":1}]
```

The schema offers exactly two branches for `Equals`: the string `"Equals"`, and an object whose `Equals` value must be `{value, evaluation_name}`. `{Equals: 1}` matches neither, so an editor with a YAML language server marks the file invalid.

The bare-name branch is wrong in the other direction. It is emitted for every evaluator, including those with a required argument, and the loader then calls the constructor with nothing:

```js
new Equals()  // TypeError: Cannot read properties of undefined (reading 'value')
```

So the schema rejects a form that loads and accepts a form that throws.

pydantic-evals derives the branches per evaluator (`pydantic_ai/_spec.py:320-333`): the bare name only when nothing is required, `{Name: value}` when there is a single argument, and `{Name: {kwargs}}` when there is more than one. This fix does the same from each evaluator's own `jsonSchema()`, with one adjustment for the TS port: the kwargs branch is always emitted, because a TS constructor takes an options object and `decodeEvaluator` always accepts that form, and the short branch is emitted only for evaluators with a primary-argument key, since that key is what turns a bare value back into the options object.

`oneOf` became `anyOf` in the same change. `Equals` has an untyped argument, so `{Equals: {value: 1}}` now matches both its short and its long branch, and `oneOf` requires exactly one match. Python's schema is a union, which pydantic also renders as `anyOf`.

Each branch rule was mutation-checked: always emitting the bare name, dropping the short branch, giving the short branch the full argument schema, and reverting to `oneOf` each fail their own assertion. 577 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
