### PR TITLE
Reject an option value that is really the next flag

### DIFF
--- a/.changeset/cli-option-value-guard.md
+++ b/.changeset/cli-option-value-guard.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Reject an option value that is really the next flag in every CLI command. `read-tokens` already refused it, but the global options, `whoami`, `projects` and `clean` each had their own copy of the check without that guard, so `logfire clean --data-dir --logs` took `--logs` as the directory name and silently dropped the flag. The four copies are gone; there is one shared helper.

--- a/packages/logfire-api/src/cli/args.ts
+++ b/packages/logfire-api/src/cli/args.ts
@@ -1,0 +1,14 @@
+import { LogfireCliError } from './errors'
+
+/**
+ * Read the value that follows an option. A value starting with `-` is another option, not
+ * this one's value: consuming it would silently swallow a flag and leave the option set to
+ * the flag's own name.
+ */
+export function readRequiredValue(args: string[], index: number, option: string): string {
+  const value = args[index]
+  if (value === undefined || value.startsWith('-')) {
+    throw new LogfireCliError(`Missing value for ${option}`)
+  }
+  return value
+}

--- a/packages/logfire-api/src/cli/commands/clean.ts
+++ b/packages/logfire-api/src/cli/commands/clean.ts
@@ -5,6 +5,7 @@ import type { CliContext } from '../context'
 import { defaultDataDir, projectCredentialsPath, readTokenPath, removeProjectCredentials } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { writeLine } from '../output'
+import { readRequiredValue } from '../args'
 
 export async function runCleanCommand(args: string[], context: CliContext): Promise<void> {
   const options = parseCleanArgs(args)
@@ -60,12 +61,4 @@ function parseCleanArgs(args: string[]): CleanOptions {
     }
   }
   return options
-}
-
-function readRequiredValue(args: string[], index: number, option: string): string {
-  const value = args[index]
-  if (value === undefined) {
-    throw new LogfireCliError(`Missing value for ${option}`)
-  }
-  return value
 }

--- a/packages/logfire-api/src/cli/commands/projects.ts
+++ b/packages/logfire-api/src/cli/commands/projects.ts
@@ -13,6 +13,7 @@ import {
 } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { prettyTable, sanitizeForTerminal, writeLine } from '../output'
+import { readRequiredValue } from '../args'
 
 const PROJECT_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u
 
@@ -426,12 +427,4 @@ function parseStatusOptions(args: string[]): StatusOptions {
     }
   }
   return options
-}
-
-function readRequiredValue(args: string[], index: number, option: string): string {
-  const value = args[index]
-  if (value === undefined) {
-    throw new LogfireCliError(`Missing value for ${option}`)
-  }
-  return value
 }

--- a/packages/logfire-api/src/cli/commands/readTokens.ts
+++ b/packages/logfire-api/src/cli/commands/readTokens.ts
@@ -3,6 +3,7 @@ import type { CliContext, GlobalOptions } from '../context'
 import { defaultDataDir, organizationFromProjectUrl, readProjectCredentials, reserveReadTokenSave } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { sanitizeForTerminal, writeLine } from '../output'
+import { readRequiredValue } from '../args'
 
 // Only tokens this CLI writes to disk get an expiry. It cannot revoke a token, so one
 // sitting in a file needs some end; a token printed for the caller to paste elsewhere
@@ -123,14 +124,6 @@ function parseOrgProject(value: string): [string, string] {
     throw new LogfireCliError(`Invalid format: ${value}. Expected <org>/<project>`)
   }
   return [organization, project]
-}
-
-function readRequiredValue(args: string[], index: number, option: string): string {
-  const value = args[index]
-  if (value === undefined || value.startsWith('-')) {
-    throw new LogfireCliError(`Missing value for ${option}`)
-  }
-  return value
 }
 
 function printReadTokensHelp(context: CliContext): void {

--- a/packages/logfire-api/src/cli/commands/whoami.ts
+++ b/packages/logfire-api/src/cli/commands/whoami.ts
@@ -5,6 +5,7 @@ import { defaultDataDir, readProjectCredentials } from '../credentials'
 import { LogfireCliError } from '../errors'
 import { writeLine } from '../output'
 import { getBaseUrlFromToken } from '../../tokenBaseUrl'
+import { readRequiredValue } from '../args'
 
 export async function runWhoamiCommand(args: string[], globalOptions: GlobalOptions, context: CliContext): Promise<void> {
   const dataDir = parseDataDir(args) ?? defaultDataDir(context.cwd)
@@ -76,12 +77,4 @@ function parseDataDir(args: string[]): string | undefined {
     }
   }
   return dataDir
-}
-
-function readRequiredValue(args: string[], index: number, option: string): string {
-  const value = args[index]
-  if (value === undefined) {
-    throw new LogfireCliError(`Missing value for ${option}`)
-  }
-  return value
 }

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -311,6 +311,30 @@ describe('CLI entrypoint', () => {
     expect(existsSync(join(victim, 'read_token.json'))).toBe(false)
   })
 
