### PR TITLE
Report a non-JSON device auth response

### DIFF
--- a/.changeset/auth-non-json-response.md
+++ b/.changeset/auth-non-json-response.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Report a non-JSON device-auth response instead of crashing with a parse error. A proxy or captive portal answering `200` with an HTML page made `logfire auth` fail with `SyntaxError: Unexpected token '<'`. `requestDeviceCode` now says the response was not JSON, and the poll treats an unparseable body the same way it already treats a rejected request, by retrying and giving up on the fourth failure.

--- a/packages/logfire-api/src/cli/client.test.ts
+++ b/packages/logfire-api/src/cli/client.test.ts
@@ -36,6 +36,42 @@ describe('CLI client', () => {
     ])
   })
 
+  it('reports a non-JSON device-auth response instead of a parse error', async () => {
+    const proxyPage = (): Response =>
+      new Response('<html><body>Sign in to continue</body></html>', {
+        headers: { 'content-type': 'text/html' },
+        status: 200,
+      })
+
+    await expect(
+      requestDeviceCode({ baseUrl: 'https://logfire-us.pydantic.dev', fetch: fetchSequence([], [proxyPage()]) })
+    ).rejects.toThrow('Failed to request a device code: the response was not JSON.')
+
+    // The poll retries an unparseable body the same way it retries a rejected request, and
+    // gives up on the fourth, so a captive portal ends the login with the CLI's own message.
+    const calls: CapturedRequest[] = []
+    const fetchImpl = fetchSequence(calls, [proxyPage(), proxyPage(), proxyPage(), proxyPage()])
+    await expect(pollForToken({ baseUrl: 'https://logfire-us.pydantic.dev', deviceCode: 'DC', fetch: fetchImpl })).rejects.toThrow(
+      'Failed to poll for token.'
+    )
+    expect(calls.length).toBe(4)
+  })
+
+  it('keeps polling while the device-auth response body is null', async () => {
+    const calls: CapturedRequest[] = []
+    const fetchImpl = fetchSequence(calls, [
+      jsonResponse(null),
+      jsonResponse(null),
+      jsonResponse({ expiration: '2099-12-31T23:59:59Z', token: 'user-token' }),
+    ])
+
+    await expect(pollForToken({ baseUrl: 'https://logfire-us.pydantic.dev', deviceCode: 'DC', fetch: fetchImpl })).resolves.toEqual({
+      expiration: '2099-12-31T23:59:59Z',
+      token: 'user-token',
+    })
+    expect(calls.length).toBe(3)
+  })
+
   it('uses project endpoints and auth headers', async () => {
     const calls: CapturedRequest[] = []
     const client = new LogfireApiClient({

--- a/packages/logfire-api/src/cli/client.ts
+++ b/packages/logfire-api/src/cli/client.ts
@@ -173,7 +173,20 @@ export async function requestDeviceCode(options: DeviceAuthOptions): Promise<Dev
   if (!response.ok) {
     throw new LogfireCliError('Failed to request a device code.')
   }
-  return (await response.json()) as DeviceCodeResponse
+  const payload = await readJsonBody(response)
+  if (payload === undefined) {
+    throw new LogfireCliError('Failed to request a device code: the response was not JSON.')
+  }
+  return payload as DeviceCodeResponse
+}
+
+/** The parsed body, or `undefined` when it is not JSON at all. */
+async function readJsonBody(response: Response): Promise<unknown> {
+  try {
+    return (await response.json()) as unknown
+  } catch {
+    return undefined
+  }
 }
 
 export interface PollForTokenOptions {
@@ -198,18 +211,20 @@ export async function pollForToken(options: PollForTokenOptions): Promise<UserTo
       method: 'GET',
     }).catch(() => undefined)
 
-    if (response === undefined || !response.ok) {
+    // A proxy or captive portal can answer 200 with HTML, which is the same kind of failure as
+    // a rejected request: it retries rather than ending the login with a raw parse error.
+    // eslint-disable-next-line no-await-in-loop -- the response body must be read before deciding to poll again.
+    const token = response?.ok === true ? await readJsonBody(response) : undefined
+    if (token === undefined) {
       errors += 1
       if (errors >= 4) {
         throw new LogfireCliError('Failed to poll for token.')
       }
       continue
     }
-
-    // eslint-disable-next-line no-await-in-loop -- the response body must be read before deciding to poll again.
-    const token = (await response.json()) as UserTokenData | null
+    // A JSON `null` is the server saying the user has not finished yet, so keep polling.
     if (token !== null) {
-      return token
+      return token as UserTokenData
     }
   }
 


### PR DESCRIPTION
### Defect

Both device-auth calls parse the response body with a bare `response.json()`. A proxy or captive portal that answers `200` with an HTML sign-in page therefore ends `logfire auth` with a raw parse error rather than anything the CLI wrote. That is the likeliest place to meet one, since the user is not authenticated yet.

### Evidence

Measured on `3d33c49`, with fetch returning `200 text/html`:

```
pollForToken       threw SyntaxError: Unexpected token '<', "<html><bod"... is not valid JSON
requestDeviceCode  threw SyntaxError: Unexpected token '<', "<html><bod"... is not valid JSON
```

`queryProject` in the same file already wraps its parse and reports a sanitized message, so the convention exists here; these two predate it.

### Fix

One `readJsonBody` helper that returns `undefined` when the body is not JSON.

`requestDeviceCode` reports it, matching its `!response.ok` sibling. The poll treats it as it already treats a rejected request: it counts an error and retries, giving up on the fourth. Retrying is the useful behaviour, because the portal is usually gone a moment later, and the loop already has a failure budget for exactly this kind of transient answer.

A JSON `null` still means the user has not finished in the browser, so it keeps polling and does not spend the error budget. Both cases are pinned, since collapsing them is the easy way to get this wrong.

Three mutations: unwrapping either parse, or treating a `null` body as a token, each fail one assertion.

Deliberately out of scope: `getJson`, `postJson` and `createNewProject` on `LogfireApiClient` parse the same way, but they run after login against an endpoint that has already authenticated the caller, and each would want its own message. Happy to extend this to them if you would rather have it in one pass.

Built this with Claude Code's help and reviewed the diff myself.
