### PR TITLE
Add user context and long animation frame telemetry to browser RUM

### DIFF
--- a/.changeset/browser-long-animation-frames.md
+++ b/.changeset/browser-long-animation-frames.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-browser': minor
+---
+
+Report severe browser main-thread congestion with opt-in, sampled Long Animation Frame spans. The browser SDK now emits bounded per-frame diagnostics and foreground window summaries with normalized script attribution, and existing INP spans include the culprit script already identified by `web-vitals`. The new data remains span-only and is not added to metrics.

--- a/.changeset/browser-user-context.md
+++ b/.changeset/browser-user-context.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-browser': minor
+---
+
+Attach the application's current user to browser spans through `rum.session.getUser`, and use the same live id for session replay when no explicit replay identity getter is configured. User context remains client asserted, span-only, and outside persisted browser-session state and Web Vitals metric labels.

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -73,7 +73,7 @@ semantic attribute.
 
 Use `getRouteName` for the application's normalized route template and
 `getSessionAttributes` for low-cardinality dimensions that should remain stable
-for a browser session:
+for a browser session. Use `getUser` for the application's current user:
 
 ```ts
 logfire.configure({
@@ -85,12 +85,29 @@ logfire.configure({
         account_tier: currentAccount.tier,
         beta_user: currentUser.isBeta,
       }),
+      getUser: () =>
+        currentUser === undefined
+          ? undefined
+          : {
+              id: currentUser.id,
+              name: currentUser.name,
+              email: currentUser.email,
+            },
     },
   },
 })
 ```
 
 `getRouteName` is evaluated for each span and becomes `logfire.page.route`.
+`getUser` is also evaluated for each span. A non-empty `id` becomes `user.id`;
+non-empty `name` and `email` values become `user.name` and `user.email`.
+Use an opaque application id. Name and email are opt-in PII. The SDK emits
+accepted strings unchanged, does not persist them, does not add them to Web
+Vitals metric labels, and does not rotate the browser session when the current
+user changes or logs out. Returning `undefined` represents an anonymous user or
+logout. These client-asserted values are observational context, not
+authentication, authorization, billing, or audit evidence.
+
 `getSessionAttributes` is evaluated once per browser session, persisted across
 same-tab reloads, and refreshed when the session rotates. Accepted values
 become span attributes prefixed with `logfire.session.` and are copied into
@@ -352,6 +369,11 @@ initializes and touches the session once before loading the optional peer, but
 subsequent replay events only peek at the session id and do not refresh the
 timeout. Span starts are the ongoing automatic activity;
 `getBrowserSessionId()` also explicitly touches the session.
+
+When `sessionReplay.getDistinctId` is not configured, replay uses the current
+`rum.session.getUser()?.id` so replay rows and span `user.id` agree. An explicit
+`getDistinctId` remains authoritative. A static `sessionReplay.distinctId`
+remains the fallback while the selected live getter returns `undefined`.
 
 After a replay reaches the minimum duration, hiding the document or receiving
 `pagehide` makes a bounded best-effort start of the earliest compressed chunks.

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -153,6 +153,10 @@ Every Web Vital span includes `web_vital.name`, `web_vital.value`,
 `web_vital.navigation_type`. Attribution fields include values such as
 `web_vital.lcp.target`, `web_vital.inp.target`, and
 `web_vital.cls.largest_shift_target`.
+When INP attribution identifies a culprit Long Animation Frame script, the INP
+span also includes its normalized source URL, bounded function name, invoker,
+and duration as `web_vital.inp.script.*` attributes. These diagnostic fields
+remain span-only and are not added to Web Vitals metrics.
 
 `rum.webVitals` implies default `rum.session` behavior so Web Vital spans get
 session and URL attributes. To sanitize URLs while reporting Web Vitals, pass
@@ -228,6 +232,69 @@ browser URL when the callback fires; route-specific Core Web Vitals need
 separate route or soft-navigation instrumentation. To add a route dimension to metrics, pass a
 low-cardinality template such as `/products/:id` through
 `rum.webVitals.metrics.attributes`.
+
+## RUM Long Animation Frames
+
+Enable `rum.longAnimationFrames` to detect and diagnose severe main-thread
+congestion in supported Chromium browsers:
+
+```ts
+logfire.configure({
+  ...frontendApplicationConfig,
+  rum: {
+    longAnimationFrames: true,
+  },
+})
+```
+
+The Long Animation Frames API observes frames over 50 ms. It is available in
+Chromium-based browsers, but not in Firefox or Safari at the time of writing.
+It does not cover all main-thread work and cannot attribute cross-origin
+frames, workers, or extension isolated worlds. Treat it as a high-coverage
+sentinel for severe congestion, complementary to INP, request volume, journey
+timing, and synthetic monitoring.
+
+The feature is off by default. When enabled, the SDK feature-detects
+`long-animation-frame`, samples 10% of browser sessions, and observes with
+`buffered: true`. Sampled-out and unsupported sessions do not install an
+observer, timer, or lifecycle listeners.
+
+For sampled sessions, the SDK emits two log-type span shapes:
+
+- `browser.long_animation_frame` diagnoses frames whose `blockingDuration` is
+  at least 100 ms. Frames are ranked within each foreground window, and the
+  worst frames are emitted up to a fixed cap of 20 per browser session.
+- `browser.main_thread_window` summarizes each foreground window with its real
+  foreground duration, total blocking duration, LoAF count, dropped diagnostic
+  count, and the top three scripts by summed duration. Hidden time is excluded,
+  and a partial window is emitted on document hide or `pagehide`.
+
+The default ranking and summary window is 60 seconds. You can tune collection
+without changing the SDK-owned event and script caps:
+
+```ts
+logfire.configure({
+  ...frontendApplicationConfig,
+  rum: {
+    longAnimationFrames: {
+      blockingDurationThresholdMs: 150,
+      sessionSampleRate: 0.25,
+      windowDurationMs: 30_000,
+    },
+  },
+})
+```
+
+`sessionSampleRate` is clamped to `0..1`. The window has a 10-second minimum to
+prevent accidental span floods. HTTP(S) script source URLs have credentials,
+query strings, and fragments removed and are capped at 2,048 Unicode code
+points. Payload-bearing and per-load URL schemes use stable scheme or origin
+placeholders. Function names are capped at 200 Unicode code points. Periodic
+window summaries do not extend the browser session idle timeout, but diagnostic
+frame spans count as session activity. LoAF data is emitted only as spans, never
+as OpenTelemetry metrics. The existing browser session processor adds session
+id, route, sanitized page URL, replay state, and service-version context to both
+span shapes.
 
 ## Session Replay
 
@@ -517,12 +584,13 @@ idempotent: repeated or concurrent calls share one promise and run the lifecycle
 once in this order:
 
 1. await session replay startup and stop replay when enabled
