### PR TITLE
Look up evaluator names as own registry properties

### DIFF
--- a/.changeset/spec-registry-own-keys.md
+++ b/.changeset/spec-registry-own-keys.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Look up evaluator names as own properties of a plain-object registry in `decodeEvaluator` and `decodeReportEvaluator`. A name read from a dataset file previously resolved through the prototype chain, so `constructor` returned `Object` and was constructed into something that is not an evaluator, while `toString` failed with `Cls is not a constructor` instead of the unknown-name error.

--- a/packages/logfire-api/src/evals/__test__/serialization.test.ts
+++ b/packages/logfire-api/src/evals/__test__/serialization.test.ts
@@ -129,6 +129,15 @@ describe('EvaluatorSpec encoding', () => {
     expect(() => decodeEvaluator('Missing', new Map([['ValueEvaluator', ValueEvaluator as never]]), new Map())).toThrow(
       'Unknown evaluator name: "Missing" (registered: ValueEvaluator)'
     )
+
+    // An evaluator name is read from a dataset file, so a plain-object registry must answer for
+    // its own entries only. `constructor` otherwise resolves to `Object` and is constructed.
+    const objectRegistry = { ValueEvaluator: ValueEvaluator as never }
+    for (const inherited of ['constructor', 'toString', 'valueOf', '__proto__']) {
+      expect(() => decodeEvaluator(inherited, objectRegistry, new Map())).toThrow(
+        `Unknown evaluator name: ${JSON.stringify(inherited)} (registered: ValueEvaluator)`
+      )
+    }
   })
 
   it('decodeReportEvaluator constructs report evaluators and reports unknown names', () => {

--- a/packages/logfire-api/src/evals/serialization/spec.ts
+++ b/packages/logfire-api/src/evals/serialization/spec.ts
@@ -140,7 +140,10 @@ function lookup<T>(registry: RegistryInput<T>, name: string): T | undefined {
   if (isLookupRegistry(registry)) {
     return registry.get(name)
   }
-  return registry[name]
+  // Own properties only. The name comes from a dataset file, so a plain-object registry would
+  // otherwise resolve `constructor` to `Object` and hand back something that is not an evaluator.
+  // `keys()` below already lists own properties, so the two agree on what the registry holds.
+  return Object.hasOwn(registry, name) ? registry[name] : undefined
 }
 
 function keys<T>(registry: RegistryInput<T>): Iterable<string> {


### PR DESCRIPTION
### Defect

`decodeEvaluator` and `decodeReportEvaluator` accept either a `Map` or a plain object as the registry, and the object branch of `lookup` reads `registry[name]` straight through the prototype chain. The name comes from a dataset file, so an evaluator the registry does not hold can still resolve to an `Object.prototype` member.

### Evidence

Measured on `3d33c49` with `{ Equals }` as the registry:

```
constructor  -> constructed [object Object]  isEvaluator=false  ctor=Object
toString     -> threw "Cls is not a constructor"
valueOf      -> threw "Cls is not a constructor"
Missing      -> threw "Unknown evaluator name: \"Missing\" (registered: Equals)"
```

Only the genuinely absent name reports the right thing. `constructor` is the one that matters: no error is raised at all, and the caller gets a plain `Object` typed as an `Evaluator`, which fails later at `evaluate()` rather than at load. The other two report an internal `Cls is not a constructor` in place of the unknown-name message.

The two halves of the same registry already disagree: `keys()`, which builds the `(registered: ...)` list in that error, uses `Object.keys` and lists own properties only.

### Fix

Gate the object branch on `Object.hasOwn`, so `lookup` answers for the same set of names `keys` reports. One line, the idiom already used elsewhere in the package. The `Map` branch is untouched, and so is the SDK's own registry, which has always been a `Map`.

Reverting the lookup to `registry[name]` fails the new assertions.

Built this with Claude Code's help and reviewed the diff myself.
