### PR TITLE
Keep a prototype-named Web Vitals metric attribute

### DIFF
--- a/.changeset/browser-metric-own-keys.md
+++ b/.changeset/browser-metric-own-keys.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-browser': patch
+---
+
+Keep a Web Vitals metric attribute whose name is an `Object.prototype` member. Attribute keys come from the `attributes` and `defaultAttributes` callbacks, and a plain record write to a `__proto__` key ran the inherited setter, so that entry was silently dropped from the recorded metric.

--- a/packages/logfire-browser/src/browserMetrics.test.ts
+++ b/packages/logfire-browser/src/browserMetrics.test.ts
@@ -251,6 +251,26 @@ describe('browser metrics runtime', () => {
     expect(getHistogram(expectedInstruments.TTFB.name).records[0]?.value).toBe(300)
   })
 
+  it('keeps a metric attribute named like an Object.prototype member', async () => {
+    const runtime = await startBrowserMetrics({ metricUrl: '/v1/metrics/browser' }, { attributes: {} } as never)
+    const recorder = runtime.createWebVitalsMetricRecorder({
+      // Built by entries: an object literal `__proto__` key sets the prototype and creates no key.
+      attributes: () =>
+        Object.fromEntries([
+          ['__proto__', 'proto-value'],
+          ['app.route', '/products/:id'],
+        ]) as never,
+    })
+
+    recorder.record(createMetric('LCP', 2500))
+
+    const recorded = getHistogram(expectedInstruments.LCP.name).records[0]?.attributes ?? {}
+    // The `__proto__` entry used to vanish, because assigning it ran the inherited setter.
+    expect(Object.getOwnPropertyDescriptor(recorded, '__proto__')?.value).toBe('proto-value')
+    expect(recorded['app.route']).toBe('/products/:id')
+    expect(Object.getPrototypeOf(recorded)).toBe(Object.prototype)
+  })
+
   it('keeps Web Vital metric attributes low-cardinality', async () => {
     const runtime = await startBrowserMetrics({ metricUrl: '/v1/metrics/browser' }, { attributes: {} } as never)
     const recorder = runtime.createWebVitalsMetricRecorder({

--- a/packages/logfire-browser/src/browserMetrics.ts
+++ b/packages/logfire-browser/src/browserMetrics.ts
@@ -138,13 +138,18 @@ function setPrimitiveAttribute(attributes: Attributes, key: string, value: unkno
   }
 
   if (typeof value === 'string' || typeof value === 'boolean') {
-    attributes[key] = value
+    defineAttribute(attributes, key, value)
     return
   }
 
   if (typeof value === 'number' && Number.isFinite(value)) {
-    attributes[key] = value
+    defineAttribute(attributes, key, value)
   }
+}
+
+/** Attribute keys come from user callbacks, and a plain write to `__proto__` drops the entry. */
+function defineAttribute(attributes: Attributes, key: string, value: boolean | number | string): void {
+  Object.defineProperty(attributes, key, { configurable: true, enumerable: true, value, writable: true })
 }
 
 function copyPrimitiveAttributes(target: Attributes, source: Attributes | undefined): void {


### PR DESCRIPTION
### Defect

`setPrimitiveAttribute` in `browserMetrics.ts` writes with a plain record assignment. The keys reaching it come from the `attributes` and `defaultAttributes` callbacks, so a `__proto__` key runs the inherited setter and the entry is dropped from the recorded metric.

This is the class `92f0868` and `a68833f` swept. Neither reached `logfire-browser`.

### Evidence

A recorder configured with `attributes: () => Object.fromEntries([['__proto__', 'proto-value'], ['app.route', '/products/:id']])` records the route and loses the other entry. Reverting the fix fails the new assertion.

### Fix

`Object.defineProperty` at that one write, the same convention `ownRecord.ts` uses. I did not reach for the shared helper because it is internal to `logfire-api` and exporting it would be an API addition rather than a fix.

### Scope, and the four sites I did not change

I started from a grep of the same shape across the browser packages and narrowed it by checking reachability, which removed most of them:

- `webVitals.ts` has two identical writes, but every caller passes a hardcoded key such as `'web_vital.value'`, so no user-supplied name reaches them.
- `browserSession.ts` filters keys through `/^[a-z][a-z0-9_]{0,63}$/` before writing, which rejects `__proto__` outright. Names like `constructor` pass that filter but assign as ordinary own properties, since only `__proto__` has an inherited setter.
- `sessionAttributes.ts` in `logfire-session-replay` has the same shape and is left alone while #309 is open in that package.

Built this with Claude Code's help and reviewed the diff myself.
