### PR TITLE
Carry a task's own return value through the evals output seams

### DIFF
--- a/.changeset/evals-bigint-output.md
+++ b/.changeset/evals-bigint-output.md
@@ -1,0 +1,12 @@
+---
+'logfire': patch
+---
+
+Stop a task's own return value from breaking the evals output seams.
+
+`renderReport` passed `JSON.stringify` straight into `truncate`, which reads `.length`. A task that
+returns nothing gives `undefined` rather than a string, so rendering the report with
+`includeOutput` threw `Cannot read properties of undefined`, and a `BigInt` anywhere in the value
+threw outright. `withOnlineEvaluation`'s `recordReturn` had the same `BigInt` gap and recorded
+`[unserializable]` for the whole return value. Both now use the replacer the attribute seam
+already applies.

--- a/packages/logfire-api/src/evals/__test__/online.test.ts
+++ b/packages/logfire-api/src/evals/__test__/online.test.ts
@@ -785,6 +785,29 @@ describe('online evals — gen_ai.evaluation.result emission', () => {
     expect(logs[0]?.attributes['tenant']).toBe('acme')
   })
 
+  it('records a returned BigInt instead of collapsing the whole return value', async () => {
+    // `JSON.stringify` throws on a BigInt at any depth, so before this the sibling fields went
+    // with it and the attribute read `[unserializable]`.
+    async function usage(): Promise<{ model: string; tokens: bigint }> {
+      return { model: 'gpt', tokens: 9007199254740993n }
+    }
+
+    const fn = withOnlineEvaluation(usage, {
+      evaluators: [new AlwaysPass()],
+      recordReturn: true,
+      target: 'bigint-return',
+    })
+
+    const { spans } = await withMemoryLogExporter(async () => {
+      await fn()
+      await waitForEvaluations()
+    })
+
+    const callSpan = spans.find((s) => s.name === 'Calling bigint-return')!
+    // The exact value, not the rounded double `9007199254740992` that `Number` would give.
+    expect(callSpan.attributes['return']).toBe('{"model":"gpt","tokens":"9007199254740993"}')
+  })
+
   it('propagates baggage keys that collide with object members', async () => {
     const fn = withOnlineEvaluation(async (input: string) => input, {
       evaluators: [new AlwaysPass()],

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -1020,9 +1020,21 @@ describe('renderReport', () => {
 
     const text = renderReport(report, { includeOutput: true })
 
-    expect(text).toContain('undefined')
-    // The exact value, not the rounded double `9007199254740992` that `Number` would give.
-    expect(text).toContain('{"tokens":"9007199254740993"}')
+    // The whole table, so column widths and row placement are pinned too. The BigInt cell holds
+    // the exact value, not the rounded double `9007199254740992` that `Number` would give.
+    expect(text).toBe(
+      [
+        'Experiment: demo',
+        'Cases: 2, Failures: 0',
+        '',
+        '+-------+-------------+-------------------------------+--------+--------+------------+',
+        '| name  | duration(s) | output                        | scores | labels | assertions |',
+        '+=======+=============+===============================+========+========+============+',
+        '| empty | 0.100       | undefined                     | -      | -      | -          |',
+        '| big   | 0.100       | {"tokens":"9007199254740993"} | -      | -      | -          |',
+        '+-------+-------------+-------------------------------+--------+--------+------------+',
+      ].join('\n')
+    )
   })
 
   it('does not leave a lone surrogate when truncating a rendered input', () => {

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -1000,6 +1000,31 @@ describe('renderReport', () => {
     expect(text).toContain('ok=✓')
   })
 
+  it('renders a case whose output JSON.stringify cannot return a string for', () => {
+    // A task that returns nothing is ordinary, and `JSON.stringify(undefined)` is `undefined`,
+    // not `'undefined'`, so `truncate` read `.length` off it and the whole render threw. A BigInt
+    // anywhere in the value throws outright, which is the seam `serializeAttributes` already
+    // covers with a replacer.
+    const report: EvaluationReport = {
+      analyses: [],
+      cases: [
+        makeReportCase({ inputs: 'a', name: 'empty', output: undefined }),
+        makeReportCase({ inputs: 'b', name: 'big', output: { tokens: 9007199254740993n } }),
+      ],
+      failures: [],
+      name: 'demo',
+      report_evaluator_failures: [],
+      span_id: 's',
+      trace_id: 't',
+    }
+
+    const text = renderReport(report, { includeOutput: true })
+
+    expect(text).toContain('undefined')
+    // The exact value, not the rounded double `9007199254740992` that `Number` would give.
+    expect(text).toContain('{"tokens":"9007199254740993"}')
+  })
+
   it('does not leave a lone surrogate when truncating a rendered input', () => {
     // The repr is '"' + value + '"' and the limit is 30, so the cut lands on the
     // emoji's high half.

--- a/packages/logfire-api/src/evals/online.ts
+++ b/packages/logfire-api/src/evals/online.ts
@@ -604,7 +604,9 @@ function encodeReturnAttribute(output: unknown): boolean | number | string {
     return `${output.name}: ${output.message}`
   }
   try {
-    return JSON.stringify(output)
+    // Same BigInt replacer as the other output seams: without it a returned BigInt, or any
+    // object carrying one, collapses to `[unserializable]` and takes every sibling field with it.
+    return JSON.stringify(output, (_key, item: unknown) => (typeof item === 'bigint' ? item.toString() : item))
   } catch {
     return '[unserializable]'
   }

--- a/packages/logfire-api/src/evals/render.ts
+++ b/packages/logfire-api/src/evals/render.ts
@@ -57,10 +57,10 @@ function renderCaseTable<I, O, M>(cases: readonly ReportCase<I, O, M>[], opts: R
   for (const c of cases) {
     const row: string[] = [c.name, c.task_duration.toFixed(3)]
     if (opts.includeInput === true) {
-      row.push(truncate(JSON.stringify(c.inputs), 30))
+      row.push(truncate(renderCell(c.inputs), 30))
     }
     if (opts.includeOutput === true) {
-      row.push(truncate(JSON.stringify(c.output), 30))
+      row.push(truncate(renderCell(c.output), 30))
     }
     row.push(formatResultMap(c.scores), formatResultMap(c.labels), formatResultMap(c.assertions))
     rows.push(row)
@@ -89,6 +89,24 @@ function formatValue(v: unknown): string {
     return v.toFixed(3).replace(/\.?0+$/u, '')
   }
   return String(v)
+}
+
+/**
+ * `JSON.stringify` is not total, and both of its gaps reach this table through a task's own
+ * return value. It gives back `undefined` rather than a string for `undefined`, a function or a
+ * symbol, and a task that returns nothing is ordinary, so `truncate` was reading `.length` off
+ * `undefined` and taking the whole report render with it. It also throws on a BigInt at any
+ * depth, the same seam `serializeAttributes` covers with a replacer.
+ */
+function renderCell(value: unknown): string {
+  try {
+    // A `typeof` check rather than `??`, the same way `stringifyJsonAttribute` reads this result:
+    // `JSON.stringify` is typed as returning `string` even though it does not always.
+    const serialized = JSON.stringify(value, (_key, item: unknown) => (typeof item === 'bigint' ? item.toString() : item))
+    return typeof serialized === 'string' ? serialized : String(value)
+  } catch {
+    return '[unserializable]'
+  }
 }
 
 function truncate(s: string, max: number): string {


### PR DESCRIPTION
Two output paths in the evals package encode a task's own return value with a bare `JSON.stringify`. That function is not total: it returns `undefined` rather than a string for `undefined`, a function or a symbol, and it throws on a `BigInt` at any depth. Both gaps are reachable from an ordinary task.

**`renderReport` crashes on a task that returns nothing.**

```ts
row.push(truncate(JSON.stringify(c.output), 30))
```

`truncate` reads `s.length`. A task typed `Promise<void>` gives `output === undefined`, `JSON.stringify` gives back `undefined`, and the whole report render dies rather than the one cell. On `main`:

```
renderReport(report, { includeOutput: true })
  output: undefined   -> TypeError: Cannot read properties of undefined (reading 'length')
  output: {tokens:5n} -> TypeError: Do not know how to serialize a BigInt
```

**`withOnlineEvaluation`'s `recordReturn` loses the whole return value to one BigInt field.**

```ts
try { return JSON.stringify(output) } catch { return '[unserializable]' }
```

A returned `{ model, tokens }` where `tokens` is a `BigInt` records `[unserializable]`, taking `model` with it. This is the same seam 4d26af7 closed for span attributes last week, in the spot that fix did not reach: `recordReturn` writes through `span.setAttribute` directly, so it never passes through `serializeAttributes`.

Both now use the replacer the attribute seam already applies, and `renderReport` reads the result with a `typeof` check the way `stringifyJsonAttribute` does, since `JSON.stringify` is typed as returning `string` even when it does not.

The tests assert the exact serialized value, `{"tokens":"9007199254740993"}`, rather than the rounded `9007199254740992` a `Number` conversion would give.

One note on the local gate: `pnpm run typecheck` currently fails here on `vite.shared.ts(13)`, `Buffer<ArrayBufferLike> is not assignable to string`. That is not from this diff. It reproduces on a clean checkout of `main`, and it is a hoisting artifact, my install has both `@types/node@20.19.28` and `@22.19.5` and the root has no pin of its own while `logfire-session-replay` asks for `^22.5.1`. Lint, test and build all pass. Flagging it rather than quietly ignoring it, and happy to open a separate issue about the missing root pin if it is not already known.

Built this with Claude Code's help and reviewed the diff myself.
