### PR TITLE
Keep a task-run attribute or metric named like a prototype member

### DIFF
--- a/.changeset/task-run-proto-names.md
+++ b/.changeset/task-run-proto-names.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep a task-run attribute or metric whose name is an `Object.prototype` member. Metric names are sliced off span attribute keys in `extractMetrics`, so a provider's usage payload chooses them. A name of `__proto__` was dropped entirely, and one like `toString` read the inherited function back, turning the metric into a string and reporting a non-numeric mean in the averages block.

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -34,6 +34,7 @@ import {
   SPAN_NAME_EXPERIMENT,
 } from '../../evals'
 import type { ReportEvaluatorContext } from '../../evals'
+import { computeAverages } from '../reporting'
 import { withMemoryExporter } from './withMemoryExporter'
 
 const sleep = async (ms: number): Promise<void> =>
@@ -718,5 +719,42 @@ describe('offline evals — span attribute parity', () => {
     expect(result.cases[0]?.evaluator_failures.map((f) => [f.name, f.error_message])).toEqual([
       ['NanScore', 'Evaluator returned a non-finite value for NanScore: NaN'],
     ])
+  })
+
+  it('keeps a task-run attribute or metric named like an Object.prototype member', async () => {
+    const dataset = new Dataset<{ x: number }, number>({
+      cases: [new Case<{ x: number }, number>({ expectedOutput: 1, inputs: { x: 1 }, name: 'a' })],
+      evaluators: [new EqualsExpected()],
+      name: 'proto-names',
+    })
+
+    // Metric names are sliced off span attribute keys in `extractMetrics`, so they arrive from
+    // the provider's usage payload rather than being chosen by the SDK.
+    const { result } = await withMemoryExporter(async () =>
+      dataset.evaluate(({ x }) => {
+        setEvalAttribute('__proto__', { polluted: true })
+        setEvalAttribute('toString', 'attr')
+        incrementEvalMetric('__proto__', 5)
+        incrementEvalMetric('toString', 5)
+        incrementEvalMetric('toString', 3)
+        return x
+      })
+    )
+
+    // Held in variables: written as a literal, `dot-notation` rewrites the lookup to
+    // `metrics.toString`, which typechecks as the inherited method and stops asserting anything.
+    const inherited = 'toString'
+    const protoName = '__proto__'
+    const only = [...result.cases][0]
+    expect(only).toBeDefined()
+    expect(Object.keys(only?.attributes ?? {}).sort()).toEqual([protoName, inherited])
+    expect(Object.keys(only?.metrics ?? {}).sort()).toEqual([protoName, inherited])
+    expect(only?.metrics[inherited]).toBe(8)
+    expect(only?.metrics[protoName]).toBe(5)
+    // Assigning `{ polluted: true }` under `__proto__` would have replaced the prototype instead.
+    expect(Object.getPrototypeOf(only?.attributes)).toBe(Object.prototype)
+
+    // A corrupted metric propagates: `sum += value` on a string yields a non-numeric mean.
+    expect(computeAverages('proto-names', result.cases).metrics[inherited]).toEqual({ count: 1, mean: 8 })
   })
 })

--- a/packages/logfire-api/src/evals/currentTaskRun.ts
+++ b/packages/logfire-api/src/evals/currentTaskRun.ts
@@ -80,7 +80,7 @@ export function setEvalAttribute(name: string, value: unknown): void {
   if (state === undefined) {
     return
   }
-  state.attributes[name] = value
+  setOwn(state.attributes, name, value)
 }
 
 /**
@@ -92,12 +92,23 @@ export function setEvalAttribute(name: string, value: unknown): void {
  * usage attribute does not invent a metric key that Python omits.
  */
 export function incrementMetric(metrics: Record<string, number>, name: string, amount: number): void {
-  const current = metrics[name] ?? 0
+  const current = Object.hasOwn(metrics, name) ? (metrics[name] ?? 0) : 0
   const next = current + amount
   if (current === 0 && next === 0) {
     return
   }
-  metrics[name] = next
+  setOwn(metrics, name, next)
+}
+
+/**
+ * Write an own property, for records whose keys are not the SDK's to choose. Metric names are
+ * sliced off span attribute keys in `extractMetrics`, so they arrive from the provider's usage
+ * payload, and attribute names come from task code. Plain assignment reaches the prototype: a
+ * `__proto__` name invokes the inherited setter and the entry is dropped, and a name like
+ * `toString` reads back the inherited function.
+ */
+function setOwn<T>(record: Record<string, T>, name: string, value: T): void {
+  Object.defineProperty(record, name, { configurable: true, enumerable: true, value, writable: true })
 }
 
 /**


### PR DESCRIPTION
### Defect

`state.attributes[name] = value` and the metric read/write in `incrementMetric` use plain-object assignment, and neither name is the SDK's to choose. `extractMetrics` slices metric names off span attribute keys (`gen_ai.usage.details.*`), so the provider's usage payload supplies them; attribute names come from task code.

A name of `__proto__` invokes the inherited setter, so the entry is dropped. A name like `toString` reads the inherited function back as the current value, and `current + amount` then concatenates onto it.

### Evidence

Measured on `3d33c49`, two `incrementMetric` calls of 5 then 3 per name:

```
tokens      own=["tokens"]     value=8
toString    own=["toString"]   value="function toString() { [native code] }53"
valueOf     own=["valueOf"]    value="function valueOf() { [native code] }53"
__proto__   own=[]             value=undefined
```

The corrupted metric propagates. Feeding one case with a `toString` metric into `computeAverages`:

```
averages.metrics {"toString":{"count":1,"mean":null},"tokens":{"count":1,"mean":10}}
```

`acc.sum += value` on a string yields a non-numeric mean, serialized as `null`. The healthy metric alongside it is unaffected, so the damage stays with that key.

This is the producing end of the family #281 fixed at the consuming end: the averaging code is prototype-safe now, but the metrics record it reads is still written by plain assignment.

### Fix

`incrementMetric` is already documented as the single place that writes metrics, and `setEvalAttribute` is the single place that writes attributes, so one own-property write shared by the two is the whole fix. The read is gated on `Object.hasOwn` so a `toString` metric starts at 0 rather than at the inherited function.

Regression drives both through a real `dataset.evaluate` and asserts the surviving keys, the values, that the attributes object still has `Object.prototype` as its prototype, and the resulting mean. Three mutations, one per guard: reverting the attribute write, the metric write, or the metric read each fails it.

One note on the test: the prototype names are held in variables rather than written as literals. As a literal, `dot-notation` rewrites `metrics['toString']` to `metrics.toString`, which typechecks as the inherited method and quietly stops asserting anything.

Built this with Claude Code's help and reviewed the diff myself.
