### PR TITLE
Report every failing flush pipeline

### DIFF
--- a/.changeset/flush-report-all.md
+++ b/.changeset/flush-report-all.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Report every failing flush pipeline from `forceFlush()` instead of only the first. The span processors, log record processors and metric readers were awaited with `Promise.all`, which rejects on the first failure, so a second failing pipeline went unreported and its rejection was left unhandled. Multiple failures are now raised together as an `AggregateError`, matching how `shutdown()` already reports its teardowns.

--- a/.changeset/flush-report-all.md
+++ b/.changeset/flush-report-all.md
@@ -2,4 +2,4 @@
 '@pydantic/logfire-node': patch
 ---
 
-Report every failing flush pipeline from `forceFlush()` instead of only the first. The span processors, log record processors and metric readers were awaited with `Promise.all`, which rejects on the first failure, so a second failing pipeline went unreported and its rejection was left unhandled. Multiple failures are now raised together as an `AggregateError`, matching how `shutdown()` already reports its teardowns.
+Report every failing flush pipeline from `forceFlush()` instead of only the first. The span processors, log record processors and metric readers were awaited with `Promise.all`, which rejects with the first failure and never surfaces the rest, so a second failing pipeline went unreported. Multiple failures are now raised together as an `AggregateError`, matching how `shutdown()` already reports its teardowns.

--- a/packages/logfire-node/src/__test__/sdk.test.ts
+++ b/packages/logfire-node/src/__test__/sdk.test.ts
@@ -660,6 +660,46 @@ describe('sdk lifecycle helpers', () => {
     await shutdown({ flush: false })
   })
 
