### PR TITLE
Document direct browser ingest with frontend application tokens

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ then `OTEL_*` environment variables.
 
 ## Tokens
 
-Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser applications use a restricted frontend application token and the generated `traceUrl` and `traceExporterHeaders` settings. Do not publish a normal Logfire write token. See the [Browser package](packages/browser.md) for setup.
+Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser applications instead use the `traceUrl`, `traceExporterHeaders`, and restricted token generated for a frontend application. Never put a normal Logfire write token in browser code. See the [Browser package](packages/browser.md) for setup.
 
 For local Node.js development, you can also let the CLI write project credentials:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ then `OTEL_*` environment variables.
 
 ## Tokens
 
-Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser code must not receive the token; use a backend proxy and configure `traceUrl` instead.
+Node.js and Cloudflare read `LOGFIRE_TOKEN` by default. Browser applications use a restricted frontend application token and the generated `traceUrl` and `traceExporterHeaders` settings. Do not publish a normal Logfire write token. See the [Browser package](packages/browser.md) for setup.
 
 For local Node.js development, you can also let the CLI write project credentials:
 

--- a/docs/frameworks/nextjs.md
+++ b/docs/frameworks/nextjs.md
@@ -61,34 +61,22 @@ npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
 
 Create a frontend application under **Project settings > Frontend applications**, then copy its generated browser setup. The token can only write telemetry for that frontend application and cannot read project data. Follow the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for setup and verification.
 
-Configure the browser package in a client-only component using the generated `traceUrl` and `traceExporterHeaders` values:
+For Next.js 15.3 and later, configure the browser package in
+`instrumentation-client.ts` using the generated `traceUrl` and
+`traceExporterHeaders` values. Next.js loads this file once in the browser
+before the application becomes interactive.
 
-```tsx
-'use client'
-
+```ts title="instrumentation-client.ts"
 import * as logfire from '@pydantic/logfire-browser'
-import { useEffect } from 'react'
 
-export function ClientInstrumentation() {
-  useEffect(() => {
-    const shutdown = logfire.configure({
-      traceUrl: 'https://logfire-us.pydantic.dev/v1/traces',
-      traceExporterHeaders: () => ({
-        Authorization: 'Bearer <frontend-application-token>',
-      }),
-      autoInstrumentations: true,
-    })
-
-    return () => {
-      void shutdown()
-    }
-  }, [])
-
-  return null
-}
+logfire.configure({
+  traceUrl: 'https://logfire-us.pydantic.dev/v1/traces',
+  traceExporterHeaders: () => ({
+    Authorization: 'Bearer <frontend-application-token>',
+  }),
+  autoInstrumentations: true,
+})
 ```
-
-If you import the component from a server-rendered page, load it with `next/dynamic` and `ssr: false` so browser instrumentation only runs in the browser.
 
 ### Optional Proxy
 
@@ -121,30 +109,16 @@ export const config = {
 }
 ```
 
-Then point the browser package at the proxy:
+Then point `instrumentation-client.ts` at the proxy:
 
-```tsx
-'use client'
-
-import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
+```ts title="instrumentation-client.ts"
 import * as logfire from '@pydantic/logfire-browser'
-import { useEffect } from 'react'
 
-export function ClientInstrumentation() {
-  useEffect(() => {
-    const shutdown = logfire.configure({
-      traceUrl: '/logfire-proxy/v1/traces',
-      serviceName: 'nextjs-browser',
-      instrumentations: [getWebAutoInstrumentations()],
-    })
-
-    return () => {
-      void shutdown()
-    }
-  }, [])
-
-  return null
-}
+logfire.configure({
+  traceUrl: '/logfire-proxy/v1/traces',
+  serviceName: 'nextjs-browser',
+  autoInstrumentations: true,
+})
 ```
 
 See `examples/nextjs` and `examples/nextjs-client-side-instrumentation` for working projects.

--- a/docs/frameworks/nextjs.md
+++ b/docs/frameworks/nextjs.md
@@ -5,7 +5,7 @@ description: Use Logfire with Next.js server-side OpenTelemetry and optional cli
 
 # Next.js
 
-Next.js can emit server-side OpenTelemetry through `@vercel/otel`. Client-side browser traces use `@pydantic/logfire-browser` with a restricted frontend application token. A proxy remains available when you need additional server-side controls.
+Next.js can emit server-side OpenTelemetry through `@vercel/otel`. Use `@pydantic/logfire-browser` with a restricted frontend application token for client-side browser traces.
 
 ## Server-Side Tracing
 
@@ -59,7 +59,7 @@ Install the browser package:
 npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
 ```
 
