### PR TITLE
Add compact browser resource timing mode

### DIFF
--- a/.changeset/compact-browser-resource-timing.md
+++ b/.changeset/compact-browser-resource-timing.md
@@ -1,0 +1,7 @@
+---
+'@pydantic/logfire-browser': minor
+---
+
+Add a first-class browser resource timing detail policy. Summary mode keeps
+document and resource spans while reducing telemetry volume by omitting network
+and DOM phase events; full mode retains them for detailed diagnostics.

--- a/docs/packages/browser.md
+++ b/docs/packages/browser.md
@@ -40,6 +40,34 @@ Logfire associates the token with the frontend application's service name, so it
 
 `autoInstrumentations` is opt-in and lazily loads OpenTelemetry browser auto-instrumentations after the Logfire browser provider is ready. For advanced integrations, `instrumentations` also accepts factories, so custom instrumentation construction can be deferred until `configure()` has registered the provider.
 
+### Resource timing detail
+
+Use compact resource timing to keep the `documentLoad`, `documentFetch`, and
+per-asset `resourceFetch` spans while omitting their DNS, connection, TLS,
+request, response, and DOM timing events:
+
+```ts
+logfire.configure({
+  ...frontendApplicationConfig,
+  autoInstrumentations: true,
+  resourceTiming: { detail: 'summary' },
+})
+```
+
+`summary` is the default when `resourceTiming` is configured, so
+`resourceTiming: {}` is equivalent. Use `detail: 'full'` when you need the
+phase events for detailed diagnostics. Full detail increases telemetry volume,
+especially on pages with many static assets.
+
+`resourceTiming` controls only the document-load instrumentation created by
+`autoInstrumentations`; it does not enable auto-instrumentation or override an
+explicitly disabled document-load instrumentation. When the raw
+`@opentelemetry/instrumentation-document-load.ignoreNetworkEvents` option is
+also present, `resourceTiming.detail` takes precedence. Other raw document-load
+options remain unchanged. Summary mode does not remove `firstPaint` or
+`firstContentfulPaint`; use the upstream `ignorePerformancePaintEvents` option
+if you also want to omit paint events.
+
 Use `diagLogLevel` while troubleshooting local browser instrumentation:
 
 ```ts

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -30,6 +30,31 @@ write token server-side. They demonstrate a local proxy, not a production proxy
 design. For direct ingest, use a restricted frontend application token. Never
 put a normal Logfire write token in browser code.
 
+## Resource timing detail
+
+When browser auto-instrumentation is enabled, compact resource timing keeps the
+`documentLoad`, `documentFetch`, and per-asset `resourceFetch` spans while
+omitting their DNS, connection, TLS, request, response, and DOM timing events:
+
+```js
+logfire.configure({
+  traceUrl: '/client-traces',
+  autoInstrumentations: true,
+  resourceTiming: { detail: 'summary' },
+})
+```
+
+`summary` is the default when `resourceTiming` is configured. Use
+`detail: 'full'` for detailed phase events at a higher telemetry volume.
+Omitting `resourceTiming` preserves the OpenTelemetry default and any raw
+document-load configuration.
+
+This option does not enable auto-instrumentation or an explicitly disabled
+document-load instrumentation. It takes precedence over the raw
+`ignoreNetworkEvents` field when both are present and preserves other raw
+document-load options. Summary mode keeps paint events; use the upstream
+`ignorePerformancePaintEvents` option to omit those separately.
+
 ## Managed Variables
 
 Browser applications can use local managed variables from `logfire/vars` when

--- a/packages/logfire-browser/src/index.test.ts
+++ b/packages/logfire-browser/src/index.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/first */
-import type { Context, ContextManager } from '@opentelemetry/api'
+import type { Context, ContextManager, Span } from '@opentelemetry/api'
 import { context, diag, ROOT_CONTEXT, trace } from '@opentelemetry/api'
 import type { Instrumentation } from '@opentelemetry/instrumentation'
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-web'
@@ -1060,6 +1060,104 @@ describe('browser span processors', () => {
     })
   })
 
+  it.each([
+    [{}, true],
+    [{ detail: 'summary' as const }, true],
+    [{ detail: 'full' as const }, false],
+  ])('maps resource timing detail to document-load network events', async (resourceTiming, ignoreNetworkEvents) => {
+    cleanup = configure({
+      autoInstrumentations: true,
+      resourceTiming,
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+    await waitForConfigureMicrotasks()
+
+    const config = mocks.autoInstrumentationConfigs.at(-1) as Record<string, { ignoreNetworkEvents?: boolean }>
+    expect(config['@opentelemetry/instrumentation-document-load']?.ignoreNetworkEvents).toBe(ignoreNetworkEvents)
+  })
+
+  it.each([
+    [null, 'logfire-browser: resourceTiming must be an object'],
+    [true, 'logfire-browser: resourceTiming must be an object'],
+    [{ detail: 'verbose' }, 'logfire-browser: resourceTiming.detail must be "summary" or "full"'],
+  ])('rejects invalid resource timing config before provider activation', (resourceTiming, expectedError) => {
+    expect(() =>
+      configure({
+        autoInstrumentations: true,
+        resourceTiming: resourceTiming as never,
+        traceUrl: 'http://localhost:8989/client-traces',
+      })
+    ).toThrow(expectedError)
+    expect(mocks.lifecycleEvents).toEqual([])
+  })
+
+  it('preserves raw document-load configuration unless the first-class policy owns the network detail', async () => {
+    const documentLoad = vi.fn<(span: Span) => void>()
+    const documentFetch = vi.fn<(span: Span) => void>()
+    const resourceFetch = vi.fn<(span: Span, resource: PerformanceResourceTiming) => void>()
+    const documentLoadConfig = {
+      applyCustomAttributesOnSpan: { documentFetch, documentLoad, resourceFetch },
+      enabled: false,
+      ignoreNetworkEvents: false,
+      ignorePerformancePaintEvents: true,
+      semconvStabilityOptIn: 'http',
+    }
+    const autoInstrumentations = {
+      '@opentelemetry/instrumentation-document-load': documentLoadConfig,
+    }
+
+    cleanup = configure({
+      autoInstrumentations,
+      resourceTiming: { detail: 'summary' },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+    await waitForConfigureMicrotasks()
+
+    const resolved = (
+      mocks.autoInstrumentationConfigs.at(-1) as Record<
+        string,
+        {
+          applyCustomAttributesOnSpan?: unknown
+          enabled?: boolean
+          ignoreNetworkEvents?: boolean
+          ignorePerformancePaintEvents?: boolean
+          semconvStabilityOptIn?: string
+        }
+      >
+    )['@opentelemetry/instrumentation-document-load']
+    expect(resolved).toEqual({ ...documentLoadConfig, ignoreNetworkEvents: true })
+    expect(resolved?.applyCustomAttributesOnSpan).toBe(documentLoadConfig.applyCustomAttributesOnSpan)
+    expect(autoInstrumentations['@opentelemetry/instrumentation-document-load']).toBe(documentLoadConfig)
+    expect(documentLoadConfig.ignoreNetworkEvents).toBe(false)
+  })
+
+  it('leaves the raw document-load network policy unchanged when resource timing is omitted', async () => {
+    cleanup = configure({
+      autoInstrumentations: {
+        '@opentelemetry/instrumentation-document-load': { ignoreNetworkEvents: true },
+      },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+    await waitForConfigureMicrotasks()
+
+    const config = mocks.autoInstrumentationConfigs.at(-1) as Record<string, { ignoreNetworkEvents?: boolean }>
+    expect(config['@opentelemetry/instrumentation-document-load']?.ignoreNetworkEvents).toBe(true)
+  })
+
+  it('lets full resource timing override a raw compact network policy', async () => {
+    cleanup = configure({
+      autoInstrumentations: {
+        '@opentelemetry/instrumentation-document-load': { ignoreNetworkEvents: true },
+      },
+      resourceTiming: { detail: 'full' },
+      traceUrl: 'http://localhost:8989/client-traces',
+    })
+    await waitForConfigureMicrotasks()
+
+    const config = mocks.autoInstrumentationConfigs.at(-1) as Record<string, { ignoreNetworkEvents?: boolean }>
+    expect(config['@opentelemetry/instrumentation-document-load']).toEqual({ ignoreNetworkEvents: false })
+  })
+
   it('merges every SDK endpoint into fetch and XHR ignores without mutating caller config', async () => {
     const fetchIgnores = [/consumer-fetch/u]
     const xhrIgnores = ['https://app.example/consumer-xhr']
@@ -1177,6 +1275,7 @@ describe('browser span processors', () => {
   it('does not load first-class browser auto-instrumentations when disabled', async () => {
     cleanup = configure({
       autoInstrumentations: { enabled: false },
+      resourceTiming: { detail: 'summary' },
       traceUrl: 'http://localhost:8989/client-traces',
     })
     await waitForConfigureMicrotasks()

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -94,6 +94,11 @@ type TraceExporterConfig = NonNullable<typeof OTLPTraceExporter extends new (con
 export type BrowserInstrumentationInput = Instrumentation | Instrumentation[] | (() => Instrumentation | Instrumentation[])
 export type AutoInstrumentationsConfig = WebAutoInstrumentationConfigMap & { enabled?: boolean }
 
+export interface BrowserResourceTimingOptions {
+  /** Resource timing detail. Defaults to `summary` when configured. */
+  detail?: 'summary' | 'full'
+}
+
 export interface BrowserSessionReplayHandle {
   readonly mode: 'full' | 'buffer' | 'off'
   readonly recording: boolean
@@ -190,6 +195,11 @@ export interface LogfireConfigOptions {
    */
   rum?: RUMOptions
   /**
+   * Controls document-load resource timing detail when auto-instrumentations
+   * are enabled. Summary mode omits network and DOM timing events.
+   */
+  resourceTiming?: BrowserResourceTimingOptions
+  /**
    * Experimental browser session replay options. Replay is disabled unless this
    * is configured.
    *
@@ -255,6 +265,21 @@ function resolveBrowserLongAnimationFramesOptions(
   }
 
   return longAnimationFrames === true ? {} : longAnimationFrames
+}
+
+function resolveBrowserResourceTimingOptions(resourceTiming: unknown): BrowserResourceTimingOptions | undefined {
+  if (resourceTiming === undefined) {
+    return undefined
+  }
+  if (typeof resourceTiming !== 'object' || resourceTiming === null || Array.isArray(resourceTiming)) {
+    throw new Error('logfire-browser: resourceTiming must be an object')
+  }
+
+  const detail = (resourceTiming as { detail?: unknown }).detail ?? 'summary'
+  if (detail !== 'summary' && detail !== 'full') {
+    throw new Error('logfire-browser: resourceTiming.detail must be "summary" or "full"')
+  }
+  return { detail }
 }
 
 function resolveBrowserMetricsOptions(metrics: LogfireConfigOptions['metrics']): BrowserMetricsOptions | undefined {
@@ -327,6 +352,7 @@ function flattenInstrumentations(instrumentations: Instrumentation | Instrumenta
 
 function resolveAutoInstrumentationsConfig(
   autoInstrumentations: LogfireConfigOptions['autoInstrumentations'],
+  resourceTiming: LogfireConfigOptions['resourceTiming'],
   telemetryUrls: { metricUrl?: string | undefined; replayUrl?: string | undefined; traceUrl: string }
 ): WebAutoInstrumentationConfigMap | undefined {
   if (autoInstrumentations === undefined || autoInstrumentations === false) {
@@ -346,11 +372,21 @@ function resolveAutoInstrumentationsConfig(
   ])
   const fetchKey = '@opentelemetry/instrumentation-fetch'
   const xhrKey = '@opentelemetry/instrumentation-xml-http-request'
+  const documentLoadKey = '@opentelemetry/instrumentation-document-load'
   const fetchConfig = instrumentationConfig[fetchKey]
   const xhrConfig = instrumentationConfig[xhrKey]
+  const documentLoadConfig = instrumentationConfig[documentLoadKey]
 
   return {
     ...instrumentationConfig,
+    ...(resourceTiming === undefined
+      ? {}
+      : {
+          [documentLoadKey]: {
+            ...documentLoadConfig,
+            ignoreNetworkEvents: resourceTiming.detail !== 'full',
+          },
+        }),
     [fetchKey]: {
       ...fetchConfig,
       ignoreUrls: [...(fetchConfig?.ignoreUrls ?? []), ...endpointPatterns],
@@ -369,6 +405,7 @@ function noopUnregister(): void {
 function startBrowserInstrumentations(options: {
   autoInstrumentations: LogfireConfigOptions['autoInstrumentations']
   instrumentations: LogfireConfigOptions['instrumentations']
+  resourceTiming: LogfireConfigOptions['resourceTiming']
   telemetryUrls: { metricUrl?: string | undefined; replayUrl?: string | undefined; traceUrl: string }
   tracerProvider: WebTracerProvider
 }): () => Promise<void> {
@@ -390,7 +427,11 @@ function startBrowserInstrumentations(options: {
       diag.error('logfire-browser: failed to start configured browser instrumentation group', error)
     }
   }
-  const autoInstrumentationsConfig = resolveAutoInstrumentationsConfig(options.autoInstrumentations, options.telemetryUrls)
+  const autoInstrumentationsConfig = resolveAutoInstrumentationsConfig(
+    options.autoInstrumentations,
+    options.resourceTiming,
+    options.telemetryUrls
+  )
   const unregisterAutoInstrumentationsPromise =
     autoInstrumentationsConfig === undefined
       ? undefined
@@ -477,6 +518,7 @@ export function configure(options: LogfireConfigOptions): BrowserConfigureHandle
   const longAnimationFramesOptions = resolveBrowserLongAnimationFramesOptions(options.rum?.longAnimationFrames)
   const sessionReplayOptions = resolveBrowserSessionReplayOptions(options.sessionReplay)
   const browserMetricsOptions = resolveBrowserMetricsOptions(options.metrics)
+  const resourceTimingOptions = resolveBrowserResourceTimingOptions(options.resourceTiming)
   const webVitalsMetricOptions = resolveBrowserWebVitalsMetricOptions(webVitalsOptions)
   if (webVitalsMetricOptions !== undefined && browserMetricsOptions === undefined) {
     throw new Error('logfire-browser: rum.webVitals.metrics requires top-level metrics.metricUrl')
@@ -607,6 +649,7 @@ export function configure(options: LogfireConfigOptions): BrowserConfigureHandle
   const unregisterInstrumentations = startBrowserInstrumentations({
     autoInstrumentations: options.autoInstrumentations,
     instrumentations: options.instrumentations,
+    resourceTiming: resourceTimingOptions,
     telemetryUrls: {
       metricUrl: browserMetricsOptions?.metricUrl,
       replayUrl:

--- a/packages/logfire-browser/src/resourceTiming.integration.test.ts
+++ b/packages/logfire-browser/src/resourceTiming.integration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-web'
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test'
+
+import { configure } from './index'
+
+vi.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
+  OTLPTraceExporter: class {
+    export(_spans: unknown, resultCallback: (result: { code: number }) => void): void {
+      resultCallback({ code: 0 })
+    }
+
+    async shutdown(): Promise<void> {
+      return Promise.resolve()
+    }
+  },
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('browser resource timing', () => {
+  it.each([
+    ['summary' as const, false],
+    ['full' as const, true],
+  ])('exports document and resource spans with %s detail', async (detail, includesNetworkEvents) => {
+    const navigation = createNavigationTiming()
+    const resources = ['script', 'css', 'font', 'img'].map((initiatorType, index) => createResourceTiming(initiatorType, index))
+    const getEntriesByType = (type: string): PerformanceEntry[] => {
+      if (type === 'navigation') {
+        return [navigation]
+      }
+      if (type === 'resource') {
+        return resources
+      }
+      if (type === 'paint') {
+        return [{ entryType: 'paint', name: 'first-contentful-paint', startTime: 95 } as unknown as PerformancePaintTiming]
+      }
+      return []
+    }
+    vi.spyOn(performance, 'getEntriesByType').mockImplementation(getEntriesByType as typeof performance.getEntriesByType)
+    const exporter = new InMemorySpanExporter()
+    const cleanup = configure({
+      autoInstrumentations: {
+        '@opentelemetry/instrumentation-document-load': { enabled: true },
+        '@opentelemetry/instrumentation-fetch': { enabled: false },
+        '@opentelemetry/instrumentation-user-interaction': { enabled: false },
+        '@opentelemetry/instrumentation-xml-http-request': { enabled: false },
+      },
+      resourceTiming: { detail },
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+      traceUrl: '/client-traces',
+    })
+
+    try {
+      await waitUntil(() => exporter.getFinishedSpans().length === 6)
+      const spans = exporter.getFinishedSpans()
+      expect(spans.map(({ name }) => name).sort()).toEqual([
+        'documentFetch',
+        'documentLoad',
+        'resourceFetch',
+        'resourceFetch',
+        'resourceFetch',
+        'resourceFetch',
+      ])
+
+      const documentLoad = spans.find(({ name }) => name === 'documentLoad')
+      const documentFetch = spans.find(({ name }) => name === 'documentFetch')
+      const resourceSpans = spans.filter(({ name }) => name === 'resourceFetch')
+      expect(documentLoad?.duration).toEqual([0, 110_000_000])
+      expect(documentFetch?.duration).toEqual([0, 80_000_000])
+      expect(resourceSpans.map(({ duration }) => duration)).toEqual([
+        [0, 25_000_000],
+        [0, 25_000_000],
+        [0, 25_000_000],
+        [0, 25_000_000],
+      ])
+      expect(resourceSpans.map(({ attributes }) => attributes['http.url'])).toEqual(resources.map(({ name }) => name))
+      expect(resourceSpans.map(({ attributes }) => attributes['http.response_content_length'])).toEqual(
+        resources.map(({ encodedBodySize }) => encodedBodySize)
+      )
+      expect(resourceSpans.map(({ attributes }) => attributes['http.response_content_length_uncompressed'])).toEqual(
+        resources.map(({ decodedBodySize }) => decodedBodySize)
+      )
+      expect(documentFetch?.attributes).toMatchObject({
+        'http.response_content_length': navigation.encodedBodySize,
+        'http.response_content_length_uncompressed': navigation.decodedBodySize,
+      })
+      expect(documentLoad?.events.map(({ name }) => name)).toEqual(
+        includesNetworkEvents
+          ? [
+              'fetchStart',
+              'unloadEventStart',
+              'unloadEventEnd',
+              'domInteractive',
+              'domContentLoadedEventStart',
+              'domContentLoadedEventEnd',
+              'domComplete',
+              'loadEventStart',
+              'loadEventEnd',
+              'firstContentfulPaint',
+            ]
+          : ['firstContentfulPaint']
+      )
+      const fetchAndResourceEventNames = [
+        'fetchStart',
+        'domainLookupStart',
+        'domainLookupEnd',
+        'connectStart',
+        'secureConnectionStart',
+        'connectEnd',
+        'requestStart',
+        'responseStart',
+        'responseEnd',
+      ]
+      expect(documentFetch?.events.map(({ name }) => name)).toEqual(includesNetworkEvents ? fetchAndResourceEventNames : [])
+      for (const span of resourceSpans) {
+        expect(span.events.map(({ name }) => name)).toEqual(includesNetworkEvents ? fetchAndResourceEventNames : [])
+        expect(span.parentSpanContext?.spanId).toBe(documentLoad?.spanContext().spanId)
+      }
+      expect(documentFetch?.parentSpanContext?.spanId).toBe(documentLoad?.spanContext().spanId)
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  return waitUntilDeadline(predicate, Date.now() + 5_000)
+}
+
+async function waitUntilDeadline(predicate: () => boolean, deadline: number): Promise<void> {
+  if (predicate()) {
+    return
+  }
+  if (Date.now() >= deadline) {
+    throw new Error('timed out waiting for resource timing spans')
+  }
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+  return waitUntilDeadline(predicate, deadline)
+}
+
+function createNavigationTiming(): PerformanceNavigationTiming {
+  return {
+    connectEnd: 30,
+    connectStart: 20,
+    decodedBodySize: 1_200,
+    domComplete: 105,
+    domContentLoadedEventEnd: 100,
+    domContentLoadedEventStart: 98,
+    domInteractive: 90,
+    domainLookupEnd: 20,
+    domainLookupStart: 15,
+    duration: 110,
+    encodedBodySize: 1_000,
+    entryType: 'navigation',
+    fetchStart: 10,
+    loadEventEnd: 120,
+    loadEventStart: 110,
+    name: 'http://localhost:3000/',
+    navigationStart: 0,
+    nextHopProtocol: 'h2',
+    redirectEnd: 0,
+    redirectStart: 0,
+    requestStart: 35,
+    responseEnd: 90,
+    responseStart: 50,
+    secureConnectionStart: 25,
+    serverTiming: [],
+    startTime: 0,
+    toJSON: () => ({}),
+    transferSize: 1_100,
+    type: 'navigate',
+    unloadEventEnd: 8,
+    unloadEventStart: 5,
+    workerStart: 0,
+  } as unknown as PerformanceNavigationTiming
+}
+
+function createResourceTiming(initiatorType: string, index: number): PerformanceResourceTiming {
+  const offset = index * 30
+  return {
+    connectEnd: 25 + offset,
+    connectStart: 20 + offset,
+    decodedBodySize: 2_000 + index,
+    domainLookupEnd: 20 + offset,
+    domainLookupStart: 15 + offset,
+    duration: 25,
+    encodedBodySize: 1_500 + index,
+    entryType: 'resource',
+    fetchStart: 10 + offset,
+    initiatorType,
+    name: `http://localhost:3000/static/asset-${String(index)}`,
+    nextHopProtocol: 'h2',
+    redirectEnd: 0,
+    redirectStart: 0,
+    requestStart: 27 + offset,
+    responseEnd: 35 + offset,
+    responseStart: 30 + offset,
+    secureConnectionStart: 22 + offset,
+    serverTiming: [],
+    startTime: 10 + offset,
+    toJSON: () => ({}),
+    transferSize: 1_700 + index,
+    workerStart: 0,
+  } as unknown as PerformanceResourceTiming
+}


### PR DESCRIPTION
## Why

Browser document-load instrumentation can emit many low-level network and DOM timing events for every page resource. Those events increase telemetry volume, while the document and resource spans are usually sufficient for routine RUM analysis. Consumers can configure the upstream OpenTelemetry switch today, but that behavior is not discoverable through the Logfire browser API.

## What changes

Add a typed `resourceTiming.detail` policy with `summary` and `full` modes. Summary mode retains document and resource spans, durations, attributes, and paint events while omitting network and DOM phase events. Full mode preserves the detailed phase events.

Existing configurations remain unchanged when `resourceTiming` is omitted. When the first-class policy and raw `ignoreNetworkEvents` option are both present, the first-class policy controls that field and preserves the rest of the caller-owned document-load configuration. Invalid JavaScript configuration fails before provider activation.

The behavior is covered through the real installed document-load instrumentation, including span relationships, durations, attributes, event sets, and both raw-option override directions. The full repository check passes.

## Limits

This policy does not enable auto-instrumentation or override an explicitly disabled document-load instrumentation. Summary mode does not remove paint events. Selective or slow-resource detail remains outside this change because the upstream integration exposes one boolean network-event switch.

Closes #300