+  it('reports every failing flush pipeline, not just the first', async () => {
+    const firstError = new Error('first processor flush failed')
+    const secondError = new Error('second processor flush failed')
+    const failing = (error: Error): SpanProcessor => ({
+      forceFlush: async () => Promise.reject(error),
+      onEnd: () => undefined,
+      onStart: () => undefined,
+      shutdown: async () => Promise.resolve(),
+    })
+    Object.assign(logfireConfig, { additionalSpanProcessors: [failing(firstError), failing(secondError)] })
+    start()
+
+    // `Promise.all` rejected on the first failure, so the second went unreported.
+    const error: unknown = await forceFlush().catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(AggregateError)
+    expect((error as AggregateError).message).toBe('logfire SDK: forceFlush failed')
+    expect((error as AggregateError).errors).toEqual([firstError, secondError])
+    // The runtime is still active with failing processors, so consume the teardown rejection.
+    await shutdown().catch(() => undefined)
+  })
+
+  it('still reports a single flush failure directly', async () => {
+    const flushError = new Error('only processor flush failed')
+    Object.assign(logfireConfig, {
+      additionalSpanProcessors: [
+        {
+          forceFlush: async () => Promise.reject(flushError),
+          onEnd: () => undefined,
+          onStart: () => undefined,
+          shutdown: async () => Promise.resolve(),
+        } satisfies SpanProcessor,
+      ],
+    })
+    start()
+
+    await expect(forceFlush()).rejects.toBe(flushError)
+    await shutdown().catch(() => undefined)
+  })
+
   it('shutdown still closes the SDK when the pre-shutdown flush fails', async () => {
     const flushError = new Error('flush failed')
     const additionalProcessor: SpanProcessor = {

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -165,15 +165,42 @@ function removeProcessListeners(runtime: ActiveRuntime): void {
 }
 
 async function flushRuntime(runtime: ActiveRuntime, deadline: Deadline): Promise<void> {
-  await withDeadline(
-    'forceFlush',
-    deadline,
-    Promise.all([
-      ...runtime.spanProcessors.map(async (processor) => processor.forceFlush()),
-      ...runtime.logRecordProcessors.map(async (processor) => processor.forceFlush()),
-      ...runtime.metricReaders.map(async (reader) => reader.forceFlush({ timeoutMillis: remainingTimeoutMillis(deadline) })),
-    ]).then(() => undefined)
+  const pipelines = [
+    ...runtime.spanProcessors.map(async (processor) => processor.forceFlush()),
+    ...runtime.logRecordProcessors.map(async (processor) => processor.forceFlush()),
+    ...runtime.metricReaders.map(async (reader) => reader.forceFlush({ timeoutMillis: remainingTimeoutMillis(deadline) })),
+  ]
+  // Each failure is recorded as its own pipeline settles, the same way `shutdownRuntime` collects
+  // its two teardowns. `Promise.all` rejected on the first failure, so a second failing pipeline
+  // went unreported and its rejection was left unhandled, and reading a combined result instead
+  // would lose an early failure whenever another pipeline outlives the deadline.
+  const errors: unknown[] = []
+  const settled = Promise.all(
+    pipelines.map(async (pipeline) => {
+      try {
+        await pipeline
+      } catch (e: unknown) {
+        errors.push(e)
+      }
+    })
   )
+  let deadlineError: unknown
+  let deadlineExceeded = false
+  try {
+    await withDeadline('forceFlush', deadline, settled)
+  } catch (e: unknown) {
+    deadlineError = e
+    deadlineExceeded = true
+  }
+  if (deadlineExceeded) {
+    errors.push(deadlineError)
+  }
+  if (errors.length === 1) {
+    throw errors[0]
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'logfire SDK: forceFlush failed')
+  }
 }
 
 async function forceFlushBestEffort(runtime: ActiveRuntime, reason: string): Promise<void> {

--- a/packages/logfire-node/src/sdk.ts
+++ b/packages/logfire-node/src/sdk.ts
@@ -171,9 +171,9 @@ async function flushRuntime(runtime: ActiveRuntime, deadline: Deadline): Promise
     ...runtime.metricReaders.map(async (reader) => reader.forceFlush({ timeoutMillis: remainingTimeoutMillis(deadline) })),
   ]
   // Each failure is recorded as its own pipeline settles, the same way `shutdownRuntime` collects
-  // its two teardowns. `Promise.all` rejected on the first failure, so a second failing pipeline
-  // went unreported and its rejection was left unhandled, and reading a combined result instead
-  // would lose an early failure whenever another pipeline outlives the deadline.
+  // its two teardowns. `Promise.all` rejects with the first failure and never surfaces the rest,
+  // so a second failing pipeline went unreported, and reading a combined result instead would
+  // lose an early failure whenever another pipeline outlives the deadline.
   const errors: unknown[] = []
   const settled = Promise.all(
     pipelines.map(async (pipeline) => {


### PR DESCRIPTION
### Defect

`flushRuntime` awaits the span processors, log record processors and metric readers with `Promise.all`, which rejects on the first failure. A second failing pipeline is never reported, and its rejection is left unhandled.

This is the same shape as `shutdownRuntime`, which was changed to collect each teardown as it settles. `flushRuntime` was not, even though `shutdown()` calls it too, so both paths report at most one flush failure.

### Evidence

Measured on `5c3402e`, with two additional span processors whose `forceFlush` rejects:

```
forceFlush() -> rejected with: first processor flush failed
```

The second processor's error is gone, and under Vitest it surfaces separately as an unhandled rejection.

pydantic/logfire made the equivalent change in #2366: `force_flush` returned only the tracer provider's status and now combines the logger, forwarding and tracer results.

### Fix

The same treatment `shutdownRuntime` already uses. Each pipeline's failure is recorded as it settles, the deadline still bounds the wait, one failure is rethrown as-is, and several are raised together as an `AggregateError`.

Rethrowing a lone failure unchanged matters for the existing contract: `shutdown still closes the SDK when the pre-shutdown flush fails` asserts identity with `rejects.toBe(flushError)`, and the timeout test asserts the `forceFlush timed out` message. Both still hold, and the second new test pins the single-failure case so a future change cannot quietly wrap it.

Two mutations: restoring `Promise.all`, or always wrapping in an `AggregateError` rather than rethrowing a lone failure, each fail.

Built this with Claude Code's help and reviewed the diff myself.
