### PR TITLE
Keep an evaluator result named like an Object.prototype member

### DIFF
--- a/.changeset/evaluator-result-proto-name.md
+++ b/.changeset/evaluator-result-proto-name.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep an evaluator result whose name collides with `Object.prototype`. The duplicate-name check read the bucket with `existing[name]`, which finds the inherited member, so a result named `toString` or `__proto__` looked like a repeat and was renamed to `toString_2`, and writing a genuine `__proto__` name ran the inherited setter instead of storing the result. The check now uses `Object.hasOwn` and the write defines an own property.

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -191,6 +191,39 @@ describe('offline evals — span attribute parity', () => {
     expect(result.cases[0]?.assertions['duplicate_2']?.value).toBe(false)
   })
 
+  it('keeps a result name that collides with Object.prototype', async () => {
+    class PrototypeNamedEvaluator extends Evaluator {
+      static override evaluatorName = 'PrototypeNamedEvaluator'
+      evaluate(): Record<string, number> {
+        // `fromEntries` is how a real result map ends up with an own `__proto__` key, the same
+        // way `JSON.parse` does; an object literal would set the prototype instead.
+        return Object.fromEntries([
+          ['__proto__', 0.9],
+          ['toString', 0.5],
+        ]) as Record<string, number>
+      }
+    }
+
+    const dataset = new Dataset<string, string>({
+      cases: [new Case<string, string>({ inputs: 'x', name: 'case' })],
+      evaluators: [new PrototypeNamedEvaluator()],
+      name: 'prototype-names',
+    })
+
+    const { result } = await withMemoryExporter(async () => dataset.evaluate((input) => input))
+
+    const scores = result.cases[0]?.scores ?? {}
+    // Reading these names off a plain object finds `Object.prototype`, so the collision check saw
+    // them as taken and renamed them, and the write ran the inherited `__proto__` setter.
+    // Read through a variable: a literal `scores.toString` would resolve to the inherited method
+    // rather than the recorded score.
+    const scoreValue = (name: string): unknown => scores[name]?.value
+    expect(Object.keys(scores).sort()).toEqual(['__proto__', 'toString'])
+    expect(scoreValue('__proto__')).toBe(0.9)
+    expect(scoreValue('toString')).toBe(0.5)
+    expect(Object.getPrototypeOf(scores)).toBe(Object.prototype)
+  })
+
   it('treats a result map containing a value key as a map, not as a single reason', async () => {
     class MapWithValueKey extends Evaluator {
       static override evaluatorName = 'MapWithValueKey'

--- a/packages/logfire-api/src/evals/runEvaluators.ts
+++ b/packages/logfire-api/src/evals/runEvaluators.ts
@@ -65,25 +65,27 @@ export async function runEvaluators(
 }
 
 function place(out: RunEvaluatorsResult, result: EvaluationResultJson): void {
-  if (typeof result.value === 'boolean') {
-    const name = nextResultName(out.assertions, result.name)
-    out.assertions[name] = { ...result, name }
-  } else if (typeof result.value === 'number') {
-    const name = nextResultName(out.scores, result.name)
-    out.scores[name] = { ...result, name }
-  } else {
-    const name = nextResultName(out.labels, result.name)
-    out.labels[name] = { ...result, name }
-  }
+  const bucket = typeof result.value === 'boolean' ? out.assertions : typeof result.value === 'number' ? out.scores : out.labels
+  const name = nextResultName(bucket, result.name)
+  setResult(bucket, name, { ...result, name })
 }
 
+/**
+ * Result names come from evaluators, so they can collide with `Object.prototype`. `hasOwn` keeps
+ * a name like `toString` or `__proto__` from looking like an existing result, and `defineProperty`
+ * stores it as an own property instead of running the inherited `__proto__` setter.
+ */
 function nextResultName(existing: Record<string, EvaluationResultJson>, baseName: string): string {
-  if (existing[baseName] === undefined) {
+  if (!Object.hasOwn(existing, baseName)) {
     return baseName
   }
   let i = 2
-  while (existing[`${baseName}_${i.toString()}`] !== undefined) {
+  while (Object.hasOwn(existing, `${baseName}_${i.toString()}`)) {
     i++
   }
   return `${baseName}_${i.toString()}`
+}
+
+function setResult(bucket: Record<string, EvaluationResultJson>, name: string, result: EvaluationResultJson): void {
+  Object.defineProperty(bucket, name, { configurable: true, enumerable: true, value: result, writable: true })
 }


### PR DESCRIPTION
Evaluator result names are user-supplied, and `runEvaluators` treats the result bucket as if it had no prototype:

```ts
function nextResultName(existing: Record<string, EvaluationResultJson>, baseName: string): string {
  if (existing[baseName] === undefined) {
    return baseName
  }
  ...
}
```

`existing['toString']` finds the inherited method, so the name reads as already taken. On `6d98c9b`, an evaluator returning `{ __proto__: 0.9, ok: 1 }` as a result map:

```
case scores keys: [ '__proto___2', 'ok' ]
```

The score is reported under a name no evaluator declared, and the same happens to `toString`, `constructor`, `valueOf` and the rest. Fixing only the lookup is not enough: the write is `out.scores[name] = ...`, so a genuine `__proto__` name would then run the inherited setter and the result would vanish instead.

So this changes both halves. The collision check uses `Object.hasOwn`, matching the reasoning in #252, and the write uses `defineProperty` so the entry is stored as an own property. The three near-identical branches collapse into one while I am there, since only the bucket differed.

The regression uses `Object.fromEntries` to build the result map, which is how a real one ends up with an own `__proto__` key, an object literal would set the prototype instead. Both halves are mutation-checked: restoring the `undefined` lookup and restoring the plain assignment each fail it.

One note on the test, since it looks odd: the scores are read through a helper rather than as `scores.toString`, because the linter rewrites the index form to dot notation and that resolves to the inherited method rather than the recorded score. 605 tests green, preflight and `pnpm run check` clean.

Built this with Claude Code's help and reviewed the diff myself.
