### PR TITLE
Read LOGFIRE_BASE_URL in the CLI

### DIFF
--- a/.changeset/cli-base-url-env.md
+++ b/.changeset/cli-base-url-env.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Read `LOGFIRE_BASE_URL` in the CLI. The SDK already resolves its endpoint from that variable and the docs present it as the way to reach a self-hosted Logfire, but the CLI only looked at `--base-url` and `--region`, so `logfire whoami` and the other commands still called the public API. Either flag continues to take precedence, and a blank value is ignored rather than rejected.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,6 +32,7 @@ The JavaScript CLI does not implement Python SDK commands such as `run`, `inspec
 - `--version`: print the CLI, Node.js, and platform versions, then exit.
 - `--region <region>`: select a Logfire data region (`us` or `eu`).
 - `--base-url <url>`: target a self-hosted or custom Logfire API. Mutually exclusive with `--region`.
+- `LOGFIRE_BASE_URL`: the same target as `--base-url`, read from the environment. Either flag takes precedence over it.
 
 ## Auth
 

--- a/packages/logfire-api/src/cli/index.test.ts
+++ b/packages/logfire-api/src/cli/index.test.ts
@@ -31,6 +31,36 @@ describe('CLI entrypoint', () => {
     expect(stdout.text()).not.toMatch(/^  gateway\s/mu)
   })
 
+  it('reads the base URL from LOGFIRE_BASE_URL, with both flags winning over it', async () => {
+    const request = async (argv: string[], env: Record<string, string | undefined>): Promise<string> => {
+      const urls: string[] = []
+      const fetchImpl = (async (input: RequestInfo | URL) => {
+        urls.push(input instanceof Request ? input.url : input.toString())
+        return new Response('{}', { headers: { 'content-type': 'application/json' }, status: 200 })
+      }) as typeof fetch
+      await runCli(argv, {
+        env: { LOGFIRE_TOKEN: 'pylf_v1_us_1234567890', ...env },
+        fetch: fetchImpl,
+        homeDir: makeTmpDir(),
+        stderr: new MemoryOutput(),
+        stdout: new MemoryOutput(),
+      })
+      return urls[0] ?? ''
+    }
+    const selfHosted = { LOGFIRE_BASE_URL: 'https://selfhosted.example.com' }
+
+    expect(await request(['whoami'], selfHosted)).toBe('https://selfhosted.example.com/v1/info')
+    expect(await request(['whoami'], {})).toBe('https://logfire-us.pydantic.dev/v1/info')
+    expect(await request(['--base-url=https://flag.example.com', 'whoami'], selfHosted)).toBe('https://flag.example.com/v1/info')
+    expect(await request(['--region=eu', 'whoami'], selfHosted)).toBe('https://logfire-eu.pydantic.dev/v1/info')
+    // A trailing slash is normalized the same way `--base-url` is.
+    expect(await request(['whoami'], { LOGFIRE_BASE_URL: 'https://selfhosted.example.com/' })).toBe(
+      'https://selfhosted.example.com/v1/info'
+    )
+    // Blank is not a request for anything, unlike `--base-url=`, which stays an error.
+    expect(await request(['whoami'], { LOGFIRE_BASE_URL: '   ' })).toBe('https://logfire-us.pydantic.dev/v1/info')
+  })
+
   it('rejects a blank --base-url value', async () => {
     const stderr = new MemoryOutput()
     const fetchImpl = vi.fn<typeof fetch>()

--- a/packages/logfire-api/src/cli/index.ts
+++ b/packages/logfire-api/src/cli/index.ts
@@ -44,7 +44,7 @@ interface ParsedArgs {
 export async function runCli(argv: string[] = process.argv.slice(2), options: CliContextOptions = {}): Promise<number> {
   const context = createCliContext(options)
   try {
-    const parsed = parseArgs(argv)
+    const parsed = parseArgs(argv, context.env)
     if (parsed.version) {
       printVersion(context)
       return 0
@@ -123,7 +123,7 @@ async function dispatch(command: string, args: string[], globalOptions: GlobalOp
   throw new LogfireCliError(`Unknown command "${command}".`)
 }
 
-function parseArgs(argv: string[]): ParsedArgs {
+function parseArgs(argv: string[], env: Record<string, string | undefined>): ParsedArgs {
   let command: string | undefined
   let baseUrl: string | undefined
   let region: string | undefined
@@ -158,7 +158,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       return {
         command,
         commandArgs: argv.slice(index + 1),
-        globalOptions: buildGlobalOptions(baseUrl, region),
+        globalOptions: buildGlobalOptions(baseUrl, region, env),
         help,
         version,
       }
@@ -168,14 +168,23 @@ function parseArgs(argv: string[]): ParsedArgs {
   return {
     command,
     commandArgs: [],
-    globalOptions: buildGlobalOptions(baseUrl, region),
+    globalOptions: buildGlobalOptions(baseUrl, region, env),
     help,
     version,
   }
 }
 
-function buildGlobalOptions(baseUrl: string | undefined, region: string | undefined): GlobalOptions {
-  const resolvedBaseUrl = resolveSelectedBaseUrl(baseUrl, region)
+function buildGlobalOptions(
+  baseUrl: string | undefined,
+  region: string | undefined,
+  env: Record<string, string | undefined>
+): GlobalOptions {
+  // `LOGFIRE_BASE_URL` is the documented way to point at a self-hosted endpoint, and the SDK
+  // already reads it. Both flags are explicit, so either one wins over it. A blank value is
+  // ignored rather than rejected: an unset-looking variable is not the user asking for anything,
+  // whereas `--base-url=` is, and stays an error.
+  const selected = baseUrl ?? (region === undefined ? nonEmpty(env['LOGFIRE_BASE_URL']) : undefined)
+  const resolvedBaseUrl = resolveSelectedBaseUrl(selected, region)
   const options: GlobalOptions = {}
   if (resolvedBaseUrl !== undefined) {
     options.baseUrl = resolvedBaseUrl
@@ -184,6 +193,10 @@ function buildGlobalOptions(baseUrl: string | undefined, region: string | undefi
     options.region = region
   }
   return options
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value === undefined || value.trim() === '' ? undefined : value
 }
 
 function assertNoRegionConflict(baseUrl: string | undefined, region: string | undefined, option: string): void {


### PR DESCRIPTION
### Defect

The CLI resolves its base URL from `--base-url` and `--region` only. It never reads `LOGFIRE_BASE_URL`, although `resolveLogfireBaseUrl` and `logfireConfig` both do, and `docs/configuration.md` presents that variable as the way to point at a self-hosted or local Logfire.

So a self-hosted user has the SDK sending telemetry to their own endpoint while every CLI command talks to the public API.

### Evidence

Measured on `3d33c49`, running `whoami` with the variable set and recording the request:

```
env  LOGFIRE_BASE_URL=https://selfhosted.example.com
url  https://logfire-us.pydantic.dev/v1/info
```

pydantic/logfire made the same change in #2323, falling back to `os.getenv('LOGFIRE_BASE_URL')` when the flag is absent.

### Fix

One expression carries the precedence: `--base-url` wins, `--region` suppresses the variable, and otherwise the environment supplies it.

```ts
const selected = baseUrl ?? (region === undefined ? nonEmpty(env['LOGFIRE_BASE_URL']) : undefined)
```

Two choices worth stating. `--region` suppresses the variable rather than conflicting with it, because `assertNoRegionConflict` exists to catch a user passing two contradictory flags, and an ambient variable is not that. A blank value is ignored rather than rejected, unlike `--base-url=`, which stays an error: an empty variable is not a request for anything.

The regression covers all five outcomes, including a trailing slash being normalized the same way the flag is. Four mutations, one per branch of the precedence rule: ignoring the variable, letting it beat `--base-url`, letting it apply despite `--region`, and dropping the blank guard each fail it.

One note on how that test got its shape. My first version guarded with `baseUrl === undefined && region === undefined` and then wrote `baseUrl ?? fromEnv`, which made the `??` order dead: swapping it changed nothing and no mutation could bite. Collapsing it to the single expression above removed the redundant condition and made that case testable.

Built this with Claude Code's help and reviewed the diff myself.
