### PR TITLE
Keep a prototype-named variable or label when normalizing

### DIFF
--- a/.changeset/vars-normalize-own-keys.md
+++ b/.changeset/vars-normalize-own-keys.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Keep a variable or label whose name is an `Object.prototype` member when normalizing the variables config. Both records were built by plain assignment, so a `__proto__` entry ran the inherited setter and vanished: a variable the store had accepted was missing from every config read back out of it, and a dropped label made the rollout validator report it as "not present in labels" for a label the payload does contain. Such a name satisfies the SDK's own identifier rule, the same one Python uses.

--- a/packages/logfire-api/src/vars.test.ts
+++ b/packages/logfire-api/src/vars.test.ts
@@ -685,6 +685,47 @@ describe('managed variables', () => {
     expect(calls[0]?.headers.get('Content-Type')).toBeNull()
   })
 
+  it('keeps a variable whose name is an Object.prototype member in the config read back out', () => {
+    const variableConfig = (name: string) => ({
+      labels: { prod: { serialized_value: JSON.stringify('v'), version: 1 } },
+      name,
+      overrides: [],
+      rollout: { labels: { prod: 1 } },
+    })
+    // `__proto__` satisfies the SDK's own name rule, `/^[A-Za-z_][A-Za-z0-9_]*$/`, the same
+    // pattern Python uses, so the store has to be able to hold one.
+    const provider = new LocalVariableProvider({ variables: {} })
+    provider.createVariable(variableConfig('__proto__'))
+    provider.createVariable(variableConfig('normal'))
+
+    const all = provider.getAllVariablesConfig()
+
+    expect(Object.keys(all.variables).sort()).toEqual(['__proto__', 'normal'])
+    expect(Object.hasOwn(all.variables, '__proto__')).toBe(true)
+    expect(Object.getPrototypeOf(all.variables)).toBe(Object.prototype)
+    // The store already considered it created, so the read-back must agree.
+    expect(() => provider.createVariable(variableConfig('__proto__'))).toThrow("Variable '__proto__' already exists")
+  })
+
+  it('keeps a label named like an Object.prototype member', () => {
+    // Built by entries: a `__proto__` key in an object literal sets the prototype instead.
+    const labels = Object.fromEntries([
+      ['__proto__', { serialized_value: JSON.stringify('proto'), version: 1 }],
+      ['prod', { serialized_value: JSON.stringify('ok'), version: 1 }],
+    ])
+    const rollout = { labels: Object.fromEntries([['__proto__', 1]]) }
+
+    // Dropping the label used to make this throw "is not present in labels" for a label the
+    // payload does contain.
+    const provider = new LocalVariableProvider({
+      variables: { main: { labels, name: 'main', overrides: [], rollout } },
+    })
+
+    const main = provider.getAllVariablesConfig().variables['main']
+    expect(Object.keys(main?.labels ?? {}).sort()).toEqual(['__proto__', 'prod'])
+    expect(Object.getPrototypeOf(main?.labels)).toBe(Object.prototype)
+  })
+
   it('can disable variables explicitly', () => {
     configureVariables(false)
 

--- a/packages/logfire-api/src/vars/index.ts
+++ b/packages/logfire-api/src/vars/index.ts
@@ -2677,15 +2677,18 @@ function normalizeVariablesConfig(data: unknown): VariablesConfig {
   if (!isRecord(rawVariables)) {
     throw new Error('Variables config requires a variables object')
   }
-  const variables: Record<string, VariableConfig> = {}
+  // Accumulate in a Map and materialize with `Object.fromEntries`, which defines own keys. A
+  // variable name is a valid identifier (`__proto__` included), so plain assignment would run
+  // the inherited setter and drop the variable from every config read back out of the store.
+  const variables = new Map<string, VariableConfig>()
   for (const [key, value] of Object.entries(rawVariables)) {
     const variableConfig = normalizeVariableConfig(value)
     if (variableConfig.name !== key) {
       throw new Error(`variables has invalid lookup key '${key}' for variable '${variableConfig.name}'`)
     }
-    variables[key] = variableConfig
+    variables.set(key, variableConfig)
   }
-  return { variables }
+  return { variables: Object.fromEntries(variables) }
 }
 
 function cloneVariablesConfig(config: VariablesConfig): VariablesConfig {
@@ -2733,22 +2736,24 @@ function normalizeLabels(data: unknown): Record<string, LabelRef | LabeledValue>
   if (!isRecord(data)) {
     throw new Error('Variable labels must be an object')
   }
-  const labels: Record<string, LabelRef | LabeledValue> = {}
+  // Same reason as the variables record: a dropped `__proto__` label is not merely missing, it
+  // makes the rollout validator below report it as "not present in labels" when it is.
+  const labels = new Map<string, LabelRef | LabeledValue>()
   for (const [label, raw] of Object.entries(data)) {
     if (!isRecord(raw)) {
       throw new Error(`Label '${label}' must be an object`)
     }
     if (typeof raw['serialized_value'] === 'string' && typeof raw['version'] === 'number') {
-      labels[label] = { serialized_value: raw['serialized_value'], version: raw['version'] }
+      labels.set(label, { serialized_value: raw['serialized_value'], version: raw['version'] })
     } else if (typeof raw['ref'] === 'string') {
-      labels[label] = { ref: raw['ref'], version: typeof raw['version'] === 'number' ? raw['version'] : null }
+      labels.set(label, { ref: raw['ref'], version: typeof raw['version'] === 'number' ? raw['version'] : null })
     } else if (typeof raw['target_type'] === 'string') {
-      labels[label] = normalizeApiLabel(raw)
+      labels.set(label, normalizeApiLabel(raw))
     } else {
       throw new Error(`Label '${label}' must contain serialized_value/version, ref, or target_type`)
     }
   }
-  return labels
+  return Object.fromEntries(labels)
 }
 
 function validateLabelRefs(labels: Record<string, LabelRef | LabeledValue>): void {


### PR DESCRIPTION
### Defect

`normalizeVariablesConfig` and `normalizeLabels` build their records by plain assignment, so an entry named `__proto__` runs the inherited setter and disappears. Both run on every config the store reads back out, since `getAllVariablesConfig` goes through `cloneVariablesConfig`.

`__proto__` satisfies the SDK's own name rule, `/^[A-Za-z_][A-Za-z0-9_]*$/`, which is the pattern Python's `VariableName` uses, so it is a legal variable name rather than a hostile one.

### Evidence

Measured on `3ed526d`. Creating two variables in a `LocalVariableProvider`:

```
getAllVariablesConfig keys = ["normal"]
own __proto__ present      = false
re-create __proto__        = VariableAlreadyExistsError
```

So the store considers the variable created, and the config read back out of it does not contain it. `createVariable` itself is fine, since it uses a computed key in an object literal, which defines an own property; the loss happens on normalization.

The label case surfaces differently, as a misleading error rather than a silent gap. A config with a `__proto__` label fails to load with:

```
Label '__proto__' present in rollout.labels is not present in labels
```

for a label the payload does contain.

### Fix

Accumulate both in a `Map` and materialize with `Object.fromEntries`, which defines own keys. That is the rule `e5e0d93` set for records whose keys the SDK does not choose, applied to the two in this file.

Two mutations, one per record: reverting either normalization to plain assignment fails its own test.

Related but separate, so it is in #297 rather than here: `getVariableConfig` reads that same record with a plain index.

Built this with Claude Code's help and reviewed the diff myself.
