### PR TITLE
Reject an unrecognised boolean environment value

### DIFF
--- a/.changeset/env-boolean-strict.md
+++ b/.changeset/env-boolean-strict.md
@@ -2,4 +2,4 @@
 'logfire': patch
 ---
 
-Reject a boolean environment variable whose value is neither a true nor a false spelling, instead of reading it as false. `LOGFIRE_DISTRIBUTED_TRACING=yes` silently turned distributed tracing off, and `LOGFIRE_CONSOLE=on` silently turned the console off, because anything unrecognised fell through to the false branch. Both now fail with the value in the message, matching `_check_bool` in the Python SDK, and `0`/`f`/`false` are recognised explicitly.
+Reject an environment value that is neither a recognised boolean nor, for `LOGFIRE_SEND_TO_LOGFIRE`, the `if-token-present` sentinel, instead of guessing. `LOGFIRE_DISTRIBUTED_TRACING=yes` silently turned distributed tracing off and `LOGFIRE_CONSOLE=on` silently turned the console off, because anything unrecognised fell through to false; `LOGFIRE_SEND_TO_LOGFIRE=yes` fell through to `Boolean()` and turned sending on. All three now fail with the variable name and the value, matching `_check_bool` in the Python SDK. Unset and blank values keep their current meaning.

--- a/.changeset/env-boolean-strict.md
+++ b/.changeset/env-boolean-strict.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Reject a boolean environment variable whose value is neither a true nor a false spelling, instead of reading it as false. `LOGFIRE_DISTRIBUTED_TRACING=yes` silently turned distributed tracing off, and `LOGFIRE_CONSOLE=on` silently turned the console off, because anything unrecognised fell through to the false branch. Both now fail with the value in the message, matching `_check_bool` in the Python SDK, and `0`/`f`/`false` are recognised explicitly.

--- a/packages/logfire-api/src/logfireApiConfig.test.ts
+++ b/packages/logfire-api/src/logfireApiConfig.test.ts
@@ -36,6 +36,18 @@ test('resolves staging base urls from the token', () => {
   expect(resolveBaseUrl({}, undefined, 'pylf_v1_stagingeu_1234567890')).toBe('https://logfire-eu.pydantic.info')
 })
 
