### PR TITLE
Keep both ends when truncating a message field or baggage value

### DIFF
--- a/.changeset/truncate-keep-both-ends.md
+++ b/.changeset/truncate-keep-both-ends.md
@@ -1,0 +1,12 @@
+---
+'logfire': patch
+---
+
+Keep both ends when truncating a message field or a baggage value.
+
+`truncateString` dropped everything past the limit and appended an ellipsis, so a long value lost
+its tail, which is usually the part that tells two values apart: the id at the end of a path, the
+filename at the end of a URL. Python's `truncate_string` puts the ellipsis in the middle and keeps
+both halves, and it is the same function behind both of the call sites here, message field values
+in `scrubbing.py` and baggage values in `baggage.py`. Both cuts are placed on a code point
+boundary, so neither end can keep half a surrogate pair.

--- a/packages/logfire-api/src/formatter.test.ts
+++ b/packages/logfire-api/src/formatter.test.ts
@@ -96,4 +96,14 @@ describe('truncateString', () => {
     expect(truncateString(`${'a'.repeat(60)}${'b'.repeat(60)}`, 100)).toBe(`${'a'.repeat(48)}...${'b'.repeat(48)}`)
     expect(truncateString('short', 100)).toBe('short')
   })
+
+  test('never returns more than it was given, however small the limit', () => {
+    // Without the clamp on `half` these produce a result longer than the input, which is what
+    // Python's `truncate_string` does today: `truncate_string('abcdefghij', max_length=1)` is
+    // `'abcdefghi...bcdefghij'`. Neither caller passes a limit this small, but the clamp is one
+    // `Math.max` and this pins it.
+    for (const limit of [0, 1, 2, 3, 4]) {
+      expect(truncateString('abcdefghij', limit)).toBe('...')
+    }
+  })
 })

--- a/packages/logfire-api/src/formatter.test.ts
+++ b/packages/logfire-api/src/formatter.test.ts
@@ -78,18 +78,22 @@ describe('message template nested field access', () => {
 })
 
 describe('truncateString', () => {
-  test('does not split a surrogate pair at the cut', () => {
-    // The emoji straddles the cut, so a code-unit slice would keep only its high half.
-    const value = `${'a'.repeat(96)}\u{1F600}${'b'.repeat(20)}`
+  test('does not split a surrogate pair at either cut', () => {
+    // Both ends are kept now, so there are two cuts to land wrong. An emoji straddles each one:
+    // the head cut at 48 and the tail cut at length - 48. A code-unit slice would keep the high
+    // half of the first and the low half of the second.
+    const value = `${'a'.repeat(47)}\u{1F600}${'m'.repeat(30)}\u{1F600}${'b'.repeat(47)}`
     const truncated = truncateString(value, 100)
 
-    expect(truncated).toBe(`${'a'.repeat(96)}...`)
+    expect(truncated).toBe(`${'a'.repeat(47)}...${'b'.repeat(47)}`)
     expect(truncated.split('').some((char) => char >= '\uD800' && char <= '\uDFFF')).toBe(false)
     expect(JSON.stringify(truncated).includes('\\ud')).toBe(false)
   })
 
-  test('cuts at the limit when the boundary is not a surrogate', () => {
-    expect(truncateString('a'.repeat(120), 100)).toBe(`${'a'.repeat(97)}...`)
+  test('keeps both ends when the boundaries are not surrogates', () => {
+    // Python's `truncate_string` is `seq[:half] + middle + seq[-half:]`, so the tail survives and
+    // the result can be one shorter than the limit when the remainder is odd.
+    expect(truncateString(`${'a'.repeat(60)}${'b'.repeat(60)}`, 100)).toBe(`${'a'.repeat(48)}...${'b'.repeat(48)}`)
     expect(truncateString('short', 100)).toBe('short')
   })
 })

--- a/packages/logfire-api/src/formatter.ts
+++ b/packages/logfire-api/src/formatter.ts
@@ -265,7 +265,14 @@ export function truncateString(str: string, maxLength: number): string {
     return str
   }
 
-  return str.substring(0, floorCodePointBoundary(str, maxLength - 3)) + '...'
+  // The ellipsis goes in the middle, keeping both ends, which is what Python's `truncate_string`
+  // does for the two values this is called with: a formatted message field and a baggage value.
+  // Dropping only the tail loses the part that usually tells two values apart, the id at the end
+  // of a path or the filename at the end of a URL.
+  const half = Math.max(0, Math.floor((maxLength - 3) / 2))
+  const head = str.slice(0, floorCodePointBoundary(str, half))
+  const tail = str.slice(ceilCodePointBoundary(str, str.length - half))
+  return `${head}...${tail}`
 }
 
 /**

--- a/packages/logfire-api/src/index.test.ts
+++ b/packages/logfire-api/src/index.test.ts
@@ -308,7 +308,9 @@ describe('baggage span attributes', () => {
 
     info('event')
 
-    expect(getStartSpanAttributes()['baggage.tenant']).toBe(`${'x'.repeat(997)}...`)
+    // Middle-truncated, matching Python's `baggage.py`, which caps at the same 1000 and uses the
+    // same `truncate_string`.
+    expect(getStartSpanAttributes()['baggage.tenant']).toBe(`${'x'.repeat(498)}...${'x'.repeat(498)}`)
   })
 
   test('copies baggage for startSpan', () => {


### PR DESCRIPTION
`truncateString` keeps the head and throws the rest away:

```ts
return str.substring(0, floorCodePointBoundary(str, maxLength - 3)) + '...'
```

Python keeps both ends. `truncate_string` in `_internal/utils.py` is:

```python
remaining_length = max_length - len(middle)
half = remaining_length // 2
return seq[:half] + middle + seq[-half:]
```

That is not an incidental difference between two helpers that happen to share a name. It is the same function behind the same two call sites:

| value | JS | Python |
|---|---|---|
| formatted message field | `cleanValue`, `MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT` | `scrubbing.py` `truncate()`, same constant |
| baggage value | `index.ts`, `MAX_BAGGAGE_VALUE_LENGTH = 1000` | `baggage.py`, same constant name and value |

The tail is usually the part that tells two values apart. `https://cdn.example.com/a/very/long/prefix/asset-9f21c4.js` and its neighbour differ in the last twelve characters; so do `/api/v1/tenants/.../orders/8813` and `.../orders/8814`. Cutting the end turns distinguishable values into identical ones in the message a user reads, and the Python SDK shows both halves for the same span.

The fix puts the ellipsis in the middle. Both cuts go through the existing boundary helpers, `floorCodePointBoundary` for the head and `ceilCodePointBoundary` for the tail, so neither end can keep half a surrogate pair. `ceilCodePointBoundary` has existed since #234 and until now had only one caller, in `Contains.ts`, which already truncates this way.

Three tests changed rather than being added, since they pinned the old shape:

- the surrogate test now puts an emoji across **both** cuts, not just the head, since there are two ways to land wrong now
- the plain-boundary test asserts both halves survive
- the baggage test in `index.test.ts` asserts the middle-truncated value

Not touching the limit itself. `MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT` is 2000 here and 128 in Python, which is a separate decision with a much larger blast radius, and I would rather ask about it than fold it in.

One note on the local gate: `pnpm run typecheck` fails here on `vite.shared.ts(13)`, `Buffer<ArrayBufferLike> is not assignable to string`. Not from this diff, it reproduces on a clean checkout of `main`, and lint, test and build all pass.

Built this with Claude Code's help and reviewed the diff myself.
