### PR TITLE
Stop writing an empty trace payload from the tail exporter

### DIFF
--- a/.changeset/tail-empty-export.md
+++ b/.changeset/tail-empty-export.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-cf-workers': patch
+---
+
+Stop writing an empty trace payload from the tail-worker exporter. Shutdown serialized a batch of zero spans, which produced `{"resourceSpans":[]}` in the log stream, and the tail worker forwards the first logged object carrying `resourceSpans`, so an empty export could be sent in place of the batch's real spans.

--- a/packages/logfire-cf-workers/src/TailWorkerExporter.test.ts
+++ b/packages/logfire-cf-workers/src/TailWorkerExporter.test.ts
@@ -1,0 +1,63 @@
+import type { ExportResult } from '@opentelemetry/core'
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base'
+
+import { ExportResultCode } from '@opentelemetry/core'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { TailWorkerExporter } from './TailWorkerExporter'
+
+// The tail worker forwards whatever object with a `resourceSpans` key it finds in the log
+// stream, so what this exporter writes is the wire payload.
+const fakeSpan = (name: string): ReadableSpan =>
+  ({
+    attributes: {},
+    droppedAttributesCount: 0,
+    droppedEventsCount: 0,
+    droppedLinksCount: 0,
+    duration: [0, 1_000],
+    endTime: [1, 0],
+    events: [],
+    instrumentationScope: { name: 'test' },
+    kind: 0,
+    links: [],
+    name,
+    resource: { attributes: {} },
+    spanContext: () => ({ spanId: '0000000000000001', traceFlags: 1, traceId: '00000000000000000000000000000001' }),
+    startTime: [0, 0],
+    status: { code: 0 },
+  }) as unknown as ReadableSpan
+
+describe('TailWorkerExporter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('writes nothing for an empty batch or a shutdown', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const exporter = new TailWorkerExporter()
+    const results: ExportResult[] = []
+
+    exporter.export([], (result) => {
+      results.push(result)
+    })
+    await exporter.shutdown()
+
+    expect(log).not.toHaveBeenCalled()
+    expect(results).toEqual([{ code: ExportResultCode.SUCCESS }])
+  })
+
+  it('writes the payload for a batch that has spans', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const exporter = new TailWorkerExporter()
+    const results: ExportResult[] = []
+
+    exporter.export([fakeSpan('real-span')], (result) => {
+      results.push(result)
+    })
+
+    expect(results).toEqual([{ code: ExportResultCode.SUCCESS }])
+    expect(log).toHaveBeenCalledTimes(1)
+    const payload = log.mock.calls[0]?.[0] as { resourceSpans: { scopeSpans: { spans: { name: string }[] }[] }[] }
+    expect(payload.resourceSpans[0]?.scopeSpans[0]?.spans[0]?.name).toBe('real-span')
+  })
+})

--- a/packages/logfire-cf-workers/src/TailWorkerExporter.ts
+++ b/packages/logfire-cf-workers/src/TailWorkerExporter.ts
@@ -11,7 +11,7 @@ export class TailWorkerExporter implements SpanExporter {
   }
 
   async shutdown(): Promise<void> {
-    this.sendSpans([])
+    // Nothing to flush: every batch is written to the tail stream as it arrives.
     return Promise.resolve()
   }
 
@@ -35,6 +35,13 @@ export class TailWorkerExporter implements SpanExporter {
   }
 
   private sendSpans(spans: ReadableSpan[], done?: (result: ExportResult) => void): void {
+    // An empty batch still serializes to `{"resourceSpans":[]}`, and the tail worker takes any
+    // logged object with a `resourceSpans` key as the payload to forward, so writing one would
+    // put an empty export in front of the batch's real spans.
+    if (spans.length === 0) {
+      done?.({ code: ExportResultCode.SUCCESS })
+      return
+    }
     const bytes = JsonTraceSerializer.serializeRequest(spans)
     const jsonString = new TextDecoder().decode(bytes)
     const response = JSON.parse(jsonString) as IExportTraceServiceRequest


### PR DESCRIPTION
`TailWorkerExporter.shutdown()` calls `sendSpans([])`, which serializes a batch of zero spans and logs the result. `JsonTraceSerializer.serializeRequest([])` returns `{"resourceSpans":[]}`, so every shutdown writes an empty export into the tail stream.

That matters because of how the payload is picked up. `exportTailEventsToLogfire` forwards the first logged object that has a `resourceSpans` key, and an empty one qualifies. On `4691011`, with the empty payload logged before the real one in the same batch:

```js
const events = [{ logs: [
  { message: [{ resourceSpans: [] }] },
  { message: [{ resourceSpans: [{ scopeSpans: [{ spans: [{ name: 'real-span' }] }] }] }] },
] }]
await exportTailEventsToLogfire(events, { LOGFIRE_TOKEN: token })
// POST -> {"resourceSpans":[]}
```

The request goes out empty and `real-span` is never sent.

The fix returns early from `sendSpans` when the batch is empty, which covers `export([])` as well, and drops the `sendSpans([])` call from `shutdown` since emitting that payload was its only effect. The exporter has nothing to flush anyway: each batch is written as it arrives.

Two regressions, in a new test file next to the exporter: an empty export plus a shutdown write nothing and still report success, and a batch with a span still writes its payload. The first fails without the guard, the second fails if the guard returns unconditionally.

Built this with Claude Code's help and reviewed the diff myself.
