### PR TITLE
Reject a non-positive OnlineEvaluator maxConcurrency

### DIFF
--- a/.changeset/online-max-concurrency.md
+++ b/.changeset/online-max-concurrency.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Reject a non-positive or fractional `maxConcurrency` on `OnlineEvaluator`. A limit of `0` built a semaphore with no permits, so the evaluator never ran, every attempt was reported as hitting the concurrency limit, and the sink still received a payload with no results. `Dataset.evaluate` already rejects the same value.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -621,6 +621,17 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(sinkPayloads[0]?.results.map((result) => result.name).sort()).toEqual(['AlwaysFail', 'AlwaysPass'])
   })
 
+  it('rejects a non-positive or fractional maxConcurrency', () => {
+    // A zero or negative limit builds a semaphore that never admits the evaluator, so the
+    // evaluator silently never runs and the sink still receives an empty payload.
+    for (const maxConcurrency of [0, -3, 1.5]) {
+      expect(() => new OnlineEvaluator({ evaluator: new AlwaysPass(), maxConcurrency })).toThrow(
+        `OnlineEvaluator: maxConcurrency must be a positive integer (got ${String(maxConcurrency)})`
+      )
+    }
+    expect(new OnlineEvaluator({ evaluator: new AlwaysPass(), maxConcurrency: 1 }).name).toBe('AlwaysPass')
+  })
+
   it('reports a sink failure through the onError configured on each evaluator', async () => {
     const calls: string[] = []
     const failingSink = (): void => {

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -119,6 +119,11 @@ export class OnlineEvaluator {
   private readonly onMaxConcurrency?: OnMaxConcurrencyCallback
 
   constructor(opts: OnlineEvaluatorOptions) {
+    if (opts.maxConcurrency !== undefined && (!Number.isInteger(opts.maxConcurrency) || opts.maxConcurrency < 1)) {
+      // A semaphore with no permits never lets the evaluator run, and `tryAcquire` reports that
+      // as "at capacity" on every call, so the misconfiguration reads as a busy pipeline.
+      throw new Error(`OnlineEvaluator: maxConcurrency must be a positive integer (got ${String(opts.maxConcurrency)})`)
+    }
     this.inner = opts.evaluator
     this.maxConcurrencySem = new Semaphore(opts.maxConcurrency ?? 10)
     if (opts.onError !== undefined) {


### PR DESCRIPTION
`OnlineEvaluator` passes `maxConcurrency` straight into a semaphore without checking it:

```ts
this.maxConcurrencySem = new Semaphore(opts.maxConcurrency ?? 10)
```

A semaphore built with zero permits never admits anything, so `tryAcquire()` returns null on every call and the evaluator is skipped for the life of the process. It does not look like a misconfiguration from the outside: each attempt takes the "at capacity" path, and the sink still receives a payload, just with no results in it.

On `6d98c9b`:

```
maxConcurrency: 0  -> evaluator ran 0 times; sink payloads: 1
maxConcurrency: -3 -> evaluator ran 0 times
```

`Dataset.evaluate` already rejects the same value on the offline path (`Dataset.ts:136`), and pydantic-evals added the equivalent guard to `OnlineEvaluator.__post_init__` in #6267, so this is the one place left where a positive integer is assumed rather than required.

The guard matches the offline message, and rejects a fractional limit for the same reason: `new Semaphore(1.5)` admits one caller and then leaves a permanent fractional permit that never admits a second.

Three mutations, each failing the new assertion on its own: dropping the guard, allowing zero, and allowing fractions. 605 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
