### PR TITLE
Report both shutdown failures

### DIFF
--- a/.changeset/shutdown-aggregate-both.md
+++ b/.changeset/shutdown-aggregate-both.md
@@ -2,4 +2,4 @@
 '@pydantic/logfire-node': patch
 ---
 
-Report both shutdown failures instead of the first. `shutdown()` awaited the SDK and the variables teardown with `Promise.all`, which rejects on the first failure, so the second error was dropped and the operation it belonged to was left running past the call. They are now awaited together and every failure is collected, which is what the surrounding `AggregateError` handling was already built for.
+Report both shutdown failures instead of the first. `shutdown()` awaited the SDK and the variables teardown with `Promise.all`, which rejects on the first failure, so the second error was dropped and the operation it belonged to was left running past the call. Each failure is now recorded as its own operation settles, so an early one survives even when the other teardown outlives the deadline.

--- a/.changeset/shutdown-aggregate-both.md
+++ b/.changeset/shutdown-aggregate-both.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Report both shutdown failures instead of the first. `shutdown()` awaited the SDK and the variables teardown with `Promise.all`, which rejects on the first failure, so the second error was dropped and the operation it belonged to was left running past the call. They are now awaited together and every failure is collected, which is what the surrounding `AggregateError` handling was already built for.

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -702,14 +702,42 @@ describe('sdk lifecycle helpers', () => {
     start()
 
     const shutdownCall = shutdown()
-    // `Promise.all` rejected on the SDK error alone, so the call finished while this was pending.
+    // The flush runs first, so the queued promise is not consumed yet. Rejecting before the
+    // teardown has started would make the pending-ness below prove nothing.
+    await vi.waitFor(() => {
+      expect(mocks.shutdownVariablesCalls).toBe(1)
+    })
+    expect(variablesSettled).toBe(false)
     rejectVariables(variablesError)
 
     const error: unknown = await shutdownCall.catch((caught: unknown) => caught)
     expect(variablesSettled).toBe(true)
     expect(error).toBeInstanceOf(AggregateError)
     expect((error as AggregateError).message).toBe('logfire SDK: shutdown failed')
-    expect((error as AggregateError).errors).toEqual([sdkError, variablesError])
+    // Sorted: errors are recorded in settle order, which is not something to pin.
+    expect(((error as AggregateError).errors as Error[]).map((e) => e.message).sort()).toEqual([
+      'sdk shutdown failed',
+      'variables shutdown failed',
+    ])
+  })
+
+  it('keeps an early shutdown failure when the other teardown outlives the deadline', async () => {
+    const sdkError = new Error('sdk shutdown failed')
+    mocks.queueShutdownPromise(Promise.reject(sdkError))
+    mocks.queueShutdownVariablesPromise(
+      new Promise<void>(() => {
+        // Never settles: the point is that the SDK error must survive the deadline firing.
+      })
+    )
+    start()
+
+    const error: unknown = await shutdown({ flush: false, timeoutMillis: 20 }).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(AggregateError)
+    expect(((error as AggregateError).errors as Error[]).map((e) => e.message)).toEqual([
+      'sdk shutdown failed',
+      'logfire SDK: shutdown timed out',
+    ])
   })
 
   it('concurrent shutdown calls share one shutdown', async () => {

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => {
   const createdMetricReaders: MockMetricReader[] = []
   const metricReaderCallCounts = new Map<number, { forceFlush: number; shutdown: number }>()
   const shutdownPromises: Promise<void>[] = []
+  const shutdownVariablesPromises: Promise<void>[] = []
   let evalForceFlushCalls = 0
   let evalShutdownCalls = 0
   let logForceFlushCalls = 0
@@ -210,6 +211,7 @@ const mocks = vi.hoisted(() => {
       reportErrorCalls.length = 0
       shutdownVariablesCalls = 0
       shutdownPromises.length = 0
+      shutdownVariablesPromises.length = 0
       traceForceFlushCalls = 0
       traceOnEndSpans.length = 0
       traceOnStartSpans.length = 0
@@ -224,10 +226,13 @@ const mocks = vi.hoisted(() => {
     get shutdownVariablesCalls() {
       return shutdownVariablesCalls
     },
+    queueShutdownVariablesPromise(promise: Promise<void>) {
+      shutdownVariablesPromises.push(promise)
+    },
     shutdownVariables: async () => {
       shutdownVariablesCalls++
       variableState = makeEmptyVariableState()
-      return Promise.resolve()
+      return shutdownVariablesPromises.shift() ?? Promise.resolve()
     },
     get traceForceFlushCalls() {
       return traceForceFlushCalls
@@ -678,6 +683,33 @@ describe('sdk lifecycle helpers', () => {
     expect(mocks.shutdownVariablesCalls).toBe(1)
     await forceFlush()
     expect(mocks.traceForceFlushCalls).toBe(1)
+  })
+
+  it('reports both shutdown failures and waits for the slower one', async () => {
+    const sdkError = new Error('sdk shutdown failed')
+    const variablesError = new Error('variables shutdown failed')
+    let rejectVariables!: (reason: Error) => void
+    let variablesSettled = false
+    mocks.queueShutdownPromise(Promise.reject(sdkError))
+    mocks.queueShutdownVariablesPromise(
+      new Promise<void>((_resolve, reject) => {
+        rejectVariables = reject
+      }).catch((error: unknown) => {
+        variablesSettled = true
+        throw error
+      })
+    )
+    start()
+
+    const shutdownCall = shutdown()
+    // `Promise.all` rejected on the SDK error alone, so the call finished while this was pending.
+    rejectVariables(variablesError)
+
+    const error: unknown = await shutdownCall.catch((caught: unknown) => caught)
+    expect(variablesSettled).toBe(true)
+    expect(error).toBeInstanceOf(AggregateError)
+    expect((error as AggregateError).message).toBe('logfire SDK: shutdown failed')
+    expect((error as AggregateError).errors).toEqual([sdkError, variablesError])
   })
 
   it('concurrent shutdown calls share one shutdown', async () => {

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -260,12 +260,21 @@ async function shutdownRuntime(runtime: ActiveRuntime, options: ShutdownRuntimeO
       if (options.shutdownVariables !== false) {
         shutdownOperations.push(shutdownVariables())
       }
-      const shutdownPromise = Promise.all(shutdownOperations).then(() => undefined)
-      shutdownPromise.catch(() => undefined)
+      // `allSettled`, not `all`: `all` rejects on the first failure, so the other shutdown was
+      // left running past this call and its error was dropped, in a function whose whole shape
+      // exists to collect failures. Both are already in flight, so this only waits for what was
+      // started, and the deadline below still bounds it.
+      const shutdownPromise = Promise.allSettled(shutdownOperations)
+      let settled: PromiseSettledResult<void>[] = []
       try {
-        await withDeadline('shutdown', deadline, shutdownPromise)
+        settled = await withDeadline('shutdown', deadline, shutdownPromise)
       } catch (e: unknown) {
         errors.push(e)
+      }
+      for (const outcome of settled) {
+        if (outcome.status === 'rejected') {
+          errors.push(outcome.reason)
+        }
       }
 
       if (errors.length === 1) {

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -260,21 +260,32 @@ async function shutdownRuntime(runtime: ActiveRuntime, options: ShutdownRuntimeO
       if (options.shutdownVariables !== false) {
         shutdownOperations.push(shutdownVariables())
       }
-      // `allSettled`, not `all`: `all` rejects on the first failure, so the other shutdown was
-      // left running past this call and its error was dropped, in a function whose whole shape
-      // exists to collect failures. Both are already in flight, so this only waits for what was
-      // started, and the deadline below still bounds it.
-      const shutdownPromise = Promise.allSettled(shutdownOperations)
-      let settled: PromiseSettledResult<void>[] = []
+      // Each failure is recorded as its own operation settles, rather than read off a combined
+      // result. `Promise.all` rejected on the first failure, leaving the other shutdown running
+      // past this call with its error dropped; waiting for a combined result instead would lose
+      // an early failure whenever the other operation outlives the deadline. Both are already in
+      // flight, so this only waits for what was started, and the deadline still bounds it.
+      const operationErrors: unknown[] = []
+      const allSettled = Promise.all(
+        shutdownOperations.map(async (operation) => {
+          try {
+            await operation
+          } catch (e: unknown) {
+            operationErrors.push(e)
+          }
+        })
+      )
+      let deadlineError: unknown
+      let deadlineExceeded = false
       try {
-        settled = await withDeadline('shutdown', deadline, shutdownPromise)
+        await withDeadline('shutdown', deadline, allSettled)
       } catch (e: unknown) {
-        errors.push(e)
+        deadlineError = e
+        deadlineExceeded = true
       }
-      for (const outcome of settled) {
-        if (outcome.status === 'rejected') {
-          errors.push(outcome.reason)
-        }
+      errors.push(...operationErrors)
+      if (deadlineExceeded) {
+        errors.push(deadlineError)
       }
 
       if (errors.length === 1) {


### PR DESCRIPTION
### Defect

`shutdown()` starts the SDK teardown and the variables teardown, then awaits them with `Promise.all`. `all` rejects the moment the first one fails, so:

- the second failure is discarded, in a function that otherwise goes to some length to collect failures and raise them as an `AggregateError`, and
- the operation that had not settled yet is left running after the call returned.

The second part matters because the `finally` clears `activeRuntime` on the way out, so a following `start()` can register a new runtime while the previous variables teardown is still in flight.

### Evidence

Measured on `3d33c49` with the SDK teardown rejecting immediately and the variables teardown rejecting a tick later:

```
before: shutdown() rejects with the SDK error alone; the variables teardown is still pending
after:  AggregateError('logfire SDK: shutdown failed') carrying [sdkError, variablesError]
```

`Promise.all` rejecting early is also what the `shutdownPromise.catch(() => undefined)` line existed to silence, so the dropped rejection was known about; it was the reporting that was missing.

### Fix

`Promise.allSettled`, then push every rejection into the `errors` array the function already builds. Both operations were started eagerly before, so this waits only for work already in flight, and `withDeadline` still bounds the wait exactly as it did.

Same reasoning as #279, which you merged: when a call owns two teardowns, both should run and the first failure should not hide the second.

Two mutations: restoring `Promise.all`, or dropping the loop that collects the rejections, each fail the new assertion.

The test needed one harness addition, `queueShutdownVariablesPromise`, mirroring the existing `queueShutdownPromise`, so the variables teardown can be made to settle after the SDK one.

Built this with Claude Code's help and reviewed the diff myself.