-2. unregister configured instrumentations
-3. await Web Vitals startup and shutdown when enabled
-4. force-flush and shut down metrics when configured
-5. force-flush spans
-6. shut down the tracer provider
-7. clear SDK-owned browser session state
+2. close and shut down Long Animation Frame reporting when enabled
+3. unregister configured instrumentations
+4. await Web Vitals startup and shutdown when enabled
+5. force-flush and shut down metrics when configured
+6. force-flush spans
+7. shut down the tracer provider
+8. clear SDK-owned browser session state
 
 If any cleanup step fails, Logfire still attempts the later steps before
 returning the first failure. Later calls return the same settled cleanup promise

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -83,7 +83,7 @@ logfire.configure({
       getRouteName: () => router.currentRoute.value.matched.at(-1)?.path,
       getSessionAttributes: () => ({
         account_tier: currentAccount.tier,
-        beta_user: currentUser.isBeta,
+        beta_user: currentUser?.isBeta,
       }),
       getUser: () =>
         currentUser === undefined

--- a/examples/browser-rum-replay/README.md
+++ b/examples/browser-rum-replay/README.md
@@ -5,6 +5,7 @@ This example is an end-to-end browser telemetry workbench. It sends:
 - browser traces and manual Logfire spans
 - automatic document-load, fetch, XHR, and click/change spans
 - normalized route names and bounded RUM session dimensions on browser spans
+- live `user.id` context from the editable application user id
 - Core Web Vitals spans and native histogram metrics
 - rrweb session replay chunks through a local backend proxy
 - replay custom events for console, fetch/XHR, navigation, and errors
@@ -91,6 +92,7 @@ In traces/logs:
   `logfire.session.experiment_variant`
 - `logfire.session_replay.active` and `logfire.session_replay.mode` on spans
   while replay is active
+- `user.id` matching the current application user without changing `session.id`
 - normalized route attributes such as `logfire.page.route=/orders/:id`
 - privacy-safe default URL attributes that retain the actual path, such as
   `logfire.page.url.path=/orders/1234`
@@ -108,6 +110,7 @@ In replay:
 
 - replay chunks uploaded to `/client-replay/:sessionId?seq=...`
 - the replay session id matching `session.id` / `browser.session.id`
+- replay `distinctId` matching span `user.id`, with `anonymous` as the fallback
 - matching unprefixed dimensions in `meta.sessionAttributes`
 - masked input values from the form
 - blocked content under `[data-logfire-block]`

--- a/examples/browser-rum-replay/README.md
+++ b/examples/browser-rum-replay/README.md
@@ -142,6 +142,7 @@ the extension for this local app.
 
 This example imports `lf-browser-recorder`, a neutral Vite virtual module,
 instead of importing `@pydantic/logfire-session-replay` directly. The virtual
-module avoids blocker-sensitive dev URLs and aliases rrweb to its browser ESM
-build. If a local Vite integration fails with an error that `rrweb.cjs` does
-not provide `record`, make sure rrweb resolves to `rrweb/dist/rrweb.js`.
+module avoids blocker-sensitive dev URLs and aliases `@rrweb/record` to its
+browser ESM build. If a local Vite integration fails with an error that
+`record.cjs` does not provide `record`, make sure `@rrweb/record` resolves to
+the adjacent `record.js` entrypoint.

--- a/examples/browser-rum-replay/index.html
+++ b/examples/browser-rum-replay/index.html
@@ -235,7 +235,7 @@
           <div class="form-grid">
             <label>
               User
-              <input id="user-id" value="demo-user-42" autocomplete="off" />
+              <input id="user-id" autocomplete="off" placeholder="anonymous until identified" />
             </label>
             <label>
               Region

--- a/examples/browser-rum-replay/src/main.ts
+++ b/examples/browser-rum-replay/src/main.ts
@@ -54,7 +54,6 @@ logfire.configure({
     captureNetwork: true,
     captureNavigation: true,
     distinctId: 'anonymous',
-    getDistinctId: () => getUserId(),
     flushIntervalMs: 2_000,
   },
   rum: {
@@ -65,6 +64,10 @@ logfire.configure({
         app_region: 'eu',
         experiment_variant: 'catalog_b',
       }),
+      getUser: () => {
+        const id = getUserId()
+        return id === undefined ? undefined : { id }
+      },
     },
     webVitals: {
       reportAllChanges: true,
@@ -215,7 +218,6 @@ async function runCheckout(): Promise<void> {
       attributes: {
         'app.route': routeTemplate(window.location.pathname),
         'example.action': 'checkout',
-        'enduser.id': getUserId(),
       },
       callback: async () => {
         await logfire.span('browser replay validate cart', {
@@ -237,7 +239,7 @@ async function runCheckout(): Promise<void> {
                 'Content-Type': 'application/json',
               },
               body: JSON.stringify({
-                userId: getUserId(),
+                userId: getUserId() ?? 'anonymous',
                 region: regionSelect.value,
                 privateNote: getInput('private-note').value,
               }),
@@ -345,8 +347,8 @@ function logEvent(message: string): void {
   logElement.textContent = `[${timestamp}] ${message}\n${logElement.textContent ?? ''}`.slice(0, 3_000)
 }
 
-function getUserId(): string {
-  return userIdInput.value.trim() || 'anonymous'
+function getUserId(): string | undefined {
+  return userIdInput.value.trim() || undefined
 }
 
 function currentView(): string {

--- a/examples/browser-rum-replay/vite.config.ts
+++ b/examples/browser-rum-replay/vite.config.ts
@@ -13,7 +13,7 @@ const recorderModuleId = 'lf-browser-recorder'
 const resolvedRecorderModuleId = `\0${recorderModuleId}`
 const packageEntrypoint = resolve(__dirname, '../../packages/logfire-session-replay/dist/index.js')
 const require = createRequire(packageEntrypoint)
-const recorderEntrypoint = require.resolve('@rrweb/record').replace(/dist\/record\.cjs$/u, 'dist/record.js')
+const recorderEntrypoint = resolve(dirname(require.resolve('@rrweb/record')), 'record.js')
 const fflateEntrypoint = resolve(dirname(require.resolve('fflate/package.json')), 'esm/browser.js')
 
 function loadRecorderModule(): string {

--- a/examples/browser-rum-replay/vite.config.ts
+++ b/examples/browser-rum-replay/vite.config.ts
@@ -8,17 +8,17 @@ import { defineConfig, loadEnv } from 'vite-plus'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // Keep the dev import URL neutral because browser privacy extensions can block
 // module URLs containing "session-replay". Loading workspace dist output also
-// needs rrweb's browser ESM build, not the CommonJS package entrypoint.
+// needs the recorder's browser ESM build, not the CommonJS package entrypoint.
 const recorderModuleId = 'lf-browser-recorder'
 const resolvedRecorderModuleId = `\0${recorderModuleId}`
 const packageEntrypoint = resolve(__dirname, '../../packages/logfire-session-replay/dist/index.js')
 const require = createRequire(packageEntrypoint)
-const rrwebEntrypoint = require.resolve('rrweb').replace(/dist\/rrweb\.cjs$/u, 'dist/rrweb.js')
+const recorderEntrypoint = require.resolve('@rrweb/record').replace(/dist\/record\.cjs$/u, 'dist/record.js')
 const fflateEntrypoint = resolve(dirname(require.resolve('fflate/package.json')), 'esm/browser.js')
 
 function loadRecorderModule(): string {
   return readFileSync(packageEntrypoint, 'utf8')
-    .replaceAll('from"rrweb"', `from${JSON.stringify(rrwebEntrypoint)}`)
+    .replaceAll('from"@rrweb/record"', `from${JSON.stringify(recorderEntrypoint)}`)
     .replaceAll('from"fflate"', `from${JSON.stringify(fflateEntrypoint)}`)
 }
 

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -81,5 +81,5 @@ If replay fails to start locally with `ERR_BLOCKED_BY_CLIENT`, a browser privacy
 extension may be blocking dev URLs that contain terms such as `session-replay`.
 Test in a clean profile or disable the extension for this local app. This
 example uses a neutral Vite virtual module named `lf-browser-recorder` so local
-workspace testing avoids blocker-sensitive module URLs and resolves rrweb to its
-browser ESM build.
+workspace testing avoids blocker-sensitive module URLs and resolves the recorder
+to its browser ESM build.

--- a/examples/browser/vite.config.ts
+++ b/examples/browser/vite.config.ts
@@ -13,7 +13,7 @@ const recorderModuleId = 'lf-browser-recorder'
 const resolvedRecorderModuleId = `\0${recorderModuleId}`
 const packageEntrypoint = resolve(__dirname, '../../packages/logfire-session-replay/dist/index.js')
 const require = createRequire(packageEntrypoint)
-const recorderEntrypoint = require.resolve('@rrweb/record').replace(/dist\/record\.cjs$/u, 'dist/record.js')
+const recorderEntrypoint = resolve(dirname(require.resolve('@rrweb/record')), 'record.js')
 const fflateEntrypoint = resolve(dirname(require.resolve('fflate/package.json')), 'esm/browser.js')
 
 function loadRecorderModule(): string {

--- a/examples/browser/vite.config.ts
+++ b/examples/browser/vite.config.ts
@@ -8,17 +8,17 @@ import { defineConfig, loadEnv } from 'vite-plus'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // Keep the dev import URL neutral because browser privacy extensions can block
 // module URLs containing "session-replay". Loading workspace dist output also
-// needs rrweb's browser ESM build, not the CommonJS package entrypoint.
+// needs the recorder's browser ESM build, not the CommonJS package entrypoint.
 const recorderModuleId = 'lf-browser-recorder'
 const resolvedRecorderModuleId = `\0${recorderModuleId}`
 const packageEntrypoint = resolve(__dirname, '../../packages/logfire-session-replay/dist/index.js')
 const require = createRequire(packageEntrypoint)
-const rrwebEntrypoint = require.resolve('rrweb').replace(/dist\/rrweb\.cjs$/u, 'dist/rrweb.js')
+const recorderEntrypoint = require.resolve('@rrweb/record').replace(/dist\/record\.cjs$/u, 'dist/record.js')
 const fflateEntrypoint = resolve(dirname(require.resolve('fflate/package.json')), 'esm/browser.js')
 
 function loadRecorderModule(): string {
   return readFileSync(packageEntrypoint, 'utf8')
-    .replaceAll('from"rrweb"', `from${JSON.stringify(rrwebEntrypoint)}`)
+    .replaceAll('from"@rrweb/record"', `from${JSON.stringify(recorderEntrypoint)}`)
     .replaceAll('from"fflate"', `from${JSON.stringify(fflateEntrypoint)}`)
 }
 

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -91,7 +91,7 @@ logfire.configure({
       getRouteName: () => router.currentRoute.value.matched.at(-1)?.path,
       getSessionAttributes: () => ({
         account_tier: currentAccount.tier,
-        beta_user: currentUser.isBeta,
+        beta_user: currentUser?.isBeta,
       }),
       getUser: () =>
         currentUser === undefined

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -80,7 +80,7 @@ or 4 hours of total duration by default. Spans get the OpenTelemetry
 
 Use `getRouteName` for the application's normalized route template and
 `getSessionAttributes` for low-cardinality dimensions that should remain stable
-for a browser session:
+for a browser session. Use `getUser` for the application's current user:
 
 ```js
 logfire.configure({
@@ -93,12 +93,29 @@ logfire.configure({
         account_tier: currentAccount.tier,
         beta_user: currentUser.isBeta,
       }),
+      getUser: () =>
+        currentUser === undefined
+          ? undefined
+          : {
+              id: currentUser.id,
+              name: currentUser.name,
+              email: currentUser.email,
+            },
     },
   },
 })
 ```
 
 `getRouteName` is evaluated for each span and becomes `logfire.page.route`.
+`getUser` is also evaluated for each span. A non-empty `id` becomes `user.id`;
+non-empty `name` and `email` values become `user.name` and `user.email`.
+Use an opaque application id. Name and email are opt-in PII. The SDK emits
+accepted strings unchanged, does not persist them, does not add them to Web
+Vitals metric labels, and does not rotate the browser session when the current
+user changes or logs out. Returning `undefined` represents an anonymous user or
+logout. These client-asserted values are observational context, not
+authentication, authorization, billing, or audit evidence.
+
 `getSessionAttributes` is evaluated once for each browser session, persisted
 across same-tab reloads, and refreshed when the session rotates. Accepted
 values become span attributes prefixed with `logfire.session.` and are also
@@ -372,6 +389,11 @@ initializes and touches the session once before loading the optional peer, but
 subsequent replay events only peek at the session id and do not refresh the
 timeout. Span starts are the ongoing automatic activity;
 `getBrowserSessionId()` also explicitly touches the session.
+
+When `sessionReplay.getDistinctId` is not configured, replay uses the current
+`rum.session.getUser()?.id` so replay rows and span `user.id` agree. An explicit
+`getDistinctId` remains authoritative. A static `sessionReplay.distinctId`
+remains the fallback while the selected live getter returns `undefined`.
 
 Use the same restricted frontend application token for traces, metrics, and
 session replay. Derive the regional replay endpoint from the generated trace

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -168,6 +168,10 @@ Each span includes base attributes such as `web_vital.name`,
 `web_vital.navigation_type`. Attribution fields include values such as
 `web_vital.lcp.target`, `web_vital.inp.target`, and
 `web_vital.cls.largest_shift_target`.
+When INP attribution identifies a culprit Long Animation Frame script, the INP
+span also includes its normalized source URL, bounded function name, invoker,
+and duration as `web_vital.inp.script.*` attributes. These diagnostic fields
+remain span-only and are not added to Web Vitals metrics.
 
 `rum.webVitals` implies default `rum.session` behavior so Web Vital spans get
 session and URL attributes. If you need to sanitize URLs, pass session options
@@ -244,6 +248,73 @@ browser URL when the callback fires; route-specific Core Web Vitals need
 separate route or soft-navigation instrumentation. To add a route dimension to metrics, pass a
 low-cardinality template such as `/products/:id` through
 `rum.webVitals.metrics.attributes`.
+
+## RUM Long Animation Frames
+
+Enable `rum.longAnimationFrames` to detect and diagnose severe main-thread
+congestion in supported Chromium browsers:
+
+```js
+import * as logfire from '@pydantic/logfire-browser'
+
+logfire.configure({
+  traceUrl: '/client-traces',
+  serviceName: 'browser-app',
+  serviceVersion: '2026.09.03',
+  rum: {
+    longAnimationFrames: true,
+  },
+})
+```
+
+The Long Animation Frames API observes frames over 50 ms. It is available in
+Chromium-based browsers, but not in Firefox or Safari at the time of writing.
+It does not cover all main-thread work and cannot attribute cross-origin
+frames, workers, or extension isolated worlds. Treat it as a high-coverage
+sentinel for severe congestion, complementary to INP, request volume, journey
+timing, and synthetic monitoring.
+
+The feature is off by default. When enabled, the SDK feature-detects
+`long-animation-frame`, samples 10% of browser sessions, and observes with
+`buffered: true`. Sampled-out and unsupported sessions do not install an
+observer, timer, or lifecycle listeners.
+
+For sampled sessions, the SDK emits two log-type span shapes:
+
+- `browser.long_animation_frame` diagnoses frames whose `blockingDuration` is
+  at least 100 ms. Frames are ranked within each foreground window, and the
+  worst frames are emitted up to a fixed cap of 20 per browser session.
+- `browser.main_thread_window` summarizes each foreground window with its real
+  foreground duration, total blocking duration, LoAF count, dropped diagnostic
+  count, and the top three scripts by summed duration. Hidden time is excluded,
+  and a partial window is emitted on document hide or `pagehide`.
+
+The default ranking and summary window is 60 seconds. You can tune collection
+without changing the SDK-owned event and script caps:
+
+```js
+logfire.configure({
+  traceUrl: '/client-traces',
+  rum: {
+    longAnimationFrames: {
+      blockingDurationThresholdMs: 150,
+      sessionSampleRate: 0.25,
+      windowDurationMs: 30_000,
+    },
+  },
+})
+```
+
+`sessionSampleRate` is clamped to `0..1`. The window has a 10-second minimum to
+prevent accidental span floods. HTTP(S) script source URLs have credentials,
+query strings, and fragments removed and are capped at 2,048 Unicode code
+points. Payload-bearing and per-load URL schemes use stable scheme or origin
+placeholders. Function names are capped at 200 Unicode code points. Periodic
+window summaries do not extend the browser session idle timeout, but diagnostic
+frame spans count as session activity. LoAF data is emitted only as spans, never
+as OpenTelemetry metrics. The existing browser session processor adds session
+id, route, sanitized page URL, replay state, and service-version context to both
+span shapes.
 
 ## Session replay
 
@@ -441,12 +512,13 @@ idempotent: repeated or concurrent calls share one promise and run the lifecycle
 once in this order:
 
 1. await session replay startup and stop replay when enabled
-2. unregister configured instrumentations
-3. await Web Vitals startup and shutdown when enabled
-4. force-flush and shut down metrics when configured
-5. force-flush spans
-6. shut down the tracer provider
-7. clear SDK-owned browser session state
+2. close and shut down Long Animation Frame reporting when enabled
+3. unregister configured instrumentations
+4. await Web Vitals startup and shutdown when enabled
+5. force-flush and shut down metrics when configured
+6. force-flush spans
+7. shut down the tracer provider
+8. clear SDK-owned browser session state
 
 If any cleanup step fails, Logfire still attempts the later steps before
 returning the first failure. Later calls return the same settled cleanup promise

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
@@ -9,6 +9,13 @@ import type { BrowserSessionReplayRuntime } from './sessionReplay'
 
 class TestSpan {
   readonly attributes: Record<string, unknown> = {}
+  readonly instrumentationScope: { name: string }
+  readonly name: string
+
+  constructor(name = 'test span', instrumentationScopeName = 'test-tracer') {
+    this.name = name
+    this.instrumentationScope = { name: instrumentationScopeName }
+  }
 
   setAttribute(key: string, value: unknown): this {
     this.attributes[key] = value
@@ -108,6 +115,58 @@ describe('BrowserSessionSpanProcessor', () => {
       'session.id': 'session-1',
     })
     expect(span.attributes).not.toHaveProperty('browser.session.id')
+  })
+
+  it('does not treat periodic main-thread summaries as session activity', () => {
+    let now = 0
+    let sessionNumber = 0
+    const sessionManager = new BrowserSessionManager({
+      generateId: () => `session-${(++sessionNumber).toString()}`,
+      idleTimeoutMs: 30_000,
+      now: () => now,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+      urlAttributes: false,
+    })
+    const processor = new BrowserSessionSpanProcessor(sessionManager)
+    const firstSpan = new TestSpan()
+    startSpan(processor, firstSpan)
+
+    now = 20_000
+    const firstSummary = new TestSpan('browser.main_thread_window', 'logfire-long-animation-frames')
+    startSpan(processor, firstSummary)
+    now = 31_000
+    const secondSummary = new TestSpan('browser.main_thread_window', 'logfire-long-animation-frames')
+    startSpan(processor, secondSummary)
+
+    expect(firstSpan.attributes['session.id']).toBe('session-1')
+    expect(firstSummary.attributes['session.id']).toBe('session-1')
+    expect(secondSummary.attributes['session.id']).toBe('session-2')
+  })
+
+  it('continues to treat long-animation-frame diagnostics as session activity', () => {
+    let now = 0
+    let sessionNumber = 0
+    const sessionManager = new BrowserSessionManager({
+      generateId: () => `session-${(++sessionNumber).toString()}`,
+      idleTimeoutMs: 30_000,
+      now: () => now,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+      urlAttributes: false,
+    })
+    const processor = new BrowserSessionSpanProcessor(sessionManager)
+    startSpan(processor, new TestSpan())
+
+    now = 20_000
+    const diagnostic = new TestSpan('browser.long_animation_frame', 'logfire-long-animation-frames')
+    startSpan(processor, diagnostic)
+    now = 31_000
+    const summary = new TestSpan('browser.main_thread_window', 'logfire-long-animation-frames')
+    startSpan(processor, summary)
+
+    expect(diagnostic.attributes['session.id']).toBe('session-1')
+    expect(summary.attributes['session.id']).toBe('session-1')
   })
 
   it('stamps session dimensions and evaluates the route for each span', () => {

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.test.ts
@@ -201,6 +201,71 @@ describe('BrowserSessionSpanProcessor', () => {
     expect(secondSpan.attributes['logfire.page.route']).toBe('')
   })
 
+  it('follows the current user without rotating the browser session', () => {
+    let user: { id: string; name?: string; email?: string } | undefined
+    const processor = createProcessor({
+      getRouteName: () => '/account',
+      getUser: () => user,
+      urlAttributes: false,
+    })
+    const anonymous = createSpan()
+    startSpan(processor, anonymous)
+    user = { email: 'alice@example.com', id: 'user-a', name: 'Alice' }
+    const identified = createSpan()
+    startSpan(processor, identified)
+    user = { id: 'user-b' }
+    const switched = createSpan()
+    startSpan(processor, switched)
+    user = undefined
+    const loggedOut = createSpan()
+    startSpan(processor, loggedOut)
+
+    expect(anonymous.attributes).toEqual({ 'logfire.page.route': '/account', 'session.id': 'session-1' })
+    expect(identified.attributes).toEqual({
+      'logfire.page.route': '/account',
+      'session.id': 'session-1',
+      'user.email': 'alice@example.com',
+      'user.id': 'user-a',
+      'user.name': 'Alice',
+    })
+    expect(switched.attributes).toEqual({
+      'logfire.page.route': '/account',
+      'session.id': 'session-1',
+      'user.id': 'user-b',
+    })
+    expect(loggedOut.attributes).toEqual({ 'logfire.page.route': '/account', 'session.id': 'session-1' })
+  })
+
+  it('contains hostile user callbacks without suppressing other context', () => {
+    const replayState = new BrowserSessionReplayState()
+    replayState.setReplay(createReplayRuntime('full'))
+    const span = createSpan()
+
+    expect(() => {
+      startSpan(
+        createProcessor(
+          {
+            getRouteName: () => '/account',
+            getSessionAttributes: () => ({ tier: 'pro' }),
+            getUser: () => {
+              throw new Error('identity unavailable')
+            },
+            urlAttributes: false,
+          },
+          replayState
+        ),
+        span
+      )
+    }).not.toThrow()
+    expect(span.attributes).toEqual({
+      'logfire.page.route': '/account',
+      'logfire.session.tier': 'pro',
+      'logfire.session_replay.active': true,
+      'logfire.session_replay.mode': 'full',
+      'session.id': 'session-1',
+    })
+  })
+
   it('keeps route evaluation independent from URL sanitization failures', () => {
     setLocation({ href: 'https://example.com/dashboard' })
     const span = createSpan()

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.ts
@@ -10,6 +10,9 @@ const ATTR_SESSION_REPLAY_MODE = 'logfire.session_replay.mode'
 const ATTR_LOGFIRE_PAGE_ROUTE = 'logfire.page.route'
 const ATTR_LOGFIRE_PAGE_URL_FULL = 'logfire.page.url.full'
 const ATTR_LOGFIRE_PAGE_URL_PATH = 'logfire.page.url.path'
+const ATTR_USER_EMAIL = 'user.email'
+const ATTR_USER_ID = 'user.id'
+const ATTR_USER_NAME = 'user.name'
 const LONG_ANIMATION_FRAME_TRACER_NAME = 'logfire-long-animation-frames'
 const MAIN_THREAD_WINDOW_SPAN_NAME = 'browser.main_thread_window'
 
@@ -66,6 +69,17 @@ export class BrowserSessionSpanProcessor implements SpanProcessor {
     if (replayState !== undefined) {
       span.setAttribute(ATTR_SESSION_REPLAY_ACTIVE, replayState.active)
       span.setAttribute(ATTR_SESSION_REPLAY_MODE, replayState.mode)
+    }
+
+    const user = this.sessionManager.getUser()
+    if (user !== undefined) {
+      span.setAttribute(ATTR_USER_ID, user.id)
+      if (user.name !== undefined) {
+        span.setAttribute(ATTR_USER_NAME, user.name)
+      }
+      if (user.email !== undefined) {
+        span.setAttribute(ATTR_USER_EMAIL, user.email)
+      }
     }
 
     const routeName = this.sessionManager.getRouteName()

--- a/packages/logfire-browser/src/BrowserSessionSpanProcessor.ts
+++ b/packages/logfire-browser/src/BrowserSessionSpanProcessor.ts
@@ -10,6 +10,8 @@ const ATTR_SESSION_REPLAY_MODE = 'logfire.session_replay.mode'
 const ATTR_LOGFIRE_PAGE_ROUTE = 'logfire.page.route'
 const ATTR_LOGFIRE_PAGE_URL_FULL = 'logfire.page.url.full'
 const ATTR_LOGFIRE_PAGE_URL_PATH = 'logfire.page.url.path'
+const LONG_ANIMATION_FRAME_TRACER_NAME = 'logfire-long-animation-frames'
+const MAIN_THREAD_WINDOW_SPAN_NAME = 'browser.main_thread_window'
 
 function getCurrentUrl(): URL | undefined {
   const maybeGlobal = globalThis as {
@@ -47,7 +49,9 @@ export class BrowserSessionSpanProcessor implements SpanProcessor {
   }
 
   onStart(span: Span, _parentContext: Context): void {
-    const session = this.sessionManager.touch()
+    const isPeriodicMainThreadWindow =
+      span.instrumentationScope.name === LONG_ANIMATION_FRAME_TRACER_NAME && span.name === MAIN_THREAD_WINDOW_SPAN_NAME
+    const session = isPeriodicMainThreadWindow ? this.sessionManager.getSession() : this.sessionManager.touch()
     span.setAttribute(ATTR_SESSION_ID, session.id)
     for (const [key, value] of Object.entries(session.sessionAttributes ?? {})) {
       span.setAttribute(`logfire.session.${key}`, value)

--- a/packages/logfire-browser/src/browserConfigure.integration.test.ts
+++ b/packages/logfire-browser/src/browserConfigure.integration.test.ts
@@ -10,6 +10,31 @@ import { clearConfiguredBrowserSessionForTests } from './browserSession'
 import { configure, startSpan } from './index'
 
 const originalFetch = globalThis.fetch
+const originalPerformanceObserver = globalThis.PerformanceObserver
+
+class MockPerformanceObserver {
+  static instances: MockPerformanceObserver[] = []
+  static supportedEntryTypes = ['long-animation-frame']
+
+  private readonly callback: PerformanceObserverCallback
+
+  constructor(callback: PerformanceObserverCallback) {
+    this.callback = callback
+    MockPerformanceObserver.instances.push(this)
+  }
+
+  disconnect(): void {
+    return undefined
+  }
+
+  observe(_options: PerformanceObserverInit): void {
+    return undefined
+  }
+
+  deliver(entries: PerformanceEntry[]): void {
+    this.callback({ getEntries: () => entries } as PerformanceObserverEntryList, this as unknown as PerformanceObserver)
+  }
+}
 
 const optionalFeatureMocks = vi.hoisted(() => {
   let metricsStartupError: Error | undefined
@@ -90,6 +115,11 @@ vi.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
 
 afterEach(() => {
   Object.defineProperty(globalThis, 'fetch', { configurable: true, value: originalFetch, writable: true })
+  Object.defineProperty(globalThis, 'PerformanceObserver', {
+    configurable: true,
+    value: originalPerformanceObserver,
+  })
+  MockPerformanceObserver.instances.length = 0
   clearConfiguredBrowserSessionForTests()
   sessionStorage.clear()
   optionalFeatureMocks.reset()
@@ -248,6 +278,75 @@ describe('public browser configure startup ordering', () => {
       expect(diagWarn).toHaveBeenCalledWith(
         'logfire-browser: browser metrics did not start; continuing Web Vitals with span reporting only'
       )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('exports ranked Long Animation Frame spans through browser session context', async () => {
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    Object.defineProperty(globalThis, 'PerformanceObserver', {
+      configurable: true,
+      value: MockPerformanceObserver,
+    })
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    const exporter = new InMemorySpanExporter()
+    const cleanup = configure({
+      rum: {
+        longAnimationFrames: { sessionSampleRate: 1 },
+        session: {
+          getRouteName: () => '/integration',
+          getSessionAttributes: () => ({ account_tier: 'pro' }),
+        },
+      },
+      serviceVersion: '2026.09.03',
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+      traceUrl: '/client-traces',
+    })
+
+    try {
+      MockPerformanceObserver.instances[0]?.deliver([
+        {
+          blockingDuration: 150,
+          duration: 210,
+          entryType: 'long-animation-frame',
+          name: 'long-animation-frame',
+          scripts: [
+            {
+              duration: 80,
+              invokerType: 'event-listener',
+              sourceFunctionName: 'renderChart',
+              sourceURL: 'https://cdn.example.com/chart.js?user=secret#render',
+            },
+          ],
+          startTime: 10,
+          styleAndLayoutStart: 170,
+          toJSON: () => ({}),
+        } as unknown as PerformanceEntry,
+      ])
+      now = 25_000
+      window.dispatchEvent(new Event('pagehide'))
+      await delay(0)
+
+      const frame = exporter.getFinishedSpans().find(({ name }) => name === 'browser.long_animation_frame')
+      const summary = exporter.getFinishedSpans().find(({ name }) => name === 'browser.main_thread_window')
+      expect(frame?.attributes).toMatchObject({
+        'browser.long_animation_frame.blocking_duration': 150,
+        'browser.long_animation_frame.script.source_url': 'https://cdn.example.com/chart.js',
+        'logfire.page.route': '/integration',
+        'logfire.session.account_tier': 'pro',
+        'logfire.span_type': 'log',
+      })
+      expect(frame?.attributes['session.id']).toBeTypeOf('string')
+      expect(frame?.resource.attributes['service.version']).toBe('2026.09.03')
+      expect(summary?.attributes).toMatchObject({
+        'browser.main_thread_window.blocking_duration': 150,
+        'browser.main_thread_window.foreground_duration': 25_000,
+        'browser.main_thread_window.long_animation_frame_count': 1,
+        'logfire.page.route': '/integration',
+        'logfire.session.account_tier': 'pro',
+      })
     } finally {
       await cleanup()
     }

--- a/packages/logfire-browser/src/browserConfigure.integration.test.ts
+++ b/packages/logfire-browser/src/browserConfigure.integration.test.ts
@@ -250,6 +250,52 @@ describe('public browser configure startup ordering', () => {
     }
   })
 
+  it('attaches the current public user to each span without rotating the session', async () => {
+    let user: { id: string; name?: string; email?: string } | undefined
+    const exporter = new InMemorySpanExporter()
+    const cleanup = configure({
+      rum: {
+        session: {
+          getRouteName: () => '/account',
+          getSessionAttributes: () => ({ account_tier: 'pro' }),
+          getUser: () => user,
+        },
+      },
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+      traceUrl: '/client-traces',
+    })
+
+    try {
+      startSpan('anonymous').end()
+      user = { email: 'alice@example.com', id: 'user-a', name: 'Alice' }
+      startSpan('identified').end()
+      user = { id: 'user-b' }
+      startSpan('switched').end()
+      user = undefined
+      startSpan('logged-out').end()
+
+      const spans = Object.fromEntries(exporter.getFinishedSpans().map((span) => [span.name, span]))
+      const sessionId = spans['anonymous']?.attributes['session.id']
+      expect(sessionId).toBeTypeOf('string')
+      expect(spans['anonymous']?.attributes).not.toHaveProperty('user.id')
+      expect(spans['identified']?.attributes).toMatchObject({
+        'logfire.page.route': '/account',
+        'logfire.session.account_tier': 'pro',
+        'session.id': sessionId,
+        'user.email': 'alice@example.com',
+        'user.id': 'user-a',
+        'user.name': 'Alice',
+      })
+      expect(spans['switched']?.attributes).toMatchObject({ 'session.id': sessionId, 'user.id': 'user-b' })
+      expect(spans['switched']?.attributes).not.toHaveProperty('user.name')
+      expect(spans['logged-out']?.attributes['session.id']).toBe(sessionId)
+      expect(spans['logged-out']?.attributes).not.toHaveProperty('user.id')
+      expect(sessionStorage.getItem('lf_browser_session')).not.toContain('user-')
+    } finally {
+      await cleanup()
+    }
+  })
+
   it('exports Web Vitals spans when browser metrics startup fails', async () => {
     const exporter = new InMemorySpanExporter()
     const diagWarn = vi.spyOn(diag, 'warn').mockImplementation(() => undefined)
@@ -260,6 +306,7 @@ describe('public browser configure startup ordering', () => {
         session: {
           getRouteName: () => '/integration',
           getSessionAttributes: () => ({ account_tier: 'pro' }),
+          getUser: () => ({ id: 'user-1' }),
         },
         webVitals: { metrics: true },
       },
@@ -275,6 +322,7 @@ describe('public browser configure startup ordering', () => {
       expect(span?.attributes['logfire.span_type']).toBe('log')
       expect(span?.attributes['logfire.page.route']).toBe('/integration')
       expect(span?.attributes['logfire.session.account_tier']).toBe('pro')
+      expect(span?.attributes['user.id']).toBe('user-1')
       expect(diagWarn).toHaveBeenCalledWith(
         'logfire-browser: browser metrics did not start; continuing Web Vitals with span reporting only'
       )

--- a/packages/logfire-browser/src/browserMetrics.test.ts
+++ b/packages/logfire-browser/src/browserMetrics.test.ts
@@ -257,6 +257,7 @@ describe('browser metrics runtime', () => {
       attributes: () =>
         ({
           'app.route': '/products/:id',
+          'user.plan': 'enterprise',
           'web_vital.id': 'custom-id',
           'web_vital.lcp.target': '#hero img',
           'web_vital.value': 999,
@@ -272,6 +273,9 @@ describe('browser metrics runtime', () => {
           'session.id': 'session-1',
           'url.full': 'https://example.com/products/123?token=secret',
           'url.path': '/products/:id',
+          'user.email': 'alice@example.com',
+          'user.id': 'user-1',
+          'user.name': 'Alice',
           'web_vital.delta': 12,
           ignored: { nested: true },
         }) as never,

--- a/packages/logfire-browser/src/browserMetrics.ts
+++ b/packages/logfire-browser/src/browserMetrics.ts
@@ -123,6 +123,7 @@ function isDisallowedWebVitalMetricAttribute(key: string): boolean {
   return (
     DISALLOWED_WEB_VITAL_METRIC_ATTRIBUTES.has(key) ||
     key.startsWith('logfire.session.') ||
+    key.startsWith('user.') ||
     key.startsWith('web_vital.cls.') ||
     key.startsWith('web_vital.fcp.') ||
     key.startsWith('web_vital.inp.') ||

--- a/packages/logfire-browser/src/browserSession.test.ts
+++ b/packages/logfire-browser/src/browserSession.test.ts
@@ -293,6 +293,70 @@ describe('BrowserSessionManager', () => {
     expect(routeCallback).toHaveBeenCalledTimes(1)
   })
 
+  it('returns a normalized live user without persisting identity', () => {
+    const storage = new MemoryStorage()
+    let user: unknown = undefined
+    const getUser = vi.fn<() => { id: string; name?: string; email?: string } | undefined>(() => user as never)
+    const manager = new BrowserSessionManager({
+      generateId: createIdGenerator(),
+      getUser,
+      now: () => 1_000,
+      storage,
+      storageKey: 'test-session',
+    })
+
+    expect(manager.getUser()).toBeUndefined()
+    user = { email: 'alice@example.com', id: 'user-1', name: 'Alice' }
+    expect(manager.getUser()).toEqual({ email: 'alice@example.com', id: 'user-1', name: 'Alice' })
+    user = { email: 'bob@example.com', id: 'user-2', name: 42 }
+    expect(manager.getUser()).toEqual({ email: 'bob@example.com', id: 'user-2' })
+    expect(manager.touch().id).toBe('session-1')
+    manager.flushPendingStorage()
+    expect(storage.getItem('test-session')).toBe('{"id":"session-1","lastActivityAt":1000,"startedAt":1000}')
+    expect(getUser).toHaveBeenCalledTimes(3)
+  })
+
+  it.each([
+    ['null', null],
+    ['array', []],
+    ['primitive', 'user-1'],
+    ['empty id', { id: '' }],
+    ['non-string id', { id: 123 }],
+    [
+      'throwing id getter',
+      Object.defineProperty({}, 'id', {
+        get: () => {
+          throw new Error('id unavailable')
+        },
+      }),
+    ],
+    [
+      'throwing optional getter',
+      Object.defineProperty({ id: 'user-1' }, 'name', {
+        get: () => {
+          throw new Error('name unavailable')
+        },
+      }),
+    ],
+  ])('omits a hostile %s user value', (_name, value) => {
+    const manager = new BrowserSessionManager({
+      getUser: () => value as never,
+      storage: null,
+    })
+
+    expect(manager.getUser()).toBeUndefined()
+  })
+
+  it('preserves accepted user strings without an identity-specific length cap', () => {
+    const id = 'user-'.padEnd(10_000, 'x')
+    const manager = new BrowserSessionManager({
+      getUser: () => ({ email: '', id, name: '' }),
+      storage: null,
+    })
+
+    expect(manager.getUser()).toEqual({ id })
+  })
+
   it('enforces the complete session attribute boundary without mutating input', () => {
     const source: Record<string, unknown> = {
       Invalid: 'uppercase',

--- a/packages/logfire-browser/src/browserSession.ts
+++ b/packages/logfire-browser/src/browserSession.ts
@@ -1,4 +1,5 @@
 import type { BrowserWebVitalsOptions } from './webVitals'
+import type { BrowserLongAnimationFramesOptions } from './longAnimationFrames'
 
 export const BROWSER_SESSION_ACTIVITY_WRITE_DELAY_MS = 1_000
 const MAX_SESSION_ATTRIBUTES = 20
@@ -66,6 +67,10 @@ export interface RUMOptions {
    * Enable browser Web Vitals reporting.
    */
   webVitals?: boolean | BrowserWebVitalsOptions
+  /**
+   * Enable sampled Long Animation Frame diagnostics and foreground summaries.
+   */
+  longAnimationFrames?: boolean | BrowserLongAnimationFramesOptions
 }
 
 export interface BrowserSessionManagerOptions extends BrowserSessionOptions {

--- a/packages/logfire-browser/src/browserSession.ts
+++ b/packages/logfire-browser/src/browserSession.ts
@@ -15,12 +15,26 @@ export interface BrowserSessionUrlAttributes {
   path?: string
 }
 
+export interface BrowserUser {
+  /** Opaque application user id. */
+  id: string
+  /** Optional display name. This is PII when provided. */
+  name?: string
+  /** Optional email address. This is PII when provided. */
+  email?: string
+}
+
 export interface BrowserSessionOptions {
   /**
    * Returns the application's current normalized, low-cardinality route name.
    * The callback is evaluated independently for every new browser span.
    */
   getRouteName?: () => string | undefined
+  /**
+   * Returns the application's current user for each new browser span. The
+   * value is client-asserted context, not authentication or authorization.
+   */
+  getUser?: () => BrowserUser | undefined
   /**
    * Returns low-cardinality, non-PII dimensions to snapshot once per browser
    * session. Invalid or oversized entries are omitted.
@@ -205,10 +219,34 @@ function normalizeBrowserSessionAttributes(value: unknown): BrowserSessionAttrib
   return Object.freeze(attributes)
 }
 
+function normalizeBrowserUser(value: unknown): BrowserUser | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined
+  }
+
+  try {
+    const id: unknown = Reflect.get(value, 'id')
+    if (typeof id !== 'string' || id.length === 0) {
+      return undefined
+    }
+
+    const name: unknown = Reflect.get(value, 'name')
+    const email: unknown = Reflect.get(value, 'email')
+    return Object.freeze({
+      id,
+      ...(typeof name === 'string' && name.length > 0 ? { name } : {}),
+      ...(typeof email === 'string' && email.length > 0 ? { email } : {}),
+    })
+  } catch {
+    return undefined
+  }
+}
+
 export class BrowserSessionManager {
   private readonly generateId: () => string
   private readonly routeNameCallback: BrowserSessionOptions['getRouteName'] | undefined
   private readonly sessionAttributesCallback: BrowserSessionOptions['getSessionAttributes'] | undefined
+  private readonly userCallback: BrowserSessionOptions['getUser'] | undefined
   private readonly idleTimeoutMs: number
   private readonly maxDurationMs: number
   private readonly now: () => number
@@ -223,6 +261,7 @@ export class BrowserSessionManager {
     this.generateId = options.generateId ?? generateBrowserSessionId
     this.routeNameCallback = options.getRouteName
     this.sessionAttributesCallback = options.getSessionAttributes
+    this.userCallback = options.getUser
     this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_BROWSER_SESSION_OPTIONS.idleTimeoutMs
     this.maxDurationMs = options.maxDurationMs ?? DEFAULT_BROWSER_SESSION_OPTIONS.maxDurationMs
     this.now = options.now ?? Date.now
@@ -288,6 +327,14 @@ export class BrowserSessionManager {
     try {
       const routeName = this.routeNameCallback?.()
       return typeof routeName === 'string' ? routeName : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  getUser(): BrowserUser | undefined {
+    try {
+      return normalizeBrowserUser(this.userCallback?.())
     } catch {
       return undefined
     }

--- a/packages/logfire-browser/src/browserSession.ts
+++ b/packages/logfire-browser/src/browserSession.ts
@@ -253,6 +253,7 @@ export class BrowserSessionManager {
   private readonly storage: Storage | null
   private readonly storageKey: string
   private readonly urlAttributes: BrowserSessionOptions['urlAttributes'] | undefined
+  private readonly sessionChangeListeners = new Set<(session: BrowserSessionState) => void>()
   private memorySession: BrowserSessionState | undefined
   private pendingSession: BrowserSessionState | undefined
   private persistenceTimer: ReturnType<typeof setTimeout> | undefined
@@ -283,11 +284,22 @@ export class BrowserSessionManager {
     return attributes === undefined ? undefined : Object.freeze({ ...attributes })
   }
 
+  getStorageKey(): string {
+    return this.storageKey
+  }
+
+  onSessionChange(listener: (session: BrowserSessionState) => void): () => void {
+    this.sessionChangeListeners.add(listener)
+    return () => {
+      this.sessionChangeListeners.delete(listener)
+    }
+  }
+
   touch(): BrowserSessionState {
     const now = this.now()
     const session = this.getSessionAt(now)
     const touchedSession = { ...session, lastActivityAt: now }
-    this.memorySession = touchedSession
+    this.setMemorySession(touchedSession)
     this.scheduleWrite(touchedSession)
     return touchedSession
   }
@@ -376,7 +388,7 @@ export class BrowserSessionManager {
           const parsedValue: unknown = JSON.parse(value)
           if (isBrowserSessionState(parsedValue)) {
             const session = this.prepareStoredSession(parsedValue)
-            this.memorySession = session
+            this.setMemorySession(session)
             if (hasOwn(parsedValue, 'sessionAttributes') || this.sessionAttributesCallback !== undefined) {
               const persisted = this.writeSession(session)
               if (!persisted && !hasOwn(parsedValue, 'sessionAttributes') && this.sessionAttributesCallback !== undefined) {
@@ -426,7 +438,7 @@ export class BrowserSessionManager {
   }
 
   private writeSession(session: BrowserSessionState): boolean {
-    this.memorySession = session
+    this.setMemorySession(session)
     if (this.storage === null) {
       return false
     }
@@ -453,6 +465,21 @@ export class BrowserSessionManager {
         this.writeSession(pendingSession)
       }
     }, BROWSER_SESSION_ACTIVITY_WRITE_DELAY_MS)
+  }
+
+  private setMemorySession(session: BrowserSessionState): void {
+    const changed = this.memorySession?.id !== session.id
+    this.memorySession = session
+    if (!changed) {
+      return
+    }
+    for (const listener of this.sessionChangeListeners) {
+      try {
+        listener(session)
+      } catch {
+        // Internal observers must not interfere with browser session state.
+      }
+    }
   }
 }
 

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
   const lifecycleEvents: string[] = []
   const autoInstrumentationConfigs: unknown[] = []
   const autoInstrumentations: unknown[] = []
+  const longAnimationFramesStartCalls: unknown[] = []
   const registerInstrumentationCalls: { instrumentations: unknown; tracerProvider: unknown }[] = []
   const registrationFailures: unknown[] = []
   const webVitalsStartCalls: unknown[] = []
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => {
       }>
     | undefined
   let unregisterCalls = 0
+  let longAnimationFramesShutdownCalls = 0
   let webVitalsShutdownCalls = 0
   let webVitalsStartupPromise:
     | Promise<{
@@ -50,10 +52,12 @@ const mocks = vi.hoisted(() => {
       return {
         name,
         provider: this,
-        startSpan: () => {
+        startSpan: (spanName: string) => {
           const attributes: Record<string, unknown> = {}
           const span = {
             attributes,
+            instrumentationScope: { name },
+            name: spanName,
             end() {
               return undefined
             },
@@ -107,6 +111,16 @@ const mocks = vi.hoisted(() => {
     }
   }
 
+  function createLongAnimationFramesHandle(): { shutdown: () => Promise<void> } {
+    return {
+      async shutdown() {
+        cleanupStepCalls.push('longAnimationFramesShutdown')
+        longAnimationFramesShutdownCalls++
+        return Promise.resolve()
+      },
+    }
+  }
+
   function createBrowserMetricsRuntime(): {
     createWebVitalsMetricRecorder: (options: unknown) => unknown
     forceFlush: () => Promise<void>
@@ -155,7 +169,10 @@ const mocks = vi.hoisted(() => {
     cleanupStepCalls,
     createBrowserMetricsRuntime,
     createWebVitalsHandle,
-    failStep(step: 'metricForceFlush' | 'metricShutdown' | 'unregister' | 'forceFlush' | 'shutdown', error: unknown) {
+    failStep(
+      step: 'longAnimationFramesStart' | 'metricForceFlush' | 'metricShutdown' | 'unregister' | 'forceFlush' | 'shutdown',
+      error: unknown
+    ) {
       failures.set(step, error)
     },
     failNextRegistration(error: unknown) {
@@ -169,6 +186,12 @@ const mocks = vi.hoisted(() => {
     },
     get lifecycleEvents() {
       return lifecycleEvents
+    },
+    get longAnimationFramesShutdownCalls() {
+      return longAnimationFramesShutdownCalls
+    },
+    get longAnimationFramesStartCalls() {
+      return longAnimationFramesStartCalls
     },
     get unregisterCalls() {
       return unregisterCalls
@@ -204,6 +227,8 @@ const mocks = vi.hoisted(() => {
       cleanupStepCalls.length = 0
       failures.clear()
       lifecycleEvents.length = 0
+      longAnimationFramesShutdownCalls = 0
+      longAnimationFramesStartCalls.length = 0
       unregisterCalls = 0
       webVitalsShutdownCalls = 0
       webVitalsStartCalls.length = 0
@@ -237,6 +262,14 @@ const mocks = vi.hoisted(() => {
       lifecycleEvents.push('browserMetricsStart')
       browserMetricsStartCalls.push({ options, resource })
       return browserMetricsStartupPromise ?? Promise.resolve(createBrowserMetricsRuntime())
+    },
+    startBrowserLongAnimationFrames(options: unknown) {
+      lifecycleEvents.push('longAnimationFramesStart')
+      longAnimationFramesStartCalls.push(options)
+      if (failures.has('longAnimationFramesStart')) {
+        throw failures.get('longAnimationFramesStart')
+      }
+      return createLongAnimationFramesHandle()
     },
     async startBrowserWebVitals(options: unknown) {
       lifecycleEvents.push('webVitalsStart')
@@ -342,6 +375,10 @@ vi.mock('@opentelemetry/sdk-trace-web', () => ({
 
 vi.mock('./webVitals', () => ({
   startBrowserWebVitals: async (options: unknown) => mocks.startBrowserWebVitals(options),
+}))
+
+vi.mock('./longAnimationFrames', () => ({
+  startBrowserLongAnimationFrames: (options: unknown) => mocks.startBrowserLongAnimationFrames(options),
 }))
 
 vi.mock('./browserMetrics', () => ({
@@ -1303,6 +1340,143 @@ describe('browser Web Vitals config', () => {
     expect(mocks.webVitalsShutdownCalls).toBe(1)
     expect(mocks.cleanupStepCalls).toEqual(['unregister', 'webVitalsShutdown', 'forceFlush', 'shutdown'])
     expect(cleanup()).toBe(cleanupPromise)
+  })
+})
+
+describe('browser Long Animation Frames config', () => {
+  beforeEach(() => {
+    mocks.reset()
+    cleanup = undefined
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        language: 'en-US',
+        userAgent: 'test-browser',
+        userAgentData: undefined,
+      },
+    })
+  })
+
+  afterEach(async () => {
+    await cleanup?.()
+    clearConfiguredBrowserSessionForTests()
+    configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('does not start Long Animation Frames by default or when disabled', async () => {
+    cleanup = configure({
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+    expect(mocks.longAnimationFramesStartCalls).toEqual([])
+    await cleanup()
+    cleanup = undefined
+
+    cleanup = configure({
+      rum: { longAnimationFrames: false },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+    expect(mocks.longAnimationFramesStartCalls).toEqual([])
+  })
+
+  it('starts Long Animation Frames with session context and public options', () => {
+    cleanup = configure({
+      rum: {
+        longAnimationFrames: {
+          blockingDurationThresholdMs: 150,
+          sessionSampleRate: 0.5,
+          windowDurationMs: 30_000,
+        },
+      },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(mocks.longAnimationFramesStartCalls).toHaveLength(1)
+    const call = mocks.longAnimationFramesStartCalls[0] as {
+      autoFlushOnDocumentHide: boolean
+      blockingDurationThresholdMs: number
+      forceFlush: () => Promise<void>
+      sessionManager: unknown
+      sessionSampleRate: number
+      tracer: { name: string }
+      windowDurationMs: number
+    }
+    expect({
+      autoFlushOnDocumentHide: call.autoFlushOnDocumentHide,
+      blockingDurationThresholdMs: call.blockingDurationThresholdMs,
+      hasForceFlush: typeof call.forceFlush === 'function',
+      hasSessionManager: call.sessionManager !== undefined,
+      sessionSampleRate: call.sessionSampleRate,
+      tracerName: call.tracer.name,
+      windowDurationMs: call.windowDurationMs,
+    }).toEqual({
+      autoFlushOnDocumentHide: true,
+      blockingDurationThresholdMs: 150,
+      hasForceFlush: true,
+      hasSessionManager: true,
+      sessionSampleRate: 0.5,
+      tracerName: 'logfire-long-animation-frames',
+      windowDurationMs: 30_000,
+    })
+    expect(getLatestSpanProcessors()[0]).toBeInstanceOf(BrowserSessionSpanProcessor)
+    expect(mocks.lifecycleEvents).toEqual(['providerCreate', 'longAnimationFramesStart'])
+  })
+
+  it('keeps tracing configured when Long Animation Frame startup fails', async () => {
+    const startupError = new Error('Long Animation Frame observer unavailable')
+    const diagError = vi.spyOn(diag, 'error').mockImplementation(() => undefined)
+    mocks.failStep('longAnimationFramesStart', startupError)
+
+    cleanup = configure({
+      rum: { longAnimationFrames: true },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(mocks.longAnimationFramesStartCalls).toHaveLength(1)
+    expect(diagError).toHaveBeenCalledWith('logfire-browser: failed to start Long Animation Frame reporting', startupError)
+    expect(() => {
+      startSpan('after Long Animation Frame startup failure').end()
+    }).not.toThrow()
+    await cleanup()
+    cleanup = undefined
+  })
+
+  it('preserves disabled document-hide auto-flush', () => {
+    cleanup = configure({
+      batchSpanProcessorConfig: { disableAutoFlushOnDocumentHide: true },
+      rum: { longAnimationFrames: true },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    expect(mocks.longAnimationFramesStartCalls[0]).toMatchObject({
+      autoFlushOnDocumentHide: false,
+    })
+  })
+
+  it('rejects Long Animation Frames when session attributes are explicitly disabled', () => {
+    expect(() => {
+      configure({
+        rum: { longAnimationFrames: true, session: false },
+        traceUrl: 'http://localhost:8989/client-traces',
+      })
+    }).toThrow('rum.longAnimationFrames requires browser session attributes')
+    expect(mocks.longAnimationFramesStartCalls).toEqual([])
+  })
+
+  it('shuts down Long Animation Frames before provider flush', async () => {
+    cleanup = configure({
+      rum: { longAnimationFrames: true },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+
+    await cleanup()
+
+    expect(mocks.longAnimationFramesShutdownCalls).toBe(1)
+    expect(mocks.cleanupStepCalls).toEqual(['longAnimationFramesShutdown', 'unregister', 'forceFlush', 'shutdown'])
   })
 })
 

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -5,7 +5,7 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import type { Instrumentation } from '@opentelemetry/instrumentation'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'
 import { resourceFromAttributes } from '@opentelemetry/resources'
-import type { BufferConfig, SpanProcessor } from '@opentelemetry/sdk-trace-web'
+import type { BatchSpanProcessorBrowserConfig, SpanProcessor } from '@opentelemetry/sdk-trace-web'
 import { BatchSpanProcessor, ParentBasedSampler, TraceIdRatioBasedSampler, WebTracerProvider } from '@opentelemetry/sdk-trace-web'
 import {
   ATTR_SERVICE_NAME,
@@ -56,6 +56,8 @@ import { BrowserSessionSpanProcessor } from './BrowserSessionSpanProcessor'
 import { clearConfiguredBrowserSession, configureBrowserSession, getBrowserSessionId } from './browserSession'
 import type { RUMOptions } from './browserSession'
 import type { BrowserMetricsOptions, BrowserWebVitalsMetricOptions } from './browserMetrics'
+import { startBrowserLongAnimationFrames } from './longAnimationFrames'
+import type { BrowserLongAnimationFramesOptions } from './longAnimationFrames'
 import { BrowserSessionReplayState, startBrowserSessionReplay } from './sessionReplay'
 import type { BrowserSessionReplayControl, BrowserSessionReplayOptions } from './sessionReplay'
 import { startBrowserWebVitals } from './webVitals'
@@ -83,6 +85,7 @@ export type {
   RUMOptions,
 } from './browserSession'
 export type { BrowserMetricsOptions, BrowserWebVitalsMetricOptions } from './browserMetrics'
+export type { BrowserLongAnimationFramesOptions } from './longAnimationFrames'
 export type { BrowserSessionReplayOptions } from './sessionReplay'
 export type { BrowserWebVitalsOptions } from './webVitals'
 
@@ -106,7 +109,7 @@ export interface LogfireConfigOptions {
   /**
    * The configuration of the batch span processor.
    */
-  batchSpanProcessorConfig?: BufferConfig
+  batchSpanProcessorConfig?: BatchSpanProcessorBrowserConfig
   /**
    * Active OpenTelemetry baggage keys to copy to Logfire manual spans/logs as span attributes.
    */
@@ -243,6 +246,16 @@ function resolveBrowserWebVitalsOptions(webVitals: RUMOptions['webVitals'] | und
   return webVitals === true ? {} : webVitals
 }
 
+function resolveBrowserLongAnimationFramesOptions(
+  longAnimationFrames: RUMOptions['longAnimationFrames'] | undefined
+): BrowserLongAnimationFramesOptions | undefined {
+  if (longAnimationFrames === undefined || longAnimationFrames === false) {
+    return undefined
+  }
+
+  return longAnimationFrames === true ? {} : longAnimationFrames
+}
+
 function resolveBrowserMetricsOptions(metrics: LogfireConfigOptions['metrics']): BrowserMetricsOptions | undefined {
   if (metrics === undefined || metrics === false) {
     return undefined
@@ -279,8 +292,9 @@ function resolveBrowserSessionOptions(
   sessionReplayOptions: BrowserSessionReplayOptions | undefined
 ): RUMOptions['session'] | undefined {
   const webVitalsOptions = resolveBrowserWebVitalsOptions(rum?.webVitals)
+  const longAnimationFramesOptions = resolveBrowserLongAnimationFramesOptions(rum?.longAnimationFrames)
   const sessionReplayRequiresSession = sessionReplayOptions !== undefined
-  if (webVitalsOptions === undefined && !sessionReplayRequiresSession) {
+  if (webVitalsOptions === undefined && longAnimationFramesOptions === undefined && !sessionReplayRequiresSession) {
     return rum?.session
   }
 
@@ -290,9 +304,8 @@ function resolveBrowserSessionOptions(
         'logfire-browser: sessionReplay requires browser session attributes; remove rum.session: false or disable sessionReplay'
       )
     }
-    throw new Error(
-      'logfire-browser: rum.webVitals requires browser session attributes; remove rum.session: false or disable rum.webVitals'
-    )
+    const feature = webVitalsOptions === undefined ? 'rum.longAnimationFrames' : 'rum.webVitals'
+    throw new Error(`logfire-browser: ${feature} requires browser session attributes; remove rum.session: false or disable ${feature}`)
   }
 
   return rum?.session ?? true
@@ -458,6 +471,7 @@ export function configure(options: LogfireConfigOptions): BrowserConfigureHandle
   assertProviderLifecycleAvailable()
 
   const webVitalsOptions = resolveBrowserWebVitalsOptions(options.rum?.webVitals)
+  const longAnimationFramesOptions = resolveBrowserLongAnimationFramesOptions(options.rum?.longAnimationFrames)
   const sessionReplayOptions = resolveBrowserSessionReplayOptions(options.sessionReplay)
   const browserMetricsOptions = resolveBrowserMetricsOptions(options.metrics)
   const webVitalsMetricOptions = resolveBrowserWebVitalsMetricOptions(webVitalsOptions)
@@ -696,6 +710,24 @@ export function configure(options: LogfireConfigOptions): BrowserConfigureHandle
             return undefined
           })
 
+  const longAnimationFramesHandle =
+    longAnimationFramesOptions === undefined || browserSessionManager === undefined
+      ? undefined
+      : (() => {
+          try {
+            return startBrowserLongAnimationFrames({
+              ...longAnimationFramesOptions,
+              autoFlushOnDocumentHide: options.batchSpanProcessorConfig?.disableAutoFlushOnDocumentHide !== true,
+              forceFlush: async () => tracerProvider.forceFlush(),
+              sessionManager: browserSessionManager,
+              tracer: tracerProvider.getTracer('logfire-long-animation-frames'),
+            })
+          } catch (error) {
+            diag.error('logfire-browser: failed to start Long Animation Frame reporting', error)
+            return undefined
+          }
+        })()
+
   let cleanupPromise: Promise<void> | undefined
 
   // Return the stored promise directly so repeated cleanup calls preserve identity.
@@ -725,6 +757,9 @@ export function configure(options: LogfireConfigOptions): BrowserConfigureHandle
       diag.info('logfire-browser: shutting down')
       if (sessionReplayHandle !== undefined) {
         await runCleanupStep('session replay shutdown', async () => sessionReplayHandle.stop())
+      }
+      if (longAnimationFramesHandle !== undefined) {
+        await runCleanupStep('long animation frames shutdown', async () => longAnimationFramesHandle.shutdown())
       }
       await runCleanupStep('instrumentation unregister', unregisterInstrumentations)
       if (webVitalsStartupPromise !== undefined) {

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -82,6 +82,7 @@ export type {
   BrowserSessionAttributeValue,
   BrowserSessionOptions,
   BrowserSessionUrlAttributes,
+  BrowserUser,
   RUMOptions,
 } from './browserSession'
 export type { BrowserMetricsOptions, BrowserWebVitalsMetricOptions } from './browserMetrics'

--- a/packages/logfire-browser/src/longAnimationFrames.test.ts
+++ b/packages/logfire-browser/src/longAnimationFrames.test.ts
@@ -1,0 +1,600 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { diag } from '@opentelemetry/api'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { BrowserSessionManager } from './browserSession'
+import { startBrowserLongAnimationFrames } from './longAnimationFrames'
+
+interface TestSpan {
+  attributes: Record<string, unknown>
+  name: string
+}
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>()
+
+  get length(): number {
+    return this.items.size
+  }
+
+  clear(): void {
+    this.items.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value)
+  }
+}
+
+class ThrowingStorage extends MemoryStorage {
+  override getItem(_key: string): string | null {
+    throw new Error('storage read failed')
+  }
+
+  override setItem(_key: string, _value: string): void {
+    throw new Error('storage write failed')
+  }
+}
+
+class MockPerformanceObserver {
+  static instances: MockPerformanceObserver[] = []
+  static supportedEntryTypes: string[] = ['long-animation-frame']
+
+  readonly disconnect = vi.fn<() => void>()
+  readonly observe = vi.fn<(options: PerformanceObserverInit) => void>()
+  private readonly callback: PerformanceObserverCallback
+
+  constructor(callback: PerformanceObserverCallback) {
+    this.callback = callback
+    MockPerformanceObserver.instances.push(this)
+  }
+
+  deliver(entries: PerformanceEntry[]): void {
+    this.callback(
+      {
+        getEntries: () => entries,
+      } as PerformanceObserverEntryList,
+      this as unknown as PerformanceObserver
+    )
+  }
+}
+
+const originalPerformanceObserver = globalThis.PerformanceObserver
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: state })
+}
+
+function createTracer(spans: TestSpan[]) {
+  return {
+    startSpan(name: string) {
+      const span: TestSpan = { attributes: {}, name }
+      spans.push(span)
+      return {
+        end() {
+          return undefined
+        },
+        setAttributes(attributes: Record<string, unknown>) {
+          Object.assign(span.attributes, attributes)
+          return this
+        },
+      }
+    },
+  }
+}
+
+function createSessionManager(storage: Storage, now: () => number, generateId: () => string = () => 'session-1') {
+  return new BrowserSessionManager({
+    generateId,
+    now,
+    storage,
+    storageKey: 'test-browser-session',
+  })
+}
+
+function createFrame(
+  blockingDuration: number,
+  options: { duration?: number; scripts?: Record<string, unknown>[]; startTime?: number; styleAndLayoutStart?: number } = {}
+): PerformanceEntry {
+  const startTime = options.startTime ?? 10
+  return {
+    blockingDuration,
+    duration: options.duration ?? blockingDuration + 50,
+    entryType: 'long-animation-frame',
+    name: 'long-animation-frame',
+    scripts: options.scripts ?? [],
+    startTime,
+    styleAndLayoutStart: options.styleAndLayoutStart ?? 0,
+    toJSON: () => ({}),
+  } as unknown as PerformanceEntry
+}
+
+function createScript(duration: number, suffix: string): Record<string, unknown> {
+  return {
+    duration,
+    invoker: `Element#${suffix}.onclick`,
+    invokerType: 'event-listener',
+    sourceFunctionName: `handler${suffix}`,
+    sourceURL: `https://cdn.example.com/${suffix}.js?user=secret#call`,
+  }
+}
+
+describe('browser long animation frame reporting', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockPerformanceObserver.instances.length = 0
+    MockPerformanceObserver.supportedEntryTypes = ['long-animation-frame']
+    Object.defineProperty(globalThis, 'PerformanceObserver', {
+      configurable: true,
+      value: MockPerformanceObserver,
+    })
+    setVisibilityState('visible')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    Object.defineProperty(globalThis, 'PerformanceObserver', {
+      configurable: true,
+      value: originalPerformanceObserver,
+    })
+  })
+
+  it('stays inert when unsupported or sampled out', () => {
+    const storage = new MemoryStorage()
+    const sessionManager = createSessionManager(storage, () => 0)
+
+    MockPerformanceObserver.supportedEntryTypes = []
+    expect(
+      startBrowserLongAnimationFrames({
+        autoFlushOnDocumentHide: true,
+        forceFlush: async () => Promise.resolve(),
+        sessionManager,
+        sessionSampleRate: 1,
+        storage,
+        tracer: createTracer([]) as never,
+      })
+    ).toBeUndefined()
+
+    MockPerformanceObserver.supportedEntryTypes = ['long-animation-frame']
+    expect(
+      startBrowserLongAnimationFrames({
+        autoFlushOnDocumentHide: true,
+        forceFlush: async () => Promise.resolve(),
+        sessionManager,
+        sessionSampleRate: 0,
+        storage,
+        tracer: createTracer([]) as never,
+      })
+    ).toBeUndefined()
+    expect(MockPerformanceObserver.instances).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('normalizes hostile collection options to bounded defaults', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      blockingDurationThresholdMs: Number.NaN,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 2,
+      storage,
+      tracer: createTracer(spans) as never,
+      windowDurationMs: 1,
+    })
+    MockPerformanceObserver.instances[0]?.deliver([createFrame(100, { startTime: 1 })])
+
+    now = 9_999
+    await vi.advanceTimersByTimeAsync(9_999)
+    expect(spans).toEqual([])
+    now = 10_000
+    await vi.advanceTimersByTimeAsync(1)
+    expect(spans.map((span) => span.name)).toEqual(['browser.long_animation_frame', 'browser.main_thread_window'])
+
+    await handle?.shutdown()
+  })
+
+  it('reports the worst frame and an exact foreground window summary', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: true,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    const observer = MockPerformanceObserver.instances[0]
+    expect(observer?.observe).toHaveBeenCalledWith({ buffered: true, type: 'long-animation-frame' })
+
+    observer?.deliver([
+      createFrame(150, {
+        duration: 210,
+        scripts: [createScript(20, 'small'), createScript(80, 'large')],
+        startTime: 10,
+        styleAndLayoutStart: 170,
+      }),
+    ])
+    now = 60_000
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(spans.map((span) => span.name)).toEqual(['browser.long_animation_frame', 'browser.main_thread_window'])
+    expect(spans[0]?.attributes).toEqual({
+      'browser.long_animation_frame.blocking_duration': 150,
+      'browser.long_animation_frame.duration': 210,
+      'browser.long_animation_frame.script.duration': 80,
+      'browser.long_animation_frame.script.function_name': 'handlerlarge',
+      'browser.long_animation_frame.script.invoker_type': 'event-listener',
+      'browser.long_animation_frame.script.source_url': 'https://cdn.example.com/large.js',
+      'browser.long_animation_frame.style_and_layout_duration': 50,
+      'logfire.span_type': 'log',
+    })
+    expect(spans[1]?.attributes).toMatchObject({
+      'browser.main_thread_window.blocking_duration': 150,
+      'browser.main_thread_window.dropped_long_animation_frame_count': 0,
+      'browser.main_thread_window.foreground_duration': 60_000,
+      'browser.main_thread_window.long_animation_frame_count': 1,
+      'browser.main_thread_window.script.0.duration': 80,
+      'browser.main_thread_window.script.0.source_url': 'https://cdn.example.com/large.js',
+      'browser.main_thread_window.script.1.duration': 20,
+      'logfire.span_type': 'log',
+    })
+
+    await handle?.shutdown()
+  })
+
+  it('ranks each window, persists the cap, and resets it for a rotated session', async () => {
+    let now = 0
+    let sessionNumber = 1
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const sessionManager = createSessionManager(
+      storage,
+      () => now,
+      () => `session-${sessionNumber.toString()}`
+    )
+    const firstHandle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: true,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager,
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    const observer = MockPerformanceObserver.instances[0]
+    observer?.deliver(Array.from({ length: 22 }, (_, index) => createFrame(101 + index, { startTime: index + 1 })))
+    now = 60_000
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    const frameSpans = spans.filter((span) => span.name === 'browser.long_animation_frame')
+    expect(frameSpans).toHaveLength(20)
+    expect(frameSpans.map((span) => span.attributes['browser.long_animation_frame.blocking_duration'])).toEqual(
+      Array.from({ length: 20 }, (_, index) => 122 - index)
+    )
+    expect(spans.find((span) => span.name === 'browser.main_thread_window')?.attributes).toMatchObject({
+      'browser.main_thread_window.dropped_long_animation_frame_count': 2,
+      'browser.main_thread_window.long_animation_frame_count': 22,
+    })
+
+    await firstHandle?.shutdown()
+    const reloadedSessionManager = createSessionManager(
+      storage,
+      () => now,
+      () => `session-${sessionNumber.toString()}`
+    )
+    const reloadedHandle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: true,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: reloadedSessionManager,
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    const reloadedObserver = MockPerformanceObserver.instances[1]
+    reloadedObserver?.deliver([createFrame(500, { startTime: 60_001 })])
+    now = 120_000
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toHaveLength(20)
+    expect(spans.filter((span) => span.name === 'browser.main_thread_window')[1]?.attributes).toMatchObject({
+      'browser.main_thread_window.dropped_long_animation_frame_count': 1,
+    })
+
+    sessionNumber = 2
+    reloadedSessionManager.reset()
+    reloadedObserver?.deliver([createFrame(600, { startTime: 120_001 })])
+    now = 180_000
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toHaveLength(21)
+
+    await reloadedHandle?.shutdown()
+  })
+
+  it('flushes positive foreground partial windows once and removes lifecycle work', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const forceFlush = vi.fn<() => Promise<void>>(async () => Promise.resolve())
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: true,
+      forceFlush,
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+
+    now = 25_000
+    setVisibilityState('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    window.dispatchEvent(new Event('pagehide'))
+    expect(forceFlush).toHaveBeenCalledTimes(1)
+
+    now = 65_000
+    setVisibilityState('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    now = 75_000
+    window.dispatchEvent(new Event('pagehide'))
+    expect(forceFlush).toHaveBeenCalledTimes(2)
+    expect(
+      spans
+        .filter((span) => span.name === 'browser.main_thread_window')
+        .map((span) => span.attributes['browser.main_thread_window.foreground_duration'])
+    ).toEqual([25_000, 10_000])
+
+    await handle?.shutdown()
+    const spanCount = spans.length
+    now = 90_000
+    setVisibilityState('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.runAllTimersAsync()
+    expect(spans).toHaveLength(spanCount)
+    expect(MockPerformanceObserver.instances[0]?.disconnect).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('ranks buffered entries separately from the foreground denominator', async () => {
+    let now = 1_000
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+      windowDurationMs: 10_000,
+    })
+    MockPerformanceObserver.instances[0]?.deliver([createFrame(120, { startTime: 500 }), createFrame(140, { startTime: 1_001 })])
+    expect(spans.map((span) => span.name)).toEqual(['browser.long_animation_frame'])
+
+    now = 11_000
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(spans.map((span) => span.name)).toEqual([
+      'browser.long_animation_frame',
+      'browser.long_animation_frame',
+      'browser.main_thread_window',
+    ])
+    expect(spans[2]?.attributes).toMatchObject({
+      'browser.main_thread_window.blocking_duration': 140,
+      'browser.main_thread_window.long_animation_frame_count': 1,
+    })
+
+    await handle?.shutdown()
+  })
+
+  it('uses deterministic fractional sampling and stops after rotation to a sampled-out session', async () => {
+    const storage = new MemoryStorage()
+    const sessionIds = ['sampled', 'unsampled']
+    const sessionManager = createSessionManager(
+      storage,
+      () => 0,
+      () => sessionIds.shift() ?? 'unsampled'
+    )
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      sessionManager,
+      sessionSampleRate: 0.5,
+      storage,
+      tracer: createTracer([]) as never,
+    })
+    const observer = MockPerformanceObserver.instances[0]
+    expect(handle).toBeDefined()
+
+    sessionManager.reset()
+    observer?.deliver([createFrame(150)])
+
+    expect(observer?.disconnect).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    await handle?.shutdown()
+
+    const sampledOutManager = createSessionManager(
+      new MemoryStorage(),
+      () => 0,
+      () => 'unsampled'
+    )
+    expect(
+      startBrowserLongAnimationFrames({
+        autoFlushOnDocumentHide: false,
+        forceFlush: async () => Promise.resolve(),
+        sessionManager: sampledOutManager,
+        sessionSampleRate: 0.5,
+        tracer: createTracer([]) as never,
+      })
+    ).toBeUndefined()
+  })
+
+  it('discards a partial window when the browser session rotates', async () => {
+    let now = 0
+    let sessionNumber = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const sessionManager = createSessionManager(
+      storage,
+      () => now,
+      () => `session-${(++sessionNumber).toString()}`
+    )
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager,
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    const observer = MockPerformanceObserver.instances[0]
+    observer?.deliver([createFrame(150, { startTime: 1 })])
+    now = 30_000
+    sessionManager.reset()
+    now = 60_000
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(spans).toEqual([])
+
+    observer?.deliver([createFrame(200, { startTime: 60_001 })])
+    now = 120_000
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(spans.map((span) => span.name)).toEqual(['browser.long_animation_frame', 'browser.main_thread_window'])
+    expect(spans[0]?.attributes['browser.long_animation_frame.blocking_duration']).toBe(200)
+
+    await handle?.shutdown()
+  })
+
+  it('aggregates matching scripts and exports only the top three', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    MockPerformanceObserver.instances[0]?.deliver([
+      createFrame(150, {
+        scripts: [createScript(40, 'shared'), createScript(90, 'second'), createScript(80, 'third'), createScript(70, 'fourth')],
+        startTime: 1,
+      }),
+      createFrame(160, { scripts: [createScript(60, 'shared')], startTime: 2 }),
+    ])
+    now = 60_000
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    const summary = spans.find((span) => span.name === 'browser.main_thread_window')
+    expect(summary?.attributes).toMatchObject({
+      'browser.main_thread_window.script.0.duration': 100,
+      'browser.main_thread_window.script.0.source_url': 'https://cdn.example.com/shared.js',
+      'browser.main_thread_window.script.1.duration': 90,
+      'browser.main_thread_window.script.1.source_url': 'https://cdn.example.com/second.js',
+      'browser.main_thread_window.script.2.duration': 80,
+      'browser.main_thread_window.script.2.source_url': 'https://cdn.example.com/third.js',
+    })
+    expect(summary?.attributes).not.toHaveProperty('browser.main_thread_window.script.3.duration')
+
+    await handle?.shutdown()
+  })
+
+  it('skips malformed frames and contains tracer and storage failures', async () => {
+    let now = 0
+    const reportError = new Error('span start failed')
+    const diagError = vi.spyOn(diag, 'error').mockImplementation(() => undefined)
+    const storage = new ThrowingStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: {
+        startSpan() {
+          throw reportError
+        },
+      } as never,
+    })
+    MockPerformanceObserver.instances[0]?.deliver([
+      createFrame(Number.NaN, { startTime: 1 }),
+      createFrame(-1, { startTime: 2 }),
+      createFrame(150, { startTime: 3 }),
+      { entryType: 'long-animation-frame', name: 'long-animation-frame', startTime: 4 } as PerformanceEntry,
+    ])
+    now = 60_000
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(diagError).toHaveBeenNthCalledWith(1, 'logfire-browser: failed to report browser.long_animation_frame', reportError)
+    expect(diagError).toHaveBeenNthCalledWith(2, 'logfire-browser: failed to report browser.main_thread_window', reportError)
+    expect(diagError).toHaveBeenCalledTimes(2)
+
+    await handle?.shutdown()
+  })
+
+  it('honors document-hide auto-flush and contains flush rejection', async () => {
+    let now = 0
+    const flushError = new Error('flush failed')
+    const diagError = vi.spyOn(diag, 'error').mockImplementation(() => undefined)
+    const forceFlush = vi.fn<() => Promise<void>>(async () => Promise.reject(flushError))
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: true,
+      forceFlush,
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer([]) as never,
+    })
+    now = 10_000
+    setVisibilityState('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.waitFor(() => {
+      expect(diagError).toHaveBeenCalledWith('logfire-browser: failed to flush long animation frame spans on document hide', flushError)
+    })
+    expect(forceFlush).toHaveBeenCalledTimes(1)
+    await handle?.shutdown()
+
+    setVisibilityState('visible')
+    const disabledFlush = vi.fn<() => Promise<void>>(async () => Promise.resolve())
+    const disabledHandle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: disabledFlush,
+      now: () => now,
+      sessionManager: createSessionManager(new MemoryStorage(), () => now),
+      sessionSampleRate: 1,
+      tracer: createTracer([]) as never,
+    })
+    now = 20_000
+    setVisibilityState('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(disabledFlush).not.toHaveBeenCalled()
+    await disabledHandle?.shutdown()
+  })
+})

--- a/packages/logfire-browser/src/longAnimationFrames.test.ts
+++ b/packages/logfire-browser/src/longAnimationFrames.test.ts
@@ -9,7 +9,9 @@ import { startBrowserLongAnimationFrames } from './longAnimationFrames'
 
 interface TestSpan {
   attributes: Record<string, unknown>
+  endTime?: unknown
   name: string
+  startTime?: unknown
 }
 
 class MemoryStorage implements Storage {
@@ -57,6 +59,12 @@ class MockPerformanceObserver {
   readonly disconnect = vi.fn<() => void>()
   readonly observe = vi.fn<(options: PerformanceObserverInit) => void>()
   private readonly callback: PerformanceObserverCallback
+  private queuedEntries: PerformanceEntry[] = []
+  readonly takeRecords = vi.fn<() => PerformanceEntry[]>(() => {
+    const entries = this.queuedEntries
+    this.queuedEntries = []
+    return entries
+  })
 
   constructor(callback: PerformanceObserverCallback) {
     this.callback = callback
@@ -71,6 +79,10 @@ class MockPerformanceObserver {
       this as unknown as PerformanceObserver
     )
   }
+
+  queue(entries: PerformanceEntry[]): void {
+    this.queuedEntries.push(...entries)
+  }
 }
 
 const originalPerformanceObserver = globalThis.PerformanceObserver
@@ -81,11 +93,12 @@ function setVisibilityState(state: DocumentVisibilityState): void {
 
 function createTracer(spans: TestSpan[]) {
   return {
-    startSpan(name: string) {
-      const span: TestSpan = { attributes: {}, name }
+    startSpan(name: string, options?: { startTime?: unknown }) {
+      const span: TestSpan = { attributes: {}, name, startTime: options?.startTime }
       spans.push(span)
       return {
-        end() {
+        end(endTime?: unknown) {
+          span.endTime = endTime
           return undefined
         },
         setAttributes(attributes: Record<string, unknown>) {
@@ -97,12 +110,17 @@ function createTracer(spans: TestSpan[]) {
   }
 }
 
-function createSessionManager(storage: Storage, now: () => number, generateId: () => string = () => 'session-1') {
+function createSessionManager(
+  storage: Storage,
+  now: () => number,
+  generateId: () => string = () => 'session-1',
+  storageKey = 'test-browser-session'
+) {
   return new BrowserSessionManager({
     generateId,
     now,
     storage,
-    storageKey: 'test-browser-session',
+    storageKey,
   })
 }
 
@@ -223,6 +241,7 @@ describe('browser long animation frame reporting', () => {
       sessionManager: createSessionManager(storage, () => now),
       sessionSampleRate: 1,
       storage,
+      timeOrigin: 1_000_000,
       tracer: createTracer(spans) as never,
     })
     const observer = MockPerformanceObserver.instances[0]
@@ -250,6 +269,7 @@ describe('browser long animation frame reporting', () => {
       'browser.long_animation_frame.style_and_layout_duration': 50,
       'logfire.span_type': 'log',
     })
+    expect(spans[0]).toMatchObject({ endTime: 1_000_010, startTime: 1_000_010 })
     expect(spans[1]?.attributes).toMatchObject({
       'browser.main_thread_window.blocking_duration': 150,
       'browser.main_thread_window.dropped_long_animation_frame_count': 0,
@@ -324,7 +344,7 @@ describe('browser long animation frame reporting', () => {
 
     sessionNumber = 2
     reloadedSessionManager.reset()
-    reloadedObserver?.deliver([createFrame(600, { startTime: 120_001 })])
+    MockPerformanceObserver.instances[2]?.deliver([createFrame(600, { startTime: 120_001 })])
     now = 180_000
     await vi.advanceTimersByTimeAsync(60_000)
     expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toHaveLength(21)
@@ -376,6 +396,63 @@ describe('browser long animation frame reporting', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
+  it('drains queued observer records before closing a foreground window', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    const observer = MockPerformanceObserver.instances[0]
+    observer?.queue([createFrame(150, { startTime: 1 })])
+
+    now = 10_000
+    setVisibilityState('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(observer?.takeRecords).toHaveBeenCalledTimes(1)
+    expect(spans.map((span) => span.name)).toEqual(['browser.long_animation_frame', 'browser.main_thread_window'])
+    expect(spans[1]?.attributes['browser.main_thread_window.long_animation_frame_count']).toBe(1)
+    await handle?.shutdown()
+  })
+
+  it('opens a fresh foreground window after a back-forward cache restore', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const handle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(storage, () => now),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+
+    now = 10_000
+    window.dispatchEvent(new Event('pagehide'))
+    now = 20_000
+    window.dispatchEvent(new Event('pageshow'))
+    MockPerformanceObserver.instances[0]?.deliver([createFrame(150, { startTime: 20_001 })])
+    now = 30_000
+    window.dispatchEvent(new Event('pagehide'))
+
+    expect(
+      spans
+        .filter((span) => span.name === 'browser.main_thread_window')
+        .map((span) => span.attributes['browser.main_thread_window.foreground_duration'])
+    ).toEqual([10_000, 10_000])
+    expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toHaveLength(1)
+    await handle?.shutdown()
+  })
+
   it('ranks buffered entries separately from the foreground denominator', async () => {
     let now = 1_000
     const spans: TestSpan[] = []
@@ -408,9 +485,9 @@ describe('browser long animation frame reporting', () => {
     await handle?.shutdown()
   })
 
-  it('uses deterministic fractional sampling and stops after rotation to a sampled-out session', async () => {
+  it('re-evaluates deterministic fractional sampling after each session rotation', async () => {
     const storage = new MemoryStorage()
-    const sessionIds = ['sampled', 'unsampled']
+    const sessionIds = ['sampled', 'unsampled', 'sampled']
     const sessionManager = createSessionManager(
       storage,
       () => 0,
@@ -432,22 +509,31 @@ describe('browser long animation frame reporting', () => {
 
     expect(observer?.disconnect).toHaveBeenCalledTimes(1)
     expect(vi.getTimerCount()).toBe(0)
+    sessionManager.reset()
+    expect(MockPerformanceObserver.instances).toHaveLength(2)
+    MockPerformanceObserver.instances[1]?.deliver([createFrame(150)])
+    await vi.advanceTimersByTimeAsync(60_000)
     await handle?.shutdown()
 
+    const sampledOutIds = ['unsampled', 'sampled']
     const sampledOutManager = createSessionManager(
       new MemoryStorage(),
       () => 0,
-      () => 'unsampled'
+      () => sampledOutIds.shift() ?? 'sampled'
     )
-    expect(
-      startBrowserLongAnimationFrames({
-        autoFlushOnDocumentHide: false,
-        forceFlush: async () => Promise.resolve(),
-        sessionManager: sampledOutManager,
-        sessionSampleRate: 0.5,
-        tracer: createTracer([]) as never,
-      })
-    ).toBeUndefined()
+    const sampledOutHandle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      sessionManager: sampledOutManager,
+      sessionSampleRate: 0.5,
+      tracer: createTracer([]) as never,
+    })
+    expect(sampledOutHandle).toBeDefined()
+    expect(MockPerformanceObserver.instances).toHaveLength(2)
+    expect(vi.getTimerCount()).toBe(0)
+    sampledOutManager.reset()
+    expect(MockPerformanceObserver.instances).toHaveLength(3)
+    await sampledOutHandle?.shutdown()
   })
 
   it('discards a partial window when the browser session rotates', async () => {
@@ -475,15 +561,64 @@ describe('browser long animation frame reporting', () => {
     sessionManager.reset()
     now = 60_000
     await vi.advanceTimersByTimeAsync(60_000)
-    expect(spans).toEqual([])
+    expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toEqual([])
 
-    observer?.deliver([createFrame(200, { startTime: 60_001 })])
+    MockPerformanceObserver.instances[1]?.deliver([createFrame(200, { startTime: 60_001 })])
     now = 120_000
     await vi.advanceTimersByTimeAsync(60_000)
-    expect(spans.map((span) => span.name)).toEqual(['browser.long_animation_frame', 'browser.main_thread_window'])
-    expect(spans[0]?.attributes['browser.long_animation_frame.blocking_duration']).toBe(200)
+    expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toHaveLength(1)
+    expect(spans.find((span) => span.name === 'browser.long_animation_frame')?.attributes).toMatchObject({
+      'browser.long_animation_frame.blocking_duration': 200,
+    })
 
     await handle?.shutdown()
+  })
+
+  it('isolates persisted diagnostic caps by browser-session storage key', async () => {
+    let now = 0
+    const spans: TestSpan[] = []
+    const storage = new MemoryStorage()
+    const firstHandle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(
+        storage,
+        () => now,
+        () => 'shared-session',
+        'session-a'
+      ),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    MockPerformanceObserver.instances[0]?.deliver(Array.from({ length: 20 }, (_, index) => createFrame(101 + index)))
+    now = 60_000
+    await vi.advanceTimersByTimeAsync(60_000)
+    await firstHandle?.shutdown()
+
+    const secondHandle = startBrowserLongAnimationFrames({
+      autoFlushOnDocumentHide: false,
+      forceFlush: async () => Promise.resolve(),
+      now: () => now,
+      sessionManager: createSessionManager(
+        storage,
+        () => now,
+        () => 'shared-session',
+        'session-b'
+      ),
+      sessionSampleRate: 1,
+      storage,
+      tracer: createTracer(spans) as never,
+    })
+    MockPerformanceObserver.instances[1]?.deliver([createFrame(500, { startTime: 60_001 })])
+    now = 120_000
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(spans.filter((span) => span.name === 'browser.long_animation_frame')).toHaveLength(21)
+    expect(storage.getItem('lf_browser_loaf:session-a')).not.toBeNull()
+    expect(storage.getItem('lf_browser_loaf:session-b')).not.toBeNull()
+    await secondHandle?.shutdown()
   })
 
   it('aggregates matching scripts and exports only the top three', async () => {

--- a/packages/logfire-browser/src/longAnimationFrames.ts
+++ b/packages/logfire-browser/src/longAnimationFrames.ts
@@ -1,0 +1,532 @@
+import type { Attributes, Tracer } from '@opentelemetry/api'
+import { diag } from '@opentelemetry/api'
+
+import type { BrowserSessionManager } from './browserSession'
+import type { NormalizedScriptAttributes } from './scriptAttributes'
+import { normalizeScriptEntry } from './scriptAttributes'
+
+const DEFAULT_BLOCKING_DURATION_THRESHOLD_MS = 100
+const DEFAULT_SESSION_SAMPLE_RATE = 0.1
+const DEFAULT_WINDOW_DURATION_MS = 60_000
+const MIN_WINDOW_DURATION_MS = 10_000
+const MAX_FRAME_SPANS_PER_SESSION = 20
+const MAX_WINDOW_SCRIPTS = 3
+const LOGFIRE_SPAN_TYPE_KEY = 'logfire.span_type'
+const STORAGE_KEY = 'lf_browser_loaf'
+
+export interface BrowserLongAnimationFramesOptions {
+  /** Minimum blockingDuration for a per-frame diagnostic. Defaults to 100 ms. */
+  blockingDurationThresholdMs?: number
+  /** Probability that one browser session is observed. Defaults to 0.1. */
+  sessionSampleRate?: number
+  /** Foreground summary and diagnostic-ranking interval. Defaults to 60 seconds. */
+  windowDurationMs?: number
+}
+
+export interface BrowserLongAnimationFramesHandle {
+  shutdown: () => Promise<void>
+}
+
+interface BrowserLongAnimationFramesStartOptions extends BrowserLongAnimationFramesOptions {
+  autoFlushOnDocumentHide: boolean
+  forceFlush: () => Promise<void>
+  now?: () => number
+  sessionManager: BrowserSessionManager
+  storage?: Storage | null
+  tracer: Tracer
+}
+
+interface NormalizedFrame {
+  blockingDuration: number
+  duration: number
+  scripts: NormalizedScriptAttributes[]
+  startTime: number
+  styleAndLayoutDuration: number
+}
+
+interface ScriptAggregate extends NormalizedScriptAttributes {
+  firstObserved: number
+}
+
+interface WindowState {
+  blockingDuration: number
+  candidates: { frame: NormalizedFrame; observed: number }[]
+  frameCount: number
+  scripts: Map<string, ScriptAggregate>
+  startedAt: number
+}
+
+interface PersistedCapState {
+  emitted: number
+  sessionId: string
+}
+
+interface ResolvedOptions {
+  blockingDurationThresholdMs: number
+  sessionSampleRate: number
+  windowDurationMs: number
+}
+
+export function startBrowserLongAnimationFrames(
+  options: BrowserLongAnimationFramesStartOptions
+): BrowserLongAnimationFramesHandle | undefined {
+  if (!supportsLongAnimationFrames()) {
+    return undefined
+  }
+
+  const resolved = resolveOptions(options)
+  const sessionId = options.sessionManager.getSession().id
+  if (!isSessionSampled(sessionId, resolved.sessionSampleRate)) {
+    return undefined
+  }
+
+  const collector = new LongAnimationFrameCollector(options, resolved, sessionId)
+  collector.start()
+  return collector.handle()
+}
+
+class LongAnimationFrameCollector {
+  private active = true
+  private capState: PersistedCapState
+  private readonly collectorStartedAt: number
+  private currentSessionId: string
+  private firstDelivery = true
+  private nextObserved = 0
+  private observer: PerformanceObserver | undefined
+  private readonly options: ResolvedOptions
+  private readonly startOptions: BrowserLongAnimationFramesStartOptions
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private window: WindowState | undefined
+
+  constructor(startOptions: BrowserLongAnimationFramesStartOptions, options: ResolvedOptions, sessionId: string) {
+    this.startOptions = startOptions
+    this.options = options
+    this.collectorStartedAt = this.now()
+    this.currentSessionId = sessionId
+    this.capState = loadCapState(this.storage(), sessionId)
+  }
+
+  start(): void {
+    this.observer = new PerformanceObserver((list) => {
+      this.onEntries(list.getEntries())
+    })
+    try {
+      this.observer.observe({ type: 'long-animation-frame', buffered: true })
+      document.addEventListener('visibilitychange', this.onVisibilityChange, true)
+      window.addEventListener('pagehide', this.onPageHide, true)
+      if (isDocumentVisible()) {
+        this.openWindow()
+      }
+    } catch (error) {
+      this.observer.disconnect()
+      this.observer = undefined
+      document.removeEventListener('visibilitychange', this.onVisibilityChange, true)
+      window.removeEventListener('pagehide', this.onPageHide, true)
+      throw error
+    }
+  }
+
+  handle(): BrowserLongAnimationFramesHandle {
+    let shutdownPromise: Promise<void> | undefined
+    return {
+      shutdown: async () => {
+        shutdownPromise ??= this.shutdown()
+        return shutdownPromise
+      },
+    }
+  }
+
+  private readonly onVisibilityChange = () => {
+    if (!this.active) {
+      return
+    }
+    if (isDocumentVisible()) {
+      const sessionState = this.refreshSession()
+      if (sessionState === undefined) {
+        return
+      }
+      if (sessionState === 'rotated') {
+        this.discardWindow()
+      }
+      this.openWindow()
+      return
+    }
+    const emitted = this.closeWindow()
+    if (emitted) {
+      this.flushAfterDocumentHide()
+    }
+  }
+
+  private readonly onPageHide = () => {
+    if (!this.active) {
+      return
+    }
+    const emitted = this.closeWindow()
+    if (emitted) {
+      this.flushAfterDocumentHide()
+    }
+  }
+
+  private onEntries(entries: PerformanceEntry[]): void {
+    if (!this.active) {
+      return
+    }
+    const sessionState = this.refreshSession()
+    if (sessionState === undefined) {
+      return
+    }
+    if (sessionState === 'rotated') {
+      this.discardWindow()
+      if (isDocumentVisible()) {
+        this.openWindow()
+      }
+    }
+
+    const startupCandidates: { frame: NormalizedFrame; observed: number }[] = []
+    const currentWindow = this.window
+    for (const entry of entries) {
+      const frame = normalizeFrame(entry)
+      if (frame === undefined) {
+        continue
+      }
+      const observed = this.nextObserved++
+      if (this.firstDelivery && frame.startTime < this.collectorStartedAt) {
+        if (frame.blockingDuration >= this.options.blockingDurationThresholdMs) {
+          startupCandidates.push({ frame, observed })
+        }
+        continue
+      }
+      if (currentWindow === undefined || frame.startTime < currentWindow.startedAt) {
+        continue
+      }
+      currentWindow.frameCount += 1
+      currentWindow.blockingDuration += frame.blockingDuration
+      addScriptAggregates(currentWindow.scripts, frame.scripts, observed)
+      if (frame.blockingDuration >= this.options.blockingDurationThresholdMs) {
+        currentWindow.candidates.push({ frame, observed })
+      }
+    }
+    this.firstDelivery = false
+    if (startupCandidates.length > 0) {
+      this.emitRankedFrames(startupCandidates)
+    }
+  }
+
+  private openWindow(): void {
+    if (this.window !== undefined || !this.active) {
+      return
+    }
+    this.window = {
+      blockingDuration: 0,
+      candidates: [],
+      frameCount: 0,
+      scripts: new Map(),
+      startedAt: this.now(),
+    }
+    this.timer = setTimeout(() => {
+      this.timer = undefined
+      if (!this.active || !isDocumentVisible()) {
+        return
+      }
+      this.closeWindow()
+      this.openWindow()
+    }, this.options.windowDurationMs)
+  }
+
+  private closeWindow(): boolean {
+    const currentWindow = this.window
+    if (currentWindow === undefined) {
+      return false
+    }
+    this.window = undefined
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+
+    const foregroundDuration = Math.max(0, this.now() - currentWindow.startedAt)
+    const sessionState = this.refreshSession()
+    if (foregroundDuration === 0 || sessionState === undefined) {
+      return false
+    }
+    if (sessionState === 'rotated') {
+      diag.debug('logfire-browser: discarded a long animation frame window after browser session rotation')
+      return false
+    }
+    const dropped = this.emitRankedFrames(currentWindow.candidates)
+    this.reportSpan('browser.main_thread_window', createWindowAttributes(currentWindow, foregroundDuration, dropped))
+    return true
+  }
+
+  private emitRankedFrames(candidates: { frame: NormalizedFrame; observed: number }[]): number {
+    const ranked = [...candidates].sort(
+      (left, right) => right.frame.blockingDuration - left.frame.blockingDuration || left.observed - right.observed
+    )
+    const remaining = Math.max(0, MAX_FRAME_SPANS_PER_SESSION - this.capState.emitted)
+    const emitted = ranked.slice(0, remaining)
+    for (const candidate of emitted) {
+      this.reportSpan('browser.long_animation_frame', createFrameAttributes(candidate.frame))
+    }
+    if (emitted.length > 0) {
+      this.capState.emitted += emitted.length
+      saveCapState(this.storage(), this.capState)
+    }
+    return ranked.length - emitted.length
+  }
+
+  private reportSpan(name: string, attributes: Attributes): void {
+    try {
+      const span = this.startOptions.tracer.startSpan(name)
+      try {
+        span.setAttributes(attributes)
+      } finally {
+        span.end()
+      }
+    } catch (error) {
+      diag.error(`logfire-browser: failed to report ${name}`, error)
+    }
+  }
+
+  private refreshSession(): 'same' | 'rotated' | undefined {
+    const sessionId = this.startOptions.sessionManager.getSession().id
+    if (sessionId === this.currentSessionId) {
+      return 'same'
+    }
+    this.currentSessionId = sessionId
+    this.capState = loadCapState(this.storage(), sessionId)
+    if (isSessionSampled(sessionId, this.options.sessionSampleRate)) {
+      return 'rotated'
+    }
+    this.stop()
+    return undefined
+  }
+
+  private discardWindow(): void {
+    this.window = undefined
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+  }
+
+  private flushAfterDocumentHide(): void {
+    if (!this.startOptions.autoFlushOnDocumentHide) {
+      return
+    }
+    this.startOptions.forceFlush().catch((error: unknown) => {
+      diag.error('logfire-browser: failed to flush long animation frame spans on document hide', error)
+    })
+  }
+
+  private async shutdown(): Promise<void> {
+    if (!this.active) {
+      return Promise.resolve()
+    }
+    this.closeWindow()
+    this.stop()
+    return Promise.resolve()
+  }
+
+  private stop(): void {
+    if (!this.active) {
+      return
+    }
+    this.active = false
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer)
+      this.timer = undefined
+    }
+    const observer = this.observer
+    if (observer !== undefined) {
+      observer.disconnect()
+    }
+    this.observer = undefined
+    document.removeEventListener('visibilitychange', this.onVisibilityChange, true)
+    window.removeEventListener('pagehide', this.onPageHide, true)
+  }
+
+  private now(): number {
+    return this.startOptions.now?.() ?? performance.now()
+  }
+
+  private storage(): Storage | null {
+    if (this.startOptions.storage !== undefined) {
+      return this.startOptions.storage
+    }
+    try {
+      return globalThis.sessionStorage
+    } catch {
+      return null
+    }
+  }
+}
+
+function createFrameAttributes(frame: NormalizedFrame): Attributes {
+  const attributes: Attributes = {
+    [LOGFIRE_SPAN_TYPE_KEY]: 'log',
+    'browser.long_animation_frame.blocking_duration': frame.blockingDuration,
+    'browser.long_animation_frame.duration': frame.duration,
+    'browser.long_animation_frame.style_and_layout_duration': frame.styleAndLayoutDuration,
+  }
+  const topScript = [...frame.scripts].sort((left, right) => right.duration - left.duration)[0]
+  if (topScript !== undefined) {
+    setScriptAttributes(attributes, 'browser.long_animation_frame.script', topScript)
+  }
+  return attributes
+}
+
+function createWindowAttributes(windowState: WindowState, foregroundDuration: number, dropped: number): Attributes {
+  const attributes: Attributes = {
+    [LOGFIRE_SPAN_TYPE_KEY]: 'log',
+    'browser.main_thread_window.blocking_duration': windowState.blockingDuration,
+    'browser.main_thread_window.dropped_long_animation_frame_count': dropped,
+    'browser.main_thread_window.foreground_duration': foregroundDuration,
+    'browser.main_thread_window.long_animation_frame_count': windowState.frameCount,
+  }
+  const scripts = [...windowState.scripts.values()]
+    .sort((left, right) => right.duration - left.duration || left.firstObserved - right.firstObserved)
+    .slice(0, MAX_WINDOW_SCRIPTS)
+  scripts.forEach((script, index) => {
+    setScriptAttributes(attributes, `browser.main_thread_window.script.${index.toString()}`, script)
+  })
+  return attributes
+}
+
+function setScriptAttributes(attributes: Attributes, prefix: string, script: NormalizedScriptAttributes): void {
+  attributes[`${prefix}.duration`] = script.duration
+  if (script.sourceUrl !== undefined) {
+    attributes[`${prefix}.source_url`] = script.sourceUrl
+  }
+  if (script.functionName !== undefined) {
+    attributes[`${prefix}.function_name`] = script.functionName
+  }
+  if (script.invokerType !== undefined) {
+    attributes[`${prefix}.invoker_type`] = script.invokerType
+  }
+}
+
+function normalizeFrame(value: unknown): NormalizedFrame | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  const frame = value as {
+    blockingDuration?: unknown
+    duration?: unknown
+    scripts?: unknown
+    startTime?: unknown
+    styleAndLayoutStart?: unknown
+  }
+  if (!isFiniteNonNegative(frame.blockingDuration) || !isFiniteNonNegative(frame.duration) || !isFiniteNonNegative(frame.startTime)) {
+    return undefined
+  }
+  const frameEnd = frame.startTime + frame.duration
+  const styleAndLayoutDuration =
+    isFiniteNonNegative(frame.styleAndLayoutStart) && frame.styleAndLayoutStart > 0 ? Math.max(0, frameEnd - frame.styleAndLayoutStart) : 0
+  const scripts = Array.isArray(frame.scripts)
+    ? frame.scripts.map((script) => normalizeScriptEntry(script)).filter((script) => script !== undefined)
+    : []
+  return {
+    blockingDuration: frame.blockingDuration,
+    duration: frame.duration,
+    scripts,
+    startTime: frame.startTime,
+    styleAndLayoutDuration,
+  }
+}
+
+function addScriptAggregates(aggregates: Map<string, ScriptAggregate>, scripts: NormalizedScriptAttributes[], observed: number): void {
+  for (const script of scripts) {
+    const key = `${script.sourceUrl ?? ''}\u0000${script.functionName ?? ''}\u0000${script.invokerType ?? ''}`
+    const current = aggregates.get(key)
+    if (current === undefined) {
+      aggregates.set(key, { ...script, firstObserved: observed })
+    } else {
+      current.duration += script.duration
+    }
+  }
+}
+
+function resolveOptions(options: BrowserLongAnimationFramesOptions): ResolvedOptions {
+  const sampleRate = options.sessionSampleRate ?? DEFAULT_SESSION_SAMPLE_RATE
+  const threshold = options.blockingDurationThresholdMs ?? DEFAULT_BLOCKING_DURATION_THRESHOLD_MS
+  const windowDuration = options.windowDurationMs ?? DEFAULT_WINDOW_DURATION_MS
+  return {
+    blockingDurationThresholdMs: Number.isFinite(threshold) && threshold >= 0 ? threshold : DEFAULT_BLOCKING_DURATION_THRESHOLD_MS,
+    sessionSampleRate: Number.isFinite(sampleRate) ? Math.min(1, Math.max(0, sampleRate)) : 0,
+    windowDurationMs:
+      Number.isFinite(windowDuration) && windowDuration > 0 ? Math.max(MIN_WINDOW_DURATION_MS, windowDuration) : DEFAULT_WINDOW_DURATION_MS,
+  }
+}
+
+function supportsLongAnimationFrames(): boolean {
+  try {
+    return typeof PerformanceObserver === 'function' && PerformanceObserver.supportedEntryTypes.includes('long-animation-frame')
+  } catch {
+    return false
+  }
+}
+
+function isSessionSampled(sessionId: string, rate: number): boolean {
+  if (rate <= 0) {
+    return false
+  }
+  if (rate >= 1) {
+    return true
+  }
+  let hash = 2_166_136_261
+  for (let index = 0; index < sessionId.length; index += 1) {
+    hash ^= sessionId.charCodeAt(index)
+    hash = Math.imul(hash, 16_777_619)
+  }
+  return (hash >>> 0) / 4_294_967_296 < rate
+}
+
+function loadCapState(storage: Storage | null, sessionId: string): PersistedCapState {
+  if (storage !== null) {
+    try {
+      const raw = storage.getItem(STORAGE_KEY)
+      if (raw !== null) {
+        const parsed: unknown = JSON.parse(raw)
+        if (isPersistedCapState(parsed) && parsed.sessionId === sessionId) {
+          return parsed
+        }
+      }
+    } catch {
+      // Session-level collection bounds are best-effort when storage is unavailable.
+    }
+  }
+  return { emitted: 0, sessionId }
+}
+
+function saveCapState(storage: Storage | null, state: PersistedCapState): void {
+  if (storage === null) {
+    return
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // Session-level collection bounds are best-effort when storage is unavailable.
+  }
+}
+
+function isPersistedCapState(value: unknown): value is PersistedCapState {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const state = value as { emitted?: unknown; sessionId?: unknown }
+  return (
+    typeof state.sessionId === 'string' &&
+    typeof state.emitted === 'number' &&
+    Number.isInteger(state.emitted) &&
+    state.emitted >= 0 &&
+    state.emitted <= MAX_FRAME_SPANS_PER_SESSION
+  )
+}
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function isDocumentVisible(): boolean {
+  return document.visibilityState === 'visible'
+}

--- a/packages/logfire-browser/src/longAnimationFrames.ts
+++ b/packages/logfire-browser/src/longAnimationFrames.ts
@@ -33,6 +33,7 @@ interface BrowserLongAnimationFramesStartOptions extends BrowserLongAnimationFra
   now?: () => number
   sessionManager: BrowserSessionManager
   storage?: Storage | null
+  timeOrigin?: number
   tracer: Tracer
 }
 
@@ -50,10 +51,15 @@ interface ScriptAggregate extends NormalizedScriptAttributes {
 
 interface WindowState {
   blockingDuration: number
-  candidates: { frame: NormalizedFrame; observed: number }[]
+  candidates: FrameCandidate[]
   frameCount: number
   scripts: Map<string, ScriptAggregate>
   startedAt: number
+}
+
+interface FrameCandidate {
+  frame: NormalizedFrame
+  observed: number
 }
 
 interface PersistedCapState {
@@ -75,11 +81,10 @@ export function startBrowserLongAnimationFrames(
   }
 
   const resolved = resolveOptions(options)
-  const sessionId = options.sessionManager.getSession().id
-  if (!isSessionSampled(sessionId, resolved.sessionSampleRate)) {
+  if (resolved.sessionSampleRate <= 0) {
     return undefined
   }
-
+  const sessionId = options.sessionManager.getSession().id
   const collector = new LongAnimationFrameCollector(options, resolved, sessionId)
   collector.start()
   return collector.handle()
@@ -87,8 +92,10 @@ export function startBrowserLongAnimationFrames(
 
 class LongAnimationFrameCollector {
   private active = true
+  private readonly capStorageKey: string
   private capState: PersistedCapState
-  private readonly collectorStartedAt: number
+  private collecting = false
+  private collectorStartedAt = 0
   private currentSessionId: string
   private firstDelivery = true
   private nextObserved = 0
@@ -96,32 +103,52 @@ class LongAnimationFrameCollector {
   private readonly options: ResolvedOptions
   private readonly startOptions: BrowserLongAnimationFramesStartOptions
   private timer: ReturnType<typeof setTimeout> | undefined
+  private unsubscribeSessionChange: (() => void) | undefined
   private window: WindowState | undefined
 
   constructor(startOptions: BrowserLongAnimationFramesStartOptions, options: ResolvedOptions, sessionId: string) {
     this.startOptions = startOptions
     this.options = options
-    this.collectorStartedAt = this.now()
+    this.capStorageKey = `${STORAGE_KEY}:${startOptions.sessionManager.getStorageKey()}`
     this.currentSessionId = sessionId
-    this.capState = loadCapState(this.storage(), sessionId)
+    this.capState = loadCapState(this.storage(), this.capStorageKey, sessionId)
   }
 
   start(): void {
-    this.observer = new PerformanceObserver((list) => {
-      this.onEntries(list.getEntries())
-    })
+    const unsubscribeSessionChange = this.startOptions.sessionManager.onSessionChange(this.onSessionChange)
+    this.unsubscribeSessionChange = unsubscribeSessionChange
     try {
-      this.observer.observe({ type: 'long-animation-frame', buffered: true })
+      if (isSessionSampled(this.currentSessionId, this.options.sessionSampleRate)) {
+        this.startCollection()
+      }
+    } catch (error) {
+      unsubscribeSessionChange()
+      this.unsubscribeSessionChange = undefined
+      throw error
+    }
+  }
+
+  private startCollection(): void {
+    if (!this.active || this.collecting) {
+      return
+    }
+    this.collectorStartedAt = this.now()
+    this.firstDelivery = true
+    const observer = new PerformanceObserver((list) => {
+      this.onEntries(list.getEntries(), observer)
+    })
+    this.observer = observer
+    try {
+      observer.observe({ type: 'long-animation-frame', buffered: true })
       document.addEventListener('visibilitychange', this.onVisibilityChange, true)
       window.addEventListener('pagehide', this.onPageHide, true)
+      window.addEventListener('pageshow', this.onPageShow, true)
+      this.collecting = true
       if (isDocumentVisible()) {
         this.openWindow()
       }
     } catch (error) {
-      this.observer.disconnect()
-      this.observer = undefined
-      document.removeEventListener('visibilitychange', this.onVisibilityChange, true)
-      window.removeEventListener('pagehide', this.onPageHide, true)
+      this.stopCollection()
       throw error
     }
   }
@@ -137,17 +164,11 @@ class LongAnimationFrameCollector {
   }
 
   private readonly onVisibilityChange = () => {
-    if (!this.active) {
+    if (!this.active || !this.collecting) {
       return
     }
+    this.startOptions.sessionManager.getSession()
     if (isDocumentVisible()) {
-      const sessionState = this.refreshSession()
-      if (sessionState === undefined) {
-        return
-      }
-      if (sessionState === 'rotated') {
-        this.discardWindow()
-      }
       this.openWindow()
       return
     }
@@ -158,7 +179,7 @@ class LongAnimationFrameCollector {
   }
 
   private readonly onPageHide = () => {
-    if (!this.active) {
+    if (!this.active || !this.collecting) {
       return
     }
     const emitted = this.closeWindow()
@@ -167,22 +188,42 @@ class LongAnimationFrameCollector {
     }
   }
 
-  private onEntries(entries: PerformanceEntry[]): void {
-    if (!this.active) {
+  private readonly onPageShow = () => {
+    if (!this.active || !this.collecting) {
       return
     }
-    const sessionState = this.refreshSession()
-    if (sessionState === undefined) {
+    this.startOptions.sessionManager.getSession()
+    if (isDocumentVisible()) {
+      this.openWindow()
+    }
+  }
+
+  private readonly onSessionChange = (session: { id: string }) => {
+    if (!this.active || session.id === this.currentSessionId) {
       return
     }
-    if (sessionState === 'rotated') {
-      this.discardWindow()
-      if (isDocumentVisible()) {
-        this.openWindow()
+    this.stopCollection()
+    this.currentSessionId = session.id
+    this.capState = loadCapState(this.storage(), this.capStorageKey, session.id)
+    if (isSessionSampled(session.id, this.options.sessionSampleRate)) {
+      try {
+        this.startCollection()
+      } catch (error) {
+        diag.error('logfire-browser: failed to restart Long Animation Frame reporting after browser session rotation', error)
       }
     }
+  }
 
-    const startupCandidates: { frame: NormalizedFrame; observed: number }[] = []
+  private onEntries(entries: PerformanceEntry[], sourceObserver: PerformanceObserver): void {
+    if (!this.active || !this.collecting || sourceObserver !== this.observer) {
+      return
+    }
+    this.startOptions.sessionManager.getSession()
+    if (sourceObserver !== this.observer) {
+      return
+    }
+
+    const startupCandidates: FrameCandidate[] = []
     const currentWindow = this.window
     for (const entry of entries) {
       const frame = normalizeFrame(entry)
@@ -213,7 +254,7 @@ class LongAnimationFrameCollector {
   }
 
   private openWindow(): void {
-    if (this.window !== undefined || !this.active) {
+    if (this.window !== undefined || !this.active || !this.collecting) {
       return
     }
     this.window = {
@@ -235,7 +276,17 @@ class LongAnimationFrameCollector {
 
   private closeWindow(): boolean {
     const currentWindow = this.window
-    if (currentWindow === undefined) {
+    const observer = this.observer
+    const pendingEntries = typeof observer?.takeRecords === 'function' ? observer.takeRecords() : []
+    if (observer !== undefined && pendingEntries.length > 0) {
+      this.onEntries(pendingEntries, observer)
+    }
+    if (currentWindow === undefined || !this.collecting || observer !== this.observer || currentWindow !== this.window) {
+      return false
+    }
+    const foregroundDuration = Math.max(0, this.now() - currentWindow.startedAt)
+    this.startOptions.sessionManager.getSession()
+    if (currentWindow !== this.window) {
       return false
     }
     this.window = undefined
@@ -243,14 +294,7 @@ class LongAnimationFrameCollector {
       clearTimeout(this.timer)
       this.timer = undefined
     }
-
-    const foregroundDuration = Math.max(0, this.now() - currentWindow.startedAt)
-    const sessionState = this.refreshSession()
-    if (foregroundDuration === 0 || sessionState === undefined) {
-      return false
-    }
-    if (sessionState === 'rotated') {
-      diag.debug('logfire-browser: discarded a long animation frame window after browser session rotation')
+    if (foregroundDuration === 0) {
       return false
     }
     const dropped = this.emitRankedFrames(currentWindow.candidates)
@@ -258,55 +302,37 @@ class LongAnimationFrameCollector {
     return true
   }
 
-  private emitRankedFrames(candidates: { frame: NormalizedFrame; observed: number }[]): number {
+  private emitRankedFrames(candidates: FrameCandidate[]): number {
     const ranked = [...candidates].sort(
       (left, right) => right.frame.blockingDuration - left.frame.blockingDuration || left.observed - right.observed
     )
     const remaining = Math.max(0, MAX_FRAME_SPANS_PER_SESSION - this.capState.emitted)
     const emitted = ranked.slice(0, remaining)
     for (const candidate of emitted) {
-      this.reportSpan('browser.long_animation_frame', createFrameAttributes(candidate.frame))
+      this.reportSpan('browser.long_animation_frame', createFrameAttributes(candidate.frame), this.frameTime(candidate.frame))
     }
     if (emitted.length > 0) {
       this.capState.emitted += emitted.length
-      saveCapState(this.storage(), this.capState)
+      saveCapState(this.storage(), this.capStorageKey, this.capState)
     }
     return ranked.length - emitted.length
   }
 
-  private reportSpan(name: string, attributes: Attributes): void {
+  private reportSpan(name: string, attributes: Attributes, timestamp?: number): void {
     try {
-      const span = this.startOptions.tracer.startSpan(name)
+      const span = this.startOptions.tracer.startSpan(name, timestamp === undefined ? undefined : { startTime: timestamp })
       try {
         span.setAttributes(attributes)
       } finally {
-        span.end()
+        span.end(timestamp)
       }
     } catch (error) {
       diag.error(`logfire-browser: failed to report ${name}`, error)
     }
   }
 
-  private refreshSession(): 'same' | 'rotated' | undefined {
-    const sessionId = this.startOptions.sessionManager.getSession().id
-    if (sessionId === this.currentSessionId) {
-      return 'same'
-    }
-    this.currentSessionId = sessionId
-    this.capState = loadCapState(this.storage(), sessionId)
-    if (isSessionSampled(sessionId, this.options.sessionSampleRate)) {
-      return 'rotated'
-    }
-    this.stop()
-    return undefined
-  }
-
-  private discardWindow(): void {
-    this.window = undefined
-    if (this.timer !== undefined) {
-      clearTimeout(this.timer)
-      this.timer = undefined
-    }
+  private frameTime(frame: NormalizedFrame): number {
+    return (this.startOptions.timeOrigin ?? performance.timeOrigin) + frame.startTime
   }
 
   private flushAfterDocumentHide(): void {
@@ -322,7 +348,9 @@ class LongAnimationFrameCollector {
     if (!this.active) {
       return Promise.resolve()
     }
-    this.closeWindow()
+    if (this.collecting) {
+      this.closeWindow()
+    }
     this.stop()
     return Promise.resolve()
   }
@@ -332,6 +360,12 @@ class LongAnimationFrameCollector {
       return
     }
     this.active = false
+    this.stopCollection()
+    this.unsubscribeSessionChange?.()
+    this.unsubscribeSessionChange = undefined
+  }
+
+  private stopCollection(): void {
     if (this.timer !== undefined) {
       clearTimeout(this.timer)
       this.timer = undefined
@@ -341,8 +375,11 @@ class LongAnimationFrameCollector {
       observer.disconnect()
     }
     this.observer = undefined
+    this.window = undefined
+    this.collecting = false
     document.removeEventListener('visibilitychange', this.onVisibilityChange, true)
     window.removeEventListener('pagehide', this.onPageHide, true)
+    window.removeEventListener('pageshow', this.onPageShow, true)
   }
 
   private now(): number {
@@ -481,10 +518,10 @@ function isSessionSampled(sessionId: string, rate: number): boolean {
   return (hash >>> 0) / 4_294_967_296 < rate
 }
 
-function loadCapState(storage: Storage | null, sessionId: string): PersistedCapState {
+function loadCapState(storage: Storage | null, storageKey: string, sessionId: string): PersistedCapState {
   if (storage !== null) {
     try {
-      const raw = storage.getItem(STORAGE_KEY)
+      const raw = storage.getItem(storageKey)
       if (raw !== null) {
         const parsed: unknown = JSON.parse(raw)
         if (isPersistedCapState(parsed) && parsed.sessionId === sessionId) {
@@ -498,12 +535,12 @@ function loadCapState(storage: Storage | null, sessionId: string): PersistedCapS
   return { emitted: 0, sessionId }
 }
 
-function saveCapState(storage: Storage | null, state: PersistedCapState): void {
+function saveCapState(storage: Storage | null, storageKey: string, state: PersistedCapState): void {
   if (storage === null) {
     return
   }
   try {
-    storage.setItem(STORAGE_KEY, JSON.stringify(state))
+    storage.setItem(storageKey, JSON.stringify(state))
   } catch {
     // Session-level collection bounds are best-effort when storage is unavailable.
   }

--- a/packages/logfire-browser/src/scriptAttributes.test.ts
+++ b/packages/logfire-browser/src/scriptAttributes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { MAX_SCRIPT_SOURCE_URL_CODE_POINTS, normalizeScriptSourceUrl } from './scriptAttributes'
+
+describe('script attribute normalization', () => {
+  it('removes credentials, queries, and fragments from HTTP URLs', () => {
+    expect(normalizeScriptSourceUrl('https://user:token@cdn.example.com/app.js?account=secret#handler')).toBe(
+      'https://cdn.example.com/app.js'
+    )
+  })
+
+  it('uses stable placeholders for URLs that can contain payloads or per-load identifiers', () => {
+    expect(normalizeScriptSourceUrl('data:text/javascript,alert(document.cookie)')).toBe('data:')
+    expect(normalizeScriptSourceUrl('blob:https://example.com/550e8400-e29b-41d4-a716-446655440000')).toBe('blob:https://example.com')
+    const scriptUrl = ['java', 'script:alert(document.cookie)'].join('')
+    expect(normalizeScriptSourceUrl(scriptUrl)).toBe(['java', 'script:'].join(''))
+  })
+
+  it('bounds normalized HTTP URLs by Unicode code point', () => {
+    const normalized = normalizeScriptSourceUrl(`https://example.com/${'😀'.repeat(MAX_SCRIPT_SOURCE_URL_CODE_POINTS)}`)
+
+    expect(Array.from(normalized ?? '')).toHaveLength(MAX_SCRIPT_SOURCE_URL_CODE_POINTS)
+    expect(normalized?.startsWith('https://example.com/')).toBe(true)
+  })
+})

--- a/packages/logfire-browser/src/scriptAttributes.ts
+++ b/packages/logfire-browser/src/scriptAttributes.ts
@@ -1,0 +1,97 @@
+export const MAX_SCRIPT_ATTRIBUTE_CODE_POINTS = 200
+export const MAX_SCRIPT_SOURCE_URL_CODE_POINTS = 2_048
+
+export interface NormalizedScriptAttributes {
+  duration: number
+  functionName?: string
+  invoker?: string
+  invokerType?: ScriptInvokerType
+  sourceUrl?: string
+}
+
+const SCRIPT_INVOKER_TYPES = new Set<ScriptInvokerType>([
+  'classic-script',
+  'module-script',
+  'event-listener',
+  'user-callback',
+  'resolve-promise',
+  'reject-promise',
+])
+
+export function capScriptAttribute(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined
+  }
+
+  return capCodePoints(value, MAX_SCRIPT_ATTRIBUTE_CODE_POINTS)
+}
+
+export function normalizeScriptSourceUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined
+  }
+
+  try {
+    const baseUrl = getCurrentPageUrl()
+    const url = baseUrl === undefined ? new URL(value) : new URL(value, baseUrl)
+    url.search = ''
+    url.hash = ''
+    url.username = ''
+    url.password = ''
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return capCodePoints(url.href, MAX_SCRIPT_SOURCE_URL_CODE_POINTS)
+    }
+    if (url.protocol === 'blob:') {
+      return url.origin === 'null' ? 'blob:' : capCodePoints(`blob:${url.origin}`, MAX_SCRIPT_SOURCE_URL_CODE_POINTS)
+    }
+    return url.protocol
+  } catch {
+    return undefined
+  }
+}
+
+export function normalizeScriptEntry(value: unknown): NormalizedScriptAttributes | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+
+  const entry = value as {
+    duration?: unknown
+    invoker?: unknown
+    invokerType?: unknown
+    sourceFunctionName?: unknown
+    sourceURL?: unknown
+  }
+  if (typeof entry.duration !== 'number' || !Number.isFinite(entry.duration) || entry.duration < 0) {
+    return undefined
+  }
+
+  const functionName = capScriptAttribute(entry.sourceFunctionName)
+  const invoker = capScriptAttribute(entry.invoker)
+  const sourceUrl = normalizeScriptSourceUrl(entry.sourceURL)
+  return {
+    duration: entry.duration,
+    ...(functionName === undefined ? {} : { functionName }),
+    ...(invoker === undefined ? {} : { invoker }),
+    ...(isScriptInvokerType(entry.invokerType) ? { invokerType: entry.invokerType } : {}),
+    ...(sourceUrl === undefined ? {} : { sourceUrl }),
+  }
+}
+
+function getCurrentPageUrl(): string | undefined {
+  try {
+    const href = (globalThis as { location?: { href?: string } }).location?.href
+    return href === undefined || href === '' ? undefined : href
+  } catch {
+    return undefined
+  }
+}
+
+function isScriptInvokerType(value: unknown): value is ScriptInvokerType {
+  return typeof value === 'string' && SCRIPT_INVOKER_TYPES.has(value as ScriptInvokerType)
+}
+
+function capCodePoints(value: string, maximum: number): string {
+  const codePoints = Array.from(value)
+  return codePoints.length <= maximum ? value : codePoints.slice(0, maximum).join('')
+}

--- a/packages/logfire-browser/src/sessionReplay.test.ts
+++ b/packages/logfire-browser/src/sessionReplay.test.ts
@@ -225,6 +225,65 @@ describe('startBrowserSessionReplay', () => {
     expect(touchSpy).toHaveBeenCalledTimes(touchCallsAfterStartup)
   })
 
+  it('derives live replay identity from the current span user', async () => {
+    let user: { id: string } | undefined
+    const manager = new BrowserSessionManager({
+      generateId: () => 'browser-session-1',
+      getUser: () => user,
+      now: () => 1_000,
+      storage: new MemoryStorage(),
+      storageKey: 'test-session',
+    })
+    let replayConfig: BrowserSessionReplayPackageConfig | undefined
+    const replayModule: BrowserSessionReplayModule = {
+      startSessionReplay: (config) => {
+        replayConfig = config
+        return createReplayRuntime()
+      },
+    }
+
+    await startBrowserSessionReplay(
+      { distinctId: 'anonymous', load: () => replayModule, replayUrl: '/logfire/replay' },
+      manager,
+      new BrowserSessionReplayState(),
+      { traceUrl: '/logfire/traces' }
+    )
+
+    expect(replayConfig?.getDistinctId?.()).toBeUndefined()
+    user = { id: 'user-a' }
+    expect(replayConfig?.getDistinctId?.()).toBe('user-a')
+    user = { id: 'user-b' }
+    expect(replayConfig?.getDistinctId?.()).toBe('user-b')
+    user = undefined
+    expect(replayConfig?.getDistinctId?.()).toBeUndefined()
+    expect(replayConfig?.distinctId).toBe('anonymous')
+  })
+
+  it('preserves an explicit replay identity getter over the span user', async () => {
+    const explicitGetDistinctId = () => 'replay-user'
+    const manager = new BrowserSessionManager({
+      getUser: () => ({ id: 'span-user' }),
+      storage: null,
+    })
+    let replayConfig: BrowserSessionReplayPackageConfig | undefined
+    const replayModule: BrowserSessionReplayModule = {
+      startSessionReplay: (config) => {
+        replayConfig = config
+        return createReplayRuntime()
+      },
+    }
+
+    await startBrowserSessionReplay(
+      { getDistinctId: explicitGetDistinctId, load: () => replayModule, replayUrl: '/logfire/replay' },
+      manager,
+      new BrowserSessionReplayState(),
+      { traceUrl: '/logfire/traces' }
+    )
+
+    expect(replayConfig?.getDistinctId).toBe(explicitGetDistinctId)
+    expect(replayConfig?.getDistinctId?.()).toBe('replay-user')
+  })
+
   it('leaves privacy options absent so the replay package owns safe defaults', async () => {
     let replayConfig: BrowserSessionReplayPackageConfig | undefined
     const replayModule: BrowserSessionReplayModule = {

--- a/packages/logfire-browser/src/sessionReplay.ts
+++ b/packages/logfire-browser/src/sessionReplay.ts
@@ -39,7 +39,9 @@ export interface BrowserSessionReplayPackageConfig {
   maxBufferBytes?: number
   /** Minimum recording duration before a replay is uploaded. Defaults to 5 seconds. */
   minSessionDurationMs?: number
+  /** Static replay identity and anonymous fallback for a live identity getter. */
   distinctId?: string
+  /** Explicit live replay identity. This takes precedence over rum.session.getUser. */
   getDistinctId?: () => string | undefined
   captureConsole?: boolean
   captureNetwork?: boolean
@@ -95,7 +97,9 @@ export interface BrowserSessionReplayOptions {
   /** Minimum recording duration before a replay is uploaded. Defaults to 5 seconds. */
   minSessionDurationMs?: number
 
+  /** Static replay identity and anonymous fallback for a live identity getter. */
   distinctId?: string
+  /** Explicit live replay identity. This takes precedence over rum.session.getUser. */
   getDistinctId?: () => string | undefined
 
   captureConsole?: boolean
@@ -236,6 +240,8 @@ function createReplayConfig(
   }
   if (options.getDistinctId !== undefined) {
     config.getDistinctId = options.getDistinctId
+  } else {
+    config.getDistinctId = () => browserSessionManager.getUser()?.id
   }
   if (options.captureConsole !== undefined) {
     config.captureConsole = options.captureConsole

--- a/packages/logfire-browser/src/webVitals.test.ts
+++ b/packages/logfire-browser/src/webVitals.test.ts
@@ -495,6 +495,55 @@ describe('browser Web Vitals reporting', () => {
     }
   })
 
+  it('maps the normalized INP culprit script only when attribution provides one', async () => {
+    const metricRecorder = createMetricRecorder()
+    await startWebVitals({ metricRecorder })
+    const functionName = 'f'.repeat(201)
+
+    const attributedMetric = createMetric('INP', {
+      inputDelay: 3,
+      interactionTarget: 'button.submit',
+      interactionTime: 100,
+      interactionType: 'pointer',
+      loadState: 'complete',
+      longestScript: {
+        entry: {
+          duration: 87,
+          invoker: 'HTMLButtonElement.onclick',
+          invokerType: 'event-listener',
+          sourceFunctionName: functionName,
+          sourceURL: 'https://cdn.example.com/app.js?user=secret#handler',
+        },
+        intersectingDuration: 45,
+        subpart: 'processing-duration',
+      },
+      presentationDelay: 5,
+      processingDuration: 4,
+    })
+    const unattributedMetric = createMetric('INP', {
+      inputDelay: 1,
+      interactionTarget: 'input',
+      interactionTime: 200,
+      interactionType: 'keyboard',
+      loadState: 'complete',
+      presentationDelay: 2,
+      processingDuration: 3,
+    })
+
+    report('INP', attributedMetric)
+    report('INP', unattributedMetric)
+
+    expect(mocks.spans[0]?.attributes).toMatchObject({
+      'web_vital.inp.script.duration': 87,
+      'web_vital.inp.script.function_name': 'f'.repeat(200),
+      'web_vital.inp.script.invoker': 'HTMLButtonElement.onclick',
+      'web_vital.inp.script.source_url': 'https://cdn.example.com/app.js',
+    })
+    expect(Object.keys(mocks.spans[1]?.attributes ?? {}).some((key) => key.startsWith('web_vital.inp.script.'))).toBe(false)
+    expect(metricRecorder.record).toHaveBeenNthCalledWith(1, attributedMetric)
+    expect(metricRecorder.record).toHaveBeenNthCalledWith(2, unattributedMetric)
+  })
+
   it('skips undefined attribution values', async () => {
     await startWebVitals()
 

--- a/packages/logfire-browser/src/webVitals.ts
+++ b/packages/logfire-browser/src/webVitals.ts
@@ -12,6 +12,7 @@ import type {
 } from 'web-vitals/attribution'
 
 import type { BrowserWebVitalsMetricOptions, BrowserWebVitalsMetricRecorder } from './browserMetrics'
+import { normalizeScriptEntry } from './scriptAttributes'
 
 const LOGFIRE_SPAN_TYPE_KEY = 'logfire.span_type'
 
@@ -169,6 +170,13 @@ function createMetricAttributes(metric: MetricWithAttribution): Attributes {
       setPrimitiveAttribute(attributes, 'web_vital.inp.processing_duration', attribution.processingDuration)
       setPrimitiveAttribute(attributes, 'web_vital.inp.presentation_delay', attribution.presentationDelay)
       setPrimitiveAttribute(attributes, 'web_vital.inp.load_state', attribution.loadState)
+      const script = normalizeScriptEntry(attribution.longestScript?.entry)
+      if (script !== undefined) {
+        setPrimitiveAttribute(attributes, 'web_vital.inp.script.source_url', script.sourceUrl)
+        setPrimitiveAttribute(attributes, 'web_vital.inp.script.function_name', script.functionName)
+        setPrimitiveAttribute(attributes, 'web_vital.inp.script.invoker', script.invoker)
+        setPrimitiveAttribute(attributes, 'web_vital.inp.script.duration', script.duration)
+      }
       break
     }
     case 'CLS': {


### PR DESCRIPTION
## Why

Browser RUM lacked two important perspectives: the current application user across spans and replays, and actionable detail for serious main-thread stalls. This made it difficult to distinguish one affected user across sessions and to identify the scripts behind visible UI freezes.

## What changes

- Adds `rum.session.getUser` so every browser span can carry the current OpenTelemetry `user.id`, with optional `user.name` and `user.email`.
- Uses the same live user id for replay labels when no explicit replay identity getter is configured.
- Adds opt-in `rum.longAnimationFrames` reporting with sampling, configurable ranking windows that default to one minute, bounded diagnostic spans, and foreground summaries.
- Enriches INP spans with the culprit script already identified by Web Vitals attribution.
- Updates browser documentation, examples, focused acceptance coverage, and release changesets.

## Boundaries

User identity is client-asserted observational context. It is not authentication, authorization, billing, or audit evidence. Accepted identity strings are emitted unchanged, are not persisted, do not become Web Vitals metric labels, and do not rotate the browser session.

Long Animation Frame reporting remains opt-in, sampled, bounded, and available only where the browser exposes the relevant performance entries.

Closes #301
Closes #302