+  it('rejects an option value that is really the next flag', async () => {
+    // `read-tokens` has always refused this; the other commands consumed the flag as the
+    // value, so the flag was silently dropped and the option took the flag's own name.
+    const cases: { args: string[]; option: string }[] = [
+      { args: ['--region', '--base-url', 'https://logfire-us.pydantic.dev', 'whoami'], option: '--region' },
+      { args: ['whoami', '--data-dir', '--data-dir', makeTmpDir()], option: '--data-dir' },
+      { args: ['projects', 'status', '--data-dir', '--json'], option: '--data-dir' },
+      { args: ['clean', '--data-dir', '--logs'], option: '--data-dir' },
+    ]
+
+    for (const { args, option } of cases) {
+      const stderr = new MemoryOutput()
+      const stdout = new MemoryOutput()
+      const fetchImpl = vi.fn<typeof fetch>()
+
+      // eslint-disable-next-line no-await-in-loop -- each case runs the CLI to completion.
+      await expect(runCli(args, { fetch: fetchImpl, homeDir: makeTmpDir(), stderr, stdout })).resolves.toBe(1)
+
+      expect(fetchImpl).not.toHaveBeenCalled()
+      expect(stdout.text()).toBe('')
+      expect(stderr.text()).toBe(`Missing value for ${option}\n`)
+    }
+  })
+
   it('read-tokens create rejects a missing --data-dir value before minting', async () => {
     const fetchImpl = fetchSequence([jsonResponse({ token: 'newly-minted-token' })])
     const stdout = new MemoryOutput()

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -18,6 +18,7 @@ import { createPrompt } from './interactivePrompt'
 import type { Prompt } from './interactivePrompt'
 import { writeLine } from './output'
 import { resolveSelectedBaseUrl } from './regions'
+import { readRequiredValue } from './args'
 
 export interface CliContextOptions {
   cwd?: string
@@ -189,14 +190,6 @@ function assertNoRegionConflict(baseUrl: string | undefined, region: string | un
   if ((option === '--region' && baseUrl !== undefined) || (option !== '--region' && region !== undefined)) {
     throw new LogfireCliError('Only one of --base-url and --region can be used.')
   }
-}
-
-function readRequiredValue(args: string[], index: number, option: string): string {
-  const value = args[index]
-  if (value === undefined) {
-    throw new LogfireCliError(`Missing value for ${option}`)
-  }
-  return value
 }
 
 function printHelp(context: CliContext): void {


### PR DESCRIPTION
`readRequiredValue` exists five times in the CLI, and only one copy rejects a value that starts with `-`:

- `cli/commands/readTokens.ts:128` guards it, added with #249 and pinned by `index.test.ts`
- `cli/index.ts:194`, `cli/commands/whoami.ts:81`, `cli/commands/projects.ts:431` and `cli/commands/clean.ts:65` check only for `undefined`

Without the guard the next flag is consumed as the value, so the flag is silently dropped and the option is set to the flag's own name. On `4691011`:

| command | today | with this change |
| --- | --- | --- |
| `--region --base-url URL whoami` | `Unknown Logfire region "--base-url"` | `Missing value for --region` |
| `whoami --data-dir --data-dir DIR` | `Unexpected argument DIR` | `Missing value for --data-dir` |
| `projects status --data-dir --json` | `No Logfire credentials found in --json` | `Missing value for --data-dir` |
| `clean --data-dir --logs` | `No Logfire data found in --logs` | `Missing value for --data-dir` |

Every message in the middle column blames the wrong thing, and in the `status` case the `--json` a script asked for is quietly gone as well. `projects new --org --default-org NAME` is the one that reaches the network: `--org` becomes the string `--default-org` and the command goes on to list organizations, where with the guard it exits before making any request at all.

The behaviour is not in question, since the repo already chose it in #249 and has a test for it. Only four copies were left behind. This deletes them and imports one shared helper from a new `cli/args.ts`, which is a net removal of code.

The regression drives all four commands through `runCli` and asserts the exact stderr, and it fails on the unguarded helper.

Built this with Claude Code's help and reviewed the diff myself.
