### PR TITLE
Send an out-of-range integer attribute as a string

### DIFF
--- a/.changeset/oversized-int-attribute.md
+++ b/.changeset/oversized-int-attribute.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Send an integer attribute outside signed 64-bit range as its exact decimal string. Every integral number is encoded as an OTLP `intValue`, so a larger one claimed a width the field does not have. Python's `prepare_otlp_attribute` converts the same values to strings.

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -48,6 +48,25 @@ describe('serializeAttributes', () => {
     expect(JSON.stringify(result)).toBe('{"inf":"Infinity","nan":"NaN","neginf":"-Infinity","ok":1.5,"zero":0}')
   })
 
+  test('sends an integer outside signed 64-bit range as its exact decimal string', () => {
+    const result = serializeAttributes({
+      big: 2 ** 64,
+      float: 1.5,
+      negative: -(2 ** 64),
+      safe: 9007199254740991,
+      // One past the int64 maximum, which is the first double the range check must reject.
+      atBoundary: 2 ** 63,
+    })
+
+    expect(result).toEqual({
+      atBoundary: '9223372036854775808',
+      big: '18446744073709551616',
+      float: 1.5,
+      negative: '-18446744073709551616',
+      safe: 9007199254740991,
+    })
+  })
+
   test('emits deterministic nested object schema for ordinary JSON-like values', () => {
     const result = serializeAttributes({
       payload: {

--- a/packages/logfire-api/src/serializeAttributes.ts
+++ b/packages/logfire-api/src/serializeAttributes.ts
@@ -22,6 +22,10 @@ interface AttributesJSONSchema {
 type SerializedAttributes = Record<string, AttributeValue>
 type ContainerKind = 'array' | 'object' | 'top-level'
 
+/** OTLP carries an integer attribute as a signed 64-bit value. */
+const OTLP_MAX_INT = 9223372036854775807n
+const OTLP_MIN_INT = -9223372036854775808n
+
 const MAX_SCHEMA_DEPTH = 4
 const MAX_OBJECT_PROPERTIES = 20
 const MAX_ARRAY_ITEMS = 20
@@ -54,10 +58,7 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
     if (value === null || value === undefined) {
       nullArgs.push(key)
     } else if (typeof value === 'number') {
-      // OTLP carries a double, and JSON has no NaN or Infinity, so these serialize to `null` and
-      // the value is lost. Python's `prepare_otlp_attribute` sends the string instead. `String`
-      // spells them the way the message template already does, so the two agree.
-      result[key] = Number.isFinite(value) ? value : String(value)
+      result[key] = serializeNumberAttribute(value)
     } else if (typeof value === 'string' || typeof value === 'boolean') {
       result[key] = value
     } else if (value instanceof Date) {
@@ -82,6 +83,27 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
     result[JSON_SCHEMA_KEY] = JSON.stringify(schema)
   }
   return result
+}
+
+/**
+ * A number as OTLP can carry it. Two cases cannot be represented and are sent as strings, which is
+ * what Python's `prepare_otlp_attribute` does with both:
+ *
+ * - `NaN` and `Infinity`, because JSON has no spelling for them and they serialize to `null`.
+ * - An integer outside signed 64-bit range. Every integral number is encoded as an OTLP `intValue`
+ *   (`otlp-transformer`'s `toAnyValue`), so a larger one claims a width the field does not have.
+ *   `BigInt` gives the double's exact value, where `String` would give its rounded decimal form.
+ */
+function serializeNumberAttribute(value: number): number | string {
+  if (!Number.isFinite(value)) {
+    // Spelled the way the message template already renders them, so the two agree.
+    return String(value)
+  }
+  if (!Number.isInteger(value)) {
+    return value
+  }
+  const exact = BigInt(value)
+  return exact > OTLP_MAX_INT || exact < OTLP_MIN_INT ? exact.toString() : value
 }
 
 function serializeJsonAttribute(


### PR DESCRIPTION
### Defect

`otlp-transformer`'s `toAnyValue` encodes every integral number as an OTLP `intValue`:

```js
if (!Number.isInteger(value)) return { doubleValue: value }
return { intValue: value }
```

That field is a signed 64-bit integer, so an attribute larger than `2^63 - 1` is sent claiming a width it does not have. `serializeAttributes` passes such a number straight through.

### Evidence

Measured on `3ed526d`:

```
2**64    emitted=18446744073709552000  typeof=number  isInteger=true
-2**64   emitted=-18446744073709552000 typeof=number  isInteger=true
```

Python converts the same values to strings in `prepare_otlp_attribute`, guarded by `OTLP_MAX_INT_SIZE = 2**63 - 1`.

Worth noting because it surprised me: the double nearest the int64 maximum is already out of range. Writing `9223372036854775807` in JS gives `9223372036854775808`, so the boundary sits at `2 ** 63` rather than at the literal maximum.

### Fix

One branch in the number path, comparing through `BigInt` so the boundary is exact rather than approximated in floating point.

The emitted string is `BigInt(value).toString()`, not `String(value)`. For `2**64` those differ: `BigInt` gives `18446744073709551616`, the double's exact value and what Python's `str(int)` produces, while `String` gives the rounded shortest-round-trip form `18446744073709552000`. A mutation swapping them fails.

Three mutations: dropping the range check, dropping the non-finite branch, or swapping `BigInt` for `String` each fail their own assertion.

Deliberately not included: Python also raises a `UserWarning` here. `console.warn` has no per-site deduplication, so on a hot attribute it would repeat once per span. Happy to add it if you would rather match that too.

This touches the same file as #304 but a different function, and the two merge cleanly. I checked rather than assumed.

Built this with Claude Code's help and reviewed the diff myself.
