### PR TITLE
Send a nested non-finite number as a string

### DIFF
--- a/.changeset/nested-non-finite.md
+++ b/.changeset/nested-non-finite.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Send a non-finite number nested inside an attribute as a string, the way a top-level one already is. `JSON.stringify` writes `NaN` and `Infinity` as `null`, so a nested one arrived indistinguishable from an actual null, and the generated JSON schema described it as `null` to match. Python's encoder returns `str(o)` for a non-finite float at any depth.

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -48,6 +48,19 @@ describe('serializeAttributes', () => {
     expect(JSON.stringify(result)).toBe('{"inf":"Infinity","nan":"NaN","neginf":"-Infinity","ok":1.5,"zero":0}')
   })
 
+  test('sends a nested non-finite number as a string, like the top-level one', () => {
+    const result = serializeAttributes({
+      nested: { inf: Number.POSITIVE_INFINITY, list: [Number.NaN, 2], nan: Number.NaN, ok: 1.5 },
+    })
+
+    // These used to reach the wire as `null`, indistinguishable from an actual null. The array
+    // schema drops `items` because the array is now heterogeneous, a string beside a number.
+    expect(result['nested']).toBe('{"inf":"Infinity","list":["NaN",2],"nan":"NaN","ok":1.5}')
+    expect(result[JSON_SCHEMA_KEY]).toBe(
+      '{"properties":{"nested":{"properties":{"inf":{"type":"string"},"list":{"type":"array"},"nan":{"type":"string"},"ok":{"type":"number"}},"type":"object"}},"type":"object"}'
+    )
+  })
+
   test('emits deterministic nested object schema for ordinary JSON-like values', () => {
     const result = serializeAttributes({
       payload: {

--- a/packages/logfire-api/src/serializeAttributes.ts
+++ b/packages/logfire-api/src/serializeAttributes.ts
@@ -122,7 +122,12 @@ function serializeJsonAttribute(
 
 function stringifyJsonAttribute(value: unknown): string | undefined {
   try {
-    const serialized = JSON.stringify(value)
+    // JSON has no spelling for NaN or Infinity, so `JSON.stringify` writes them as `null` and the
+    // value is lost at any depth. Python's encoder returns `str(o)` for a non-finite float
+    // wherever it appears, and the top-level branch above already sends the string.
+    const serialized = JSON.stringify(value, (_key, item: unknown) =>
+      typeof item === 'number' && !Number.isFinite(item) ? String(item) : item
+    )
     return typeof serialized === 'string' ? serialized : undefined
   } catch {
     return undefined
@@ -151,7 +156,8 @@ function inferJsonSchema(
     case 'boolean':
       return { type: 'boolean' }
     case 'number':
-      return Number.isFinite(value) ? { type: 'number' } : { type: 'null' }
+      // Sent as a string by `stringifyJsonAttribute`, so the schema has to say so.
+      return Number.isFinite(value) ? { type: 'number' } : { type: 'string' }
     case 'string':
       return { type: 'string' }
     case 'bigint':


### PR DESCRIPTION
### Defect

#292 fixed this for a top-level numeric attribute. A non-finite number nested inside an object or array attribute is still lost: `stringifyJsonAttribute` calls `JSON.stringify`, which has no spelling for `NaN` or `Infinity` and writes `null`. The generated schema then describes it as `null` too, so the two agree with each other and both disagree with what the value was.

### Evidence

Measured on `3ed526d`:

```
serializeAttributes({ nested: { inf: Infinity, nan: NaN, ok: 1.5 }, top: NaN })

nested = "{\"inf\":null,\"nan\":null,\"ok\":1.5}"
top    = "NaN"
```

The top-level value survives and the nested ones do not, in the same call. A consumer cannot tell a dropped `NaN` from an attribute that really was `null`.

Python does not have the split: `to_json_value` in `json_encoder.py` returns `str(o)` for any non-finite float, at any depth, and dumps with `allow_nan=False` so a raw one could never reach the wire.

### Fix

A replacer on the existing `JSON.stringify` call, which reaches every depth, using the same `String(value)` spelling #292 chose. The schema branch moves from `{type: 'null'}` to `{type: 'string'}` so it keeps describing what is actually sent.

Two mutations: dropping the replacer, or reverting the schema branch, each fail the new assertion.

One visible consequence worth calling out. An array like `[NaN, 2]` becomes `["NaN", 2]`, which is heterogeneous, so its schema loses `items` and falls back to a bare `array`. That is the existing heterogeneous-array behaviour rather than anything new here, and the test pins it so the change is not silent.

Built this with Claude Code's help and reviewed the diff myself.
