### PR TITLE
Restore the data directory gitignore after logfire clean

### DIFF
--- a/.changeset/gitignore-after-clean.md
+++ b/.changeset/gitignore-after-clean.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Restore the data directory's `.gitignore` when credentials are written after `logfire clean`. The rule was only seeded when the directory was created, so re-authenticating into a directory that `clean` had emptied wrote `logfire_credentials.json` with no ignore rule covering it. A directory holding anything besides the files Logfire writes itself is still left alone.

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -106,6 +106,39 @@ token = "ignored"
     expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('node_modules\n')
   })
 
+  it('restores .gitignore when credentials are written after logfire clean', () => {
+    const dir = join(makeTmpDir(), '.logfire')
+    const credentials = {
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'myproject',
+      project_url: 'https://logfire.pydantic.dev/org/myproject',
+      token: 'write-token',
+    }
+    writeProjectCredentials(dir, credentials)
+    // `logfire clean` removes the ignore rule along with the credentials, and leaves the
+    // directory in place, so re-authenticating has to write the rule again.
+    removeProjectCredentials(dir)
+    expect(readdirSync(dir)).toEqual([])
+
+    writeProjectCredentials(dir, credentials)
+
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('*')
+  })
+
+  it("leaves a data directory holding the user's own files unignored", () => {
+    const dir = makeTmpDir()
+    writeFileSync(join(dir, 'notes.txt'), 'mine\n')
+
+    writeProjectCredentials(dir, {
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'myproject',
+      project_url: 'https://logfire.pydantic.dev/org/myproject',
+      token: 'write-token',
+    })
+
+    expect(existsSync(join(dir, '.gitignore'))).toBe(false)
+  })
+
   it("adds the saved token to an existing data directory's ignore rules", () => {
     const dir = makeTmpDir()
     writeFileSync(join(dir, '.gitignore'), 'logfire_credentials.json\n')

--- a/packages/logfire-api/src/cli/credentials.test.ts
+++ b/packages/logfire-api/src/cli/credentials.test.ts
@@ -139,6 +139,39 @@ token = "ignored"
     expect(existsSync(join(dir, '.gitignore'))).toBe(false)
   })
 
