### PR TITLE
Keep the top stack frame when there is no header line

### DIFF
--- a/.changeset/firefox-top-frame.md
+++ b/.changeset/firefox-top-frame.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep the top stack frame when fingerprinting an error in Firefox or Safari. Frame parsing dropped the first line of `error.stack` to skip V8's `Error: message` header, but those engines have no header line, so the frame that identifies the error was discarded and two unrelated errors sharing the frame below it received the same `logfire.exception.fingerprint`.

--- a/packages/logfire-api/src/fingerprint.test.ts
+++ b/packages/logfire-api/src/fingerprint.test.ts
@@ -249,6 +249,32 @@ describe('computeFingerprint', () => {
     expect(fp1).toBe(fp2)
   })
 
+  test('keeps the top frame of a stack that has no header line', () => {
+    // Firefox and Safari start at the top frame. Mocked rather than thrown, so the
+    // assertion does not depend on the engine running the tests.
+    const firefox = new Error('boom')
+    firefox.stack = `handleClick@http://app.example/src/ui.js:12:9
+submit@http://app.example/src/form.js:4:3`
+
+    expect(canonicalizeError(firefox)).toBe(`Error
+----
+src/ui:handleClick
+src/form:submit`)
+
+    // Two errors that differ only in their top frame must not group together.
+    const other = new Error('boom')
+    other.stack = `renderChart@http://app.example/src/chart.js:88:1
+submit@http://app.example/src/form.js:4:3`
+    expect(computeFingerprint(firefox) === computeFingerprint(other)).toBe(false)
+
+    // Safari writes a frame with a space in the function name.
+    const safari = new Error('boom')
+    safari.stack = `global code@http://app.example/src/boot.js:1:1`
+    expect(canonicalizeError(safari)).toBe(`Error
+----
+src/boot:global code`)
+  })
+
   test('parses Firefox stack trace format', () => {
     const error1 = new Error('test')
     const error2 = new Error('test')

--- a/packages/logfire-api/src/fingerprint.ts
+++ b/packages/logfire-api/src/fingerprint.ts
@@ -24,7 +24,11 @@ function parseStackFrames(stack: string | undefined): StackFrame[] {
   }
 
   const frames: StackFrame[] = []
-  const lines = stack.split('\n').slice(1)
+  const allLines = stack.split('\n')
+  // V8 puts `Error: message` on the first line, which is why it gets dropped. Firefox and
+  // Safari have no such header and start at the top frame, so dropping it there threw away
+  // the one frame that tells two otherwise identical stacks apart.
+  const lines = looksLikeFrame(allLines[0]) ? allLines : allLines.slice(1)
 
   for (const line of lines) {
     const withParensMatch = V8_PATTERN_WITH_PARENS.exec(line)
@@ -61,6 +65,11 @@ function parseStackFrames(stack: string | undefined): StackFrame[] {
   }
 
   return frames
+}
+
+/** Whether a line parses as a stack frame, so a first line that is a frame is not mistaken for a header. */
+function looksLikeFrame(line: string | undefined): boolean {
+  return line !== undefined && (V8_PATTERN_BARE.test(line) || FIREFOX_PATTERN.test(line))
 }
 
 /**


### PR DESCRIPTION
`parseStackFrames` drops the first line of `error.stack` to skip V8's `Error: message` header. Firefox and Safari write no header, so the line it drops there is the top frame.

The file already handles those engines, `FIREFOX_PATTERN` on line 12 exists for exactly that format, but the frame that identifies the error never reaches the parser. On `4691011`, with two unrelated Firefox errors:

```js
// handleClick@http://app.example/src/ui.js:12:9      + submit@.../src/form.js:4:3
// renderChart@http://app.example/src/chart.js:88:1   + submit@.../src/form.js:4:3
canonicalizeError(first)   // "Error\n----\nsrc/form:submit"
canonicalizeError(second)  // "Error\n----\nsrc/form:submit"
computeFingerprint(first) === computeFingerprint(second)  // true
```

`computeFingerprint` is what `index.ts:818` writes to `logfire.exception.fingerprint`, so in those browsers any two errors that pass through a common caller group into one issue, and a stack of depth one fingerprints as an empty stack.

The existing Firefox test does not catch this because it mocks a stack with a V8 header line above Firefox frames, which is a shape no engine produces.

The fix keeps the first line when it parses as a frame, using the same two patterns the loop already uses rather than a new heuristic. A V8 header cannot match them: `Error: ...` fails the `at ` pattern, and the Firefox pattern needs an `@` followed by `line:column`. The one case that still skips a header is a V8 message that itself contains something like `user@host:1:2`, which would contribute one deterministic extra line. That is a far smaller cost than dropping every Firefox top frame, and grouping stays stable because the same error still produces the same string.

Regressions cover a real Firefox stack, a Safari frame with a space in the function name, and the two errors above no longer sharing a fingerprint. They fail on the unconditional `slice(1)`.

Built this with Claude Code's help and reviewed the diff myself.
