### PR TITLE
Record an absolute schema path relative to the dataset file

### DIFF
--- a/.changeset/dataset-absolute-schema-path.md
+++ b/.changeset/dataset-absolute-schema-path.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Record an absolute `schemaPath` relative to the dataset file in `Dataset.toFile`. The absolute path was written verbatim into `$schema` and into the `yaml-language-server` comment, so a dataset committed from one machine pointed at a directory that exists nowhere else and the schema silently stopped resolving. A path outside the dataset's own directory is still written as given.

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -669,12 +669,13 @@ function resolveSiblingPath(filePath: string, siblingPath: string): string {
 }
 
 /**
- * The `$schema` value to record inside the dataset. An absolute path under the dataset's own
- * directory becomes relative to it, so a committed dataset does not carry the writer's machine
- * layout; anything else is kept as given. Mirrors `Dataset.to_file` in pydantic-evals.
+ * The `$schema` value to record inside the dataset. A path under the dataset's own directory
+ * becomes relative to it, so a committed dataset does not carry the writer's machine layout.
+ * Anything else, including a URL and a path on another drive, is kept as given. Mirrors
+ * `Dataset.to_file` in pydantic-evals.
  */
 function schemaReference(filePath: string, schemaPath: string): string {
-  if (!isRooted(schemaPath) || /^[a-zA-Z][a-zA-Z\d+.-]*:/u.test(schemaPath)) {
+  if (!isRooted(schemaPath)) {
     return schemaPath
   }
   const { dir, sep } = directoryOf(filePath)

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -308,9 +308,11 @@ export class Dataset<Inputs = unknown, Output = unknown, Metadata = unknown> {
       throw new Error('Dataset.toFile is only supported on Node, Bun, and Deno (no filesystem in browser/CF Workers)')
     }
     const format: 'json' | 'yaml' = filePath.endsWith('.json') ? 'json' : 'yaml'
-    const text = this.toText(format, opts)
-    const finalText =
-      format === 'yaml' && opts.schemaPath !== undefined ? `# yaml-language-server: $schema=${opts.schemaPath}\n${text}` : text
+    // The schema is written where the caller asked, but the reference recorded inside the
+    // dataset is relative whenever it can be, so the file stays readable on another machine.
+    const reference = opts.schemaPath === undefined ? undefined : schemaReference(filePath, opts.schemaPath)
+    const text = this.toText(format, reference === undefined ? opts : { ...opts, schemaPath: reference })
+    const finalText = format === 'yaml' && reference !== undefined ? `# yaml-language-server: $schema=${reference}\n${text}` : text
     await writeTextFile(filePath, finalText)
     if (opts.schemaPath !== undefined) {
       const schemaText = `${JSON.stringify(this.jsonSchema(), null, 2)}\n`
@@ -659,14 +661,36 @@ function fileStem(filePath: string): string {
 }
 
 function resolveSiblingPath(filePath: string, siblingPath: string): string {
-  if (/^(?:[a-zA-Z]:[\\/]|[\\/]|[a-zA-Z][a-zA-Z\d+.-]*:)/u.test(siblingPath)) {
+  if (isRooted(siblingPath)) {
     return siblingPath
   }
+  const { dir, sep } = directoryOf(filePath)
+  return dir === '.' ? siblingPath : `${dir}${sep}${siblingPath}`
+}
+
+/**
+ * The `$schema` value to record inside the dataset. An absolute path under the dataset's own
+ * directory becomes relative to it, so a committed dataset does not carry the writer's machine
+ * layout; anything else is kept as given. Mirrors `Dataset.to_file` in pydantic-evals.
+ */
+function schemaReference(filePath: string, schemaPath: string): string {
+  if (!isRooted(schemaPath) || /^[a-zA-Z][a-zA-Z\d+.-]*:/u.test(schemaPath)) {
+    return schemaPath
+  }
+  const { dir, sep } = directoryOf(filePath)
+  const prefix = dir === '.' ? '' : `${dir}${sep}`
+  return prefix !== '' && schemaPath.startsWith(prefix) ? schemaPath.slice(prefix.length) : schemaPath
+}
+
+function isRooted(path: string): boolean {
+  return /^(?:[a-zA-Z]:[\\/]|[\\/]|[a-zA-Z][a-zA-Z\d+.-]*:)/u.test(path)
+}
+
+function directoryOf(filePath: string): { dir: string; sep: string } {
   const trimmed = filePath.replace(/[\\/]+$/u, '')
   const sep = trimmed.includes('\\') ? '\\' : '/'
   const lastSep = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
-  const dir = lastSep === -1 ? '.' : trimmed.slice(0, lastSep)
-  return dir === '.' ? siblingPath : `${dir}${sep}${siblingPath}`
+  return { dir: lastSep === -1 ? '.' : trimmed.slice(0, lastSep), sep }
 }
 
 async function runLifecycleTeardown<Inputs, Output, Metadata>(

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -606,6 +606,40 @@ describe('Dataset YAML round-trip', () => {
     }
   })
 
+  it('records an absolute schemaPath relative to the dataset file', async () => {
+    const ds = new Dataset({ cases: [new Case({ inputs: { v: 1 }, name: 'tmp' })], name: 'file-test' })
+    const fs = await import('node:fs/promises')
+    const os = await import('node:os')
+    const path = await import('node:path')
+    const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'logfire-evals-abs-schema-'))
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'logfire-evals-elsewhere-'))
+    try {
+      // Absolute and next to the dataset: the file records the bare name, so the dataset is
+      // still readable after it is committed and opened somewhere else.
+      const insidePath = path.join(tmpdir, 'dataset.schema.json')
+      const yamlPath = path.join(tmpdir, 'dataset.yaml')
+      await ds.toFile(yamlPath, { schemaPath: insidePath })
+      expect((await fs.readFile(yamlPath, 'utf8')).split('\n')[0]).toBe('# yaml-language-server: $schema=dataset.schema.json')
+      const insideSchema = JSON.parse(await fs.readFile(insidePath, 'utf8')) as { title: string }
+      expect(insideSchema.title).toBe('PydanticEvalsDataset')
+
+      const jsonPath = path.join(tmpdir, 'dataset.json')
+      await ds.toFile(jsonPath, { schemaPath: insidePath })
+      const written = JSON.parse(await fs.readFile(jsonPath, 'utf8')) as { $schema: string }
+      expect(written.$schema).toBe('dataset.schema.json')
+
+      // Absolute and somewhere else: there is no relative form to prefer, so it is kept.
+      const outsidePath = path.join(outsideDir, 'shared.schema.json')
+      await ds.toFile(yamlPath, { schemaPath: outsidePath })
+      expect((await fs.readFile(yamlPath, 'utf8')).split('\n')[0]).toBe(`# yaml-language-server: $schema=${outsidePath}`)
+      const outsideSchema = JSON.parse(await fs.readFile(outsidePath, 'utf8')) as { title: string }
+      expect(outsideSchema.title).toBe('PydanticEvalsDataset')
+    } finally {
+      await fs.rm(tmpdir, { force: true, recursive: true })
+      await fs.rm(outsideDir, { force: true, recursive: true })
+    }
+  })
+
   it('prefers Deno readTextFile/writeTextFile helpers when present', async () => {
     const originalDeno = (globalThis as { Deno?: unknown }).Deno
     const files = new Map<string, string>()

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -640,6 +640,39 @@ describe('Dataset YAML round-trip', () => {
     }
   })
 
+  it('records a Windows drive-letter schema path relative to the dataset file', async () => {
+    // Driven through the Deno stub so the paths stay strings and the test runs anywhere. A drive
+    // letter looks like a URI scheme, which is what kept it out of the relative-reference path.
+    const originalDeno = (globalThis as { Deno?: unknown }).Deno
+    const files = new Map<string, string>()
+    ;(globalThis as { Deno?: unknown }).Deno = {
+      readTextFile: async (path: string) => {
+        const text = files.get(path)
+        return text === undefined ? Promise.reject(new Error(`missing ${path}`)) : Promise.resolve(text)
+      },
+      writeTextFile: async (path: string, text: string) => {
+        files.set(path, text)
+        return Promise.resolve()
+      },
+    }
+
+    try {
+      const ds = new Dataset({ cases: [new Case({ inputs: { v: 1 }, name: 'tmp' })], name: 'win-file-test' })
+      await ds.toFile('C:\\data\\dataset.yaml', { schemaPath: 'C:\\data\\dataset.schema.json' })
+
+      expect(files.get('C:\\data\\dataset.yaml')?.split('\n')[0]).toBe('# yaml-language-server: $schema=dataset.schema.json')
+      expect(files.has('C:\\data\\dataset.schema.json')).toBe(true)
+
+      // A real URI is still recorded as given.
+      await ds.toFile('C:\\data\\dataset.yaml', { schemaPath: 'https://example.com/dataset.schema.json' })
+      expect(files.get('C:\\data\\dataset.yaml')?.split('\n')[0]).toBe(
+        '# yaml-language-server: $schema=https://example.com/dataset.schema.json'
+      )
+    } finally {
+      ;(globalThis as { Deno?: unknown }).Deno = originalDeno
+    }
+  })
+
   it('prefers Deno readTextFile/writeTextFile helpers when present', async () => {
     const originalDeno = (globalThis as { Deno?: unknown }).Deno
     const files = new Map<string, string>()


### PR DESCRIPTION
`Dataset.toFile` writes the schema file wherever the caller asked, but records the option verbatim as the reference inside the dataset. With an absolute `schemaPath`, that reference is an absolute path from the writer's machine.

On `6d98c9b`, writing into a temp directory:

```
# yaml-language-server: $schema=/var/folders/vy/.../T/ds-r6d6D0/cases_schema.json
"$schema": "/var/folders/vy/.../T/ds-r6d6D0/cases_schema.json"
```

The sidecar itself lands correctly, so nothing fails at write time. The cost appears later: commit that dataset, open it anywhere else, and the language server resolves the schema to a directory that does not exist, silently losing validation and completion for the file the schema was generated for.

pydantic-evals hit the same thing and fixed it in #6143: when the schema path is absolute and sits under the dataset file's own directory, the recorded reference is made relative to that directory, and anything outside it is kept as given.

This does the same. The sidecar is still written to the absolute location; only the reference changes, and only when a relative form exists:

```
# yaml-language-server: $schema=cases_schema.json
"$schema": "cases_schema.json"
```

A relative `schemaPath` and a URL are untouched, and the existing idempotent-sidecar test still passes unchanged.

Two mutations, each failing the new assertion: recording the raw option again, and stripping to the basename unconditionally, which would rewrite an unrelated absolute path into a sibling that is not there. 605 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
