### PR TITLE
Report a sink failure through each evaluator's own onError

### DIFF
--- a/.changeset/sink-per-evaluator-onerror.md
+++ b/.changeset/sink-per-evaluator-onerror.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Report a failing online-evaluation sink through the `onError` configured on each evaluator. Evaluators that share a sink are batched into one submit call, and the batch resolved a single handler from the first evaluator, so a handler set on any other evaluator in the batch never fired. The same resolution applies on the default-sink path, where a per-evaluator handler was skipped in favour of the config-level one.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -586,6 +586,73 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(sinkPayloads[0]?.results.map((result) => result.name).sort()).toEqual(['AlwaysFail', 'AlwaysPass'])
   })
 
+  it('reports a sink failure through the onError configured on each evaluator', async () => {
+    const calls: string[] = []
+    const failingSink = (): void => {
+      throw new Error('sink is down')
+    }
+    const fn = withOnlineEvaluation(async () => 'x', {
+      emitOtelEvents: false,
+      evaluators: [
+        new OnlineEvaluator({
+          evaluator: new AlwaysPass(),
+          onError: (_error, _context, evaluator, location) => {
+            calls.push(`pass-handler:${evaluator.getResultName()}:${location}`)
+          },
+          sink: failingSink,
+        }),
+        new OnlineEvaluator({
+          evaluator: new AlwaysFail(),
+          onError: (_error, _context, evaluator, location) => {
+            calls.push(`fail-handler:${evaluator.getResultName()}:${location}`)
+          },
+          sink: failingSink,
+        }),
+      ],
+      target: 'shared-sink-target',
+    })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    // Both evaluators share one sink, so they are batched into a single submit call. Each still
+    // reports through the handler configured on it.
+    expect(calls).toEqual(['pass-handler:AlwaysPass:sink', 'fail-handler:AlwaysFail:sink'])
+  })
+
+  it('prefers the evaluator onError over the config one for a failing default sink', async () => {
+    const calls: string[] = []
+    const fn = withOnlineEvaluation(async () => 'x', {
+      emitOtelEvents: false,
+      evaluators: [
+        new OnlineEvaluator({
+          evaluator: new AlwaysPass(),
+          onError: (_error, _context, evaluator) => {
+            calls.push(`evaluator-handler:${evaluator.getResultName()}`)
+          },
+        }),
+        new OnlineEvaluator({ evaluator: new AlwaysFail() }),
+      ],
+      onError: (_error, _context, evaluator) => {
+        calls.push(`config-handler:${evaluator.getResultName()}`)
+      },
+      sink: (): void => {
+        throw new Error('sink is down')
+      },
+      target: 'default-sink-target',
+    })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    // The evaluator that configured a handler uses it; the one that did not falls back.
+    expect(calls).toEqual(['evaluator-handler:AlwaysPass', 'config-handler:AlwaysFail'])
+  })
+
   it('runs sampled online evaluators concurrently', async () => {
     let fastStarted = false
     class SlowOnlineEvaluator extends Evaluator {

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -432,25 +432,14 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
   const allFailures: EvaluatorFailureRecord[] = []
   const perEvaluatorSinks = new Map<
     EvaluationSink,
-    { evaluators: Evaluator[]; failures: EvaluatorFailureRecord[]; onError?: OnErrorCallback; results: EvaluationResultJson[] }
+    { failures: EvaluatorFailureRecord[]; results: EvaluationResultJson[]; targets: SinkTarget[] }
   >()
   for (const { ev, failures, results } of runs) {
     allResults.push(...results)
     allFailures.push(...failures)
     if (ev.sink !== undefined) {
-      let group = perEvaluatorSinks.get(ev.sink)
-      if (group === undefined) {
-        group = {
-          evaluators: [],
-          failures: [],
-          results: [],
-        }
-        const onError = ev.onError ?? args.userOptions.onError ?? args.cfg.onError
-        if (onError !== undefined) {
-          group.onError = onError
-        }
-      }
-      group.evaluators.push(ev.evaluator)
+      const group = perEvaluatorSinks.get(ev.sink) ?? { failures: [], results: [], targets: [] }
+      group.targets.push(sinkTarget(ev, args.userOptions, args.cfg))
       group.failures.push(...failures)
       group.results.push(...results)
       perEvaluatorSinks.set(ev.sink, group)
@@ -478,8 +467,7 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
           spanReference: args.callSpanRef,
           target: args.target,
         },
-        group.evaluators,
-        group.onError
+        group.targets
       )
     )
   }
@@ -494,8 +482,7 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
           spanReference: args.callSpanRef,
           target: args.target,
         },
-        args.sampledEvaluators.map((ev) => ev.evaluator),
-        args.userOptions.onError ?? args.cfg.onError
+        args.sampledEvaluators.map((ev) => sinkTarget(ev, args.userOptions, args.cfg))
       )
     )
   }
@@ -516,18 +503,26 @@ function processOutput(
   }
 }
 
-async function submitSink(
-  sink: EvaluationSink,
-  payload: SinkPayload,
-  evaluators: readonly Evaluator[],
+/** One evaluator in a sink's batch, with the error handler that evaluator resolves to. */
+interface SinkTarget {
+  evaluator: Evaluator
   onError: OnErrorCallback | undefined
-): Promise<void> {
+}
+
+function sinkTarget(ev: OnlineEvaluator, userOptions: WithOnlineOptions, cfg: OnlineEvalConfig): SinkTarget {
+  return { evaluator: ev.evaluator, onError: ev.onError ?? userOptions.onError ?? cfg.onError }
+}
+
+async function submitSink(sink: EvaluationSink, payload: SinkPayload, targets: readonly SinkTarget[]): Promise<void> {
   try {
     await sink(payload)
   } catch (err) {
-    for (const evaluator of evaluators) {
+    for (const target of targets) {
+      // Each evaluator reports through its own handler: evaluators sharing a sink are batched
+      // into one submit call, so resolving a single handler for the batch would drop the
+      // handlers configured on every evaluator but the first.
       // eslint-disable-next-line no-await-in-loop -- preserve deterministic onError ordering for sink failures.
-      await reportPipelineError(onError, err, payload.context, evaluator, 'sink')
+      await reportPipelineError(target.onError, err, payload.context, target.evaluator, 'sink')
     }
   }
 }


### PR DESCRIPTION
Evaluators that share a sink are batched into one `submit` call, and the batch resolves a single `onError` from whichever evaluator created the group. Every other evaluator's handler is dropped, and the first one's is called again in its place.

On `dbd68a7`, with two evaluators sharing a throwing sink and a different handler on each:

```
["first:AlwaysPass", "first:AlwaysFail"]
```

The second evaluator's handler never runs, and the first one is invoked for an evaluator it was not configured for. The default-sink path resolves the same way: `args.userOptions.onError ?? args.cfg.onError` for the whole batch, so an evaluator with its own handler and no sink of its own is reported through the config-level handler instead.

pydantic-evals resolves the handler per evaluator inside the group (`_online.py:398-409`, `online_eval.on_error if online_eval.on_error is not None else config.on_error`), with the docstring saying every handler represented in the group fires. This port kept the batching and collapsed the handler.

The fix carries an `{evaluator, onError}` pair per batch member instead of one handler for the batch. The per-evaluator call shape is unchanged: a shared handler still fires once per evaluator, rather than Python's dedupe by handler identity, since that is what this port has always done and the handler receives the evaluator as an argument.

Two regressions, one per path, each mutation-checked: collapsing the group back to a single handler fails the shared-sink case, and resolving only the config handler on the default-sink path fails the other. 591 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
