### PR TITLE
Warn when a token names an unknown region

### DIFF
--- a/.changeset/unknown-token-region.md
+++ b/.changeset/unknown-token-region.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Warn when a Logfire token names a region this version does not recognise. The region was silently ignored and the US endpoint used, so a token minted for a newer region shipped its data to the wrong place with no signal. Tokens with a known region, tokens minted before regions existed, and values that are not Logfire tokens are unaffected.

--- a/packages/logfire-api/src/cli/regions.test.ts
+++ b/packages/logfire-api/src/cli/regions.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await -- test stubs satisfy async signatures without awaiting. */
-import { describe, expect, it } from 'vite-plus/test'
+import { describe, expect, it, vi } from 'vite-plus/test'
 
 import { getBaseUrlFromToken } from '../tokenBaseUrl'
 import { NoAnswerAvailableError } from './interactivePrompt'
@@ -29,6 +29,27 @@ describe('CLI regions', () => {
     expect(getBaseUrlFromToken('pylf_v1_constructor_abc123')).toBe('https://logfire-us.pydantic.dev')
     expect(getBaseUrlFromToken('pylf_v1_eu_abc123')).toBe('https://logfire-eu.pydantic.dev')
     expect(getBaseUrlFromToken(undefined)).toBe('https://logfire-us.pydantic.dev')
+  })
+
+  it('warns when a token names a region this version does not know', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      expect(getBaseUrlFromToken('pylf_v1_apac_abc123')).toBe('https://logfire-us.pydantic.dev')
+      expect(warn.mock.calls).toEqual([
+        ['Unknown region "apac" in Logfire token, falling back to the US region. Known regions: eu, stagingeu, stagingus, us.'],
+      ])
+
+      // A token with a known region, one minted before regions existed, and one that is not a
+      // Logfire token all carry no disagreement to report.
+      warn.mockClear()
+      expect(getBaseUrlFromToken('pylf_v1_eu_abc123')).toBe('https://logfire-eu.pydantic.dev')
+      expect(getBaseUrlFromToken('pylf_v1_stagingus_abc123')).toBe('https://logfire-us.pydantic.info')
+      expect(getBaseUrlFromToken('not-a-logfire-token')).toBe('https://logfire-us.pydantic.dev')
+      expect(getBaseUrlFromToken(undefined)).toBe('https://logfire-us.pydantic.dev')
+      expect(warn.mock.calls).toEqual([])
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   describe('promptForRegion', () => {

--- a/packages/logfire-api/src/tokenBaseUrl.ts
+++ b/packages/logfire-api/src/tokenBaseUrl.ts
@@ -39,13 +39,23 @@ export function removeTrailingSlash(url: string): string {
 }
 
 export function getBaseUrlFromToken(token: string | undefined): string {
+  // Default to US for tokens minted before regions existed, and for anything that is not a
+  // Logfire token at all: neither carries a region to disagree with.
   let regionKey = 'us'
   if (token !== undefined && token !== '') {
     const match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.exec(token)
     if (match) {
       const region = match.groups?.['region']
-      if (region !== undefined && Object.hasOwn(LOGFIRE_REGIONS, region)) {
-        regionKey = region
+      if (region !== undefined) {
+        if (Object.hasOwn(LOGFIRE_REGIONS, region)) {
+          regionKey = region
+        } else {
+          // The token names a region this version does not know, so the US fallback sends its
+          // data somewhere the token was not minted for. Silence there looks like success.
+          console.warn(
+            `Unknown region "${region}" in Logfire token, falling back to the US region. Known regions: ${Object.keys(LOGFIRE_REGIONS).sort().join(', ')}.`
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
### Defect

`getBaseUrlFromToken` reads the region out of a Logfire token and falls back to the US endpoint when it does not recognise it. The fallback is right, but it is silent, so a token minted for a region a given SDK version predates sends that project's telemetry to the US with nothing said.

### Evidence

Measured on `3d33c49`:

```
pylf_v1_us_abc         -> https://logfire-us.pydantic.dev
pylf_v1_eu_abc         -> https://logfire-eu.pydantic.dev
pylf_v1_ap_abc         -> https://logfire-us.pydantic.dev
pylf_v1_apac_abc       -> https://logfire-us.pydantic.dev
not-a-logfire-token    -> https://logfire-us.pydantic.dev
```

Rows three and four are the problem: the token states a region, the SDK disagrees, and the disagreement is not reported. `resolveBaseUrl` returns the same, so this reaches configuration.

pydantic/logfire warns here and turned it on for every caller in #2281, with the reasoning that the warning is the actionable part.

### Fix

Warn only when the token matches the token pattern and names a region that is not in `LOGFIRE_REGIONS`, which is Python's condition. The three quiet cases stay quiet, because none of them carries a region to disagree with: a known region, a token minted before regions existed, and a value that is not a Logfire token at all.

`console.warn` rather than `diag.warn`, because `tokenBaseUrl.ts` is in the runtime-agnostic base package and `formatter.ts` and `vars/index.ts` already warn that way there. The resolved URL does not change, so the existing assertions still hold, including the one pinning `constructor` to the US fallback.

Three mutations: removing the warning, warning for every token, and moving the fallback region each fail. The second fails six assertions rather than one, which is the existing suite objecting to noise on the quiet paths.

Built this with Claude Code's help and reviewed the diff myself.
