### PR TITLE
Send a BigInt attribute as its exact decimal string

### DIFF
--- a/.changeset/bigint-attribute.md
+++ b/.changeset/bigint-attribute.md
@@ -1,0 +1,5 @@
+---
+'logfire': patch
+---
+
+Send a BigInt attribute as its exact decimal string instead of discarding it. `JSON.stringify` throws on a BigInt, so one anywhere in an attribute produced `[unserializable]`, and a nested one took the whole surrounding object with it.

--- a/packages/logfire-api/src/serializeAttributes.test.ts
+++ b/packages/logfire-api/src/serializeAttributes.test.ts
@@ -332,11 +332,29 @@ describe('serializeAttributes', () => {
       symbol: Symbol('top-level'),
     })
 
-    expect(result['bigintPayload']).toBe('[unserializable]')
+    // A BigInt is representable now, so it no longer stands in for a serialization failure here;
+    // `handler` and `symbol` below still cover the graceful-degradation guarantee this test exists for.
+    expect(result['bigintPayload']).toBe('{"value":"1"}')
     expect(result['circular']).toBe('{"password":"[Scrubbed due to \'password\']","self":"[Scrubbed due to cycle]"}')
     expect(result['circularArray']).toBe('["[Scrubbed due to cycle]"]')
     expect(result['handler']).toBe('[unserializable]')
     expect(result['symbol']).toBe('[unserializable]')
+  })
+
+  test('sends a BigInt attribute as its exact decimal string at any depth', () => {
+    const result = serializeAttributes({
+      big: 12345678901234567890n,
+      nested: { id: 99n, name: 'row' },
+      small: 7n,
+    })
+
+    // These used to be `[unserializable]`, and the nested one took the whole attribute with it.
+    expect(result['big']).toBe('12345678901234567890')
+    expect(result['small']).toBe('7')
+    expect(result['nested']).toBe('{"id":"99","name":"row"}')
+    expect(result[JSON_SCHEMA_KEY]).toBe(
+      '{"properties":{"nested":{"properties":{"id":{"type":"string"},"name":{"type":"string"}},"type":"object"}},"type":"object"}'
+    )
   })
 
   test('does not throw for deeply nested attributes before JSON serialization', () => {

--- a/packages/logfire-api/src/serializeAttributes.ts
+++ b/packages/logfire-api/src/serializeAttributes.ts
@@ -63,6 +63,11 @@ export function serializeAttributes(attributes: RawAttributes): SerializedAttrib
       nullArgs.push(key)
     } else if (typeof value === 'number') {
       result.set(key, serializeNumberAttribute(value))
+    } else if (typeof value === 'bigint') {
+      // OTLP has no arbitrary-precision integer, and a BigInt exists precisely because the value
+      // may not survive as a double, so it is sent as its exact decimal string rather than
+      // narrowed. `JSON.stringify` throws on one, which used to lose the whole attribute.
+      result.set(key, value.toString())
     } else if (typeof value === 'string' || typeof value === 'boolean') {
       result.set(key, value)
     } else if (value instanceof Date) {
@@ -164,9 +169,13 @@ function stringifyJsonAttribute(value: unknown): string | undefined {
     // JSON writes NaN and Infinity as `null`, so a nested one is lost at any depth. Python's
     // encoder returns `str(o)` for a non-finite float wherever it appears, and
     // `serializeNumberAttribute` already sends the string for a top-level one.
-    const serialized = JSON.stringify(value, (_key, item: unknown) =>
-      typeof item === 'number' && !Number.isFinite(item) ? String(item) : item
-    )
+    const serialized = JSON.stringify(value, (_key, item: unknown) => {
+      // A nested BigInt makes `JSON.stringify` throw, which discarded the entire attribute.
+      if (typeof item === 'bigint') {
+        return item.toString()
+      }
+      return typeof item === 'number' && !Number.isFinite(item) ? String(item) : item
+    })
     return typeof serialized === 'string' ? serialized : undefined
   } catch {
     return undefined
@@ -200,7 +209,7 @@ function inferJsonSchema(
     case 'string':
       return { type: 'string' }
     case 'bigint':
-      return undefined
+      return { type: 'string' }
     case 'function':
     case 'symbol':
       return state.container === 'array' ? { type: 'null' } : undefined


### PR DESCRIPTION
### Defect

`JSON.stringify` throws on a BigInt, and `stringifyJsonAttribute` catches that at the top, so any BigInt in an attribute produced `[unserializable]`. A nested one took the whole surrounding object with it, which is the damaging half: one `id` field discards every sibling.

BigInt is the JS analogue of a Python `int` with no width limit, and it is what a user reaches for after hitting the 64-bit ceiling `2b0d673` just addressed.

### Evidence

Measured on `5c3402e`:

```
big       = "[unserializable]"     // 12345678901234567890n
small     = "[unserializable]"     // 7n
nestedBig = "[unserializable]"     // { id: 99n }, the whole object
```

Even `7n` is discarded. Python has no equivalent gap: `isinstance(o, int)` covers arbitrary precision, and `to_json_value` only reaches for a string above the OTLP limit.

### Fix

Send the exact decimal string, at the top level and through the existing replacer for nested values, with the schema branch changed from `undefined` to `{type: 'string'}` so it describes what is sent.

Always a string, rather than a number when small. Python splits because `int` is its native integer type; in JS a BigInt is an explicit opt-in to arbitrary precision, so narrowing the small ones would make the emitted type depend on magnitude, which is harder to consume than one consistent representation.

Three mutations: dropping the top-level branch, the replacer clause, or the schema change each fail.

One existing expectation changes, deliberately. `does not throw when object or array serialization fails` asserted `[unserializable]` for `{value: 1n}`, using a BigInt as one of several ways to trigger a failure. It now expects `{"value":"1"}`. That test's actual guarantee, graceful degradation, is still carried by its `handler` and `symbol` cases, which remain unserializable.

Built this with Claude Code's help and reviewed the diff myself.