+  it('leaves a file that only looks like a Logfire token file unignored', () => {
+    // Logfire writes `read_token.json`, `read_token.json.lock` and
+    // `read_token.json.<uuid>.tmp`, and nothing else that starts with that name.
+    for (const userFile of ['read_token.jsonl', 'read_token.json.bak', 'read_token.json..tmp']) {
+      const dir = makeTmpDir()
+      writeFileSync(join(dir, userFile), 'mine\n')
+
+      writeProjectCredentials(dir, {
+        logfire_api_url: 'https://logfire-us.pydantic.dev',
+        project_name: 'myproject',
+        project_url: 'https://logfire.pydantic.dev/org/myproject',
+        token: 'write-token',
+      })
+
+      expect(existsSync(join(dir, '.gitignore'))).toBe(false)
+    }
+  })
+
+  it('seeds the ignore rule alongside an in-flight read-token save', () => {
+    const dir = makeTmpDir()
+    writeFileSync(join(dir, 'read_token.json.lock'), '')
+    writeFileSync(join(dir, 'read_token.json.123e4567-e89b-12d3-a456-426614174000.tmp'), '')
+
+    writeProjectCredentials(dir, {
+      logfire_api_url: 'https://logfire-us.pydantic.dev',
+      project_name: 'myproject',
+      project_url: 'https://logfire.pydantic.dev/org/myproject',
+      token: 'write-token',
+    })
+
+    expect(readFileSync(join(dir, '.gitignore'), 'utf8')).toBe('*')
+  })
+
   it("adds the saved token to an existing data directory's ignore rules", () => {
     const dir = makeTmpDir()
     writeFileSync(join(dir, '.gitignore'), 'logfire_credentials.json\n')

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -31,6 +31,9 @@ export const PROJECT_CREDENTIALS_FILENAME = 'logfire_credentials.json'
 // the other.
 export const READ_TOKEN_FILENAME = 'read_token.json'
 const READ_TOKEN_IGNORE_PATTERN = `${READ_TOKEN_FILENAME}*`
+const TEMPORARY_SAVE_SUFFIX = '.tmp'
+/** `randomUUID()`, the middle segment of the temporary file `reserveReadTokenSave` renames from. */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u
 
 export interface UserTokenData {
   token: string
@@ -600,8 +603,24 @@ function seedGitignore(dataDir: string): void {
   }
 }
 
+/**
+ * The exact names Logfire writes into a data directory: the ignore rule, the two credential
+ * files, and the lock and temporary files a read-token save holds while it runs. Matching a
+ * prefix instead would accept a user's own `read_token.jsonl` and hide it behind the `*` rule.
+ */
 function isDataDirFile(name: string): boolean {
-  return name === '.gitignore' || name === PROJECT_CREDENTIALS_FILENAME || name.startsWith(READ_TOKEN_FILENAME)
+  if (
+    name === '.gitignore' ||
+    name === PROJECT_CREDENTIALS_FILENAME ||
+    name === READ_TOKEN_FILENAME ||
+    name === `${READ_TOKEN_FILENAME}.lock`
+  ) {
+    return true
+  }
+  if (!name.startsWith(`${READ_TOKEN_FILENAME}.`) || !name.endsWith(TEMPORARY_SAVE_SUFFIX)) {
+    return false
+  }
+  return UUID_PATTERN.test(name.slice(READ_TOKEN_FILENAME.length + 1, -TEMPORARY_SAVE_SUFFIX.length))
 }
 
 function ensureReadTokenIgnored(dataDir: string): void {

--- a/packages/logfire-api/src/cli/credentials.ts
+++ b/packages/logfire-api/src/cli/credentials.ts
@@ -8,6 +8,7 @@ import {
   lstatSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -557,8 +558,6 @@ function writeUserTokensFile(path: string, tokens: ReadonlyMap<string, UserToken
 }
 
 export function ensureDataDir(dataDir: string): void {
-  // Match Python's `ensure_data_dir_exists`: only seed `.gitignore` when creating the
-  // directory, so an existing dir's ignore rules are never clobbered.
   if (existsSync(dataDir)) {
     // `lstatSync`, not `statSync`: the data directory lives inside the user's repository,
     // so a symlink can arrive by being committed to it, the same way a symlinked
@@ -574,10 +573,35 @@ export function ensureDataDir(dataDir: string): void {
     if (!stat.isDirectory()) {
       throw new LogfireCliError(`Data directory ${dataDir} exists but is not a directory`)
     }
+  } else {
+    mkdirSync(dataDir, { recursive: true })
+  }
+  seedGitignore(dataDir)
+}
+
+/**
+ * Write the `*` ignore rule for a directory that holds nothing but the files Logfire writes
+ * itself. That covers a newly created directory and one `logfire clean` has emptied, which
+ * removes the `.gitignore` along with the credentials. A directory with any other contents is
+ * left alone: `--data-dir` can point at a directory of the user's own, and `*` would ignore it.
+ */
+function seedGitignore(dataDir: string): void {
+  if (!readdirSync(dataDir).every(isDataDirFile)) {
     return
   }
-  mkdirSync(dataDir, { recursive: true })
-  writeFileSync(join(dataDir, '.gitignore'), '*')
+  try {
+    // Exclusive creation, so an existing `.gitignore` keeps its rules and a symlink planted in a
+    // data directory that arrived from elsewhere is refused rather than written through.
+    writeFileSync(join(dataDir, '.gitignore'), '*', { flag: 'wx' })
+  } catch (error) {
+    if (!hasErrorCode(error, 'EEXIST')) {
+      throw error
+    }
+  }
+}
+
+function isDataDirFile(name: string): boolean {
+  return name === '.gitignore' || name === PROJECT_CREDENTIALS_FILENAME || name.startsWith(READ_TOKEN_FILENAME)
 }
 
 function ensureReadTokenIgnored(dataDir: string): void {


### PR DESCRIPTION
### Defect

`logfire clean` empties the data directory but leaves the directory itself in place. `ensureDataDir` only seeded the `.gitignore` when it created the directory, so the next `logfire auth` / project setup wrote `logfire_credentials.json` back into a directory with no ignore rule covering it. The data directory usually lives inside the user's repository, so the credentials file is then an untracked, unignored file that `git add .` will pick up.

### Evidence

Measured on `3d33c49`, driving the real functions:

```
after first write     [".gitignore", "logfire_credentials.json"]
after logfire clean   []                                          dir still exists: true
after second write    ["logfire_credentials.json"]
```

`removeProjectCredentials` deletes the `.gitignore` along with the two credential files (`credentials.ts:293`), which is what the `clean` confirmation prompt lists, so the deletion itself is intended. What was missing is the other half: nothing ever writes the rule back.

pydantic/logfire fixed the same thing in `ensure_data_dir_exists` two weeks ago, in #2173.

### Fix

Seed the rule for a directory that holds nothing but the files Logfire itself writes, which covers both a newly created directory and one `clean` has emptied. A directory with any other contents is left alone, because `--data-dir` can point at a directory of the user's own and `*` would ignore all of it.

The write uses exclusive creation, so an existing `.gitignore` keeps its rules and a symlink planted in a data directory that arrived from elsewhere is refused rather than written through. That matches the `lstatSync` guard already above it and the `O_NOFOLLOW` handling on the read-token path.

Two regressions: the clean-then-rewrite cycle, and a data directory holding a file of the user's own staying unignored. Three mutations, one per guard: restoring the seed-on-create-only shape, dropping the only-our-files check, and swapping exclusive creation for a plain write each fail a different assertion, the last one being the existing `does not clobber an existing .gitignore` test.

Built this with Claude Code's help and reviewed the diff myself.
