### PR TITLE
Reject an unreadable trace sample rate environment value

### DIFF
--- a/.changeset/node-sample-rate-strict.md
+++ b/.changeset/node-sample-rate-strict.md
@@ -1,0 +1,11 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Reject an unreadable `LOGFIRE_TRACE_SAMPLE_RATE` instead of silently exporting every trace.
+
+An unparseable or out-of-range value was discarded and head sampling was left off, so
+`LOGFIRE_TRACE_SAMPLE_RATE=10%` exported all traces rather than a tenth, and `-1` exported all of
+them when the user had asked for none. `parseFloat` also accepted `0.1x` as `0.1`. The value is now
+parsed with `Number` and must be a number from `0` to `1`, matching `parseBooleanEnv` in the same
+file and Python's `float()` cast for this parameter.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -20,7 +20,7 @@ description: Environment variables used by the Logfire TypeScript SDK packages.
 | `LOGFIRE_MIN_LEVEL`           | Minimum manual Logfire level to emit.                                    |
 | `LOGFIRE_SEND_TO_LOGFIRE`     | Set sending behavior. `true`, `false`, or `if-token-present`.            |
 | `LOGFIRE_DISTRIBUTED_TRACING` | Set to `false` to suppress extraction of incoming trace context.         |
-| `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`.                                      |
+| `LOGFIRE_TRACE_SAMPLE_RATE`   | Head sampling rate from `0` to `1`. Anything else is an error.           |
 | `LOGFIRE_BASE_URL`            | Override the Logfire API base URL.                                       |
 | `LOGFIRE_CREDENTIALS_DIR`     | Directory containing `logfire_credentials.json` for local Node projects. |
 | `OTEL_SERVICE_NAME`           | Service name fallback when `LOGFIRE_SERVICE_NAME` is unset.              |

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -20,7 +20,9 @@ logfire.configure({
 })
 ```
 
-In Node.js, `LOGFIRE_TRACE_SAMPLE_RATE=0.1` configures head sampling from the environment.
+In Node.js, `LOGFIRE_TRACE_SAMPLE_RATE=0.1` configures head sampling from the environment. The
+value must be a number from `0` to `1`; anything else raises at `configure()` rather than leaving
+head sampling off, since a rate nobody can read is a typo and quietly exporting every trace hides it.
 
 ## Tail Sampling
 

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -327,7 +327,17 @@ describe('logfire config', () => {
       process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = value
       expect(() => {
         configure()
-      }).toThrow(`Expected LOGFIRE_TRACE_SAMPLE_RATE to be a number from 0 to 1, got ${JSON.stringify(value)}`)
+        // An Error rather than a string, which Vitest matches as a substring.
+      }).toThrow(new Error(`Expected LOGFIRE_TRACE_SAMPLE_RATE to be a number from 0 to 1, got ${JSON.stringify(value)}`))
+    }
+
+    // Blank is unset, not a typo. Python's `load_param` says so in as many words, "`None` (unset)
+    // and `''` (empty string) are generally considered the same", and `parseBooleanEnv` above
+    // returns `false` for `''` rather than raising.
+    for (const blank of ['', '   ']) {
+      process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = blank
+      configure()
+      expect(logfireConfig.sampling).toBe(undefined)
     }
 
     // Both bounds are meaningful: `0` drops every trace, so it must not be read as "unset".

--- a/packages/logfire-node/src/__test__/logfireConfig.test.ts
+++ b/packages/logfire-node/src/__test__/logfireConfig.test.ts
@@ -25,6 +25,7 @@ describe('logfire config', () => {
   const originalOtelServiceName = process.env['OTEL_SERVICE_NAME']
   const originalOtelServiceVersion = process.env['OTEL_SERVICE_VERSION']
   const originalToken = process.env['LOGFIRE_TOKEN']
+  const originalTraceSampleRate = process.env['LOGFIRE_TRACE_SAMPLE_RATE']
   const originalCredentialsDir = process.env['LOGFIRE_CREDENTIALS_DIR']
   const tmpDirs: string[] = []
 
@@ -41,6 +42,7 @@ describe('logfire config', () => {
     delete process.env['LOGFIRE_TOKEN']
     delete process.env['LOGFIRE_CREDENTIALS_DIR']
     delete process.env['LOGFIRE_DISTRIBUTED_TRACING']
+    delete process.env['LOGFIRE_TRACE_SAMPLE_RATE']
     configureLogfireApi({ baggage: { spanAttributes: [] }, jsonSchema: 'rich', minLevel: null })
     await shutdownVariables()
   })
@@ -100,6 +102,11 @@ describe('logfire config', () => {
       delete process.env['LOGFIRE_CREDENTIALS_DIR']
     } else {
       process.env['LOGFIRE_CREDENTIALS_DIR'] = originalCredentialsDir
+    }
+    if (originalTraceSampleRate === undefined) {
+      delete process.env['LOGFIRE_TRACE_SAMPLE_RATE']
+    } else {
+      process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = originalTraceSampleRate
     }
     for (const dir of tmpDirs.splice(0)) {
       rmSync(dir, { force: true, recursive: true })
@@ -308,6 +315,33 @@ describe('logfire config', () => {
     expect(() => {
       configure()
     }).toThrow(`Expected LOGFIRE_CONSOLE to be a boolean, got ${JSON.stringify(value)}`)
+  })
+
+  it('rejects a LOGFIRE_TRACE_SAMPLE_RATE that is not a number from 0 to 1, and keeps the rates that are', () => {
+    // Head sampling is off by default, so an unparsed rate used to export every trace without a
+    // word. `-1` was the worst of it: the user asked for no traces and got all of them, and
+    // `0.1x` was accepted as `0.1` because `parseFloat` stops at the first character it cannot
+    // read. The accepted half is asserted too, since a rejection test alone would still pass if
+    // every value threw.
+    for (const value of ['10%', '0.1x', '-1', '1.5']) {
+      process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = value
+      expect(() => {
+        configure()
+      }).toThrow(`Expected LOGFIRE_TRACE_SAMPLE_RATE to be a number from 0 to 1, got ${JSON.stringify(value)}`)
+    }
+
+    // Both bounds are meaningful: `0` drops every trace, so it must not be read as "unset".
+    process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = '0'
+    configure()
+    expect(logfireConfig.sampling).toEqual({ head: 0 })
+
+    process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = '1'
+    configure()
+    expect(logfireConfig.sampling).toEqual({ head: 1 })
+
+    process.env['LOGFIRE_TRACE_SAMPLE_RATE'] = '0.1'
+    configure()
+    expect(logfireConfig.sampling).toEqual({ head: 0.1 })
   })
 
   it('rejects a LOGFIRE_DISTRIBUTED_TRACING value that is not a boolean', () => {

--- a/packages/logfire-node/src/logfireConfig.ts
+++ b/packages/logfire-node/src/logfireConfig.ts
@@ -407,17 +407,22 @@ function configureSharedApi(apiConfig: logfireApi.LogfireApiConfigOptions, minLe
 }
 
 function resolveSampling(option: SamplingOptions | undefined): SamplingOptions | undefined {
-  const envRate = process.env['LOGFIRE_TRACE_SAMPLE_RATE']
   if (option) {
     return option
   }
-  if (envRate !== undefined) {
-    const rate = parseFloat(envRate)
-    if (!isNaN(rate) && rate >= 0 && rate <= 1) {
-      return { head: rate }
-    }
+  const envRate = readNonEmptyEnv(process.env, 'LOGFIRE_TRACE_SAMPLE_RATE')
+  if (envRate === undefined) {
+    return undefined
   }
-  return undefined
+  // Same policy as `parseBooleanEnv` above, and as Python's `float(value)` cast for this
+  // parameter: a value nobody recognises is a typo, and quietly sampling everything hides it.
+  // `Number` rather than `parseFloat`, which reads a leading number out of `0.1x` and drops
+  // the rest, so a truncated value used to be accepted as though it were written that way.
+  const rate = Number(envRate)
+  if (!Number.isFinite(rate) || rate < 0 || rate > 1) {
+    throw new Error(`Expected LOGFIRE_TRACE_SAMPLE_RATE to be a number from 0 to 1, got ${JSON.stringify(envRate)}`)
+  }
+  return { head: rate }
 }
 
 function resolveSendToLogfire(option: LogfireConfigOptions['sendToLogfire'], token: LogfireToken | undefined): boolean {


### PR DESCRIPTION
`resolveSampling` in `logfireConfig.ts` read `LOGFIRE_TRACE_SAMPLE_RATE` like this:

```ts
const rate = parseFloat(envRate)
if (!isNaN(rate) && rate >= 0 && rate <= 1) {
  return { head: rate }
}
return undefined
```

A value that fails either check is dropped on the floor. `resolveSampling` returning `undefined` means head sampling is off, so the misconfiguration does not fail, it exports everything.

Current behaviour on `main`, read off `logfireConfig.sampling` after `configure()`:

```
'10%'  -> undefined     every trace exported, not a tenth
'-1'   -> undefined     every trace exported, when the user asked for none
'1.5'  -> undefined     every trace exported
'0.1x' -> { head: 0.1 } trailing junk accepted, parseFloat stops at 'x'
'0.1'  -> { head: 0.1 }
```

The `-1` row is the sharp one: the requested rate and the delivered rate are at opposite ends. The others are the same class as the boolean typo `f25ccd9` already addressed, and cost export volume rather than dropping it.

This file already documents the opposite policy for the variables next to it. `parseBooleanEnv`, twenty lines up:

> `_check_bool` in `config_params.py` lowercases and takes `1`/`true`/`t` and `0`/`false`/`f`, and raises on anything else rather than guessing, because a value nobody recognises is a typo and silently picking a side hides it.

Python treats this parameter the same way. `TRACE_SAMPLE_RATE` is declared `tp=float` and `_cast` runs `float(value)`, which raises on `10%` and on `0.1x` alike.

The fix parses with `Number` instead of `parseFloat`, so a partly numeric value is rejected rather than truncated, and throws the same shape of message as the booleans. The `option` check moves above the env read so an explicit `sampling` option is unaffected by an unrelated typo in the environment.

I took throwing rather than warning because that is what the sibling variables in this file do and what Python does, and because the failure it replaces is invisible. If you would rather this warn and fall back to no sampling, that is a one-line change and I will make it.

The test asserts both branches. A rejection-only test would still pass if every value threw, so the accepted rates are pinned too, including `0`, which drops every trace and must not be read as unset.

Built this with Claude Code's help and reviewed the diff myself.