-Create a frontend application under **Project settings > Frontend applications**, then copy its generated browser setup. The restricted token can only write data for that application and is safe to include in the browser bundle. See the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for the complete flow.
+Create a frontend application under **Project settings > Frontend applications**, then copy its generated browser setup. The token can only write telemetry for that frontend application and cannot read project data. Follow the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for setup and verification.
 
 Configure the browser package in a client-only component using the generated `traceUrl` and `traceExporterHeaders` values:
 
@@ -92,7 +92,7 @@ If you import the component from a server-rendered page, load it with `next/dyna
 
 ### Optional Proxy
 
-Use a proxy route or middleware if you need application-specific authentication, origin checks, or rate limits in front of browser ingest.
+Use a proxy route or middleware if you need to authenticate browser requests, restrict origins, or apply application-specific rate limits.
 
 For Next.js 16 and later, place this code in `proxy.ts` in the project root, or in `src/proxy.ts` if your app uses `src`.
 

--- a/docs/frameworks/nextjs.md
+++ b/docs/frameworks/nextjs.md
@@ -5,7 +5,7 @@ description: Use Logfire with Next.js server-side OpenTelemetry and optional cli
 
 # Next.js
 
-Next.js can emit server-side OpenTelemetry through `@vercel/otel`. Client-side browser traces use `@pydantic/logfire-browser` and a proxy endpoint so the write token stays server-side.
+Next.js can emit server-side OpenTelemetry through `@vercel/otel`. Client-side browser traces use `@pydantic/logfire-browser` with a restricted frontend application token. A proxy remains available when you need additional server-side controls.
 
 ## Server-Side Tracing
 
@@ -59,7 +59,40 @@ Install the browser package:
 npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
 ```
 
-Create a proxy route or middleware that forwards browser OTLP requests to Logfire with the `Authorization` header. Browser requests should go to this same-origin proxy, not directly to the Logfire API.
+Create a frontend application under **Project settings > Frontend applications**, then copy its generated browser setup. The restricted token can only write data for that application and is safe to include in the browser bundle. See the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for the complete flow.
+
+Configure the browser package in a client-only component using the generated `traceUrl` and `traceExporterHeaders` values:
+
+```tsx
+'use client'
+
+import * as logfire from '@pydantic/logfire-browser'
+import { useEffect } from 'react'
+
+export function ClientInstrumentation() {
+  useEffect(() => {
+    const shutdown = logfire.configure({
+      traceUrl: 'https://logfire-us.pydantic.dev/v1/traces',
+      traceExporterHeaders: () => ({
+        Authorization: 'Bearer <frontend-application-token>',
+      }),
+      autoInstrumentations: true,
+    })
+
+    return () => {
+      void shutdown()
+    }
+  }, [])
+
+  return null
+}
+```
+
+If you import the component from a server-rendered page, load it with `next/dynamic` and `ssr: false` so browser instrumentation only runs in the browser.
+
+### Optional Proxy
+
+Use a proxy route or middleware if you need application-specific authentication, origin checks, or rate limits in front of browser ingest.
 
 For Next.js 16 and later, place this code in `proxy.ts` in the project root, or in `src/proxy.ts` if your app uses `src`.
 
@@ -88,7 +121,7 @@ export const config = {
 }
 ```
 
-Then configure the browser package in a client-only component:
+Then point the browser package at the proxy:
 
 ```tsx
 'use client'
@@ -113,7 +146,5 @@ export function ClientInstrumentation() {
   return null
 }
 ```
-
-If you import the component from a server-rendered page, load it with `next/dynamic` and `ssr: false` so browser instrumentation only runs in the browser.
 
 See `examples/nextjs` and `examples/nextjs-client-side-instrumentation` for working projects.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,6 @@ The TypeScript SDK provides Logfire support for JavaScript and TypeScript applic
 Use [Getting Started](get-started.md) for a minimal script, then move to the package page for your runtime:
 
 - Server-side Node.js applications should start with [Node.js](packages/node.md).
-- Browser applications should start with [Browser](packages/browser.md) and create a restricted frontend application token. A backend proxy is optional.
+- Browser applications should start with [Browser](packages/browser.md) and create a restricted frontend application token. Direct trace, metric, and session replay ingestion does not require a backend proxy.
 - Cloudflare Workers should start with [Cloudflare Workers](packages/cloudflare.md).
 - Framework users can use the [Express](frameworks/express.md), [Next.js](frameworks/nextjs.md), [Deno](frameworks/deno.md), or [Vercel AI SDK](frameworks/vercel-ai.md) guides.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,6 @@ The TypeScript SDK provides Logfire support for JavaScript and TypeScript applic
 Use [Getting Started](get-started.md) for a minimal script, then move to the package page for your runtime:
 
 - Server-side Node.js applications should start with [Node.js](packages/node.md).
-- Browser applications should start with [Browser](packages/browser.md), especially the proxy requirement.
+- Browser applications should start with [Browser](packages/browser.md) and create a restricted frontend application token. A backend proxy is optional.
 - Cloudflare Workers should start with [Cloudflare Workers](packages/cloudflare.md).
 - Framework users can use the [Express](frameworks/express.md), [Next.js](frameworks/nextjs.md), [Deno](frameworks/deno.md), or [Vercel AI SDK](frameworks/vercel-ai.md) guides.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,6 @@ The TypeScript SDK provides Logfire support for JavaScript and TypeScript applic
 Use [Getting Started](get-started.md) for a minimal script, then move to the package page for your runtime:
 
 - Server-side Node.js applications should start with [Node.js](packages/node.md).
-- Browser applications should start with [Browser](packages/browser.md) and create a restricted frontend application token. Direct trace, metric, and session replay ingestion does not require a backend proxy.
+- Browser applications should start with [Browser](packages/browser.md) and use a restricted frontend application token for direct trace, metric, and session replay ingest.
 - Cloudflare Workers should start with [Cloudflare Workers](packages/cloudflare.md).
 - Framework users can use the [Express](frameworks/express.md), [Next.js](frameworks/nextjs.md), [Deno](frameworks/deno.md), or [Vercel AI SDK](frameworks/vercel-ai.md) guides.

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -243,18 +243,15 @@ Install the optional replay package when you want rrweb session recording:
 npm install @pydantic/logfire-session-replay
 ```
 