+test('rejects a LOGFIRE_SEND_TO_LOGFIRE value that is neither a boolean nor the sentinel', () => {
+  const token = 'pylf_v1_us_token'
+
+  // `Boolean('yes')` is true, so a typo used to turn sending on rather than being reported.
+  expect(() => resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'yes' }, undefined, token)).toThrow(
+    `Expected LOGFIRE_SEND_TO_LOGFIRE to be a boolean or 'if-token-present', got "yes"`
+  )
+  // A boolean passed in code still resolves without touching the env var.
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'yes' }, false, token)).toBe(false)
+  expect(resolveSendToLogfire({ LOGFIRE_SEND_TO_LOGFIRE: 'yes' }, true, undefined)).toBe(true)
+})
+
 test('reads LOGFIRE_SEND_TO_LOGFIRE=false as disabled', () => {
   const token = 'pylf_v1_us_1234567890'
 

--- a/packages/logfire-api/src/logfireApiConfig.ts
+++ b/packages/logfire-api/src/logfireApiConfig.ts
@@ -160,7 +160,16 @@ export function resolveSendToLogfire(env: Env, option: SendToLogfire, token: str
   if (sendToLogfireConfig === 'true' || sendToLogfireConfig === 't' || sendToLogfireConfig === '1') {
     return true
   }
-  return Boolean(sendToLogfireConfig)
+  if (typeof sendToLogfireConfig === 'boolean') {
+    return sendToLogfireConfig
+  }
+  // A blank value keeps its existing meaning: nothing was configured, so nothing is sent.
+  if (sendToLogfireConfig === '') {
+    return false
+  }
+  // Any other unrecognised string is a typo. `Boolean('yes')` is true, so guessing here turns
+  // sending ON for a value the user may have meant as off. Python raises instead.
+  throw new Error(`Expected LOGFIRE_SEND_TO_LOGFIRE to be a boolean or 'if-token-present', got ${JSON.stringify(configured)}`)
 }
 
 export function resolveBaseUrl(env: Env, passedUrl: string | undefined, token: string): string {

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -40,6 +40,7 @@ describe('logfire config', () => {
     delete process.env['OTEL_SERVICE_VERSION']
     delete process.env['LOGFIRE_TOKEN']
     delete process.env['LOGFIRE_CREDENTIALS_DIR']
+    delete process.env['LOGFIRE_DISTRIBUTED_TRACING']
     configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     await shutdownVariables()
   })
@@ -298,12 +299,24 @@ describe('logfire config', () => {
     }
   })
 
-  it('does not parse LOGFIRE_CONSOLE as object-style console config', () => {
-    process.env['LOGFIRE_CONSOLE'] = '{"enabled":true}'
+  it('rejects LOGFIRE_CONSOLE values that are not booleans, including object-style config', () => {
+    const value = '{"enabled":true}'
+    process.env['LOGFIRE_CONSOLE'] = value
 
-    configure()
+    // Object-style console config is still not supported through the env var. It now says so
+    // rather than resolving to `false`, which reads as "console deliberately off".
+    expect(() => {
+      configure()
+    }).toThrow(`Expected LOGFIRE_CONSOLE to be a boolean, got ${JSON.stringify(value)}`)
+  })
 
-    expect(logfireConfig.console).toBe(false)
+  it('rejects a LOGFIRE_DISTRIBUTED_TRACING value that is not a boolean', () => {
+    // The default is on, so a typo used to turn distributed tracing off without a word.
+    process.env['LOGFIRE_DISTRIBUTED_TRACING'] = 'yes'
+
+    expect(() => {
+      configure()
+    }).toThrow('Expected LOGFIRE_DISTRIBUTED_TRACING to be a boolean, got "yes"')
   })
 
   it('passes baggage span attributes config to the shared API', () => {

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -189,12 +189,22 @@ const DEFAULT_AUTO_INSTRUMENTATION_CONFIG: InstrumentationConfigMap = {
 
 /**
  * Recognise the boolean spellings the Python SDK accepts. `_check_bool` in `config_params.py`
- * lowercases and takes `1`/`true`/`t`, so `LOGFIRE_DISTRIBUTED_TRACING=TRUE` has to mean the same
- * thing here. Anything unrecognised stays falsy, as it was before.
+ * lowercases and takes `1`/`true`/`t` and `0`/`false`/`f`, and raises on anything else rather
+ * than guessing, because a value nobody recognises is a typo and silently picking a side hides
+ * it. An unset variable keeps its previous meaning here.
  */
-function parseBooleanEnv(value: string | undefined): boolean {
+function parseBooleanEnv(value: string | undefined, name: string): boolean {
   const normalized = value?.trim().toLowerCase()
-  return normalized === '1' || normalized === 't' || normalized === 'true'
+  if (normalized === undefined || normalized === '') {
+    return false
+  }
+  if (normalized === '1' || normalized === 't' || normalized === 'true') {
+    return true
+  }
+  if (normalized === '0' || normalized === 'f' || normalized === 'false') {
+    return false
+  }
+  throw new Error(`Expected ${name} to be a boolean, got ${JSON.stringify(value)}`)
 }
 
 function readNonEmptyEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
@@ -282,7 +292,7 @@ export function configure(config: LogfireConfigOptions = {}): void {
 
   const env = process.env
   const envMinLevel = env['LOGFIRE_MIN_LEVEL']
-  const console = 'console' in cnf ? cnf.console : parseBooleanEnv(env['LOGFIRE_CONSOLE'])
+  const console = 'console' in cnf ? cnf.console : parseBooleanEnv(env['LOGFIRE_CONSOLE'], 'LOGFIRE_CONSOLE')
   const shouldReadLocalCredentials =
     cnf.token === undefined && readNonEmptyEnv(env, 'LOGFIRE_TOKEN') === undefined && cnf.sendToLogfire !== false
 
@@ -465,7 +475,7 @@ function resolveDistributedTracing(option: LogfireConfigOptions['distributedTrac
   }
   const envDistributedTracing = readNonEmptyEnv(process.env, 'LOGFIRE_DISTRIBUTED_TRACING')
   if (envDistributedTracing !== undefined) {
-    return parseBooleanEnv(envDistributedTracing)
+    return parseBooleanEnv(envDistributedTracing, 'LOGFIRE_DISTRIBUTED_TRACING')
   }
   return true
 }


### PR DESCRIPTION
`parseBooleanEnv` treats every value it does not recognise as false:

```ts
function parseBooleanEnv(value: string | undefined): boolean {
  const normalized = value?.trim().toLowerCase()
  return normalized === '1' || normalized === 't' || normalized === 'true'
}
```

So a typo picks a side silently, and for `LOGFIRE_DISTRIBUTED_TRACING` it picks the opposite of the default:

| value | today | intent |
| --- | --- | --- |
| `LOGFIRE_DISTRIBUTED_TRACING=yes` | distributed tracing off | on, and the user was trying to say so |
| `LOGFIRE_CONSOLE=on` | console off | on |
| `LOGFIRE_CONSOLE=ture` | console off | on |

Python does not guess. `_check_bool` in `config_params.py:250-260` takes `1`/`true`/`t` and `0`/`false`/`f`, and raises `LogfireConfigError` naming the value for anything else.

This does the same: the false spellings are recognised explicitly, and an unrecognised value throws with the variable name and the value. An unset or empty variable keeps its current meaning.

One behaviour change worth calling out. `LOGFIRE_CONSOLE={"enabled":true}` used to resolve to `false`, and there was a test pinning that. Object-style console config through the env var is still unsupported, so I kept the test and changed what it asserts: it now expects the error rather than a silent `false`, which read as "console deliberately off". If you would rather warn than throw on an unrecognised value, say so and I will switch it; throwing is what Python does, which is why I started there.

Each call site is mutation-checked separately, and reverting the parser to the silent-false version fails both new tests. 112 node tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
