### PR TITLE
Forward forceFlush and shutdown to the deferred processor

### DIFF
--- a/.changeset/tail-deferred-lifecycle.md
+++ b/.changeset/tail-deferred-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Forward `forceFlush` and `shutdown` from `TailSamplingProcessor` to its deferred processor. The processor owns that instance, so nothing else flushes or shuts it down, and it was left running at shutdown.

--- a/packages/logfire-api/src/TailSamplingProcessor.ts
+++ b/packages/logfire-api/src/TailSamplingProcessor.ts
@@ -63,7 +63,9 @@ export class TailSamplingProcessor implements SpanProcessor {
   }
 
   async forceFlush(): Promise<void> {
-    return this.wrapped.forceFlush()
+    await this.wrapped.forceFlush()
+    // The deferred processor is owned by this one, so nothing else will flush it.
+    await this.deferredProcessor?.forceFlush()
   }
 
   onEnd(span: ReadableSpan): void {
@@ -140,7 +142,9 @@ export class TailSamplingProcessor implements SpanProcessor {
   async shutdown(): Promise<void> {
     this.buffers.clear()
     this.retainedAfterRoot.clear()
-    return this.wrapped.shutdown()
+    await this.wrapped.shutdown()
+    // Same ownership: without this the deferred processor is never shut down at all.
+    await this.deferredProcessor?.shutdown()
   }
 
   private retainAfterRoot(traceId: string): void {

--- a/packages/logfire-api/src/TailSamplingProcessor.ts
+++ b/packages/logfire-api/src/TailSamplingProcessor.ts
@@ -48,6 +48,30 @@ function hrTimeToSeconds(hrTime: HrTime): number {
  */
 const MAX_TRACES_RETAINED_AFTER_ROOT = 1000
 
+/**
+ * Run both lifecycle calls in order and report the first failure. Awaiting them in sequence would
+ * skip the second one whenever the first rejects, which is exactly when the deferred processor
+ * still needs the call.
+ */
+async function runBoth(first: () => Promise<void>, second: () => Promise<void>): Promise<void> {
+  let failure: unknown
+  try {
+    await first()
+  } catch (error) {
+    failure = error
+  }
+  try {
+    await second()
+  } catch (error) {
+    failure ??= error
+  }
+  if (failure !== undefined) {
+    // Rethrown as an error object, which is what a caller awaiting these methods expects. An
+    // error rejection is passed through untouched; anything else keeps its JSON form.
+    throw failure instanceof Error ? failure : new Error(JSON.stringify(failure))
+  }
+}
+
 export class TailSamplingProcessor implements SpanProcessor {
   private readonly buffers = new Map<string, TraceBuffer>()
   /** Traces still held after their root ended, in insertion order for eviction. */
@@ -63,9 +87,13 @@ export class TailSamplingProcessor implements SpanProcessor {
   }
 
   async forceFlush(): Promise<void> {
-    await this.wrapped.forceFlush()
-    // The deferred processor is owned by this one, so nothing else will flush it.
-    await this.deferredProcessor?.forceFlush()
+    // The deferred processor is owned by this one, so nothing else will flush it. Both run even
+    // if the first rejects, since a wrapped processor that fails to flush is exactly when the
+    // deferred one still needs to.
+    await runBoth(
+      async () => this.wrapped.forceFlush(),
+      async () => this.deferredProcessor?.forceFlush()
+    )
   }
 
   onEnd(span: ReadableSpan): void {
@@ -142,9 +170,12 @@ export class TailSamplingProcessor implements SpanProcessor {
   async shutdown(): Promise<void> {
     this.buffers.clear()
     this.retainedAfterRoot.clear()
-    await this.wrapped.shutdown()
-    // Same ownership: without this the deferred processor is never shut down at all.
-    await this.deferredProcessor?.shutdown()
+    // Same ownership, and the same reason to run both: without this the deferred processor is
+    // never shut down at all.
+    await runBoth(
+      async () => this.wrapped.shutdown(),
+      async () => this.deferredProcessor?.shutdown()
+    )
   }
 
   private retainAfterRoot(traceId: string): void {

--- a/packages/logfire-api/src/sampling.test.ts
+++ b/packages/logfire-api/src/sampling.test.ts
@@ -799,6 +799,24 @@ describe('TailSamplingProcessor', () => {
     expect(downstream.shutdown).toHaveBeenCalledTimes(1)
   })
 
+  test('still reaches the deferred processor when the wrapped one rejects', async () => {
+    const downstream = makeProcessor()
+    const flushFailure = new Error('flush failed')
+    const shutdownFailure = new Error('shutdown failed')
+    vi.mocked(downstream.forceFlush).mockRejectedValueOnce(flushFailure)
+    vi.mocked(downstream.shutdown).mockRejectedValueOnce(shutdownFailure)
+    const deferred = makeProcessor()
+    const processor = new TailSamplingProcessor(downstream, () => 1.0, { deferredProcessor: deferred })
+
+    // A wrapped processor that cannot flush is exactly when the deferred one still has to, and
+    // the failure is still reported rather than swallowed.
+    await expect(processor.forceFlush()).rejects.toBe(flushFailure)
+    expect(deferred.forceFlush).toHaveBeenCalledTimes(1)
+
+    await expect(processor.shutdown()).rejects.toBe(shutdownFailure)
+    expect(deferred.shutdown).toHaveBeenCalledTimes(1)
+  })
+
   test('shutdown with deferred pending processor does not double-shutdown the wrapped processor', async () => {
     const downstream = makeProcessor()
     const processor = new TailSamplingProcessor(downstream, () => 0.0, {

--- a/packages/logfire-api/src/sampling.test.ts
+++ b/packages/logfire-api/src/sampling.test.ts
@@ -783,6 +783,22 @@ describe('TailSamplingProcessor', () => {
     expect(downstream.shutdown).toHaveBeenCalled()
   })
 
+  test('forwards forceFlush and shutdown to the deferred processor', async () => {
+    const downstream = makeProcessor()
+    const deferred = makeProcessor()
+    const processor = new TailSamplingProcessor(downstream, () => 1.0, { deferredProcessor: deferred })
+
+    await processor.forceFlush()
+    await processor.shutdown()
+
+    // This processor owns the deferred one, so nothing else can flush or shut it down.
+    expect(deferred.forceFlush).toHaveBeenCalledTimes(1)
+    expect(deferred.shutdown).toHaveBeenCalledTimes(1)
+    // The wrapped processor is still called exactly once for each.
+    expect(downstream.forceFlush).toHaveBeenCalledTimes(1)
+    expect(downstream.shutdown).toHaveBeenCalledTimes(1)
+  })
+
   test('shutdown with deferred pending processor does not double-shutdown the wrapped processor', async () => {
     const downstream = makeProcessor()
     const processor = new TailSamplingProcessor(downstream, () => 0.0, {


### PR DESCRIPTION
`TailSamplingProcessor` constructs nothing but owns the deferred processor it is handed, and it never flushes or shuts it down:

```ts
async forceFlush(): Promise<void> {
  return this.wrapped.forceFlush()
}

async shutdown(): Promise<void> {
  this.buffers.clear()
  this.retainedAfterRoot.clear()
  return this.wrapped.shutdown()
}
```

Nothing else holds that reference. In `logfire-node/src/sdk.ts` the `PendingSpanProcessor` is passed straight into the constructor and is not registered with the provider, so when the SDK shuts down, the deferred processor never hears about it.

Python forwards both (`logfire/sampling/_tail_sampling.py:277-292`), calling the main processor first and then the deferred one.

Today this is a contract gap rather than a live bug: `PendingSpanProcessor.forceFlush` and `.shutdown` both just resolve. It bites the first deferred processor that has real work to finish, and the fix is two lines.

The existing "does not double-flush the wrapped processor" tests still hold, because `PendingSpanProcessor` does not delegate either call to the processor it wraps. The new test asserts that with a plain spy as the deferred processor: one call each on both sides.

Both forwards are mutation-checked, each fails the new assertion on its own. This is the third item from #242, the one with no dependency on the other two. 605 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