-Unlike browser traces, replay uploads still require a browser-safe proxy endpoint. The replay ingest endpoint does not currently accept arbitrary-origin browser requests:
+Session replay uses the same restricted frontend application token as traces and metrics:
 
 ```ts
 const cleanup = logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   sessionReplay: {
     load: () => import('@pydantic/logfire-session-replay'),
-    replayUrl: '/logfire-proxy/v1/replay',
-    headers: async () => ({
-      'X-CSRF': await getCsrfToken(),
-    }),
+    replayUrl: new URL('/v1/replay', frontendApplicationConfig.traceUrl).toString(),
+    headers: frontendApplicationConfig.traceExporterHeaders,
     maskAllText: true,
     maskAllInputs: true,
   },
@@ -298,16 +295,15 @@ browser's keepalive quota is also shared with unrelated page traffic. Delivery
 after page freeze or termination is therefore not guaranteed. Functional
 `headers` and `token` values are resolved for every upload; an asynchronous
 resolver can finish too late for a lifecycle request, so prefer credentials that
-are synchronously available from your same-origin proxy flow.
+are synchronously available, such as the generated frontend application headers.
 
 Ordinary replay uploads automatically fall back to synchronous gzip if a
 restrictive Content Security Policy blocks the compressor worker. The fallback
 preserves the batch and is remembered for the active replay controller, but it
 may briefly use the main thread.
 
-Direct token usage is available as an advanced escape hatch for trusted or
-same-origin runtimes, but it exposes a normal write token and is not the default
-browser deployment model:
+A backend proxy remains available when your application needs additional
+server-side authentication, origin checks, or rate limits:
 
 ```ts
 logfire.configure({
@@ -315,8 +311,10 @@ logfire.configure({
   serviceName: 'web-app',
   sessionReplay: {
     load: () => import('@pydantic/logfire-session-replay'),
-    replayUrl: 'https://logfire-api.pydantic.dev/v1/replay',
-    token: '<write-token>',
+    replayUrl: '/logfire-proxy/v1/replay',
+    headers: async () => ({
+      'X-CSRF': await getCsrfToken(),
+    }),
   },
 })
 ```

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -302,7 +302,8 @@ preserves the batch and is remembered for the active replay controller, but it
 may briefly use the main thread.
 
 A backend proxy can add application-specific authentication, origin checks, or
-rate limits:
+rate limits. Keep its replay headers synchronous so lifecycle uploads do not
+wait on asynchronous work:
 
 ```ts
 logfire.configure({
@@ -311,8 +312,8 @@ logfire.configure({
   sessionReplay: {
     load: () => import('@pydantic/logfire-session-replay'),
     replayUrl: '/logfire-proxy/v1/replay',
-    headers: async () => ({
-      'X-CSRF': await getCsrfToken(),
+    headers: () => ({
+      'X-CSRF': getCsrfToken(),
     }),
   },
 })

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -1,15 +1,15 @@
 ---
 title: Browser Package
-description: Configure @pydantic/logfire-browser with a restricted frontend application token or an optional backend proxy.
+description: Configure @pydantic/logfire-browser for browser tracing, RUM, metrics, and session replay.
 ---
 
 # `@pydantic/logfire-browser`
 
 `@pydantic/logfire-browser` configures OpenTelemetry browser tracing and re-exports the manual `logfire` API for client-side spans and logs.
 
-Create a frontend application under **Project settings > Frontend applications**, then paste its generated setup into your browser code. The generated token is deliberately safe to publish: it can only write data for that frontend application and cannot read project data. A backend proxy is not required.
+Create a frontend application under **Project settings > Frontend applications**, then paste its generated setup into your browser code. Its token can only write telemetry for that frontend application and cannot read project data.
 
-See the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for the complete setup and verification flow. Do not publish a normal Logfire write token. Only frontend application tokens have the restricted permissions intended for browser bundles.
+Follow the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for setup and verification. Never put a normal Logfire write token in browser code.
 
 ## Install
 
@@ -36,7 +36,7 @@ logfire.configure({
 })
 ```
 
-The frontend application supplies the service name, so the browser cannot use its public token to report as another service. Keep the generated `traceUrl` and `traceExporterHeaders` when adding the options shown in the rest of this page.
+Logfire associates the token with the frontend application's service name, so it cannot report data for another application. Keep the generated `traceUrl` and `traceExporterHeaders` when adding the options shown in the rest of this page.
 
 `autoInstrumentations` is opt-in and lazily loads OpenTelemetry browser auto-instrumentations after the Logfire browser provider is ready. For advanced integrations, `instrumentations` also accepts factories, so custom instrumentation construction can be deferred until `configure()` has registered the provider.
 
@@ -182,9 +182,8 @@ and metric destination but ignore changed observer options with a diagnostic
 warning. If the initial lazy load or observer startup fails, a later
 `configure()` call retries it.
 
-To emit native OpenTelemetry histogram metrics in parallel with those spans,
-use the frontend application token for the regional metrics endpoint and opt
-Web Vitals into metrics:
+To also export Web Vitals as OpenTelemetry histogram metrics, configure the
+regional metrics endpoint with the same headers:
 
 ```ts
 logfire.configure({
@@ -243,7 +242,7 @@ Install the optional replay package when you want rrweb session recording:
 npm install @pydantic/logfire-session-replay
 ```
 
-Session replay uses the same restricted frontend application token as traces and metrics:
+Use the same endpoint host and headers for session replay:
 
 ```ts
 const cleanup = logfire.configure({
@@ -294,16 +293,16 @@ budget is shared across its own unfinished keepalive requests, while the
 browser's keepalive quota is also shared with unrelated page traffic. Delivery
 after page freeze or termination is therefore not guaranteed. Functional
 `headers` and `token` values are resolved for every upload; an asynchronous
-resolver can finish too late for a lifecycle request, so prefer credentials that
-are synchronously available, such as the generated frontend application headers.
+resolver can finish too late for a lifecycle request. The generated frontend
+application headers are synchronous and work for these uploads.
 
 Ordinary replay uploads automatically fall back to synchronous gzip if a
 restrictive Content Security Policy blocks the compressor worker. The fallback
 preserves the batch and is remembered for the active replay controller, but it
 may briefly use the main thread.
 
-A backend proxy remains available when your application needs additional
-server-side authentication, origin checks, or rate limits:
+A backend proxy can add application-specific authentication, origin checks, or
+rate limits:
 
 ```ts
 logfire.configure({
@@ -417,15 +416,14 @@ baggage.
 
 ## Optional Backend Proxy
 
-Direct ingest with a frontend application token is the standard setup. Use a
-backend proxy only when your application needs additional server-side access
-control, origin checks, or rate limits. A browser proxy should:
+Use a backend proxy when you need to authenticate browser requests, restrict
+origins, or apply application-specific rate limits. A browser proxy should:
 
-- accept requests from your frontend only
+- authenticate browser requests and restrict their origins
 - add `Authorization: <write-token>` server-side
-- forward traces to the Logfire OTLP trace endpoint and metrics to the OTLP
-  metrics endpoint
-- apply authentication, rate limiting, or origin checks for production apps
+- forward traces, metrics, and session replays to the corresponding Logfire
+  ingest endpoints
+- apply application-specific rate limits
 
 For Next.js, see [Next.js](../frameworks/nextjs.md). For a standalone browser example, see the `examples/browser` project in this repository.
 

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -1,13 +1,15 @@
 ---
 title: Browser Package
-description: Configure @pydantic/logfire-browser for browser tracing with an authenticated backend proxy.
+description: Configure @pydantic/logfire-browser with a restricted frontend application token or an optional backend proxy.
 ---
 
 # `@pydantic/logfire-browser`
 
 `@pydantic/logfire-browser` configures OpenTelemetry browser tracing and re-exports the manual `logfire` API for client-side spans and logs.
 
-Browser telemetry must be sent through your own backend proxy. Do not put a Logfire write token in browser code, and do not configure browser code to send directly to `https://logfire-api.pydantic.dev/v1/traces`. Requests from arbitrary browser origins are blocked by CORS, and adding an `Authorization` header in client code would expose the write token.
+Create a frontend application under **Project settings > Frontend applications**, then paste its generated setup into your browser code. The generated token is deliberately safe to publish: it can only write data for that frontend application and cannot read project data. A backend proxy is not required.
+
+See the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for the complete setup and verification flow. Do not publish a normal Logfire write token. Only frontend application tokens have the restricted permissions intended for browser bundles.
 
 ## Install
 
@@ -20,17 +22,21 @@ npm install @pydantic/logfire-browser
 ```ts
 import * as logfire from '@pydantic/logfire-browser'
 
-const url = new URL('/logfire-proxy/v1/traces', window.location.origin)
+const frontendApplicationConfig = {
+  // Copy these region-specific values from the frontend application page.
+  traceUrl: 'https://logfire-us.pydantic.dev/v1/traces',
+  traceExporterHeaders: () => ({
+    Authorization: 'Bearer <frontend-application-token>',
+  }),
+}
 
 logfire.configure({
-  traceUrl: url.toString(),
-  serviceName: 'web-app',
-  serviceVersion: '1.0.0',
+  ...frontendApplicationConfig,
   autoInstrumentations: true,
 })
 ```
 
-`traceUrl` should point to a server-side endpoint that accepts OTLP trace requests from your browser instrumentation, forwards them to Logfire, and adds the `Authorization` header on the server.
+The frontend application supplies the service name, so the browser cannot use its public token to report as another service. Keep the generated `traceUrl` and `traceExporterHeaders` when adding the options shown in the rest of this page.
 
 `autoInstrumentations` is opt-in and lazily loads OpenTelemetry browser auto-instrumentations after the Logfire browser provider is ready. For advanced integrations, `instrumentations` also accepts factories, so custom instrumentation construction can be deferred until `configure()` has registered the provider.
 
@@ -38,8 +44,7 @@ Use `diagLogLevel` while troubleshooting local browser instrumentation:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   autoInstrumentations: true,
   diagLogLevel: logfire.DiagLogLevel.ALL,
 })
@@ -56,8 +61,7 @@ created by the configured browser provider:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   rum: { session: true },
 })
 ```
@@ -73,8 +77,7 @@ for a browser session:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   rum: {
     session: {
       getRouteName: () => router.currentRoute.value.matched.at(-1)?.path,
@@ -107,8 +110,7 @@ raw page URL, or suppress them:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   rum: {
     session: {
       urlAttributes: (url) => ({ full: url.href, path: url.pathname }),
@@ -117,8 +119,7 @@ logfire.configure({
 })
 
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   rum: {
     session: {
       urlAttributes: false,
@@ -136,8 +137,7 @@ Enable `rum.webVitals` to record Core Web Vitals from real browser sessions:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   rum: { webVitals: true },
 })
 ```
@@ -160,8 +160,7 @@ session options alongside Web Vitals:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   rum: {
     session: {
       urlAttributes: (url) => ({
@@ -184,15 +183,16 @@ warning. If the initial lazy load or observer startup fails, a later
 `configure()` call retries it.
 
 To emit native OpenTelemetry histogram metrics in parallel with those spans,
-configure a browser-safe metrics proxy and opt Web Vitals into metrics:
+use the frontend application token for the regional metrics endpoint and opt
+Web Vitals into metrics:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
+  ...frontendApplicationConfig,
   metrics: {
-    metricUrl: '/logfire-proxy/v1/metrics',
+    metricUrl: new URL('/v1/metrics', frontendApplicationConfig.traceUrl).toString(),
+    metricExporterHeaders: frontendApplicationConfig.traceExporterHeaders,
   },
-  serviceName: 'web-app',
   rum: {
     webVitals: {
       metrics: true,
@@ -243,7 +243,7 @@ Install the optional replay package when you want rrweb session recording:
 npm install @pydantic/logfire-session-replay
 ```
 
-Configure replay with a browser-safe proxy endpoint:
+Unlike browser traces, replay uploads still require a browser-safe proxy endpoint. The replay ingest endpoint does not currently accept arbitrary-origin browser requests:
 
 ```ts
 const cleanup = logfire.configure({
@@ -305,9 +305,9 @@ restrictive Content Security Policy blocks the compressor worker. The fallback
 preserves the batch and is remembered for the active replay controller, but it
 may briefly use the main thread.
 
-Direct token usage is available as an advanced escape hatch, but it exposes the
-write token to browser code and should not be the default browser deployment
-model:
+Direct token usage is available as an advanced escape hatch for trusted or
+same-origin runtimes, but it exposes a normal write token and is not the default
+browser deployment model:
 
 ```ts
 logfire.configure({
@@ -348,8 +348,7 @@ the browser tracer provider:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   spanProcessors: [customProcessor],
 })
 ```
@@ -382,8 +381,7 @@ are created:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   minLevel: 'warning',
 })
 ```
@@ -402,8 +400,7 @@ values onto Logfire manual spans and logs:
 
 ```ts
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   baggage: {
     spanAttributes: ['tenant', 'region'],
   },
@@ -420,9 +417,11 @@ Baggage propagates across service boundaries. Do not store secrets,
 credentials, session cookies, raw emails, or other sensitive user data in
 baggage.
 
-## Proxy Requirement
+## Optional Backend Proxy
 
-A browser proxy should:
+Direct ingest with a frontend application token is the standard setup. Use a
+backend proxy only when your application needs additional server-side access
+control, origin checks, or rate limits. A browser proxy should:
 
 - accept requests from your frontend only
 - add `Authorization: <write-token>` server-side

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -142,4 +142,4 @@ Both commands accept `--data-dir <dir>` to read or remove credentials from a dir
 
 ## Browser Safety
 
-Local credential files are Node-only. Browser applications use the restricted token and ingest URL generated under **Project settings > Frontend applications**. Do not publish a normal Logfire write token. See the [Browser package](../packages/browser.md) for setup.
+Local credential files are Node-only. Browser applications use the restricted token and ingest settings generated under **Project settings > Frontend applications**. Never put a normal Logfire write token in browser code. See the [Browser package](../packages/browser.md) for setup.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -142,4 +142,4 @@ Both commands accept `--data-dir <dir>` to read or remove credentials from a dir
 
 ## Browser Safety
 
-Local credential files are Node-only. Browser code must not receive a Logfire write token; configure `@pydantic/logfire-browser` with a backend `traceUrl` proxy instead.
+Local credential files are Node-only. Browser applications use the restricted token and ingest URL generated under **Project settings > Frontend applications**. Do not publish a normal Logfire write token. See the [Browser package](../packages/browser.md) for setup.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -63,7 +63,7 @@ Store production values as Worker secrets.
 
 ## Browser
 
-`@pydantic/logfire-browser` does not read Logfire credentials from environment variables. Use the restricted token, `traceUrl`, and `traceExporterHeaders` generated for a frontend application. A backend proxy remains optional for applications that need additional server-side controls.
+`@pydantic/logfire-browser` does not read Logfire credentials from environment variables. Use the restricted token, `traceUrl`, and `traceExporterHeaders` generated for a frontend application. Use a backend proxy only if browser traffic needs application-specific authentication, origin restrictions, or rate limits.
 
 ## Generic OpenTelemetry
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -63,7 +63,7 @@ Store production values as Worker secrets.
 
 ## Browser
 
-`@pydantic/logfire-browser` does not read Logfire credentials from environment variables. Configure a `traceUrl` that points at your backend proxy.
+`@pydantic/logfire-browser` does not read Logfire credentials from environment variables. Use the restricted token, `traceUrl`, and `traceExporterHeaders` generated for a frontend application. A backend proxy remains optional for applications that need additional server-side controls.
 
 ## Generic OpenTelemetry
 

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -19,13 +19,17 @@ If you're instrumenting Cloudflare, see the [Logfire CF workers package](https:/
 
 ## Basic usage
 
-See the [Logfire Browser docs for a primer](https://logfire.pydantic.dev/docs/integrations/javascript/browser/). Ready to run examples are available in the repository [in vanilla browser](https://github.com/pydantic/logfire-js/tree/main/examples/browser), [with RUM and replay](https://github.com/pydantic/logfire-js/tree/main/examples/browser-rum-replay), and [in Next.js variants](https://github.com/pydantic/logfire-js/tree/main/examples/nextjs-client-side-instrumentation).
+Create a frontend application under **Project settings > Frontend applications** and paste its generated setup into your browser code. Its restricted token is safe to publish: it can only write data for that application and cannot read project data. A backend proxy is not required. See the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for the complete setup and the [Browser package docs](https://pydantic.dev/docs/logfire/instrument/typescript/packages/browser/) for SDK options.
+
+Ready to run examples are available in the repository [in vanilla browser](https://github.com/pydantic/logfire-js/tree/main/examples/browser), [with RUM and replay](https://github.com/pydantic/logfire-js/tree/main/examples/browser-rum-replay), and [in Next.js variants](https://github.com/pydantic/logfire-js/tree/main/examples/nextjs-client-side-instrumentation).
 
 Build the workspace packages before running the Vite examples. The standalone
 examples use same-origin browser URLs and development-only Express helpers that
 bind to `127.0.0.1`, accept exact configured origins, and inject the Logfire
-write token server-side. Do not put a write token in a browser bundle or treat
-those loopback helpers as a production proxy design.
+write token server-side. They demonstrate an optional proxy setup for local
+development, not a production proxy design. Never put a normal Logfire write
+token in a browser bundle; use a restricted frontend application token for
+direct ingest.
 
 ## Managed Variables
 
@@ -299,10 +303,12 @@ subsequent replay events only peek at the session id and do not refresh the
 timeout. Span starts are the ongoing automatic activity;
 `getBrowserSessionId()` also explicitly touches the session.
 
-Use a backend proxy for browser replay uploads. The proxy should authenticate
-the browser request with your application session or CSRF mechanism and add the
-Logfire write token server-side. Direct token configuration is available as an
-advanced escape hatch:
+Unlike browser traces, replay uploads still require a browser-safe proxy
+endpoint. The replay ingest endpoint does not currently accept arbitrary-origin
+browser requests. The proxy should authenticate the browser request with your
+application session or CSRF mechanism and add the Logfire write token
+server-side. Direct token configuration remains an advanced escape hatch for
+trusted or same-origin runtimes:
 
 ```js
 logfire.configure({
@@ -336,11 +342,11 @@ restrictive Content Security Policy blocks the compressor worker. The fallback
 preserves the batch and is remembered for the active replay controller, but it
 may briefly use the main thread.
 
-Do not use direct tokens in normal browser applications. Replay masks all
-rendered text and input values by default, leaves console capture off, and
-removes query strings and fragments from captured page, fetch/XHR, and
-navigation URLs. Network and navigation capture remain enabled. These defaults
-are inherited when the corresponding browser options are omitted.
+Replay masks all rendered text and input values by default, leaves console
+capture off, and removes query strings and fragments from captured page,
+fetch/XHR, and navigation URLs. Network and navigation capture remain enabled.
+These defaults are inherited when the corresponding browser options are
+omitted.
 
 Use `blockSelector` to omit a subtree. Set `maskAllText: false` only when
 visible text recording is acceptable; `maskTextSelector` can then selectively

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -303,24 +303,30 @@ subsequent replay events only peek at the session id and do not refresh the
 timeout. Span starts are the ongoing automatic activity;
 `getBrowserSessionId()` also explicitly touches the session.
 
-Unlike browser traces, replay uploads still require a browser-safe proxy
-endpoint. The replay ingest endpoint does not currently accept arbitrary-origin
-browser requests. The proxy should authenticate the browser request with your
-application session or CSRF mechanism and add the Logfire write token
-server-side. Direct token configuration remains an advanced escape hatch for
-trusted or same-origin runtimes:
+Session replay uses the same restricted frontend application token as traces
+and metrics. Derive the regional replay endpoint from the generated trace URL:
 
 ```js
+const frontendApplicationConfig = {
+  // Copy these values from Project settings > Frontend applications.
+  traceUrl: 'https://logfire-us.pydantic.dev/v1/traces',
+  traceExporterHeaders: () => ({
+    Authorization: 'Bearer <frontend-application-token>',
+  }),
+}
+
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'browser-app',
+  ...frontendApplicationConfig,
   sessionReplay: {
     load: () => import('@pydantic/logfire-session-replay'),
-    replayUrl: 'https://logfire-api.pydantic.dev/v1/replay',
-    token: '<write-token>',
+    replayUrl: new URL('/v1/replay', frontendApplicationConfig.traceUrl).toString(),
+    headers: frontendApplicationConfig.traceExporterHeaders,
   },
 })
 ```
+
+Use a backend proxy only when your application needs additional server-side
+authentication, origin checks, or rate limits.
 
 After a replay reaches the minimum duration, hiding the document or receiving
 `pagehide` makes a bounded best-effort start of the earliest compressed chunks.
@@ -330,7 +336,7 @@ browser's keepalive quota is also shared with unrelated page traffic. Delivery
 after page freeze or termination is therefore not guaranteed. Functional
 `headers` and `token` values are resolved for every upload; an asynchronous
 resolver can finish too late for a lifecycle request, so prefer credentials that
-are synchronously available from your same-origin proxy flow.
+are synchronously available, such as the generated frontend application headers.
 
 Replays shorter than `minSessionDurationMs` are not uploaded (5 seconds by
 default). An earlier flush remains buffered until the minimum is reached, and

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -19,17 +19,16 @@ If you're instrumenting Cloudflare, see the [Logfire CF workers package](https:/
 
 ## Basic usage
 
-Create a frontend application under **Project settings > Frontend applications** and paste its generated setup into your browser code. Its restricted token is safe to publish: it can only write data for that application and cannot read project data. A backend proxy is not required. See the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for the complete setup and the [Browser package docs](https://pydantic.dev/docs/logfire/instrument/typescript/packages/browser/) for SDK options.
+Create a frontend application under **Project settings > Frontend applications** and paste its generated setup into your browser code. Its token can only write telemetry for that frontend application and cannot read project data. Follow the [Frontend guide](https://pydantic.dev/docs/logfire/observe/frontend/) for setup and verification, then use the [Browser package docs](https://pydantic.dev/docs/logfire/instrument/typescript/packages/browser/) for SDK options.
 
 Ready to run examples are available in the repository [in vanilla browser](https://github.com/pydantic/logfire-js/tree/main/examples/browser), [with RUM and replay](https://github.com/pydantic/logfire-js/tree/main/examples/browser-rum-replay), and [in Next.js variants](https://github.com/pydantic/logfire-js/tree/main/examples/nextjs-client-side-instrumentation).
 
 Build the workspace packages before running the Vite examples. The standalone
 examples use same-origin browser URLs and development-only Express helpers that
 bind to `127.0.0.1`, accept exact configured origins, and inject the Logfire
-write token server-side. They demonstrate an optional proxy setup for local
-development, not a production proxy design. Never put a normal Logfire write
-token in a browser bundle; use a restricted frontend application token for
-direct ingest.
+write token server-side. They demonstrate a local proxy, not a production proxy
+design. For direct ingest, use a restricted frontend application token. Never
+put a normal Logfire write token in browser code.
 
 ## Managed Variables
 
@@ -303,8 +302,9 @@ subsequent replay events only peek at the session id and do not refresh the
 timeout. Span starts are the ongoing automatic activity;
 `getBrowserSessionId()` also explicitly touches the session.
 
-Session replay uses the same restricted frontend application token as traces
-and metrics. Derive the regional replay endpoint from the generated trace URL:
+Use the same restricted frontend application token for traces, metrics, and
+session replay. Derive the regional replay endpoint from the generated trace
+URL:
 
 ```js
 const frontendApplicationConfig = {
@@ -325,8 +325,8 @@ logfire.configure({
 })
 ```
 
-Use a backend proxy only when your application needs additional server-side
-authentication, origin checks, or rate limits.
+Use a backend proxy only when you need to authenticate browser requests,
+restrict origins, or apply application-specific rate limits.
 
 After a replay reaches the minimum duration, hiding the document or receiving
 `pagehide` makes a bounded best-effort start of the earliest compressed chunks.
@@ -335,8 +335,8 @@ budget is shared across its own unfinished keepalive requests, while the
 browser's keepalive quota is also shared with unrelated page traffic. Delivery
 after page freeze or termination is therefore not guaranteed. Functional
 `headers` and `token` values are resolved for every upload; an asynchronous
-resolver can finish too late for a lifecycle request, so prefer credentials that
-are synchronously available, such as the generated frontend application headers.
+resolver can finish too late for a lifecycle request. The generated frontend
+application headers are synchronous and work for these uploads.
 
 Replays shorter than `minSessionDurationMs` are not uploaded (5 seconds by
 default). An earlier flush remains buffered until the minimum is reached, and

--- a/packages/logfire-browser/src/browserMetrics.ts
+++ b/packages/logfire-browser/src/browserMetrics.ts
@@ -11,8 +11,9 @@ export interface BrowserMetricsOptions {
    */
   metricUrl: string
   /**
-   * Dynamic headers for the metric exporter. Direct ingest should use a
-   * restricted frontend application token, never a normal Logfire write token.
+   * Dynamic headers for the metric exporter. Direct Logfire ingest requires a
+   * restricted frontend application token. Never use a normal write token in
+   * browser code.
    */
   metricExporterHeaders?: () => Record<string, string> | Promise<Record<string, string>>
   /**

--- a/packages/logfire-browser/src/browserMetrics.ts
+++ b/packages/logfire-browser/src/browserMetrics.ts
@@ -7,13 +7,12 @@ import type { MetricWithAttribution } from 'web-vitals/attribution'
 
 export interface BrowserMetricsOptions {
   /**
-   * Browser-safe OTLP metrics proxy URL, e.g. `/logfire-proxy/v1/metrics`.
+   * Browser-safe OTLP metrics URL, either direct Logfire ingest or a proxy.
    */
   metricUrl: string
   /**
-   * Dynamic headers for the metric exporter. Browser apps should normally
-   * authenticate through their backend proxy, not with a Logfire write token in
-   * client code.
+   * Dynamic headers for the metric exporter. Direct ingest should use a
+   * restricted frontend application token, never a normal Logfire write token.
    */
   metricExporterHeaders?: () => Record<string, string> | Promise<Record<string, string>>
   /**


### PR DESCRIPTION
## Summary

- document restricted frontend application tokens as the standard browser setup
- show direct regional ingest for traces, metrics, and session replay
- keep backend proxies as an optional layer for additional access controls
- link the TypeScript SDK docs to the Frontend setup guide

## Validation

- `pnpm run check`
- fresh Vite app using published `@pydantic/logfire-browser@0.18.13`
- direct trace and Web Vitals metric uploads returned `200`
- Frontend overview populated with the test application

Depends on pydantic/logfire#2339 for the new Frontend guide destination.
