### PR TITLE
Shut the batch span processor down when the console one fails

### DIFF
--- a/.changeset/node-processor-lifecycle.md
+++ b/.changeset/node-processor-lifecycle.md
@@ -1,0 +1,10 @@
+---
+'@pydantic/logfire-node': patch
+---
+
+Shut the batch span processor down even when the console processor fails.
+
+`LogfireSpanProcessor.forceFlush` and `.shutdown` awaited the console processor before the wrapped
+one, so a console failure skipped the batch processor entirely and every span still queued for
+export was dropped. Both calls now settle together, a lone failure is rethrown unchanged, and two
+are raised as an `AggregateError`.

--- a/packages/logfire-node/src/__test__/traceExporter.test.ts
+++ b/packages/logfire-node/src/__test__/traceExporter.test.ts
@@ -1,0 +1,38 @@
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { LogfireConsoleSpanExporter } from '../LogfireConsoleSpanExporter'
+import { logfireConfig } from '../logfireConfig'
+import { logfireSpanProcessor } from '../traceExporter'
+
+describe('logfire span processor lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('still shuts the batch processor down when the console one fails, and reports both failures', async () => {
+    // The batch processor is what holds spans that have not reached the exporter yet, so skipping
+    // its shutdown drops every span still queued.
+    Object.assign(logfireConfig, { sendToLogfire: false })
+    vi.spyOn(LogfireConsoleSpanExporter.prototype, 'shutdown').mockRejectedValue(new Error('console down'))
+    const batchShutdown = vi.spyOn(BatchSpanProcessor.prototype, 'shutdown').mockResolvedValue()
+
+    const processor = logfireSpanProcessor(true)
+    await expect(processor.shutdown()).rejects.toThrow('console down')
+    expect(batchShutdown.mock.calls.length).toBe(1)
+
+    // A lone failure is rethrown unchanged, so both failing raises them together instead of
+    // silently keeping only the first.
+    vi.spyOn(LogfireConsoleSpanExporter.prototype, 'forceFlush').mockRejectedValue(new Error('console flush down'))
+    const batchFlush = vi.spyOn(BatchSpanProcessor.prototype, 'forceFlush').mockRejectedValue(new Error('batch flush down'))
+
+    const raised: unknown = await logfireSpanProcessor(true)
+      .forceFlush()
+      .then(() => undefined)
+      .catch((error: unknown) => error)
+
+    expect(batchFlush.mock.calls.length).toBe(1)
+    expect(raised).toBeInstanceOf(AggregateError)
+    expect((raised as AggregateError).errors.map((error: Error) => error.message)).toEqual(['console flush down', 'batch flush down'])
+  })
+})

--- a/packages/logfire-node/src/traceExporter.ts
+++ b/packages/logfire-node/src/traceExporter.ts
@@ -35,6 +35,25 @@ export function traceExporter(): SpanExporter {
   })
 }
 
+/**
+ * Wait for both lifecycle calls rather than awaiting them in sequence, which skipped the second
+ * one whenever the first rejected. The wrapped processor is the batch that holds unexported
+ * spans, so letting a console failure skip its `shutdown` drops everything still queued. Both
+ * calls are already in flight by the time this runs, so waiting for both costs nothing and also
+ * stops a slow console flush from eating into the caller's deadline. A lone failure is rethrown
+ * unchanged; several are raised together.
+ */
+async function settleBoth(consoleCall: Promise<void> | undefined, wrappedCall: Promise<void>): Promise<void> {
+  const settled = await Promise.allSettled([consoleCall, wrappedCall])
+  const errors = settled.filter((result) => result.status === 'rejected').map((result) => result.reason as unknown)
+  if (errors.length === 1) {
+    throw errors[0]
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, 'logfire SDK: span processor lifecycle failed')
+  }
+}
+
 class LogfireSpanProcessor implements SpanProcessor {
   private readonly console?: SpanProcessor
   private readonly wrapped: SpanProcessor
@@ -48,8 +67,7 @@ class LogfireSpanProcessor implements SpanProcessor {
   }
 
   async forceFlush(): Promise<void> {
-    await this.console?.forceFlush()
-    return this.wrapped.forceFlush()
+    await settleBoth(this.console?.forceFlush(), this.wrapped.forceFlush())
   }
 
   onEnd(span: ReadableSpan): void {
@@ -66,7 +84,6 @@ class LogfireSpanProcessor implements SpanProcessor {
   }
 
   async shutdown(): Promise<void> {
-    await this.console?.shutdown()
-    return this.wrapped.shutdown()
+    await settleBoth(this.console?.shutdown(), this.wrapped.shutdown())
   }
 }


### PR DESCRIPTION
`LogfireSpanProcessor` is the span processor the Node SDK installs by default (`sdk.ts:391`). It wraps the `BatchSpanProcessor` that holds spans on their way to OTLP, and optionally a console processor. Both lifecycle methods awaited them in sequence:

```ts
async forceFlush(): Promise<void> {
  await this.console?.forceFlush()
  return this.wrapped.forceFlush()
}

async shutdown(): Promise<void> {
  await this.console?.shutdown()
  return this.wrapped.shutdown()
}
```

If the console call rejects, the second line never runs. `this.wrapped` is the batch processor, and its `shutdown` is what exports whatever is still queued, so the failure that skips it is exactly the moment those spans are lost.

Against `main`, with the console exporter's `shutdown` rejecting:

```
BatchSpanProcessor.prototype.shutdown calls: 0
```

This repo has settled the same shape twice. `TailSamplingProcessor.runBoth` says it directly:

> Awaiting them in sequence would skip the second one whenever the first rejects, which is exactly when the deferred processor still needs the call.

And f9dedfa gave `flushRuntime` and `shutdownRuntime` a shared settle-and-report seam for the same reason. This processor was not covered by either.

The fix starts both calls, waits for both, rethrows a lone failure unchanged so the existing rejection contract is unaffected, and raises two as an `AggregateError`. Waiting concurrently also stops a slow console flush from eating into the deadline `flushRuntime` now applies.

Being straight about severity: I did not find an input that makes the console side reject on its own today. `LogfireConsoleSpanExporter.shutdown` resolves, and the global `console` swallows write errors, so this is currently a contract gap rather than a live data loss. It matters because the console exporter is the replaceable, I/O-doing half of the pair and the batch processor is the half whose loss is unrecoverable, and because the two precedents above already decided this ordering is wrong.

Built this with Claude Code's help and reviewed the diff myself.
