### PR TITLE
Report an unregister that throws undefined

### DIFF
--- a/.changeset/browser-unregister-sentinel.md
+++ b/.changeset/browser-unregister-sentinel.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-browser': patch
+---
+
+Report an instrumentation `unregister` that throws `undefined` instead of resolving cleanup as if it had succeeded. The accumulator held the raw thrown value and treated it as the failure sentinel, so `undefined` read as no failure at all, and a first `null` was overwritten by a later error through `??=`. Failures are now normalized to an `Error` when captured, the way the other two error accumulators in that file already do.

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -1767,6 +1767,25 @@ describe('browser cleanup', () => {
     expect(tracerProvider.shutdownCalls).toBe(1)
   })
 
+  it('reports an unregister that throws undefined instead of resolving', async () => {
+    // An unregister callback is user supplied, so `undefined` is a legal thing for it to throw.
+    // It used to leave the accumulator nullish, and cleanup resolved as if nothing had failed.
+    mocks.failStep('unregister', undefined)
+    cleanup = configure({ traceUrl: 'http://localhost:8989/client-traces' })
+
+    const rejection: unknown = await cleanup().then(
+      () => 'RESOLVED',
+      (error: unknown) => error
+    )
+
+    expect(rejection).toBeInstanceOf(Error)
+    expect((rejection as Error).message).toBe('logfire-browser: instrumentation unregister failed')
+    // Wrapped once more by the cleanup-step reporter, the same as any other step failure.
+    expect((rejection as Error).cause).toBeInstanceOf(Error)
+    expect(((rejection as Error).cause as Error).message).toBe('logfire-browser: instrumentation unregister failed')
+    cleanup = undefined
+  })
+
   it('memoizes cleanup failure from unregister without retrying later', async () => {
     expect.hasAssertions()
     await expectCleanupFailureIsMemoized('unregister')

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -406,15 +406,23 @@ function startBrowserInstrumentations(options: {
         ...unregisterConfigured,
         ...(unregisterAutoInstrumentations === undefined ? [] : [unregisterAutoInstrumentations]),
       ]
+      // A separate flag, not the thrown value, records that something failed. An unregister
+      // callback is user supplied, so `undefined` is a legal thing for it to throw, and the raw
+      // value read as no failure at all; a first `null` was overwritten by a later error through
+      // `??=`, despite the name. Same shape as `runBoth` in TailSamplingProcessor.
+      let failed = false
       let firstError: unknown
       for (let index = unregisters.length - 1; index >= 0; index -= 1) {
         try {
           unregisters[index]?.()
         } catch (error) {
-          firstError ??= error
+          if (!failed) {
+            failed = true
+            firstError = error
+          }
         }
       }
-      if (firstError !== undefined) {
+      if (failed) {
         throw firstError instanceof Error
           ? firstError
           : new Error('logfire-browser: instrumentation unregister failed', { cause: firstError })


### PR DESCRIPTION
### Defect

The instrumentation-unregister loop in `startBrowserInstrumentations` used the thrown value itself as its failure sentinel:

```ts
let firstError: unknown
...
catch (error) { firstError ??= error }
...
if (firstError !== undefined) { throw ... }
```

An unregister callback is user supplied, so `undefined` and `null` are both legal things for it to throw. `undefined` leaves the accumulator nullish and reads as no failure at all, and a first `null` is overwritten by a later error through `??=`, despite the name.

This is the same defect `ecc431b` fixed in `runBoth` this morning, in a different package.

### Evidence

Measured on `3ed526d`, with the unregister step throwing `undefined`:

```
unregister threw undefined -> RESOLVED (the unregister failure was swallowed)
```

Cleanup reports success and the caller is never told an instrumentation failed to unregister. With a real `Error` it rejects, which the existing memoization test already covers, so the two paths disagree only for the values a raw sentinel cannot represent.

### Fix

A separate `failed` flag decides whether to rethrow, the same shape as `runBoth`. The two other error accumulators in this file, `rollbackError` and `firstCleanupError`, already avoid the problem by normalizing to an `Error` at capture; this was the odd one out.

One thing left unpinned, deliberately. The regression covers the `undefined` case. The `null`-overwrite half is not covered, because the test harness exposes a single failing unregister step and I could not express two failing callbacks through it. The `if (!failed)` guard stays because it is what makes the variable's name true, and mutating it away accordingly fails no test.

Built this with Claude Code's help and reviewed the diff myself.
