### PR TITLE
fix: use exclusive bound in checkTraceIdRatio

### DIFF
--- a/.changeset/trace-id-ratio-exclusive.md
+++ b/.changeset/trace-id-ratio-exclusive.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Match OTel's exclusive TraceIdRatioBasedSampler bound in `checkTraceIdRatio`. An accumulation equal to `floor(rate * 0xffffffff)` was sampled; the spec comparison is `<`, so the 0.5 threshold ID `7fffffff` followed by 24 zeros is now dropped.

--- a/packages/logfire-api/src/PendingSpanProcessor.test.ts
+++ b/packages/logfire-api/src/PendingSpanProcessor.test.ts
@@ -241,7 +241,7 @@ describe('PendingSpanProcessor', () => {
     processor.onStart(
       makeSpan({
         attributes: { [ATTRIBUTES_SAMPLE_RATE_KEY]: 0.5, [ATTRIBUTES_SPAN_TYPE_KEY]: 'span' },
-        traceId: '7fffffff000000000000000000000000',
+        traceId: '7ffffffe000000000000000000000000',
       }),
       ROOT_CONTEXT
     )

--- a/packages/logfire-api/src/sampling.test.ts
+++ b/packages/logfire-api/src/sampling.test.ts
@@ -66,6 +66,13 @@ describe('checkTraceIdRatio', () => {
   test('all-zeros trace ID is always sampled at any positive rate', () => {
     expect(checkTraceIdRatio('00000000000000000000000000000000', 0.001)).toBe(true)
   })
+
+  test('matches OTel exclusive bound at the 0.5 threshold accumulation', () => {
+    // 7fffffff XOR remaining zeros = 2147483647 = floor(0.5 * 0xffffffff).
+    // OTel TraceIdRatioBasedSampler uses accumulation < upperBound, not <=.
+    expect(checkTraceIdRatio('7fffffff000000000000000000000000', 0.5)).toBe(false)
+    expect(checkTraceIdRatio('7ffffffe000000000000000000000000', 0.5)).toBe(true)
+  })
 })
 
 describe('levelOrDuration', () => {

--- a/packages/logfire-api/src/sampling.ts
+++ b/packages/logfire-api/src/sampling.ts
@@ -77,7 +77,7 @@ export function checkTraceIdRatio(traceId: string, rate: number): boolean {
   }
 
   const threshold = Math.floor(rate * 0xffffffff)
-  return accumulation <= threshold
+  return accumulation < threshold
 }
 
 /**


### PR DESCRIPTION
`checkTraceIdRatio` documented matching OTel `TraceIdRatioBasedSampler`, but the final comparison used `accumulation <= threshold` while OTel uses an exclusive `<` bound.

Trace ID `7fffffff` followed by 24 zeros accumulates to `floor(0.5 * 0xffffffff)` and was sampled at rate `0.5`; the OTel sampler drops it. Switch to `<` so the two agree.

Fixes #213