### PR TITLE
Guard OTel emission so one evaluator cannot drop the sinks

### DIFF
--- a/.changeset/online-emit-guard.md
+++ b/.changeset/online-emit-guard.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep online-evaluation sinks running when OTel emission fails for one evaluator. Emission ran unguarded before the sinks, so an evaluator whose spec could not be JSON-serialized threw out of the whole dispatch: the other evaluators' results never reached the sink, and the configured `onError` was never called because the dispatch promise is discarded.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -563,6 +563,41 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(logs).toHaveLength(0)
   })
 
+  it('keeps the sinks running when one evaluator cannot be emitted', async () => {
+    // `getSpec()` feeds `JSON.stringify` during emission, so a spec value that JSON cannot
+    // represent throws there. Emission runs before the sinks.
+    class BigIntSpecEvaluator extends Evaluator {
+      static override evaluatorName = 'BigIntSpecEvaluator'
+      evaluate(): boolean {
+        return true
+      }
+      override toJSON(): Record<string, unknown> {
+        return { threshold: 1n }
+      }
+    }
+    const sinkPayloads: SinkPayload[] = []
+    const errors: string[] = []
+    const fn = withOnlineEvaluation(async () => 'x', {
+      evaluators: [new OnlineEvaluator({ evaluator: new BigIntSpecEvaluator() }), new OnlineEvaluator({ evaluator: new AlwaysPass() })],
+      onError: (error, _context, evaluator, location) => {
+        errors.push(`${evaluator.getResultName()}:${location}:${(error as Error).constructor.name}`)
+      },
+      sink: (payload) => {
+        sinkPayloads.push(payload)
+      },
+      target: 'emit-failure-target',
+    })
+
+    await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    expect(errors).toEqual(['BigIntSpecEvaluator:sink:TypeError'])
+    expect(sinkPayloads).toHaveLength(1)
+    expect(sinkPayloads[0]?.results.map((result) => result.name).sort()).toEqual(['AlwaysPass', 'BigIntSpecEvaluator'])
+  })
+
   it('batches OnlineEvaluator sinks by sink identity', async () => {
     const sinkPayloads: SinkPayload[] = []
     const sharedSink = (payload: SinkPayload): void => {

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -458,11 +458,23 @@ async function dispatchEvaluators(args: DispatchArgs): Promise<void> {
   }
 
   if (emitOtel) {
-    for (const r of allResults) {
-      emitEvaluationResult(r, { baggageAttrs: args.baggageAttrs, parentSpanRef: args.callSpanRef, target: args.target })
-    }
-    for (const f of allFailures) {
-      emitEvaluatorFailure(f, { baggageAttrs: args.baggageAttrs, parentSpanRef: args.callSpanRef, target: args.target })
+    // Per evaluator and guarded: emission runs before the sinks, so an evaluator whose spec or
+    // result cannot be serialized would otherwise take the whole dispatch down with it and the
+    // sinks would never see the evaluators that did succeed. A failure is reported under the
+    // `sink` location, which is the one that means "delivering results downstream went wrong".
+    for (const { ev, failures, results } of runs) {
+      const emitOptions = { baggageAttrs: args.baggageAttrs, parentSpanRef: args.callSpanRef, target: args.target }
+      try {
+        for (const r of results) {
+          emitEvaluationResult(r, emitOptions)
+        }
+        for (const f of failures) {
+          emitEvaluatorFailure(f, emitOptions)
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-await-in-loop -- preserve deterministic onError ordering.
+        await reportPipelineError(ev.onError ?? args.userOptions.onError ?? args.cfg.onError, err, ctx, ev.evaluator, 'sink')
+      }
     }
   }
 


### PR DESCRIPTION
OTel event emission for online evaluations runs unguarded, and it runs before the sinks. `emitEvaluationResult` puts the evaluator's spec through `JSON.stringify`, so a spec value JSON cannot represent throws there, and the throw leaves `dispatchEvaluators` entirely. The dispatch promise is discarded with `.catch(() => undefined)`, so nothing is reported and nothing downstream runs.

On `dbd68a7`, with one evaluator whose `toJSON()` returns `{ threshold: 1n }` and a healthy evaluator alongside it, both feeding one sink:

```
sinkCalls=0 errors=[]
```

The healthy evaluator's results are gone too, and the configured `onError` never fires.

pydantic-evals emits per evaluator inside a `try`, and routes a failure to that evaluator's handler under the `sink` location, with a comment explaining that `sink` is the catch-all for "something went wrong delivering results downstream" (`_online.py:362-376`). The port kept the emission and dropped the guard.

The fix moves emission into the per-evaluator loop and wraps it, so one evaluator that cannot be emitted is reported and the rest of the dispatch continues. After it, the same case reports `BigIntSpecEvaluator:sink:TypeError` and the sink receives both evaluators' results.

Mutation-checked both halves: restoring the unguarded flat loops fails the regression, and swallowing the error instead of reporting it fails it too. 590 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
