### PR TITLE
Pin the composition depth boundary that both walks share

### DIFF
--- a/packages/logfire-api/src/vars/index.ts
+++ b/packages/logfire-api/src/vars/index.ts
@@ -2008,6 +2008,10 @@ function collectReferenceDiagnosticsFromSource(
   referenceCycles: Set<string>,
   depth: number
 ): void {
+  // `>`, where `expandNamedReference` uses `>=`. The two walks count from different places:
+  // this one enters the root's own source at depth 0, while composition calls
+  // expandNamedReference for reference k at depth k-1. The operators absorb that one-level
+  // offset, so both refuse the same chain. `runtimeComposition.test.ts` pins the boundary.
   if (depth > MAX_COMPOSITION_DEPTH) {
     referenceErrors.add(
       `Variable '${rootVariable}' reference graph exceeded maximum depth of ${String(MAX_COMPOSITION_DEPTH)} via ${referencePath.join(' -> ')}`
@@ -2087,6 +2091,8 @@ function collectTemplateFieldIssuesFromSource(
   issues: TemplateFieldIssue[],
   depth: number
 ): void {
+  // Same off-by-one pairing as `collectReferenceDiagnosticsFromSource` above: `>` here matches
+  // composition's `>=` because this walk starts one level higher.
   if (depth > MAX_COMPOSITION_DEPTH) {
     return
   }

--- a/packages/logfire-api/src/vars/runtimeComposition.test.ts
+++ b/packages/logfire-api/src/vars/runtimeComposition.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { configureVariables, defineVar, getVariableProvider, variablesClear } from './index'
+import { configureVariables, defineVar, getVariableProvider, variablesClear, variablesValidate } from './index'
 import type { VariableCodec, VariablesConfig } from './index'
 
 const config = (variables: VariablesConfig['variables']): VariablesConfig => ({ variables })
@@ -180,5 +180,52 @@ describe('variable runtime composition parity', () => {
     expect(resolved.exception).toBeInstanceOf(Error)
     expect(calls).toBe(1)
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('code default raised'))
+  })
+
+  it('accepts the deepest chain composition can expand and refuses the next one in both walks', async () => {
+    // A chain of n variables is n-1 hops. `expandNamedReference` refuses at
+    // `depth >= MAX_COMPOSITION_DEPTH`, and the validation walks compare with `>` because they
+    // start one level higher, so the two agree on where the limit falls. These are the boundary
+    // cases that keep them agreeing.
+    const chain = (count: number): VariablesConfig['variables'] => {
+      const variables: VariablesConfig['variables'] = {}
+      for (let index = 0; index < count; index++) {
+        const value = index === count - 1 ? 'end' : `@{v${String(index + 1)}}@`
+        variables[`v${String(index)}`] = {
+          labels: { prod: { serialized_value: JSON.stringify(value), version: 1 } },
+          name: `v${String(index)}`,
+          overrides: [],
+          rollout: { labels: { prod: 1 } },
+        }
+      }
+      return variables
+    }
+    const probe = async (count: number) => {
+      variablesClear()
+      configureVariables({ config: config(chain(count)), instrument: false })
+      const root = defineVar('v0', { default: 'code-default' })
+      const report = await variablesValidate([root])
+      return { referenceErrors: report.referenceErrors, resolved: await root.get() }
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    // 21 variables is 20 hops, the deepest chain composition expands.
+    const deepest = await probe(21)
+    expect(deepest.referenceErrors).toEqual([])
+    expect(deepest.resolved.value).toBe('end')
+    expect(deepest.resolved.reason).toBe('resolved')
+
+    // 22 variables is 21 hops. Validation reports it and composition refuses it, so a config
+    // that passes validation never fails later at resolve time.
+    const tooDeep = await probe(22)
+    expect(tooDeep.referenceErrors).toEqual([
+      `Variable 'v0' reference graph exceeded maximum depth of 20 via ${Array.from({ length: 22 }, (_unused, index) => `v${String(index)}`).join(' -> ')}`,
+    ])
+    expect(tooDeep.resolved.value).toBe('code-default')
+    expect(tooDeep.resolved.reason).toBe('other_error')
+    expect((tooDeep.resolved.exception as Error).message).toBe(
+      'VariableCompositionDepthError: Variable composition exceeded maximum depth of 20'
+    )
+    expect(warn).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Follow-up to the review on #256, taking the salvageable half of it.

`vars/index.ts` compares depth with `>` while `composition.ts` uses `>=`, and nothing in the tree explained why, so the mismatch reads like an off-by-one. It is not: the validation walks enter the root's own source at depth 0, while composition calls `expandNamedReference` for reference k at depth k-1, and the two operators absorb that one-level offset.

Checked on `dbd68a7` rather than assumed. A chain of n variables is n-1 hops:

| chain | referenceErrors | resolve |
| --- | --- | --- |
| 21 variables, 20 hops | none | `"end"`, reason `resolved` |
| 22 variables, 21 hops | depth error naming the full path | falls back to the code default, reason `other_error`, exception `VariableCompositionDepthError` |

Both walks refuse the same chain, so a config that passes validation cannot fail later at resolve time. That agreement was unpinned, which is how I read it wrong in the first place.

This adds the boundary as a test, asserting both sides at 21 and at 22 variables, and a comment at each `>` comparison naming the pairing. Changing either comparison to `>=` fails the new test, which is exactly the edit #256 proposed.

Tests and a comment only, so there is no changeset, matching the other test-only PRs in this repo. 590 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
