### PR TITLE
Send a non-finite numeric attribute as a string

### DIFF
--- a/.changeset/non-finite-attribute.md
+++ b/.changeset/non-finite-attribute.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Send a non-finite numeric attribute as a string. `NaN`, `Infinity` and `-Infinity` were passed through as OTLP doubles, and since JSON has no spelling for them they serialized to `null`, so the value was lost. They are now sent the way the message template already renders them, matching the Python SDK's `prepare_otlp_attribute`.

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -28,6 +28,26 @@ describe('serializeAttributes', () => {
     })
   })
 
+  test('sends a non-finite number as a string rather than losing it to JSON null', () => {
+    const result = serializeAttributes({
+      inf: Number.POSITIVE_INFINITY,
+      nan: Number.NaN,
+      neginf: Number.NEGATIVE_INFINITY,
+      ok: 1.5,
+      zero: -0,
+    })
+
+    expect(result).toEqual({
+      inf: 'Infinity',
+      nan: 'NaN',
+      neginf: '-Infinity',
+      ok: 1.5,
+      zero: -0,
+    })
+    // The point of the change: these used to reach the wire as null.
+    expect(JSON.stringify(result)).toBe('{"inf":"Infinity","nan":"NaN","neginf":"-Infinity","ok":1.5,"zero":0}')
+  })
+
   test('emits deterministic nested object schema for ordinary JSON-like values', () => {
     const result = serializeAttributes({
       payload: {

--- a/packages/logfire-api/src/serializeAttributes.ts
+++ b/packages/logfire-api/src/serializeAttributes.ts
@@ -53,7 +53,12 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
 
     if (value === null || value === undefined) {
       nullArgs.push(key)
-    } else if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    } else if (typeof value === 'number') {
+      // OTLP carries a double, and JSON has no NaN or Infinity, so these serialize to `null` and
+      // the value is lost. Python's `prepare_otlp_attribute` sends the string instead. `String`
+      // spells them the way the message template already does, so the two agree.
+      result[key] = Number.isFinite(value) ? value : String(value)
+    } else if (typeof value === 'string' || typeof value === 'boolean') {
       result[key] = value
     } else if (value instanceof Date) {
       try {


### PR DESCRIPTION
### Defect

`serializeAttributes` passes any `number` straight through to the span attribute. OTLP carries those as doubles, and JSON has no spelling for `NaN` or `Infinity`, so they serialize to `null` and the value is gone by the time it leaves the process.

### Evidence

Measured on `3d33c49`:

```
serializeAttributes({ nan: NaN, inf: Infinity, neginf: -Infinity, ok: 1.5 })
  -> { nan: NaN, inf: Infinity, neginf: -Infinity, ok: 1.5 }
JSON.stringify of that
  -> {"nan":null,"inf":null,"neginf":null,"ok":1.5}
```

Python's `prepare_otlp_attribute` sends the string instead (`if not math.isfinite(value): return str(value)`), so the same value survives there and is lost here.

The package already treats these as a problem elsewhere: `inferJsonSchema` maps a non-finite number to `{type: 'null'}`, and `evaluatorResults` rejects a non-finite evaluator score outright. Only the top-level primitive path was left.

### Fix

`Number.isFinite(value) ? value : String(value)` in the number branch, which the `AttributeValue` type already allows.

On the spelling: `String()` gives `NaN` and `Infinity` rather than Python's `nan` and `inf`. I went with the JS spelling because the message template already renders them that way, so `logfire.info('value is {x}', { x: NaN })` now has the message and the attribute agreeing. Happy to switch to Python's spelling if cross-SDK consistency in one dashboard matters more to you than internal consistency here.

`-0` stays a number, since it is finite and JSON already writes it as `0`.

Two mutations: passing numbers through unchanged fails the new assertion, and stringifying every number fails seven existing ones.

Out of scope, and I would rather raise it separately than guess: Python also converts an integer above 2^63-1 to a string with a `UserWarning`, and JS has no equivalent, so `2 ** 64` is still sent as an integer attribute it cannot represent. That one needs a threshold decision, since any JS integer past 2^53 has already lost precision, so the Python boundary is not the obvious one to copy.

Built this with Claude Code's help and reviewed the diff myself.
