### PR TITLE
Look up a variable by own name only

### DIFF
--- a/.changeset/vars-lookup-own-keys.md
+++ b/.changeset/vars-lookup-own-keys.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Treat a variable named like an `Object.prototype` member as unconfigured. `getVariableConfig` read the variables record with a plain index, so `defineVar('constructor')` or `defineVar('valueOf')` found the inherited member, handed it back as if it were a variable config, and failed downstream: the value still fell back to the code default but the resolution reason was reported as `other_error` rather than `code_default`.

--- a/packages/logfire-api/src/vars/index.ts
+++ b/packages/logfire-api/src/vars/index.ts
@@ -1,6 +1,7 @@
 import { context as ContextAPI, createContextKey, propagation, trace as TraceAPI } from '@opentelemetry/api'
 
 import { murmurhash3x64128 } from '../murmurhash'
+import { getOwn } from '../ownRecord'
 import { startSpan } from '../index'
 import { PlatformAPIClient, encodePathSegment } from '../platform/http'
 import { PlatformHTTPError } from '../platform/errors'
@@ -2626,7 +2627,9 @@ function followRef(
 }
 
 function getVariableConfig(config: VariablesConfig, name: string): VariableConfig | undefined {
-  const direct = config.variables[name]
+  // Own properties only. The name comes from `defineVar`, so `constructor` or `valueOf` would
+  // otherwise resolve to the inherited member and be handed back as if it were a variable config.
+  const direct = getOwn(config.variables, name)
   if (direct !== undefined) {
     return direct
   }

--- a/packages/logfire-api/src/vars/runtimeComposition.test.ts
+++ b/packages/logfire-api/src/vars/runtimeComposition.test.ts
@@ -27,6 +27,34 @@ describe('variable runtime composition parity', () => {
     configureVariables(false)
   })
 
+  it('treats a variable named like an Object.prototype member as unconfigured', async () => {
+    configureVariables({
+      config: config({
+        main: {
+          labels: { prod: { serialized_value: JSON.stringify('Hello'), version: 1 } },
+          name: 'main',
+          overrides: [],
+          rollout: { labels: { prod: 1 } },
+        },
+      }),
+      instrument: false,
+    })
+
+    // An ordinary absent name is the reference point: it reports `code_default`.
+    await expect(defineVar('absentname', { default: 'fallback' }).get()).resolves.toMatchObject({
+      reason: 'code_default',
+      value: 'fallback',
+    })
+
+    // These used to find the inherited member, hand it back as a variable config, and fail
+    // somewhere downstream, reporting `other_error` for a name nobody configured.
+    const inherited = await Promise.all(
+      ['constructor', 'valueOf', 'hasOwnProperty'].map(async (name) => defineVar(name, { default: 'fallback' }).get())
+    )
+    expect(inherited.map((resolved) => resolved.reason)).toEqual(['code_default', 'code_default', 'code_default'])
+    expect(inherited.map((resolved) => resolved.value)).toEqual(['fallback', 'fallback', 'fallback'])
+  })
+
   it('falls back to the variable code default when a provider value has a missing reference', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     configureVariables({


### PR DESCRIPTION
### Defect

`getVariableConfig` reads the variables record with a plain index, and the name comes from `defineVar`. A variable named after an `Object.prototype` member therefore resolves to the inherited member, which is returned as if it were a `VariableConfig` and then fails somewhere downstream.

### Evidence

Measured on `3ed526d`, against a config holding only `main`:

```
absentname     reason=code_default  value="fallback"
constructor    reason=other_error   value="fallback"
valueOf        reason=other_error   value="fallback"
```

The value is right either way, so nothing is corrupted, but a name nobody configured is reported as an internal failure instead of as unconfigured, and a real error is being swallowed to produce it. `other_error` is part of the resolution reason a caller can read.

This is the shape `e5e0d93` just consolidated. That pass covered the evaluator registry, result buckets and task-run state; the variables lookup is the same read in a file it did not touch.

### Fix

`getOwn`, the helper from that commit, in the one place that needed it. Reverting the read fails the new assertion.

Two notes on scope.

The alias scan below it is already safe, since it iterates `Object.values`.

I also changed `followRef`'s `config.labels[labeled.ref]` and then reverted it: mutating that line broke no test, and the reason turned out to be that `validateLabelRefs` already rejects a ref that is not an own key of `labels`, using `Object.hasOwn`. So that read cannot see an inherited member, and guarding it would have been a change with no reachable case behind it.

Built this with Claude Code's help and reviewed the diff myself.
