### PR TITLE
Give every concurrent eval case its own task run

### DIFF
--- a/.changeset/evals-als-probe-race.md
+++ b/.changeset/evals-als-probe-race.md
@@ -1,0 +1,11 @@
+---
+'logfire': patch
+---
+
+Fix concurrent eval cases sharing one task-run context on the first `Dataset.evaluate` call.
+
+The `AsyncLocalStorage` probe recorded "probe started" in a boolean before awaiting its dynamic
+`import('node:async_hooks')`. Every case that began while that import was still in flight saw the
+flag already set, skipped the await, and fell through to the no-ALS fallback slot, so
+`setEvalAttribute` and `incrementEvalMetric` silently recorded nothing for those cases. The probe
+is now cached as a promise that all callers await.

--- a/packages/logfire-api/src/evals/__test__/offline.test.ts
+++ b/packages/logfire-api/src/evals/__test__/offline.test.ts
@@ -790,4 +790,25 @@ describe('offline evals — span attribute parity', () => {
     // A corrupted metric propagates: `sum += value` on a string yields a non-numeric mean.
     expect(computeAverages('proto-names', result.cases).metrics[inherited]).toEqual({ count: 1, mean: 8 })
   })
+
+  it('gives every concurrent case its own task run on the first evaluate', async () => {
+    // A fresh module instance, because the ALS probe only runs once per module and every other
+    // test in this file has already warmed it. The first `Dataset.evaluate` of a process is the
+    // case that matters: cases that start while the `node:async_hooks` import is still in flight
+    // used to skip ALS entirely and share one storage slot.
+    vi.resetModules()
+    const { getCurrentTaskRun, runWithTaskRun } = await import('../currentTaskRun')
+
+    const seen: (string | undefined)[] = []
+    await Promise.all(
+      ['a', 'b', 'c', 'd'].map(async (id) =>
+        runWithTaskRun({ attributes: {}, exporterContextId: id, metrics: {} }, async () => {
+          await sleep(5)
+          seen.push(getCurrentTaskRun()?.exporterContextId)
+        })
+      )
+    )
+
+    expect([...seen].sort()).toEqual(['a', 'b', 'c', 'd'])
+  })
 })

--- a/packages/logfire-api/src/evals/currentTaskRun.ts
+++ b/packages/logfire-api/src/evals/currentTaskRun.ts
@@ -20,18 +20,12 @@ interface ALSLike<T> {
 }
 
 let alsImpl: ALSLike<TaskRunState> | null = null
-let alsProbeComplete = false
+/** The one in-flight (or settled) ALS probe, awaited by every caller. */
+let alsProbe: null | Promise<void> = null
 /** Fallback storage cell for runtimes without ALS. Single-slot, single-execute. */
 let fallbackStore: null | TaskRunState = null
 
-async function ensureALS(): Promise<void> {
-  if (alsImpl !== null) {
-    return
-  }
-  if (alsProbeComplete) {
-    return
-  }
-  alsProbeComplete = true
+async function probeALS(): Promise<void> {
   if (!hasAsyncLocalStorage()) {
     return
   }
@@ -44,6 +38,14 @@ async function ensureALS(): Promise<void> {
   } catch {
     alsImpl = null
   }
+}
+
+async function ensureALS(): Promise<void> {
+  // The probe is cached as a promise rather than a "already started" flag: a flag let every
+  // caller that arrived while the import was still in flight skip the await and fall through
+  // to the single-slot fallback, which is not safe to share between concurrent cases.
+  alsProbe ??= probeALS()
+  await alsProbe
 }
 
 /** Run `fn` with `state` set as the current task-run context. */


### PR DESCRIPTION
`Dataset.evaluate` runs its cases concurrently (default concurrency is the whole case list), and each case calls `runWithTaskRun` to install its own task-run context. On the first call of a process, that context comes from an `AsyncLocalStorage` instance the module still has to import.

`ensureALS` marked the probe as done with a boolean *before* awaiting the import:

```ts
alsProbeComplete = true
if (!hasAsyncLocalStorage()) return
const mod = await import('node:async_hooks')   // <- everyone else runs past here
alsImpl = new mod.AsyncLocalStorage<TaskRunState>()
```

The first case suspends on the import. Every case that starts while it is in flight sees `alsProbeComplete === true`, returns immediately, still finds `alsImpl === null`, and takes the no-ALS fallback path — the single-slot `fallbackStore` the file itself documents as unsafe to share. Once the import lands and `alsImpl` becomes non-null, `getCurrentTaskRun` switches to reading the ALS store, which those cases were never registered in, so it returns `undefined` for them.

The user-visible effect is silent: `setEvalAttribute` and `incrementEvalMetric` are no-ops when there is no current task run, so attributes and metrics recorded by those cases are dropped from the report. It only affects the first `evaluate` call, and which cases lose their context depends on timing.

Four concurrent runs on `main`, on Node:

```
expected [ 'a', 'b', 'c', 'd' ]
received [ 'a', undefined, undefined, undefined ]
```

The fix caches the probe as a promise instead of a flag, so every caller awaits the same import and sees `alsImpl` set before deciding which path to take. The regression test uses `vi.resetModules()` because the probe only runs once per module instance and the rest of `offline.test.ts` has already warmed it; without the fix it fails as above.

Built this with Claude Code's help and reviewed the diff myself.
