### PR TITLE
Record a lifecycle constructor error as a case failure

### DIFF
--- a/.changeset/lifecycle-ctor-failure.md
+++ b/.changeset/lifecycle-ctor-failure.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Record a `CaseLifecycle` constructor error as a case failure instead of rejecting the whole experiment. The lifecycle was instantiated before the case span and outside the try that turns a case error into a `ReportCaseFailure`, so one throwing constructor made `Dataset.evaluate` reject and every completed case's results were lost.

--- a/packages/logfire-api/src/evals/Dataset.ts
+++ b/packages/logfire-api/src/evals/Dataset.ts
@@ -393,8 +393,10 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
   taskName: string
 }): Promise<ReportCase<Inputs, Output, Metadata> | ReportCaseFailure<Inputs, Output, Metadata>> {
   const { caseName, datasetEvaluators, lifecycleClass, originalCase, retryEvaluators, retryTask, sourceCaseName, task, taskName } = args
-  // eslint-disable-next-line new-cap
-  const lifecycle: CaseLifecycle<Inputs, Output, Metadata> | null = lifecycleClass ? new lifecycleClass(originalCase) : null
+  // Constructed inside the case span's try below, not here, so a constructor that throws fails
+  // that one case instead of rejecting the whole run. Python instantiates it in the same place
+  // (`dataset.py:1135-1137`).
+  let lifecycle: CaseLifecycle<Inputs, Output, Metadata> | null = null
 
   const exporterContextId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 
@@ -432,6 +434,10 @@ async function runOneCase<Inputs, Output, Metadata>(args: {
     let output: Output
     let taskDuration = 0
     try {
+      if (lifecycleClass !== undefined) {
+        // eslint-disable-next-line new-cap
+        lifecycle = new lifecycleClass(originalCase)
+      }
       if (lifecycle?.setup !== undefined) {
         await lifecycle.setup()
       }

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -113,6 +113,32 @@ describe('lifecycle hooks', () => {
     expect(events).toEqual(['teardown'])
   })
 
+  it('records a lifecycle constructor error as a case failure without rejecting the experiment', async () => {
+    class ThrowingConstructor extends CaseLifecycle<string, string> {
+      constructor(c: Case<string, string>) {
+        super(c)
+        if (c.name === 'b') {
+          throw new Error('ctor boom')
+        }
+      }
+    }
+    const ds = new Dataset<string, string>({
+      cases: [
+        new Case<string, string>({ inputs: 'a', name: 'a' }),
+        new Case<string, string>({ inputs: 'b', name: 'b' }),
+        new Case<string, string>({ inputs: 'c', name: 'c' }),
+      ],
+      name: 'lifecycle-ctor-test',
+    })
+
+    const { result } = await withMemoryExporter(async () => ds.evaluate((input) => input.toUpperCase(), { lifecycle: ThrowingConstructor }))
+
+    // Sorted: cases land in completion order, which concurrency makes non-deterministic.
+    expect(result.cases.map((c) => c.name).sort()).toEqual(['a', 'c'])
+    expect(result.failures.map((f) => f.name)).toEqual(['b'])
+    expect(result.failures[0]?.error_message).toBe('ctor boom')
+  })
+
   it('records teardown errors on failed cases without rejecting the experiment', async () => {
     class TeardownThrows extends CaseLifecycle<string, string> {
       override async teardown(): Promise<void> {


### PR DESCRIPTION
### Defect

`runOneCase` instantiates the `CaseLifecycle` before the case span opens and outside the try that turns a case error into a `ReportCaseFailure`. The per-case runner has no catch of its own and the cases run under `Promise.all`, so a constructor that throws rejects the whole experiment and every case that already finished is thrown away.

A constructor is a natural place to put per-case validation, since it is handed the `Case`.

### Evidence

Measured on `3d33c49`, three cases where the lifecycle constructor throws only for case `b`:

```
evaluate() REJECTED: bad case
```

Cases `a` and `c` had already produced results. Every other per-case failure mode is handled: a throwing task, a throwing `prepareContext` and a throwing `teardown` each become a failure or a recorded exception on that case alone.

Python instantiates it inside the same try (`dataset.py:1135-1137`), so there it is one case failure.

### Fix

Move the construction into that try, which is where Python has it. `teardown` is correctly skipped when the constructor threw, because `lifecycle` is still null and nothing was set up.

The regression asserts the two healthy cases still report and `b` becomes a failure carrying the constructor's message. Moving the construction back out fails it.

One note on the test: it sorts the case names, because cases land in completion order and the semaphore makes that non-deterministic.

Built this with Claude Code's help and reviewed the diff myself.
