### PR TITLE
Add `@pydantic/logfire-node/agent-control`, the framework-neutral core of Agent Control

### DIFF
--- a/.changeset/agent-control-core.md
+++ b/.changeset/agent-control-core.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-node': minor
+---
+
+Add `@pydantic/logfire-node/agent-control`, the framework-neutral core of Logfire Agent Control: change an agent's instructions, model, model settings, and tool definitions from the Logfire UI without a deploy. An agent's config is one `agent__<name>` managed variable holding an `AgentConfig`, and every section of it is a patch — present means managed, absent means code, and a value that cannot be resolved or understood leaves the agent running exactly as written. `AgentControl` owns the variable and the baseline it publishes as the variable's `example`; `applyInstructions`, `applyToolDefinitions`, `applySettings`, and `buildBaseline` are pure functions over plain data, so a framework adapter is a thin layer on top rather than a fork of the contract. `@pydantic/logfire-node/agent-control/testing` exports the resets an adapter's test suite needs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ vp run logfire#typecheck
 - `packages/logfire-node/src/logfireConfig.ts` owns Node SDK configuration and environment variable handling.
 - Relevant environment variables include `LOGFIRE_TOKEN`, `LOGFIRE_SERVICE_NAME`, `LOGFIRE_SERVICE_VERSION`, `LOGFIRE_ENVIRONMENT`, `LOGFIRE_CONSOLE`, `LOGFIRE_SEND_TO_LOGFIRE`, and `LOGFIRE_DISTRIBUTED_TRACING`.
 - `packages/logfire-api` is the base API package and should not depend on runtime-specific packages.
+- `packages/logfire-node/src/agent-control/spec` is vendored from the Python repository, which owns those cross-language conformance vectors. It is excluded from `vp fmt` and pinned by a digest test; re-vendor by copying the files and updating the digests, never by editing them here.
 - Cloudflare Workers code should stay compatible with Worker runtime constraints.
 - Browser code should avoid Node-only APIs.
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -120,7 +120,7 @@ Two rules about what a baseline carries are worth stating outright, because both
 
 `buildBaseline` produces the document and `control.publishBaseline` writes it. The write happens in the background, at most once per process per variable, and never throws. Pass `{ source: 'observed' }` when the earliest anything could be read was one request rather than the agent object, because the two mean different things to whoever reads them. If the variable does not exist it is created with the contract's stored JSON schema, which the Logfire backend then validates every written value against.
 
-Set `publishBaseline: false` when the variables token is intentionally read-only, or when code must not write variable metadata. Updating an existing variable is read-modify-write — the platform API takes the whole definition and offers no conditional write — so a value saved in the Logfire UI during that one round trip can be overwritten. The variable is re-read immediately before the write and the write is skipped when the baseline is already current, which is the steady state for a deployed agent, but a deployment that cannot tolerate that window should turn the publish off and create the variable in the UI.
+Set `publishBaseline: false` when the variables token is intentionally read-only, or when code must not write variable metadata. Updating an existing variable is read-modify-write — the platform API takes the whole definition and offers no conditional write — so a value saved in the Logfire UI during that one round trip can be overwritten. The provider is refreshed from the server first, the variable is re-read immediately before the write, and the write is skipped when the baseline is already current, which is the steady state for a deployed agent; a deployment that cannot tolerate that window should turn the publish off and create the variable in the UI.
 
 ## The Contract
 
@@ -138,7 +138,9 @@ The stored JSON schema is pinned by `SCHEMA_SHA256`, and the cross-language rule
 
 ## Framework Adapters
 
-The core is framework-neutral on purpose: it knows about instruction blocks, tool definitions, and settings, and about no framework's spelling of them. An adapter enumerates a baseline, installs its framework's hook, and calls the pure helpers. Three TypeScript adapters are built on it — for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Codex SDK** — each its own package, because a project that uses one has no reason to install the other two.
+The core is framework-neutral on purpose: it knows about instruction blocks, tool definitions, and settings, and about no framework's spelling of them. An adapter is what maps one framework onto those three: it enumerates a baseline, installs the framework's hook, and calls the pure helpers.
+
+TypeScript adapters for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Codex SDK** are in progress, each as its own package, because a project that uses one has no reason to install the other two. Until they land, the paragraph below is how to drive Agent Control from any framework directly.
 
 Python users get the same contract from [`logfire`](https://logfire.pydantic.dev/docs/) and [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness). A config published from the Logfire UI drives every one of them, because the variable name, the baseline, and the parse are the same three rules in both languages.
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -144,7 +144,7 @@ TypeScript adapters for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Code
 
 Python users get the same contract from [`logfire`](https://logfire.pydantic.dev/docs/) and [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness). A config published from the Logfire UI drives every one of them, because the variable name, the baseline, and the parse are the same three rules in both languages.
 
-Writing an adapter for something else is five things and nothing else: construct an `AgentControl`, resolve once per run, call `applyInstructions` / `applyToolDefinitions` / `applySettings`, build a baseline with `buildBaseline`, and publish it. `reportUnmatched` is how an adapter puts a section its framework cannot honor at all — a published `model` where models cannot be switched — through the same policy as everything else, rather than dropping it in silence.
+Writing an adapter for something else is five things and nothing else: construct an `AgentControl`, resolve once per run, call `applyInstructions` / `applyToolDefinitions` / `applySettings`, build a baseline with `buildBaseline`, and publish it. `control.reportUnmatched(message)` is how an adapter puts a section its framework cannot honor at all — a published `model` where models cannot be switched — through the same policy as everything else, rather than dropping it in silence; `reportUnapplied(keys)` does the same for the settings keys it has no knob for.
 
 See `examples/node/agent-control.ts` for a complete runnable example against a local variables config.
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -1,0 +1,153 @@
+---
+title: Agent Control
+description: Use @pydantic/logfire-node/agent-control to change an agent's instructions, model, settings, and tool definitions from Logfire.
+---
+
+# Agent Control
+
+Agent Control lets someone change what a running agent does — its instructions, its model, its model settings, the names and descriptions its tools are advertised under — from the Logfire UI, without a deploy.
+
+An agent's configuration lives in one [managed variable](managed-variables.md) named `agent__<name>`, holding a document called an `AgentConfig`. Every value in it is a _patch_ on the agent as written: a section that is present is managed from Logfire, a section that is absent keeps its code-defined behavior, and deleting a section in Logfire is a deliberate revert to code. If Logfire is unreachable, if nothing has been published, or if a published value cannot be understood, the agent runs on its code. A remote configuration must never take an agent down.
+
+`@pydantic/logfire-node/agent-control` is that mechanism with no agent framework attached: the contract, the variable plumbing, and pure helpers that apply a published value to whatever a given framework calls its instructions, its tools, and its settings. A framework adapter is a thin layer on top.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-node
+```
+
+Agent Control resolves its variable through the same configuration as every other managed variable, so there is nothing of its own to configure:
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure({
+  apiKey: process.env.LOGFIRE_API_KEY,
+  serviceName: 'checkout-api',
+})
+```
+
+## Usage
+
+```ts
+import { AgentControl, applyInstructions, applySettings, applyToolDefinitions, buildBaseline } from '@pydantic/logfire-node/agent-control'
+
+const control = new AgentControl('checkout_assistant', { label: 'production' })
+const options = { onUnmatched: control.onUnmatched }
+
+// Once per process, so the Logfire editor knows what it is editing.
+control.publishBaseline(buildBaseline({ instructions: codeBlocks, model, settings, tools: codeTools }))
+
+// Once per run: resolve, then do the whole run inside the resolution's telemetry context.
+const answer = await control.run(async ({ config }) => {
+  if (config === null) {
+    return runTheAgent({ blocks: codeBlocks, tools: codeTools, settings, model })
+  }
+  const { blocks } = applyInstructions(codeBlocks, config, options)
+  const { tools, routes } = applyToolDefinitions(codeTools, config, options)
+  return runTheAgent({
+    blocks,
+    tools,
+    routes,
+    settings: { ...settings, ...applySettings(config, options) },
+    model: config.model ?? model,
+  })
+})
+```
+
+Every span opened inside `run` carries the selected label on the SDK's own `logfire.variables.agent__checkout_assistant` baggage key, so a trace says which published version drove it. That is the difference between "this agent regressed" and "this agent regressed on the value someone saved at 14:02".
+
+`resolution()` and `resolve()` are there for an adapter whose framework offers no single scope to wrap. Where a framework hands out two hooks per run — an instructions callable and a model wrapper — resolve once and install that one resolution for the rest with `useResolution`, so a publish between the two cannot send prompt A with model B.
+
+## The Config Shape
+
+This is what someone publishes in the Logfire UI. Every key is optional.
+
+```jsonc
+{
+  "instructions": [
+    "Escalate anything over $500 to a human.", // no id -> adds a block
+    { "id": "agent", "instructions": "You are a refund specialist." }, // rewrites the agent's own text
+    { "id": "agent:refunds", "instructions": "Confirm the order total." }, // rewrites one named block
+    { "id": "toolset:legacy_crm" }, // no text -> removes that block
+  ],
+  "model": "anthropic:claude-fable-5-1",
+  "settings": { "temperature": 0.4, "max_tokens": 2048, "thinking": "high" },
+  "tool_definitions": [
+    {
+      "name": "get_weather",
+      "new_name": "lookup_weather",
+      "description": "Look up the current weather for a city.",
+      "parameters": { "city": { "description": "City name, e.g. 'London'" } },
+    },
+  ],
+}
+```
+
+A bare `"instructions": "text"` is also valid and means one added block, so a hand-written value gets the short form.
+
+`settings` carries eleven canonical keys, and only those: `max_tokens`, `temperature`, `top_p`, `top_k`, `seed`, `presence_penalty`, `frequency_penalty`, `parallel_tool_calls`, `timeout`, `stop_sequences`, `thinking`. These are the settings every framework Agent Control drives has a knob for, under the names Pydantic AI's `ModelSettings` gives them, so one published value means the same thing to every SDK reading it. Anything else is ignored and reported.
+
+## The Baseline
+
+The **baseline** is the same shape, describing the agent rather than changing it. The Logfire editor renders it as the thing a managed value is layered onto: it is published as the variable's `example`, and it is never resolved and never applied.
+
+```jsonc
+{
+  "instructions": [
+    { "id": "agent", "instructions": "You are a concise checkout assistant.", "dynamic": false },
+    { "id": "agent:refunds", "instructions": "Always confirm the order total.", "dynamic": false },
+    { "id": "agent:today", "dynamic": true },
+  ],
+  "model": "anthropic:claude-fable-5-1",
+  "settings": { "temperature": 0.1 },
+  "tool_definitions": [
+    {
+      "name": "get_weather",
+      "description": "Get the current weather for a city.",
+      "parameters": { "city": { "description": "City to look up." } },
+      "toolset": "<agent>",
+    },
+  ],
+}
+```
+
+Two rules about what a baseline carries are worth stating outright, because both are about not leaking anything into a document every member of a Logfire project can read:
+
+- **A dynamic block publishes its seam, never its text.** An instruction recomputed per request reads the run — a tenant, a user id, a retrieved document — so the baseline says only that the block exists and that it is not editable. That is also exactly what the editor needs.
+- **Settings are filtered to the canonical keys.** A framework's settings also carry provider-specific ones and things like extra headers and bodies, which is where authorization headers live. Those still apply to the run; they are just not part of this contract.
+
+`buildBaseline` produces the document and `control.publishBaseline` writes it. The write happens in the background, at most once per process per variable, and never throws. Pass `{ source: 'observed' }` when the earliest anything could be read was one request rather than the agent object, because the two mean different things to whoever reads them. If the variable does not exist it is created with the contract's stored JSON schema, which the Logfire backend then validates every written value against.
+
+Set `publishBaseline: false` when the variables token is intentionally read-only, or when code must not write variable metadata. Updating an existing variable is read-modify-write — the platform API takes the whole definition and offers no conditional write — so a value saved in the Logfire UI during that one round trip can be overwritten. The variable is re-read immediately before the write and the write is skipped when the baseline is already current, which is the steady state for a deployed agent, but a deployment that cannot tolerate that window should turn the publish off and create the variable in the UI.
+
+## The Contract
+
+Three things have to give the same answer in every language that implements Agent Control, because a Logfire project is shared and the SDKs are not.
+
+**Agent name to variable key.** A config lives at `agent__<key>`, where the key is the name trimmed, lowercased, with every character outside `[a-z0-9_]` replaced by `_`, runs of `_` collapsed, and `_` stripped from both ends. A name with nothing left after that is refused rather than turned into a variable. Lowercasing is the lossy step and it is the point: it is the rule the Logfire UI applies, so a Pydantic AI agent called `Checkout Assistant` and a Mastra agent called `checkout-assistant` land on the one config the UI shows for them. `control.name` stays the display name you passed; `control.variableName` is the key.
+
+**The unit of resolution.** Resolve once per run where the framework has a run seam, and hold that one `Resolution` for the whole of it: every span then agrees on the version that produced it, and a value published mid-run takes effect on the next run. Where a framework offers only a per-model-request hook, resolution is per request. Both are supportable. What is not supportable is resolving twice in one request.
+
+**Parsing a published value.** Leniency is per section: a section, entry, or setting this release cannot make sense of costs only itself, and everything around it still applies — because a value that fails validation outright falls back to the code-defined agent in its entirety. An invalid `model` drops only `model`. The instruction budget is charged to surviving entries only. Text length is counted in Unicode code points, so an emoji costs the same here as it does in Python. And `''` is never a value: not "no model", not "no instructions", just a field someone left half-filled.
+
+A published entry that is perfectly valid but reaches nothing in _this_ deployment — an instruction `id` no block carries, an override no advertised tool matches, a settings key that could not be applied — goes through the control's `onUnmatched` policy: `'warn'` (the default, once per process per message), `'error'`, or `'ignore'`. Each is a place where Logfire shows one thing and the agent does another, so none of them is dropped in silence.
+
+The stored JSON schema is pinned by `SCHEMA_SHA256`, and the cross-language rules above are pinned by conformance vectors this package runs against in its own test suite.
+
+## Framework Adapters
+
+The core is framework-neutral on purpose: it knows about instruction blocks, tool definitions, and settings, and about no framework's spelling of them. An adapter enumerates a baseline, installs its framework's hook, and calls the pure helpers. Three TypeScript adapters are built on it — for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Codex SDK** — each its own package, because a project that uses one has no reason to install the other two.
+
+Python users get the same contract from [`logfire`](https://logfire.pydantic.dev/docs/) and [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness). A config published from the Logfire UI drives every one of them, because the variable name, the baseline, and the parse are the same three rules in both languages.
+
+Writing an adapter for something else is five things and nothing else: construct an `AgentControl`, resolve once per run, call `applyInstructions` / `applyToolDefinitions` / `applySettings`, build a baseline with `buildBaseline`, and publish it. `reportUnmatched` is how an adapter puts a section its framework cannot honor at all — a published `model` where models cannot be switched — through the same policy as everything else, rather than dropping it in silence.
+
+See `examples/node/agent-control.ts` for a complete runnable example against a local variables config.
+
+## Related Guides
+
+- [Managed Variables](managed-variables.md)
+- [Node.js](packages/node.md)
+- [Configuration](configuration.md)

--- a/docs/managed-variables.md
+++ b/docs/managed-variables.md
@@ -119,3 +119,5 @@ await resolved.withContext(async () => {
 ```
 
 See `examples/node/variables.ts` for a complete local and remote example.
+
+[Agent Control](agent-control.md) is built on managed variables: an agent's instructions, model, settings, and tool definitions live in one `agent__<name>` variable that the Logfire UI edits.

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -77,6 +77,10 @@
         "slug": "managed-variables"
       },
       {
+        "label": "Agent Control",
+        "slug": "agent-control"
+      },
+      {
         "label": "Reference",
         "items": [
           {

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -246,3 +246,5 @@ unhandled-rejection behavior.
 - [Sampling](../sampling.md)
 - [Scrubbing](../scrubbing.md)
 - [Resource Attributes](../resource-attributes.md)
+- [Managed Variables](../managed-variables.md)
+- [Agent Control](../agent-control.md)

--- a/examples/node/agent-control.ts
+++ b/examples/node/agent-control.ts
@@ -1,0 +1,122 @@
+import 'dotenv/config'
+import * as logfire from '@pydantic/logfire-node'
+import { AgentControl, applyInstructions, applySettings, applyToolDefinitions, buildBaseline } from '@pydantic/logfire-node/agent-control'
+import type { InstructionBlock, ToolDef } from '@pydantic/logfire-node/agent-control'
+import type { VariablesConfig } from '@pydantic/logfire-node/vars'
+import { getVariableProvider } from '@pydantic/logfire-node/vars'
+
+// What someone would have saved in the Logfire UI for an agent named `Checkout Assistant`. The
+// variable name is the agent's name normalized: lowercased, with everything outside `[a-z0-9_]`
+// turned into `_`, which is the rule the UI and every Agent Control SDK share.
+const publishedConfig = {
+  instructions: [
+    // No `id`, so this adds a block rather than replacing one.
+    'Escalate anything over $500 to a human.',
+    // An `id` the baseline lists, so this rewrites that block in place.
+    { id: 'agent:refunds', instructions: 'Confirm the order total before issuing a refund.' },
+  ],
+  model: 'anthropic:claude-fable-5-1',
+  settings: { max_tokens: 2048, temperature: 0.4 },
+  tool_definitions: [
+    {
+      description: 'Look up the current weather for a city.',
+      name: 'get_weather',
+      new_name: 'lookup_weather',
+      parameters: { city: { description: "City name, e.g. 'London'" } },
+    },
+  ],
+}
+
+const localVariablesConfig = {
+  variables: {
+    agent__checkout_assistant: {
+      labels: {
+        production: { serialized_value: JSON.stringify(publishedConfig), version: 1 },
+      },
+      name: 'agent__checkout_assistant',
+      overrides: [],
+      rollout: { labels: { production: 1 } },
+    },
+  },
+} satisfies VariablesConfig
+
+logfire.configure({
+  console: false,
+  diagLogLevel: logfire.DiagLogLevel.NONE,
+  environment: 'local',
+  sendToLogfire: false,
+  serviceName: 'example-node-agent-control',
+  serviceVersion: '1.0.0',
+  variables: { config: localVariablesConfig, instrument: false },
+})
+
+// The agent as written. `dynamic` marks a block the agent recomputes per request: it cannot be
+// addressed by a managed value, because replacing it would pin one rendering forever and dropping
+// it would remove the computation, and its text is never published to the shared baseline.
+const codeBlocks: InstructionBlock[] = [
+  { dynamic: false, id: 'agent', text: 'You are a concise checkout assistant.' },
+  { dynamic: false, id: 'agent:refunds', text: 'Always confirm the order total.' },
+  { dynamic: true, id: 'agent:today', text: `Today is ${new Date().toDateString()}.` },
+]
+
+const codeTools: ToolDef[] = [
+  {
+    description: 'Get the current weather for a city.',
+    name: 'get_weather',
+    parametersJsonSchema: {
+      properties: { city: { description: 'City to look up.', type: 'string' } },
+      required: ['city'],
+      type: 'object',
+    },
+    toolset: '<agent>',
+  },
+]
+
+const codeModel = 'openai:gpt-5.6-sol'
+const codeSettings = { extra_headers: { 'x-tenant': 'acme' }, temperature: 0.1 }
+
+const control = new AgentControl('Checkout Assistant', { label: 'production' })
+console.log('display name:', control.name, '-> variable:', control.variableName)
+
+// Once per process: describe the agent for the Logfire editor to layer a value onto. It writes in
+// the background, at most once per variable, and never throws.
+control.publishBaseline(buildBaseline({ instructions: codeBlocks, model: codeModel, settings: codeSettings, tools: codeTools }))
+
+// Once per run: resolve, then do the whole run inside the resolution's telemetry context, so every
+// span carries the label the run was actually driven by.
+await control.run(async ({ config, label, reason, version }) => {
+  console.log('resolved:', { label, reason, version })
+  if (config === null) {
+    console.log('nothing published; running on the code-defined agent')
+    return
+  }
+
+  const options = { onUnmatched: control.onUnmatched }
+  const { blocks, unapplied: unappliedInstructions } = applyInstructions(codeBlocks, config, options)
+  const { tools, routes, unapplied: unappliedTools } = applyToolDefinitions(codeTools, config, options)
+  const settings = { ...codeSettings, ...applySettings(config, options) }
+
+  console.log('instructions sent to the model:')
+  for (const block of blocks) {
+    console.log(`  [${block.id ?? '<added>'}${block.dynamic ? ', dynamic' : ''}] ${block.text}`)
+  }
+  console.log(
+    'tools advertised:',
+    tools.map((tool) => tool.name)
+  )
+  // Routing is handed over rather than applied, because frameworks differ on whether the
+  // implementation should see its old name or its new one.
+  console.log('a call to `lookup_weather` runs:', routes['lookup_weather'])
+  console.log('model:', config.model ?? codeModel)
+  console.log('settings:', settings)
+  console.log('published entries that reached nothing:', [...unappliedInstructions, ...unappliedTools].length)
+
+  await logfire.span('checkout assistant run', {}, {}, async () => {
+    logfire.info('this span carries the resolved label on baggage')
+  })
+})
+
+const stored = await getVariableProvider().getVariableConfig?.('agent__checkout_assistant')
+console.log('baseline published as the variable example:\n', stored?.example)
+
+await logfire.shutdown()

--- a/examples/node/agent-control.ts
+++ b/examples/node/agent-control.ts
@@ -53,7 +53,10 @@ logfire.configure({
 // The agent as written. `dynamic` marks a block the agent recomputes per request: it cannot be
 // addressed by a managed value, because replacing it would pin one rendering forever and dropping
 // it would remove the computation, and its text is never published to the shared baseline.
-const codeBlocks: InstructionBlock[] = [
+// A function, not a constant: `dynamic: true` says the framework recomputes this block on every
+// request, so evaluating the date once at startup would have a long-running process telling the
+// model yesterday's date. Its text is never published either way -- the baseline gets the seam.
+const buildCodeBlocks = (): InstructionBlock[] => [
   { dynamic: false, id: 'agent', text: 'You are a concise checkout assistant.' },
   { dynamic: false, id: 'agent:refunds', text: 'Always confirm the order total.' },
   { dynamic: true, id: 'agent:today', text: `Today is ${new Date().toDateString()}.` },
@@ -80,7 +83,7 @@ console.log('display name:', control.name, '-> variable:', control.variableName)
 
 // Once per process: describe the agent for the Logfire editor to layer a value onto. It writes in
 // the background, at most once per variable, and never throws.
-control.publishBaseline(buildBaseline({ instructions: codeBlocks, model: codeModel, settings: codeSettings, tools: codeTools }))
+control.publishBaseline(buildBaseline({ instructions: buildCodeBlocks(), model: codeModel, settings: codeSettings, tools: codeTools }))
 
 // Once per run: resolve, then do the whole run inside the resolution's telemetry context, so every
 // span carries the label the run was actually driven by.
@@ -92,6 +95,8 @@ await control.run(async ({ config, label, reason, version }) => {
   }
 
   const options = { onUnmatched: control.onUnmatched }
+  // Rebuilt for this run, so the dynamic block carries this run's date rather than the process's.
+  const codeBlocks = buildCodeBlocks()
   const { blocks, unapplied: unappliedInstructions } = applyInstructions(codeBlocks, config, options)
   const { tools, routes, unapplied: unappliedTools } = applyToolDefinitions(codeTools, config, options)
   const settings = { ...codeSettings, ...applySettings(config, options) }

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,6 +9,7 @@
     "start-and-throw-error": "TRIGGER_ERROR=true node --experimental-strip-types --disable-warning=ExperimentalWarning index.ts",
     "sampling": "node --experimental-strip-types --disable-warning=ExperimentalWarning sampling.ts",
     "variables": "node --experimental-strip-types --disable-warning=ExperimentalWarning variables.ts",
+    "agent-control": "node --experimental-strip-types --disable-warning=ExperimentalWarning agent-control.ts",
     "evals": "node --experimental-strip-types --disable-warning=ExperimentalWarning evals.ts",
     "demo-evals": "node --experimental-strip-types --disable-warning=ExperimentalWarning demo_evals.ts",
     "demo-online-evals": "node --experimental-strip-types --disable-warning=ExperimentalWarning demo_online_evals.ts",

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -356,6 +356,30 @@ const resolved = await featureEnabled.get({ targetingKey: 'user-123' })
 
 Use local variables for tests and development without network access.
 
+## Agent Control
+
+Agent Control is available from `@pydantic/logfire-node/agent-control`. It backs one agent
+with one `agent__<name>` managed variable, so an agent's instructions, model, model
+settings, and tool definitions can be changed from the Logfire UI without a deploy. Every
+section of a published value is a patch: absent means code, and a value that cannot be
+resolved or understood leaves the agent running exactly as written.
+
+```ts
+import { AgentControl, applyInstructions, buildBaseline } from '@pydantic/logfire-node/agent-control'
+
+const control = new AgentControl('checkout_assistant', { label: 'production' })
+control.publishBaseline(buildBaseline({ instructions: codeBlocks, model, tools }))
+
+const answer = await control.run(async ({ config }) => {
+  const blocks = config === null ? codeBlocks : applyInstructions(codeBlocks, config).blocks
+  return runTheAgent(blocks)
+})
+```
+
+The core is framework-neutral; a framework adapter builds on it. See
+[the Agent Control guide](https://github.com/pydantic/logfire-js/blob/main/docs/agent-control.md)
+and `examples/node/agent-control.ts`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/pydantic/logfire-js/blob/main/CONTRIBUTING.md) for development instructions.

--- a/packages/logfire-node/package.json
+++ b/packages/logfire-node/package.json
@@ -60,6 +60,26 @@
         "types": "./dist/vars.d.cts",
         "default": "./dist/vars.cjs"
       }
+    },
+    "./agent-control": {
+      "import": {
+        "types": "./dist/agent-control/index.d.ts",
+        "default": "./dist/agent-control/index.js"
+      },
+      "require": {
+        "types": "./dist/agent-control/index.d.cts",
+        "default": "./dist/agent-control/index.cjs"
+      }
+    },
+    "./agent-control/testing": {
+      "import": {
+        "types": "./dist/agent-control/testing.d.ts",
+        "default": "./dist/agent-control/testing.js"
+      },
+      "require": {
+        "types": "./dist/agent-control/testing.d.cts",
+        "default": "./dist/agent-control/testing.cjs"
+      }
     }
   },
   "scripts": {
@@ -74,7 +94,8 @@
   },
   "dependencies": {
     "logfire": "workspace:*",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@opentelemetry/api": "catalog:",

--- a/packages/logfire-node/src/agent-control/__test__/baseline.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/baseline.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { buildBaseline } from '../index'
+import type { InstructionBlock, ToolDef } from '../index'
+import { captureWarnings } from './helpers'
+
+captureWarnings()
+
+const blocks: InstructionBlock[] = [
+  { id: 'agent', text: 'You are a checkout assistant.', dynamic: false },
+  { id: null, text: 'An unaddressable contribution.', dynamic: false },
+  { id: 'capability:clock', text: 'Today is 2026-09-09, and the user is u_8812.', dynamic: true },
+]
+
+const tools: ToolDef[] = [
+  {
+    name: 'search',
+    description: 'Search the CRM.',
+    parametersJsonSchema: {
+      type: 'object',
+      properties: { q: { type: 'string', description: 'Query.' }, limit: { type: 'integer' } },
+      required: ['q'],
+    },
+    toolset: 'crm',
+  },
+]
+
+describe('buildBaseline', () => {
+  it('describes the agent as written, in contract order and with nothing unset', () => {
+    const baseline = buildBaseline({
+      instructions: blocks,
+      model: 'anthropic:claude-fable-5-1',
+      settings: { temperature: 0.2, max_tokens: 1024 },
+      tools,
+    })
+    // The exact bytes that become the variable's `example`, which is what the Logfire editor shows
+    // as the thing a managed value is layered onto.
+    expect(JSON.stringify(baseline, null, 2)).toMatchInlineSnapshot(`
+      "{
+        "instructions": [
+          {
+            "id": "agent",
+            "instructions": "You are a checkout assistant.",
+            "dynamic": false
+          },
+          {
+            "instructions": "An unaddressable contribution.",
+            "dynamic": false
+          },
+          {
+            "id": "capability:clock",
+            "dynamic": true
+          }
+        ],
+        "model": "anthropic:claude-fable-5-1",
+        "settings": {
+          "max_tokens": 1024,
+          "temperature": 0.2
+        },
+        "tool_definitions": [
+          {
+            "name": "search",
+            "description": "Search the CRM.",
+            "parameters": {
+              "q": {
+                "description": "Query."
+              },
+              "limit": {}
+            },
+            "toolset": "crm"
+          }
+        ]
+      }"
+    `)
+  })
+
+  it("publishes a dynamic block's seam and never its text", () => {
+    const baseline = buildBaseline({ instructions: blocks })
+    const serialized = JSON.stringify(baseline)
+    expect(serialized).not.toContain('u_8812')
+    expect(serialized).toContain('{"id":"capability:clock","dynamic":true}')
+  })
+
+  it('drops a dynamic block nothing can address, which has neither an address nor safe text', () => {
+    const baseline = buildBaseline({
+      instructions: [{ id: null, text: 'Computed.', dynamic: true }],
+    })
+    expect(baseline.instructions).toBeUndefined()
+  })
+
+  it('drops a blank static block, which has nothing to describe', () => {
+    const baseline = buildBaseline({
+      instructions: [{ id: 'agent', text: '  \n ', dynamic: false }],
+    })
+    expect(baseline.instructions).toBeUndefined()
+  })
+
+  it('publishes the seam of a dynamic block whose text the adapter could not read', () => {
+    // A framework that renders its dynamic instructions inside a binary -- Codex, the Claude Agent
+    // SDK -- can name the block and nothing else, so it passes an empty `text`. That text was never
+    // going to be published anyway, which is why blankness must not cost the block its seam:
+    // dropping it erases from the baseline the one block the editor has no other way to learn about.
+    const baseline = buildBaseline({
+      instructions: [
+        { id: 'agent', text: 'You are a checkout assistant.', dynamic: false },
+        { id: 'harness:system', text: '', dynamic: true },
+      ],
+    })
+    expect(baseline.instructions).toEqual([
+      { id: 'agent', instructions: 'You are a checkout assistant.', dynamic: false },
+      { id: 'harness:system', dynamic: true },
+    ])
+  })
+
+  it('filters settings to the canonical keys, keeping provider secrets out of a shared variable', () => {
+    const baseline = buildBaseline({
+      settings: {
+        temperature: 0.2,
+        extra_headers: { authorization: 'Bearer sk-secret' },
+        top_k: null,
+      },
+    })
+    expect(baseline.settings).toEqual({ temperature: 0.2 })
+    expect(JSON.stringify(baseline)).not.toContain('sk-secret')
+  })
+
+  it('omits a section with nothing in it, rather than publishing an empty one', () => {
+    expect(buildBaseline({})).toEqual({})
+    expect(buildBaseline({ instructions: [], model: null, settings: null, tools: [] })).toEqual({})
+    expect(buildBaseline({ settings: {} })).toEqual({})
+  })
+
+  it('reports a tool with no description, no parameters, and no toolset as just its name', () => {
+    const baseline = buildBaseline({
+      tools: [{ name: 'ping', description: '', parametersJsonSchema: { type: 'object', properties: {} } }],
+    })
+    expect(baseline.tool_definitions).toEqual([{ name: 'ping' }])
+  })
+
+  it('lists every top-level parameter, so an undocumented one can be described from Logfire', () => {
+    const baseline = buildBaseline({
+      tools: [
+        {
+          name: 'a',
+          parametersJsonSchema: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+        { name: 'b', parametersJsonSchema: { type: 'string' } },
+        { name: 'c', parametersJsonSchema: { type: 'object', properties: { q: 'not a schema' } } },
+      ],
+    })
+    // `a`'s `q` and `c`'s `q` carry an empty entry rather than being left out: an undocumented
+    // parameter is exactly the one somebody wants to describe from Logfire, and a baseline listing
+    // only the documented ones would hide it until it had been documented in code first. `b` has no
+    // `properties` object at all, which is not a parameter list to guess at.
+    expect(baseline.tool_definitions).toEqual([{ name: 'a', parameters: { q: {} } }, { name: 'b' }, { name: 'c', parameters: { q: {} } }])
+  })
+
+  it('round-trips through the helpers it feeds, so a baseline is a config an override can address', () => {
+    const baseline = buildBaseline({ instructions: blocks, tools })
+    const ids = (baseline.instructions as { id?: string }[]).map((entry) => entry.id)
+    expect(ids).toEqual(['agent', undefined, 'capability:clock'])
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/config.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/config.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { CANONICAL_SETTINGS_KEYS, canonicalSettings, parseAgentConfig } from '../index'
+import { UNRECOGNIZED_SETTINGS } from '../config'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('parseAgentConfig', () => {
+  it('keeps a fully valid value as written', () => {
+    const value = {
+      instructions: ['Be brief.', { id: 'agent', instructions: 'You are a checkout assistant.' }],
+      model: 'anthropic:claude-fable-5-1',
+      settings: { temperature: 0.2, thinking: 'high', stop_sequences: ['STOP'] },
+      tool_definitions: [{ name: 'search', new_name: 'find', parameters: { q: { description: 'Query.' } } }],
+    }
+    // A string *inside the list* is normalized to the entry it is shorthand for, so every consumer
+    // sees one shape. Only the bare-string *section* keeps its shape; see the next test.
+    expect(parseAgentConfig(value)).toEqual({
+      ...value,
+      instructions: [{ instructions: 'Be brief.' }, { id: 'agent', instructions: 'You are a checkout assistant.' }],
+    })
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('keeps a bare instructions string in the shape its author wrote', () => {
+    expect(parseAgentConfig({ instructions: 'Be brief.' })).toEqual({ instructions: 'Be brief.' })
+  })
+
+  it('leaves absent sections absent, so nothing is managed by accident', () => {
+    expect(parseAgentConfig({})).toEqual({})
+  })
+
+  it('returns an empty config for a value that is not an object', () => {
+    expect(parseAgentConfig(['not', 'a', 'config'])).toEqual({})
+    expect(warnings.messages).toEqual(['Managed agent config is not an object -- ["not","a","config"]; ignoring it and running on code.'])
+  })
+
+  it('returns an empty config silently for a missing value', () => {
+    expect(parseAgentConfig(undefined)).toEqual({})
+    expect(parseAgentConfig(null)).toEqual({})
+    expect(warnings.messages).toEqual([])
+  })
+
+  describe('instructions', () => {
+    it('drops an invalid entry and keeps its siblings', () => {
+      const config = parseAgentConfig({ instructions: ['Keep me.', '', { id: 'agent' }] })
+      expect(config.instructions).toEqual([{ instructions: 'Keep me.' }, { id: 'agent' }])
+      expect(warnings.messages).toHaveLength(1)
+      expect(warnings.messages[0]).toContain("Managed instruction entry '' is invalid -- instructions=''")
+      expect(warnings.messages[0]).toContain('keeping the rest of the managed config')
+    })
+
+    it('drops an entry that says neither what nor where', () => {
+      expect(parseAgentConfig({ instructions: [{ dynamic: true }] }).instructions).toEqual([])
+      expect(warnings.messages[0]).toContain('has neither an `id` to address nor text to add')
+    })
+
+    it('drops an entry that is not a string or an object', () => {
+      expect(parseAgentConfig({ instructions: [42, 'Keep me.'] }).instructions).toEqual([{ instructions: 'Keep me.' }])
+      expect(warnings.messages[0]).toContain('Managed instruction entry 42 is invalid -- entry=42')
+    })
+
+    it('drops a section that is not a string or a list', () => {
+      expect(parseAgentConfig({ instructions: { id: 'agent' } }).instructions).toBeUndefined()
+      expect(warnings.messages[0]).toContain('Managed instructions section has invalid container')
+    })
+
+    it('ignores an absent section without a word', () => {
+      expect(parseAgentConfig({ instructions: null }).instructions).toBeUndefined()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('drops an empty section string', () => {
+      expect(parseAgentConfig({ instructions: '' }).instructions).toBeUndefined()
+      expect(warnings.messages[0]).toContain("Managed instructions section is invalid -- instructions=''")
+    })
+
+    it('drops a section string past the model-facing limit', () => {
+      expect(parseAgentConfig({ instructions: 'x'.repeat(65_537) }).instructions).toBeUndefined()
+      expect(warnings.messages[0]).toContain('contains 65537 characters, exceeding the 65536-character limit')
+    })
+
+    it('caps the total across entries, not just each one', () => {
+      const config = parseAgentConfig({
+        instructions: ['x'.repeat(65_000), 'y'.repeat(1_000), 'fits'],
+      })
+      expect(config.instructions).toEqual([{ instructions: 'x'.repeat(65_000) }, { instructions: 'fits' }])
+      expect(warnings.messages[0]).toContain('does not fit in the 536 remaining of the 65536-character limit')
+    })
+
+    it('strips a key the contract does not define', () => {
+      expect(parseAgentConfig({ instructions: [{ instructions: 'Hi.', nonsense: 1 }] }).instructions).toEqual([{ instructions: 'Hi.' }])
+    })
+  })
+
+  describe('model', () => {
+    it("drops an empty model rather than taking the agent down with a model named ''", () => {
+      expect(parseAgentConfig({ model: '', instructions: 'Kept.' })).toEqual({
+        instructions: 'Kept.',
+      })
+      expect(warnings.messages[0]).toContain("Managed agent config selects invalid model ''")
+    })
+
+    it('ignores an absent model without a word', () => {
+      expect(parseAgentConfig({ model: null }).model).toBeUndefined()
+      expect(warnings.messages).toEqual([])
+    })
+  })
+
+  describe('settings', () => {
+    it('drops one malformed value and keeps its siblings', () => {
+      const config = parseAgentConfig({ settings: { temperature: 'warm', max_tokens: 100 } })
+      expect(config.settings).toEqual({ max_tokens: 100 })
+      expect(warnings.messages[0]).toContain("Managed agent config setting 'temperature' has invalid value 'warm'")
+    })
+
+    it('drops a value a newer SDK would know, with its own message', () => {
+      const config = parseAgentConfig({ settings: { thinking: 'xxhigh', seed: 7 } })
+      expect(config.settings).toEqual({ seed: 7 })
+      expect(warnings.messages[0]).toContain(
+        "Managed agent config sets 'thinking' to 'xxhigh', which this version of the SDK does not recognize"
+      )
+    })
+
+    it('remembers an unrecognized key instead of dropping it silently', () => {
+      const config = parseAgentConfig({ settings: { service_tier: 'flex', temperature: 0 } })
+      expect(config.settings).toEqual({ temperature: 0 })
+      expect(config.settings?.[UNRECOGNIZED_SETTINGS]).toEqual(['service_tier'])
+      // Reported by `applySettings`, where it is applied, not here -- see `reportUnmatched`.
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('drops a section that is not an object', () => {
+      expect(parseAgentConfig({ settings: [1] }).settings).toBeUndefined()
+      expect(warnings.messages[0]).toContain('Managed settings section has invalid container [1]')
+    })
+
+    it('ignores an absent section without a word', () => {
+      expect(parseAgentConfig({ settings: null }).settings).toBeUndefined()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('names every canonical key exactly once', () => {
+      expect([...CANONICAL_SETTINGS_KEYS]).toEqual([
+        'max_tokens',
+        'temperature',
+        'top_p',
+        'top_k',
+        'seed',
+        'presence_penalty',
+        'frequency_penalty',
+        'parallel_tool_calls',
+        'timeout',
+        'stop_sequences',
+        'thinking',
+      ])
+    })
+  })
+
+  describe('tool_definitions', () => {
+    it('drops an override with no usable name and keeps its siblings', () => {
+      const config = parseAgentConfig({ tool_definitions: [{ name: '' }, { name: 'search' }] })
+      expect(config.tool_definitions).toEqual([{ name: 'search' }])
+      expect(warnings.messages[0]).toContain('Managed tool definition override {"name":""} is invalid -- name=\'\'')
+    })
+
+    it('drops an entry that is not an object at all', () => {
+      expect(parseAgentConfig({ tool_definitions: ['search'] }).tool_definitions).toEqual([])
+      expect(warnings.messages[0]).toContain("override='search'")
+    })
+
+    it('drops a section that is not a list', () => {
+      expect(parseAgentConfig({ tool_definitions: { name: 'search' } }).tool_definitions).toBeUndefined()
+      expect(warnings.messages[0]).toContain('Managed tool definitions section has invalid container')
+    })
+
+    it('ignores an absent section without a word', () => {
+      expect(parseAgentConfig({ tool_definitions: null }).tool_definitions).toBeUndefined()
+      expect(warnings.messages).toEqual([])
+    })
+  })
+
+  it('warns once per process per message, however many runs resolve the value', () => {
+    for (let i = 0; i < 3; i++) {
+      parseAgentConfig({ settings: { temperature: 'warm' } })
+    }
+    expect(warnings.messages).toHaveLength(1)
+  })
+})
+
+describe('a settings key that names something on Object.prototype', () => {
+  it('is unrecognized, not an inherited validator that throws the whole parse away', () => {
+    // `PLAIN_SETTINGS['constructor']` on an object literal is `Object`, a function with no
+    // `safeParse`, so looking a key up without an own-property check turned one odd JSON key into a
+    // `TypeError` out of the parse -- which the SDK's resolution reads as "nothing is published" and
+    // reverts instructions, model, settings, and every tool override to code along with it.
+    // Parsed from JSON rather than written as a literal, because that is where such a key comes
+    // from -- and because a literal's `__proto__` sets a prototype instead of becoming a key.
+    const stored: unknown = JSON.parse(
+      '{"settings": {"constructor": 1, "__proto__": {"temperature": 9}, "toString": "x", "temperature": 0.2},' +
+        ' "model": "openai:gpt-5.6-sol"}'
+    )
+    const config = parseAgentConfig(stored)
+    expect(config.model).toBe('openai:gpt-5.6-sol')
+    expect(config.settings).toEqual({ temperature: 0.2 })
+    expect(config.settings?.[UNRECOGNIZED_SETTINGS]).toEqual(['constructor', '__proto__', 'toString'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('cannot reach a validator through the prototype chain of the versioned table either', () => {
+    const config = parseAgentConfig({ settings: { hasOwnProperty: 'thinking' } })
+    expect(config.settings).toEqual({})
+    expect(config.settings?.[UNRECOGNIZED_SETTINGS]).toEqual(['hasOwnProperty'])
+  })
+})
+
+describe('canonicalSettings', () => {
+  it('keeps the canonical keys and drops everything a baseline must not carry', () => {
+    // Provider-specific keys and extra headers are where authorization headers live, and a baseline
+    // is published to a variable every member of the project can read.
+    expect(
+      canonicalSettings({
+        temperature: 0.2,
+        max_tokens: 1024,
+        extra_headers: { authorization: 'Bearer sk-secret' },
+        openai_service_tier: 'flex',
+        top_k: null,
+        seed: undefined,
+      })
+    ).toEqual({ max_tokens: 1024, temperature: 0.2 })
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('omits a value the contract cannot hold, and says so, rather than approximating it', () => {
+    // A framework's `'max'` effort is not `'xhigh'`. Publishing it as one describes the code as doing
+    // something it does not do, in the one artifact the Logfire editor presents as the truth.
+    expect(canonicalSettings({ thinking: 'max', temperature: 0.3 })).toEqual({ temperature: 0.3 })
+    expect(warnings.messages).toEqual([
+      "The agent runs with thinking='max', which the Agent Control contract cannot describe; leaving it " +
+        'out of the published baseline.',
+    ])
+  })
+
+  it('omits a timeout outside the representable range under its own message', () => {
+    expect(canonicalSettings({ timeout: -1, max_tokens: 512 })).toEqual({ max_tokens: 512 })
+    expect(warnings.messages[0]).toContain('The agent runs with a request timeout of -1 seconds')
+  })
+
+  it('emits the keys in contract order, so two SDKs publish the same bytes', () => {
+    const settings = canonicalSettings({ thinking: 'high', temperature: 0.2, max_tokens: 8 })
+    expect(Object.keys(settings)).toEqual(['max_tokens', 'temperature', 'thinking'])
+    expect(CANONICAL_SETTINGS_KEYS.indexOf('max_tokens')).toBe(0)
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/control.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/control.test.ts
@@ -2,7 +2,8 @@ import { configureVariables, getVariableProvider } from 'logfire/vars'
 import type { SerializedResolvedVariable, VariableConfig } from 'logfire/vars'
 import { describe, expect, it } from 'vite-plus/test'
 
-import { AgentControl, AGENT_CONFIG_JSON_SCHEMA, buildBaseline } from '../index'
+import { AgentControl, AGENT_CONFIG_JSON_SCHEMA, buildBaseline, UnmatchedConfigError } from '../index'
+import type { ApplyIssue } from '../index'
 import { captureWarnings, emptyVariable, publishedValue, settle, storedConfigFor, useLocalVariables, useNoVariables } from './helpers'
 
 const warnings = captureWarnings()
@@ -397,5 +398,54 @@ describe('AgentControl', () => {
         "Failed to publish the code baseline for Logfire managed variable 'agent__checkout': 403 read-only token",
       ])
     })
+  })
+})
+describe('report', () => {
+  const unknownTool: ApplyIssue = {
+    section: 'tool_definitions',
+    reason: 'unknown-tool',
+    tool: 'refund',
+    message: "Managed agent config patches tool 'refund', which no toolset advertises for this request.",
+  }
+  const unknownSetting: ApplyIssue = {
+    section: 'settings',
+    reason: 'unknown-setting',
+    setting: 'service_tier',
+    message: "Managed agent config sets 'service_tier', which this SDK has no model setting for.",
+  }
+
+  it('applies the policy to every section at once', () => {
+    new AgentControl('checkout').report(unknownTool, unknownSetting)
+    expect(warnings.messages).toEqual([unknownTool.message, unknownSetting.message])
+  })
+
+  it('throws once naming every issue, rather than on the first', () => {
+    // The defect this replaces: `'error'` threw inside the first section's apply call, so the other
+    // sections were never planned and the strictest policy reported the least.
+    const control = new AgentControl('checkout', { onUnmatched: 'error' })
+    let thrown: unknown
+    try {
+      control.report(unknownTool, unknownSetting)
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toBeInstanceOf(UnmatchedConfigError)
+    // Carried, so an adapter can raise its own framework's error type without restating a message.
+    expect((thrown as UnmatchedConfigError).message).toBe(`${unknownTool.message}\n${unknownSetting.message}`)
+    expect((thrown as UnmatchedConfigError).issues).toEqual([unknownTool, unknownSetting])
+  })
+
+  it('says nothing under ignore, and nothing at all for a request with no issues', () => {
+    new AgentControl('checkout', { onUnmatched: 'ignore' }).report(unknownTool)
+    new AgentControl('checkout', { onUnmatched: 'error' }).report()
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('still takes a message with no path to give', () => {
+    new AgentControl('checkout').reportUnmatched('Managed agent config selects a model this framework cannot switch.')
+    expect(warnings.messages).toEqual(['Managed agent config selects a model this framework cannot switch.'])
+    expect(() => {
+      new AgentControl('checkout', { onUnmatched: 'error' }).reportUnmatched('nope')
+    }).toThrow(UnmatchedConfigError)
   })
 })

--- a/packages/logfire-node/src/agent-control/__test__/control.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/control.test.ts
@@ -1,0 +1,376 @@
+import { configureVariables, getVariableProvider } from 'logfire/vars'
+import type { SerializedResolvedVariable, VariableConfig } from 'logfire/vars'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { AgentControl, AGENT_CONFIG_JSON_SCHEMA, buildBaseline } from '../index'
+import { captureWarnings, emptyVariable, publishedValue, settle, storedConfigFor, useLocalVariables, useNoVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+/** A provider that fails every read, the way an unreachable Logfire API does. */
+function useBrokenProvider(): void {
+  configureVariables(false)
+  const provider = getVariableProvider() as {
+    getSerializedValue: () => Promise<SerializedResolvedVariable>
+  }
+  provider.getSerializedValue = async () => Promise.reject(new Error('connection refused'))
+}
+
+describe('AgentControl', () => {
+  it('backs an agent with the `agent__<name>` variable the Logfire UI lists', () => {
+    const control = new AgentControl('checkout_assistant')
+    expect(control.name).toBe('checkout_assistant')
+    expect(control.variableName).toBe('agent__checkout_assistant')
+    expect(control.onUnmatched).toBe('warn')
+    expect(control.label).toBeUndefined()
+  })
+
+  it('refuses a name with no variable key in it, rather than pointing every agent at one config', () => {
+    expect(() => new AgentControl('')).toThrow(/has nothing a variable key can be made of/u)
+    expect(() => new AgentControl('   ')).toThrow(/has nothing a variable key can be made of/u)
+  })
+
+  it('keeps the display name verbatim and normalizes only the variable key', () => {
+    // Two SDKs and the Logfire UI have to land on one variable for one agent, so the key is
+    // normalized; the name a person recognizes the agent by is not.
+    const control = new AgentControl('Checkout Assistant')
+    expect(control.name).toBe('Checkout Assistant')
+    expect(control.variableName).toBe('agent__checkout_assistant')
+    expect(new AgentControl('checkout-assistant').variableName).toBe(control.variableName)
+    expect(new AgentControl('  checkout  ').name).toBe('checkout')
+  })
+
+  it('shares one variable between two controls for the same agent', () => {
+    // `defineVar` refuses a name it has already registered, and two controls for one agent is an
+    // ordinary thing for an adapter to end up with.
+    expect(() => [new AgentControl('twice'), new AgentControl('twice')]).not.toThrow()
+  })
+
+  it("falls back to an unregistered variable when the name is already someone else's", async () => {
+    const { defineVar } = await import('logfire/vars')
+    defineVar('agent__taken', { default: {} })
+    useLocalVariables(publishedValue('agent__taken', { model: 'openai:gpt-5.6-sol' }))
+    // Still resolves: the registry entry is theirs, but the variable reads the same name through the
+    // same provider.
+    expect(await new AgentControl('taken', { label: 'production' }).resolve()).toEqual({
+      model: 'openai:gpt-5.6-sol',
+    })
+  })
+
+  describe('resolve', () => {
+    it('returns the published value for the label it was given', async () => {
+      useLocalVariables(publishedValue('agent__checkout', { instructions: 'Be brief.', model: 'openai:gpt-5.6-sol' }, 'production'))
+      const control = new AgentControl('checkout', { label: 'production' })
+      expect(await control.resolve()).toEqual({
+        instructions: 'Be brief.',
+        model: 'openai:gpt-5.6-sol',
+      })
+    })
+
+    it("returns the rollout's choice when no label is pinned", async () => {
+      useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+      expect(await new AgentControl('checkout').resolve()).toEqual({ model: 'openai:gpt-5.6-sol' })
+    })
+
+    it('returns null when nothing is published, so an adapter can tell managed from unmanaged', async () => {
+      useLocalVariables(emptyVariable('agent__checkout'))
+      expect(await new AgentControl('checkout').resolve()).toBeNull()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('returns null when the variable does not exist at all', async () => {
+      useLocalVariables()
+      expect(await new AgentControl('checkout').resolve()).toBeNull()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('returns null when variables are switched off', async () => {
+      useNoVariables()
+      expect(await new AgentControl('checkout').resolve()).toBeNull()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('applies the lenient parse, so one bad field does not un-manage the rest', async () => {
+      useLocalVariables(
+        publishedValue('agent__checkout', {
+          model: 'openai:gpt-5.6-sol',
+          settings: { temperature: 'warm', max_tokens: 100 },
+        })
+      )
+      expect(await new AgentControl('checkout').resolve()).toEqual({
+        model: 'openai:gpt-5.6-sol',
+        settings: { max_tokens: 100 },
+      })
+      expect(warnings.messages[0]).toContain("setting 'temperature' has invalid value")
+    })
+
+    describe('when the provider is down', () => {
+      it('returns null and warns once, so the agent keeps running on code', async () => {
+        useBrokenProvider()
+        const control = new AgentControl('checkout')
+        expect(await control.resolve()).toBeNull()
+        expect(await control.resolve()).toBeNull()
+        expect(warnings.messages).toEqual([
+          "Logfire managed variable 'agent__checkout' could not be resolved (other_error); running on the code-defined agent.",
+        ])
+      })
+    })
+
+    it('returns null and warns when the published value itself cannot be resolved', async () => {
+      // Nothing this package writes can land here -- `parseAgentConfig` never throws -- but a
+      // composition reference the value cannot expand does, and the agent runs on code either way.
+      useLocalVariables(publishedValue('agent__checkout', '@{no_such_variable}@'))
+      expect(await new AgentControl('checkout', { label: 'production' }).resolve()).toBeNull()
+      expect(warnings.messages).toContain(
+        "Logfire managed variable 'agent__checkout' could not be resolved (other_error); running on the code-defined agent."
+      )
+    })
+  })
+
+  describe('publishBaseline', () => {
+    const baseline = buildBaseline({
+      instructions: [{ id: 'agent', text: 'You are a checkout assistant.', dynamic: false }],
+      model: 'openai:gpt-5.6-sol',
+    })
+    const example = JSON.stringify(baseline, null, 2)
+
+    it('creates the variable with the shared JSON schema when it does not exist', async () => {
+      useLocalVariables()
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      const stored = storedConfigFor('agent__checkout')
+      expect(stored?.name).toBe('agent__checkout')
+      expect(stored?.example).toBe(example)
+      // The stored schema is what the Logfire backend validates every written value against, so
+      // whichever side creates the variable first fixes the contract for the other.
+      expect(stored?.json_schema).toEqual(AGENT_CONFIG_JSON_SCHEMA)
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('publishes exactly the canonical JSON of the baseline', async () => {
+      useLocalVariables()
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(storedConfigFor('agent__checkout')?.example).toMatchInlineSnapshot(`
+        "{
+          "instructions": [
+            {
+              "id": "agent",
+              "instructions": "You are a checkout assistant.",
+              "dynamic": false
+            }
+          ],
+          "model": "openai:gpt-5.6-sol"
+        }"
+      `)
+    })
+
+    it('syncs only `example` on a variable that already exists', async () => {
+      useLocalVariables(
+        emptyVariable('agent__checkout', {
+          example: '{"model": "stale"}',
+          description: 'Set by hand in the Logfire UI.',
+          labels: {
+            production: { version: 3, serialized_value: '{"model":"openai:gpt-5.6-sol"}' },
+          },
+          rollout: { labels: { production: 1 } },
+        })
+      )
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      const stored = storedConfigFor('agent__checkout')
+      expect(stored?.example).toBe(example)
+      // Every other field of the definition someone edited in the UI survives the write.
+      expect(stored?.description).toBe('Set by hand in the Logfire UI.')
+      expect(stored?.labels['production']).toEqual({
+        version: 3,
+        serialized_value: '{"model":"openai:gpt-5.6-sol"}',
+      })
+    })
+
+    it('writes nothing when `example` already matches', async () => {
+      useLocalVariables(emptyVariable('agent__checkout', { example }))
+      const provider = getVariableProvider() as { updateVariable: unknown }
+      const original = provider.updateVariable
+      let updates = 0
+      provider.updateVariable = (...args: unknown[]) => {
+        updates += 1
+        return (original as (...a: unknown[]) => unknown).apply(provider, args)
+      }
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(updates).toBe(0)
+    })
+
+    it('runs at most once per process per variable, however many requests call it', async () => {
+      useLocalVariables()
+      const control = new AgentControl('checkout')
+      control.publishBaseline(baseline)
+      control.publishBaseline(buildBaseline({ model: 'anthropic:claude-fable-5-1' }))
+      new AgentControl('checkout').publishBaseline(buildBaseline({ model: 'anthropic:claude-fable-5-1' }))
+      await settle()
+      // The first snapshot wins: the guard is marked before the work, so a second request cannot
+      // schedule a duplicate write and a failure is not retried by every later run.
+      expect(storedConfigFor('agent__checkout')?.example).toBe(example)
+    })
+
+    it('does nothing at all when it is switched off', async () => {
+      useLocalVariables()
+      new AgentControl('checkout', { publishBaseline: false }).publishBaseline(baseline)
+      await settle()
+      expect(storedConfigFor('agent__checkout')).toBeUndefined()
+    })
+
+    it('does nothing when variables are switched off, since there is nowhere to publish', async () => {
+      useNoVariables()
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('warns and never throws when the write fails', async () => {
+      useLocalVariables()
+      const provider = getVariableProvider() as { createVariable: unknown }
+      provider.createVariable = async () => Promise.reject(new Error('403 read-only token'))
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(warnings.messages).toEqual([
+        "Failed to publish the code baseline for Logfire managed variable 'agent__checkout': 403 read-only token",
+      ])
+    })
+
+    it('warns and never throws when the baseline will not serialize', async () => {
+      useLocalVariables()
+      const circular: Record<string, unknown> = {}
+      circular['self'] = circular
+      new AgentControl('checkout').publishBaseline({ settings: circular })
+      await settle()
+      expect(warnings.messages[0]).toContain("Failed to publish the code baseline for Logfire managed variable 'agent__checkout'")
+      expect(storedConfigFor('agent__checkout')).toBeUndefined()
+    })
+
+    it('tolerates a provider with no write path at all', async () => {
+      useLocalVariables()
+      const provider = getVariableProvider() as {
+        createVariable?: unknown
+        updateVariable?: unknown
+      }
+      delete provider.createVariable
+      delete provider.updateVariable
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('tolerates a provider that cannot be asked what it holds', async () => {
+      useLocalVariables()
+      const provider = getVariableProvider() as { getVariableConfig?: unknown }
+      delete provider.getVariableConfig
+      // Unanswerable reads as "not there", which creates rather than blindly overwriting.
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(storedConfigFor('agent__checkout')?.example).toBe(example)
+    })
+
+    it('treats a null definition the same as a missing one', async () => {
+      useLocalVariables()
+      const provider = getVariableProvider() as {
+        getVariableConfig: unknown
+        createVariable: unknown
+      }
+      provider.getVariableConfig = () => null
+      let created: VariableConfig | undefined
+      provider.createVariable = (config: VariableConfig) => {
+        created = config
+        return config
+      }
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(created?.example).toBe(example)
+    })
+
+    it('writes back the read it took immediately before the write, never an earlier one', async () => {
+      // The lost-update window is one HTTP round trip and cannot be closed from this side, so what
+      // *can* be done is: never write a definition read before the decision to write. This test
+      // stands in for the UI saving between the two reads -- the write must carry what that later
+      // read returned, not what the first one did.
+      useLocalVariables(emptyVariable('agent__checkout', { example: '{"model": "stale"}' }))
+      const provider = getVariableProvider() as {
+        getVariableConfig: (name: string) => VariableConfig | undefined
+        updateVariable: (name: string, config: VariableConfig) => VariableConfig
+      }
+      const read = provider.getVariableConfig.bind(provider)
+      let reads = 0
+      provider.getVariableConfig = (name: string) => {
+        reads += 1
+        const config = read(name)
+        // Between the existence check and the write, someone publishes in the Logfire UI.
+        if (reads === 1 && config !== undefined) {
+          return {
+            ...config,
+            labels: { production: { version: 7, serialized_value: '{"model":"openai:gpt-5.6-sol"}' } },
+          }
+        }
+        return config
+      }
+      let written: VariableConfig | undefined
+      provider.updateVariable = (_name: string, config: VariableConfig) => {
+        written = config
+        return config
+      }
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(reads).toBe(2)
+      // The freshly read definition, with only `example` changed -- not the one read a round trip
+      // earlier, which is the object a stale write would have restored.
+      expect(written?.labels['production']).toBeUndefined()
+      expect(written?.example).toBe(example)
+    })
+
+    it('writes nothing when the variable vanished between the two reads', async () => {
+      useLocalVariables(emptyVariable('agent__checkout', { example: '{"model": "stale"}' }))
+      const provider = getVariableProvider() as {
+        getVariableConfig: (name: string) => VariableConfig | undefined
+        updateVariable: unknown
+      }
+      const read = provider.getVariableConfig.bind(provider)
+      let reads = 0
+      provider.getVariableConfig = (name: string) => (++reads === 1 ? read(name) : undefined)
+      let updates = 0
+      provider.updateVariable = () => {
+        updates += 1
+      }
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      // Re-creating a variable someone just deleted is not this call's decision to make.
+      expect(updates).toBe(0)
+    })
+
+    it('says on a new variable whether the example is the code or one observed request', async () => {
+      useLocalVariables()
+      new AgentControl('checkout').publishBaseline(baseline, { source: 'observed' })
+      await settle()
+      expect(storedConfigFor('agent__checkout')?.description).toContain('snapshotted from one request')
+
+      useLocalVariables()
+      new AgentControl('other').publishBaseline(baseline)
+      await settle()
+      expect(storedConfigFor('agent__other')?.description).toContain('the agent as written')
+    })
+
+    it('warns about a failure that is not an Error at all', async () => {
+      useLocalVariables()
+      const provider = getVariableProvider() as { createVariable: unknown }
+      // Deliberately not an `Error`: a hand-rolled provider or a raw HTTP client can reject with a
+      // bare string, and the warning has to name it rather than print `undefined`.
+      const notAnError: unknown = '403 read-only token'
+      // eslint-disable-next-line prefer-promise-reject-errors, @typescript-eslint/prefer-promise-reject-errors -- see above
+      provider.createVariable = async () => Promise.reject(notAnError)
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(warnings.messages).toEqual([
+        "Failed to publish the code baseline for Logfire managed variable 'agent__checkout': 403 read-only token",
+      ])
+    })
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/control.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/control.test.ts
@@ -289,6 +289,31 @@ describe('AgentControl', () => {
       expect(created?.example).toBe(example)
     })
 
+    it('refreshes the provider before deciding whether the variable exists', async () => {
+      // `getVariableConfig` answers out of the provider's cached config and never fetches, so a
+      // process that has not resolved yet would see every existing variable as missing, take the
+      // create path, conflict, and -- because the publish guard is already marked -- never retry.
+      useLocalVariables(emptyVariable('agent__checkout', { example: '{"model": "stale"}' }))
+      const provider = getVariableProvider() as { refresh?: (force?: boolean) => void }
+      const forced: (boolean | undefined)[] = []
+      provider.refresh = (force?: boolean) => {
+        forced.push(force)
+      }
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(forced).toEqual([true])
+    })
+
+    it('publishes through a provider that has no refresh at all', async () => {
+      // `refresh` is optional on `VariableProvider`, and a provider reading a config it was handed
+      // has nothing to refresh from. The publish still has to happen.
+      useLocalVariables(emptyVariable('agent__checkout', { example: '{"model": "stale"}' }))
+      expect('refresh' in getVariableProvider()).toBe(false)
+      new AgentControl('checkout').publishBaseline(baseline)
+      await settle()
+      expect(storedConfigFor('agent__checkout')?.example).toBe(example)
+    })
+
     it('writes back the read it took immediately before the write, never an earlier one', async () => {
       // The lost-update window is one HTTP round trip and cannot be closed from this side, so what
       // *can* be done is: never write a definition read before the decision to write. This test

--- a/packages/logfire-node/src/agent-control/__test__/helpers.ts
+++ b/packages/logfire-node/src/agent-control/__test__/helpers.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared test scaffolding: a local variables provider, and a way to see what was warned.
+ *
+ * Everything here is offline. The Logfire SDK's `LocalVariableProvider` is a full provider backed by
+ * an in-memory `VariablesConfig` -- it reads, creates, and updates -- so the publish path is
+ * exercised against the same interface the remote provider implements, with no network and no
+ * recorded fixtures to drift.
+ */
+
+import { configureVariables, getVariableProvider } from 'logfire/vars'
+import type { VariableConfig, VariablesConfig } from 'logfire/vars'
+import { afterEach, beforeEach, vi } from 'vite-plus/test'
+
+import { resetAgentControl } from '../testing'
+
+/**
+ * A variables config in which `name` holds `value` under one label at full rollout.
+ *
+ * The shape a Logfire project has once someone has saved a value in the UI, which is what a control
+ * with a matching label then resolves.
+ */
+export function publishedValue(name: string, value: unknown, label = 'production'): VariablesConfig {
+  return {
+    variables: {
+      [name]: {
+        name,
+        labels: { [label]: { version: 1, serialized_value: JSON.stringify(value) } },
+        rollout: { labels: { [label]: 1 } },
+        overrides: [],
+      },
+    },
+  }
+}
+
+/** A variables config in which `name` exists but nothing is published for it. */
+export function emptyVariable(name: string, config: Partial<VariableConfig> = {}): VariablesConfig {
+  return {
+    variables: { [name]: { name, labels: {}, rollout: { labels: {} }, overrides: [], ...config } },
+  }
+}
+
+/** Point the SDK at a local provider holding `config`. */
+export function useLocalVariables(config: VariablesConfig = { variables: {} }): void {
+  configureVariables({ config, instrument: false })
+}
+
+/** Switch variables off entirely, which installs the no-op provider. */
+export function useNoVariables(): void {
+  configureVariables(false)
+}
+
+/**
+ * Capture `console.warn` for the duration of a test, and reset every once-per-process guard.
+ *
+ * The guards are the reason this is a fixture rather than a per-test spy: "warns once per process"
+ * is a property worth asserting, which means each test has to start from a process that has not
+ * warned yet.
+ */
+export function captureWarnings(): { messages: string[] } {
+  const captured: { messages: string[] } = { messages: [] }
+  beforeEach(() => {
+    captured.messages.length = 0
+    // The same entry point an adapter's suite uses, so the package's own tests exercise the thing it
+    // ships rather than a private shortcut past it.
+    resetAgentControl()
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+      captured.messages.push(String(message))
+    })
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    useNoVariables()
+  })
+  return captured
+}
+
+/** Wait for the background baseline publish to settle. */
+export async function settle(): Promise<void> {
+  await Promise.all(Array.from({ length: 5 }, async () => Promise.resolve()))
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+/** Read a variable's stored definition back out of whichever provider is configured. */
+export function storedConfigFor(name: string): VariableConfig | undefined {
+  return getVariableProvider().getVariableConfig?.(name) as VariableConfig | undefined
+}

--- a/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
@@ -189,6 +189,74 @@ describe('what reached nothing comes back structured', () => {
     expect(unapplied[1]?.message).not.toContain('for instruction block')
   })
 
+  describe('and the budget is the total across entries, not a per-entry allowance', () => {
+    // `parseInstructions` already charges a published value this way. A typed caller reaching
+    // `applyInstructions` directly went through a per-entry check only, so two entries each at the
+    // budget both applied and the request carried twice the limit.
+    const half = 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH / 2)
+
+    it('refuses the entry that does not fit in what is left', () => {
+      const { blocks, unapplied } = applyInstructions(
+        codeBlocks,
+        {
+          instructions: [
+            { id: 'agent', instructions: half },
+            { id: 'toolset:crm', instructions: half },
+            { id: 'capability:clock', instructions: 'x' },
+          ],
+        },
+        { onUnmatched: 'ignore' }
+      )
+      // The first two fill the budget exactly; the third is refused for the budget, not for being
+      // dynamic, because it never gets that far.
+      expect(blocks[0]?.text).toBe(half)
+      expect(blocks[1]?.text).toBe(half)
+      expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['dynamic-id', 'capability:clock']])
+
+      const over = applyInstructions(
+        codeBlocks,
+        {
+          instructions: [
+            { id: 'agent', instructions: half },
+            { id: 'toolset:crm', instructions: `${half}a` },
+          ],
+        },
+        { onUnmatched: 'ignore' }
+      )
+      expect(over.blocks[0]?.text).toBe(half)
+      expect(over.blocks[1]?.text).toBe('Use the CRM tools.')
+      expect(over.unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', 'toolset:crm']])
+      expect(over.unapplied[0]?.message).toContain('does not fit in the 32768 remaining')
+    })
+
+    it('charges added blocks against the same budget as replacements', () => {
+      const { blocks, unapplied } = applyInstructions(
+        codeBlocks,
+        { instructions: [{ id: 'agent', instructions: half }, half, 'one more'] },
+        { onUnmatched: 'ignore' }
+      )
+      expect(blocks.some((block) => block.text === 'one more')).toBe(false)
+      expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', undefined]])
+    })
+
+    it('charges only the text that survives, so one refused entry does not shrink the budget', () => {
+      // The refused entry adds nothing to the request, so charging it would make the entries a value
+      // keeps depend on the ones it does not.
+      const { blocks, unapplied } = applyInstructions(
+        codeBlocks,
+        {
+          instructions: [
+            { id: 'agent', instructions: 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH + 1) },
+            { id: 'toolset:crm', instructions: half },
+          ],
+        },
+        { onUnmatched: 'ignore' }
+      )
+      expect(blocks[1]?.text).toBe(half)
+      expect(unapplied.map((entry) => entry.reason)).toEqual(['oversized-text'])
+    })
+  })
+
   it('measures that budget in code points, the way the contract counts text', () => {
     // An astral character is one code point and two UTF-16 units; counting units would put this
     // exactly at twice the budget in one core and inside it in the other.

--- a/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { applyInstructions, instructionEntries, MAX_MODEL_FACING_TEXT_LENGTH, parseAgentConfig, UnmatchedConfigError } from '../index'
+import { applyInstructions, instructionEntries, MAX_MODEL_FACING_TEXT_LENGTH, parseAgentConfig } from '../index'
 import type { InstructionBlock } from '../index'
 import { captureWarnings } from './helpers'
 
@@ -91,62 +91,60 @@ describe('applyInstructions', () => {
   })
 
   describe('a dynamic block cannot be addressed', () => {
-    it('warns and keeps what the code produces', () => {
-      const { blocks: result } = applyInstructions(codeBlocks, {
+    it('keeps what the code produces and says which entry it refused', () => {
+      const { blocks: result, issues } = applyInstructions(codeBlocks, {
         instructions: [{ id: 'capability:clock', instructions: 'Today is never.' }],
       })
       expect(result).toEqual(codeBlocks)
-      expect(warnings.messages).toHaveLength(1)
-      expect(warnings.messages[0]).toContain("addresses instruction block 'capability:clock', which the agent recomputes")
+      expect(issues.map((issue) => [issue.section, issue.reason, issue.instructionId])).toEqual([
+        ['instructions', 'dynamic-id', 'capability:clock'],
+      ])
+      expect(issues[0]?.message).toContain("addresses instruction block 'capability:clock', which the agent recomputes")
     })
 
     it('is not reported a second time as a key nothing carries', () => {
-      applyInstructions(codeBlocks, { instructions: [{ id: 'capability:clock' }] })
-      expect(warnings.messages).toHaveLength(1)
-      expect(warnings.messages[0]).not.toContain('does not assemble')
+      const { issues } = applyInstructions(codeBlocks, { instructions: [{ id: 'capability:clock' }] })
+      expect(issues).toHaveLength(1)
+      expect(issues[0]?.message).not.toContain('does not assemble')
     })
   })
 
-  describe('onUnmatched', () => {
-    const config = { instructions: [{ id: 'toolset:gone', instructions: 'Never seen.' }] }
-
-    it("warns by default, once per process, because another deployment's config may be right", () => {
-      applyInstructions(codeBlocks, config)
-      applyInstructions(codeBlocks, config)
-      expect(warnings.messages).toEqual([
-        "Managed agent config addresses instruction block 'toolset:gone', which this request does not " +
-          'assemble; that entry applies to nothing.',
-      ])
-    })
-
-    it('says nothing under ignore', () => {
-      applyInstructions(codeBlocks, config, { onUnmatched: 'ignore' })
-      expect(warnings.messages).toEqual([])
-    })
-
-    it('fails the run under error, with the message the warning would have carried', () => {
-      expect(() => applyInstructions(codeBlocks, config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
-      expect(() => applyInstructions(codeBlocks, config, { onUnmatched: 'error' })).toThrow(
-        /addresses instruction block 'toolset:gone', which this request does not assemble/u
-      )
-    })
-
-    it('governs the dynamic case too', () => {
-      expect(() => applyInstructions(codeBlocks, { instructions: [{ id: 'capability:clock' }] }, { onUnmatched: 'error' })).toThrow(
-        /which the agent recomputes per request/u
-      )
-    })
+  it('reports nothing itself, whatever it could not apply', () => {
+    // The policy is applied once per request, by `AgentControl.report`, so that `'error'` fails on
+    // everything the request got wrong rather than on whichever section was applied first.
+    const { issues } = applyInstructions(codeBlocks, { instructions: [{ id: 'toolset:gone', instructions: 'x' }] })
+    expect(issues).toHaveLength(1)
+    expect(warnings.messages).toEqual([])
   })
 
-  it('keeps the first of two entries naming the same id', () => {
-    const { blocks: result } = applyInstructions(codeBlocks, {
+  it('keeps the first of two entries naming the same id and reports the rest', () => {
+    // It used to warn straight from indexing, which made `'ignore'` warn anyway and `'error'` not
+    // throw at all -- the one decision the policy never governed.
+    const { blocks: result, issues } = applyInstructions(codeBlocks, {
       instructions: [
         { id: 'agent', instructions: 'First wins.' },
         { id: 'agent', instructions: 'Second loses.' },
       ],
     })
     expect(result[0]?.text).toBe('First wins.')
-    expect(warnings.messages[0]).toContain("names instruction id 'agent' more than once")
+    expect(issues.map((issue) => [issue.section, issue.reason, issue.instructionId])).toEqual([
+      ['instructions', 'duplicate-entry', 'agent'],
+    ])
+    expect(issues[0]?.message).toContain("names instruction id 'agent' more than once")
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('carries a duplicate back even when nothing else is published', () => {
+    // The duplicate is found while indexing, before the early return for a config that addresses no
+    // block this request assembles.
+    const { blocks: result, issues } = applyInstructions([], {
+      instructions: [
+        { id: 'agent', instructions: 'First.' },
+        { id: 'agent', instructions: 'Last.' },
+      ],
+    })
+    expect(result).toEqual([])
+    expect(issues.map((issue) => issue.reason)).toEqual(['duplicate-entry', 'unknown-id'])
   })
 })
 
@@ -160,12 +158,10 @@ describe('instructionEntries', () => {
 
 describe('what reached nothing comes back structured', () => {
   it('names the entry rather than leaving an adapter to parse a message', () => {
-    const { unapplied } = applyInstructions(
-      codeBlocks,
-      { instructions: [{ id: 'toolset:gone', instructions: 'Never seen.' }, { id: 'capability:clock' }] },
-      { onUnmatched: 'ignore' }
-    )
-    expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([
+    const { issues } = applyInstructions(codeBlocks, {
+      instructions: [{ id: 'toolset:gone', instructions: 'Never seen.' }, { id: 'capability:clock' }],
+    })
+    expect(issues.map((entry) => [entry.reason, entry.instructionId])).toEqual([
       ['dynamic-id', 'capability:clock'],
       ['unknown-id', 'toolset:gone'],
     ])
@@ -175,18 +171,14 @@ describe('what reached nothing comes back structured', () => {
     // Half a prompt is not a smaller version of the prompt. The parser caps a published value, so
     // reaching here means an adapter built the config itself -- and the answer is the same.
     const oversized = 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH + 1)
-    const { blocks, unapplied } = applyInstructions(
-      codeBlocks,
-      { instructions: [{ id: 'agent', instructions: oversized }, oversized] },
-      { onUnmatched: 'ignore' }
-    )
+    const { blocks, issues } = applyInstructions(codeBlocks, { instructions: [{ id: 'agent', instructions: oversized }, oversized] })
     expect(blocks).toEqual(codeBlocks)
-    expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([
+    expect(issues.map((entry) => [entry.reason, entry.instructionId])).toEqual([
       ['oversized-text', 'agent'],
       ['oversized-text', undefined],
     ])
-    expect(unapplied[0]?.message).toContain("for instruction block 'agent'")
-    expect(unapplied[1]?.message).not.toContain('for instruction block')
+    expect(issues[0]?.message).toContain("for instruction block 'agent'")
+    expect(issues[1]?.message).not.toContain('for instruction block')
   })
 
   describe('and the budget is the total across entries, not a per-entry allowance', () => {
@@ -196,47 +188,35 @@ describe('what reached nothing comes back structured', () => {
     const half = 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH / 2)
 
     it('refuses the entry that does not fit in what is left', () => {
-      const { blocks, unapplied } = applyInstructions(
-        codeBlocks,
-        {
-          instructions: [
-            { id: 'agent', instructions: half },
-            { id: 'toolset:crm', instructions: half },
-            { id: 'capability:clock', instructions: 'x' },
-          ],
-        },
-        { onUnmatched: 'ignore' }
-      )
+      const { blocks, issues } = applyInstructions(codeBlocks, {
+        instructions: [
+          { id: 'agent', instructions: half },
+          { id: 'toolset:crm', instructions: half },
+          { id: 'capability:clock', instructions: 'x' },
+        ],
+      })
       // The first two fill the budget exactly; the third is refused for the budget, not for being
       // dynamic, because it never gets that far.
       expect(blocks[0]?.text).toBe(half)
       expect(blocks[1]?.text).toBe(half)
-      expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['dynamic-id', 'capability:clock']])
+      expect(issues.map((entry) => [entry.reason, entry.instructionId])).toEqual([['dynamic-id', 'capability:clock']])
 
-      const over = applyInstructions(
-        codeBlocks,
-        {
-          instructions: [
-            { id: 'agent', instructions: half },
-            { id: 'toolset:crm', instructions: `${half}a` },
-          ],
-        },
-        { onUnmatched: 'ignore' }
-      )
+      const over = applyInstructions(codeBlocks, {
+        instructions: [
+          { id: 'agent', instructions: half },
+          { id: 'toolset:crm', instructions: `${half}a` },
+        ],
+      })
       expect(over.blocks[0]?.text).toBe(half)
       expect(over.blocks[1]?.text).toBe('Use the CRM tools.')
-      expect(over.unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', 'toolset:crm']])
-      expect(over.unapplied[0]?.message).toContain('does not fit in the 32768 remaining')
+      expect(over.issues.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', 'toolset:crm']])
+      expect(over.issues[0]?.message).toContain('does not fit in the 32768 remaining')
     })
 
     it('charges added blocks against the same budget as replacements', () => {
-      const { blocks, unapplied } = applyInstructions(
-        codeBlocks,
-        { instructions: [{ id: 'agent', instructions: half }, half, 'one more'] },
-        { onUnmatched: 'ignore' }
-      )
+      const { blocks, issues } = applyInstructions(codeBlocks, { instructions: [{ id: 'agent', instructions: half }, half, 'one more'] })
       expect(blocks.some((block) => block.text === 'one more')).toBe(false)
-      expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', undefined]])
+      expect(issues.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', undefined]])
     })
 
     it('charges in published order, so a typed config keeps what the same JSON would keep', () => {
@@ -248,10 +228,10 @@ describe('what reached nothing comes back structured', () => {
       const big = 'a'.repeat(40_000)
       const config = { instructions: [big, { id: 'agent', instructions: big }] }
 
-      const { blocks, unapplied } = applyInstructions(codeBlocks, config, { onUnmatched: 'ignore' })
+      const { blocks, issues } = applyInstructions(codeBlocks, config)
       expect(blocks.map((block) => block.text)).toContain(big)
       expect(blocks[0]?.text).toBe('You are a checkout assistant.')
-      expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', 'agent']])
+      expect(issues.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', 'agent']])
 
       // The parser, given the same value, keeps the same entry.
       const parsed = parseAgentConfig(config)
@@ -261,18 +241,14 @@ describe('what reached nothing comes back structured', () => {
     it('charges only the text that survives, so one refused entry does not shrink the budget', () => {
       // The refused entry adds nothing to the request, so charging it would make the entries a value
       // keeps depend on the ones it does not.
-      const { blocks, unapplied } = applyInstructions(
-        codeBlocks,
-        {
-          instructions: [
-            { id: 'agent', instructions: 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH + 1) },
-            { id: 'toolset:crm', instructions: half },
-          ],
-        },
-        { onUnmatched: 'ignore' }
-      )
+      const { blocks, issues } = applyInstructions(codeBlocks, {
+        instructions: [
+          { id: 'agent', instructions: 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH + 1) },
+          { id: 'toolset:crm', instructions: half },
+        ],
+      })
       expect(blocks[1]?.text).toBe(half)
-      expect(unapplied.map((entry) => entry.reason)).toEqual(['oversized-text'])
+      expect(issues.map((entry) => entry.reason)).toEqual(['oversized-text'])
     })
   })
 
@@ -280,14 +256,14 @@ describe('what reached nothing comes back structured', () => {
     // An astral character is one code point and two UTF-16 units; counting units would put this
     // exactly at twice the budget in one core and inside it in the other.
     const atBudget = '\u{1D11E}'.repeat(MAX_MODEL_FACING_TEXT_LENGTH)
-    const { unapplied } = applyInstructions([], { instructions: [atBudget] }, { onUnmatched: 'ignore' })
-    expect(unapplied).toEqual([])
+    const { issues } = applyInstructions([], { instructions: [atBudget] })
+    expect(issues).toEqual([])
   })
 
   it('reports nothing, and copies the blocks, when the config touches instructions at all', () => {
-    const { blocks, unapplied } = applyInstructions(codeBlocks, { model: 'openai:gpt-5.6-sol' })
+    const { blocks, issues } = applyInstructions(codeBlocks, { model: 'openai:gpt-5.6-sol' })
     expect(blocks).toEqual(codeBlocks)
     expect(blocks).not.toBe(codeBlocks)
-    expect(unapplied).toEqual([])
+    expect(issues).toEqual([])
   })
 })

--- a/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { applyInstructions, instructionEntries, MAX_MODEL_FACING_TEXT_LENGTH, UnmatchedConfigError } from '../index'
+import type { InstructionBlock } from '../index'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+const codeBlocks: InstructionBlock[] = [
+  { id: 'agent', text: 'You are a checkout assistant.', dynamic: false },
+  { id: 'toolset:crm', text: 'Use the CRM tools.', dynamic: false },
+  { id: null, text: 'Anonymous contribution.', dynamic: false },
+  { id: 'capability:clock', text: 'Today is 2026-09-09.', dynamic: true },
+]
+
+describe('applyInstructions', () => {
+  it('leaves every block alone when nothing is published', () => {
+    expect(applyInstructions(codeBlocks, {}).blocks).toEqual(codeBlocks)
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('replaces an addressed block in place, keeping its position and dynamic flag', () => {
+    const { blocks: result } = applyInstructions(codeBlocks, {
+      instructions: [{ id: 'toolset:crm', instructions: 'Use the CRM tools sparingly.' }],
+    })
+    expect(result).toEqual([
+      codeBlocks[0],
+      { id: 'toolset:crm', text: 'Use the CRM tools sparingly.', dynamic: false },
+      codeBlocks[2],
+      codeBlocks[3],
+    ])
+  })
+
+  it('drops an addressed block when the entry publishes no text', () => {
+    const { blocks: result } = applyInstructions(codeBlocks, { instructions: [{ id: 'agent' }] })
+    expect(result.map((block) => block.id)).toEqual(['toolset:crm', null, 'capability:clock'])
+  })
+
+  it('adds a block after the last static one and before the first dynamic one', () => {
+    const { blocks: result } = applyInstructions(codeBlocks, { instructions: 'Answer in French.' })
+    expect(result.map((block) => block.text)).toEqual([
+      'You are a checkout assistant.',
+      'Use the CRM tools.',
+      'Anonymous contribution.',
+      'Answer in French.',
+      'Today is 2026-09-09.',
+    ])
+    // New text, addressable by nothing, and fixed by construction -- so it cannot move the cache
+    // boundary the dynamic block sits behind.
+    expect(result[3]).toEqual({ id: null, text: 'Answer in French.', dynamic: false })
+  })
+
+  it('appends to the end when the agent has no dynamic blocks', () => {
+    const statics = codeBlocks.slice(0, 3)
+    const { blocks: result } = applyInstructions(statics, { instructions: ['One.', 'Two.'] })
+    expect(result.map((block) => block.text)).toEqual([
+      'You are a checkout assistant.',
+      'Use the CRM tools.',
+      'Anonymous contribution.',
+      'One.',
+      'Two.',
+    ])
+  })
+
+  it('adds ahead of everything when every block is dynamic', () => {
+    const { blocks: result } = applyInstructions([codeBlocks[3] as InstructionBlock], {
+      instructions: 'First.',
+    })
+    expect(result.map((block) => block.text)).toEqual(['First.', 'Today is 2026-09-09.'])
+  })
+
+  it('gives each added entry its own block, rather than joining them', () => {
+    const { blocks: result } = applyInstructions([], { instructions: ['One.', 'Two.'] })
+    expect(result).toEqual([
+      { id: null, text: 'One.', dynamic: false },
+      { id: null, text: 'Two.', dynamic: false },
+    ])
+  })
+
+  it('adds and replaces in one config without either disturbing the other', () => {
+    const { blocks: result } = applyInstructions(codeBlocks, {
+      instructions: [{ id: 'agent', instructions: 'You are terse.' }, 'Answer in French.'],
+    })
+    expect(result.map((block) => block.text)).toEqual([
+      'You are terse.',
+      'Use the CRM tools.',
+      'Anonymous contribution.',
+      'Answer in French.',
+      'Today is 2026-09-09.',
+    ])
+  })
+
+  describe('a dynamic block cannot be addressed', () => {
+    it('warns and keeps what the code produces', () => {
+      const { blocks: result } = applyInstructions(codeBlocks, {
+        instructions: [{ id: 'capability:clock', instructions: 'Today is never.' }],
+      })
+      expect(result).toEqual(codeBlocks)
+      expect(warnings.messages).toHaveLength(1)
+      expect(warnings.messages[0]).toContain("addresses instruction block 'capability:clock', which the agent recomputes")
+    })
+
+    it('is not reported a second time as a key nothing carries', () => {
+      applyInstructions(codeBlocks, { instructions: [{ id: 'capability:clock' }] })
+      expect(warnings.messages).toHaveLength(1)
+      expect(warnings.messages[0]).not.toContain('does not assemble')
+    })
+  })
+
+  describe('onUnmatched', () => {
+    const config = { instructions: [{ id: 'toolset:gone', instructions: 'Never seen.' }] }
+
+    it("warns by default, once per process, because another deployment's config may be right", () => {
+      applyInstructions(codeBlocks, config)
+      applyInstructions(codeBlocks, config)
+      expect(warnings.messages).toEqual([
+        "Managed agent config addresses instruction block 'toolset:gone', which this request does not " +
+          'assemble; that entry applies to nothing.',
+      ])
+    })
+
+    it('says nothing under ignore', () => {
+      applyInstructions(codeBlocks, config, { onUnmatched: 'ignore' })
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('fails the run under error, with the message the warning would have carried', () => {
+      expect(() => applyInstructions(codeBlocks, config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+      expect(() => applyInstructions(codeBlocks, config, { onUnmatched: 'error' })).toThrow(
+        /addresses instruction block 'toolset:gone', which this request does not assemble/u
+      )
+    })
+
+    it('governs the dynamic case too', () => {
+      expect(() => applyInstructions(codeBlocks, { instructions: [{ id: 'capability:clock' }] }, { onUnmatched: 'error' })).toThrow(
+        /which the agent recomputes per request/u
+      )
+    })
+  })
+
+  it('keeps the first of two entries naming the same id', () => {
+    const { blocks: result } = applyInstructions(codeBlocks, {
+      instructions: [
+        { id: 'agent', instructions: 'First wins.' },
+        { id: 'agent', instructions: 'Second loses.' },
+      ],
+    })
+    expect(result[0]?.text).toBe('First wins.')
+    expect(warnings.messages[0]).toContain("names instruction id 'agent' more than once")
+  })
+})
+
+describe('instructionEntries', () => {
+  it('reads both shapes of the section as the same list of entries', () => {
+    expect(instructionEntries({ instructions: 'One.' })).toEqual([{ instructions: 'One.' }])
+    expect(instructionEntries({ instructions: ['One.', { id: 'agent' }] })).toEqual([{ instructions: 'One.' }, { id: 'agent' }])
+    expect(instructionEntries({})).toEqual([])
+  })
+})
+
+describe('what reached nothing comes back structured', () => {
+  it('names the entry rather than leaving an adapter to parse a message', () => {
+    const { unapplied } = applyInstructions(
+      codeBlocks,
+      { instructions: [{ id: 'toolset:gone', instructions: 'Never seen.' }, { id: 'capability:clock' }] },
+      { onUnmatched: 'ignore' }
+    )
+    expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([
+      ['dynamic-id', 'capability:clock'],
+      ['unknown-id', 'toolset:gone'],
+    ])
+  })
+
+  it('refuses text past the budget rather than truncating it', () => {
+    // Half a prompt is not a smaller version of the prompt. The parser caps a published value, so
+    // reaching here means an adapter built the config itself -- and the answer is the same.
+    const oversized = 'a'.repeat(MAX_MODEL_FACING_TEXT_LENGTH + 1)
+    const { blocks, unapplied } = applyInstructions(
+      codeBlocks,
+      { instructions: [{ id: 'agent', instructions: oversized }, oversized] },
+      { onUnmatched: 'ignore' }
+    )
+    expect(blocks).toEqual(codeBlocks)
+    expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([
+      ['oversized-text', 'agent'],
+      ['oversized-text', undefined],
+    ])
+    expect(unapplied[0]?.message).toContain("for instruction block 'agent'")
+    expect(unapplied[1]?.message).not.toContain('for instruction block')
+  })
+
+  it('measures that budget in code points, the way the contract counts text', () => {
+    // An astral character is one code point and two UTF-16 units; counting units would put this
+    // exactly at twice the budget in one core and inside it in the other.
+    const atBudget = '\u{1D11E}'.repeat(MAX_MODEL_FACING_TEXT_LENGTH)
+    const { unapplied } = applyInstructions([], { instructions: [atBudget] }, { onUnmatched: 'ignore' })
+    expect(unapplied).toEqual([])
+  })
+
+  it('reports nothing, and copies the blocks, when the config touches instructions at all', () => {
+    const { blocks, unapplied } = applyInstructions(codeBlocks, { model: 'openai:gpt-5.6-sol' })
+    expect(blocks).toEqual(codeBlocks)
+    expect(blocks).not.toBe(codeBlocks)
+    expect(unapplied).toEqual([])
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/instructions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { applyInstructions, instructionEntries, MAX_MODEL_FACING_TEXT_LENGTH, UnmatchedConfigError } from '../index'
+import { applyInstructions, instructionEntries, MAX_MODEL_FACING_TEXT_LENGTH, parseAgentConfig, UnmatchedConfigError } from '../index'
 import type { InstructionBlock } from '../index'
 import { captureWarnings } from './helpers'
 
@@ -237,6 +237,25 @@ describe('what reached nothing comes back structured', () => {
       )
       expect(blocks.some((block) => block.text === 'one more')).toBe(false)
       expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', undefined]])
+    })
+
+    it('charges in published order, so a typed config keeps what the same JSON would keep', () => {
+      // Entries are *applied* replacements-first and additions-second, but `parseInstructions`
+      // charges a published value in the order it was written. Charging in apply order made the two
+      // disagree about which entries survive: with a 40,000-character addition published before a
+      // 40,000-character replacement, the parser kept the addition and `applyInstructions` kept the
+      // replacement -- the same value applying differently depending on how it reached the SDK.
+      const big = 'a'.repeat(40_000)
+      const config = { instructions: [big, { id: 'agent', instructions: big }] }
+
+      const { blocks, unapplied } = applyInstructions(codeBlocks, config, { onUnmatched: 'ignore' })
+      expect(blocks.map((block) => block.text)).toContain(big)
+      expect(blocks[0]?.text).toBe('You are a checkout assistant.')
+      expect(unapplied.map((entry) => [entry.reason, entry.instructionId])).toEqual([['oversized-text', 'agent']])
+
+      // The parser, given the same value, keeps the same entry.
+      const parsed = parseAgentConfig(config)
+      expect(parsed.instructions).toEqual([{ instructions: big }])
     })
 
     it('charges only the text that survives, so one refused entry does not shrink the budget', () => {

--- a/packages/logfire-node/src/agent-control/__test__/merge.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/merge.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { mergeSettings } from '../index'
+
+describe('mergeSettings', () => {
+  it('applies code < published < the values a run passed explicitly', () => {
+    const { settings, sources } = mergeSettings(
+      { temperature: 0.2, max_tokens: 1024 },
+      { temperature: 0.8, top_p: 0.9 },
+      { max_tokens: 4096 }
+    )
+    expect(settings).toEqual({ temperature: 0.8, max_tokens: 4096, top_p: 0.9 })
+    expect(sources.get('temperature')).toBe('published')
+    expect(sources.get('top_p')).toBe('published')
+    expect(sources.get('max_tokens')).toBe('run')
+  })
+
+  it('lets a run keep a value the published config would otherwise have taken from it', () => {
+    // The case diffing effective settings cannot see: code 0.2, published 0.8, and a run that passes
+    // 0.2 explicitly looks exactly like a run that passed nothing, so the published value wins a key
+    // the caller overrode. Only the explicit key set at the call boundary tells them apart.
+    const { settings, sources } = mergeSettings({ temperature: 0.2 }, { temperature: 0.8 }, { temperature: 0.2 })
+    expect(settings['temperature']).toBe(0.2)
+    expect(sources.get('temperature')).toBe('run')
+  })
+
+  it('reads code and published as patches, so an unset key there does not erase the layer under it', () => {
+    const { settings, sources } = mergeSettings({ temperature: 0.2 }, { temperature: undefined, top_p: null })
+    expect(settings).toEqual({ temperature: 0.2 })
+    expect(sources.get('temperature')).toBe('code')
+    expect(sources.has('top_p')).toBe(false)
+  })
+
+  it('lets a run clear a key, which is not the same as never setting it', () => {
+    const { settings, sources } = mergeSettings({ temperature: 0.2 }, {}, { temperature: undefined })
+    expect('temperature' in settings).toBe(false)
+    // "Send no value for this" -- which an adapter has to be able to tell from "whatever the
+    // framework does by default", and only `sources` carries that difference.
+    expect(sources.get('temperature')).toBe('run')
+  })
+
+  it('passes a key outside the canonical eleven through with its provenance', () => {
+    const { settings, sources } = mergeSettings({ openai_service_tier: 'flex' })
+    expect(settings).toEqual({ openai_service_tier: 'flex' })
+    expect(sources.get('openai_service_tier')).toBe('code')
+  })
+
+  it('merges nothing into nothing', () => {
+    const { settings, sources } = mergeSettings()
+    expect(settings).toEqual({})
+    expect(sources.size).toBe(0)
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/merge.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/merge.test.ts
@@ -50,4 +50,23 @@ describe('mergeSettings', () => {
     expect(settings).toEqual({})
     expect(sources.size).toBe(0)
   })
+
+  it('keeps a `__proto__` key as an entry rather than letting it become a prototype', () => {
+    // The published layer comes from JSON, where `__proto__` parses as an ordinary own key. On a
+    // plain object `settings[key] =` would have replaced the prototype instead, so `sources` would
+    // report a key the merged patch does not carry -- and the run would silently not get it.
+    const published = JSON.parse('{"__proto__": 1, "temperature": 0.5}') as Record<string, unknown>
+    const { settings, sources } = mergeSettings({ temperature: 0.1 }, published)
+    expect(Object.hasOwn(settings, '__proto__')).toBe(true)
+    expect(settings['__proto__']).toBe(1)
+    expect(sources.get('__proto__')).toBe('published')
+  })
+
+  it('clears a `__proto__` key a run explicitly unset, like any other', () => {
+    const published = JSON.parse('{"__proto__": 1}') as Record<string, unknown>
+    const runExplicit = JSON.parse('{"__proto__": null}') as Record<string, unknown>
+    const { settings, sources } = mergeSettings(undefined, published, runExplicit)
+    expect(Object.hasOwn(settings, '__proto__')).toBe(false)
+    expect(sources.get('__proto__')).toBe('run')
+  })
 })

--- a/packages/logfire-node/src/agent-control/__test__/names.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/names.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { AGENT_VARIABLE_PREFIX, agentVariableName, normalizeAgentName } from '../index'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('normalizeAgentName', () => {
+  it('reduces a display name to the key its variable is built from', () => {
+    // The rule, in the order it runs: trim, lowercase, replace, collapse, strip.
+    expect(normalizeAgentName('  Checkout Assistant  ')).toBe('checkout_assistant')
+    expect(normalizeAgentName('a -- b')).toBe('a_b')
+    expect(normalizeAgentName('_leading_and_trailing_')).toBe('leading_and_trailing')
+  })
+
+  it('gives one key to names that differ only in punctuation or case, which is the point', () => {
+    // Lossy on purpose: it is what makes a Pydantic AI `Checkout Assistant` and a Mastra
+    // `checkout-assistant` the one config the Logfire UI shows for them.
+    const keys = ['checkout-assistant', 'Checkout Assistant', 'checkout_assistant', 'checkout.assistant']
+    expect(new Set(keys.map(normalizeAgentName))).toEqual(new Set(['checkout_assistant']))
+  })
+
+  it('returns the empty string for a name with nothing usable in it', () => {
+    expect(normalizeAgentName('   ')).toBe('')
+    expect(normalizeAgentName('---')).toBe('')
+    expect(normalizeAgentName('日本語')).toBe('')
+  })
+})
+
+describe('agentVariableName', () => {
+  it('is the prefix plus the key', () => {
+    expect(agentVariableName('checkout-assistant')).toBe(`${AGENT_VARIABLE_PREFIX}checkout_assistant`)
+  })
+
+  it('warns rather than doubling a prefix the caller passed itself', () => {
+    expect(agentVariableName('agent__checkout')).toBe('agent__checkout')
+    expect(warnings.messages).toEqual([
+      "The 'agent__' prefix is added automatically; pass the bare agent name rather than 'agent__checkout'.",
+    ])
+  })
+
+  it('refuses a name with no key in it, naming the rule and what it needs', () => {
+    expect(() => agentVariableName('---')).toThrow(/has nothing a variable key can be made of/u)
+    expect(() => agentVariableName('---')).toThrow(/at least one ASCII letter, digit, or underscore/u)
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/resolution.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/resolution.test.ts
@@ -223,4 +223,48 @@ describe('one resolution, two hooks', () => {
     expect(resolution.label).toBeNull()
     expect(await useResolution(resolution, () => baggageFor('agent__checkout'))).toBe('<code_default>')
   })
+
+  describe('a pinned label with nothing published under it', () => {
+    // `Variable.get` does not keep a pinned label on the way down: with nothing published under it, it
+    // retries the read without the label and hands back whatever the rollout would have picked. A
+    // control pinned to `staging` came back holding `production`'s value, applied, under
+    // `reason: 'resolved'` and `label: 'production'` -- the one outcome pinning a label exists to
+    // prevent.
+    const staging = (): AgentControl => new AgentControl('checkout', { label: 'staging' })
+
+    it('runs on code rather than on another label’s value', async () => {
+      useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+      expect(await staging().resolution()).toEqual({
+        config: null,
+        variableName: 'agent__checkout',
+        label: null,
+        version: null,
+        reason: 'code_default',
+      })
+    })
+
+    it('says so once, because a deployment pinned that label expecting a value under it', async () => {
+      useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+      await staging().resolution()
+      await staging().resolution()
+      expect(warnings.messages).toEqual([
+        "Logfire managed variable 'agent__checkout' has nothing published under the pinned label " +
+          "'staging'; the project resolved 'production' instead, which this control does not apply. " +
+          'Running on the code-defined agent.',
+      ])
+    })
+
+    it('does not tag the run’s spans with the label whose value it refused', async () => {
+      useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+      expect(await staging().run(async () => baggageFor('agent__checkout'))).toBe('<code_default>')
+    })
+
+    it('still applies the value once that label has one', async () => {
+      useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'staging'))
+      const resolution = await staging().resolution()
+      expect(resolution.config).toEqual({ model: 'openai:gpt-5.6-sol' })
+      expect(resolution.label).toBe('staging')
+      expect(warnings.messages).toEqual([])
+    })
+  })
 })

--- a/packages/logfire-node/src/agent-control/__test__/resolution.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/resolution.test.ts
@@ -1,0 +1,226 @@
+/* eslint-disable @typescript-eslint/require-await -- `run` takes an async callback; several of these have nothing to await. */
+import { context, propagation } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { beforeAll, describe, expect, it } from 'vite-plus/test'
+
+import { AgentControl, currentResolution, UnmatchedConfigError, useResolution } from '../index'
+import type { Resolution } from '../index'
+import { captureWarnings, emptyVariable, publishedValue, useLocalVariables, useNoVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+// Baggage only propagates into a callback once a context manager is registered, which `logfire.configure`
+// does in a real process. Registering one here is what lets the test observe what a span would see.
+beforeAll(() => {
+  context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable())
+})
+
+/** The baggage entry the Logfire SDK writes for a resolved variable, as seen from inside `run`. */
+function baggageFor(variableName: string): string | undefined {
+  return propagation.getBaggage(context.active())?.getEntry(`logfire.variables.${variableName}`)?.value
+}
+
+describe('AgentControl.resolution', () => {
+  it('reports the value, the label, the version, and how resolution ended', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    expect(await new AgentControl('checkout', { label: 'production' }).resolution()).toEqual({
+      config: { model: 'openai:gpt-5.6-sol' },
+      variableName: 'agent__checkout',
+      label: 'production',
+      version: 1,
+      reason: 'resolved',
+    })
+  })
+
+  it('reports a null config with the reason that explains it', async () => {
+    // A variable that exists with nothing targeted, and one that does not exist at all, both fall
+    // back to the code default -- so `reason` is what an adapter logs, and `config: null` is what it
+    // acts on. Neither is worth a warning: an agent nobody has configured yet is the normal state.
+    useLocalVariables(emptyVariable('agent__checkout'))
+    const known: Resolution = await new AgentControl('checkout').resolution()
+    expect(known).toEqual({
+      config: null,
+      variableName: 'agent__checkout',
+      label: null,
+      version: null,
+      reason: 'code_default',
+    })
+
+    useLocalVariables()
+    expect((await new AgentControl('checkout').resolution()).reason).toBe('code_default')
+
+    // Variables switched off entirely lands in the same place, and is just as unremarkable.
+    useNoVariables()
+    expect((await new AgentControl('checkout').resolution()).reason).toBe('code_default')
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('reports null for every field but the reason when the provider is unreachable', async () => {
+    useNoVariables()
+    const provider = (await import('logfire/vars')).getVariableProvider() as {
+      getSerializedValue: () => Promise<never>
+    }
+    provider.getSerializedValue = async () => Promise.reject(new Error('connection refused'))
+    expect(await new AgentControl('checkout').resolution()).toEqual({
+      config: null,
+      variableName: 'agent__checkout',
+      label: null,
+      version: null,
+      reason: 'other_error',
+    })
+    expect(warnings.messages).toHaveLength(1)
+  })
+})
+
+describe('AgentControl.resolve', () => {
+  it('is sugar over the same path, warnings included', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }))
+    const control = new AgentControl('checkout')
+    expect(await control.resolve()).toEqual((await control.resolution()).config)
+  })
+})
+
+describe('AgentControl.run', () => {
+  it('hands the callback the resolution and returns what it returns', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    const control = new AgentControl('checkout', { label: 'production' })
+    const seen: Resolution[] = []
+    const result = await control.run(async (resolution) => {
+      seen.push(resolution)
+      return 'ran'
+    })
+    expect(result).toBe('ran')
+    expect(seen).toEqual([
+      {
+        config: { model: 'openai:gpt-5.6-sol' },
+        variableName: 'agent__checkout',
+        label: 'production',
+        version: 1,
+        reason: 'resolved',
+      },
+    ])
+  })
+
+  it("puts the selected label on the SDK's own baggage key for the duration of the callback", async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    expect(baggageFor('agent__checkout')).toBeUndefined()
+    const inside = await new AgentControl('checkout', { label: 'production' }).run(async () => baggageFor('agent__checkout'))
+    // This is what makes a trace say which published version drove the run.
+    expect(inside).toBe('production')
+    // And it is scoped to the callback, not leaked into whatever runs next.
+    expect(baggageFor('agent__checkout')).toBeUndefined()
+  })
+
+  it('marks a run that fell back to code, rather than leaving the trace silent about it', async () => {
+    useLocalVariables()
+    const inside = await new AgentControl('checkout').run(async () => baggageFor('agent__checkout'))
+    expect(inside).toBe('<code_default>')
+  })
+
+  it('resolves once, so the config the callback sees and the label its spans carry cannot disagree', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    const provider = (await import('logfire/vars')).getVariableProvider()
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- captured to be re-bound on the next line.
+    const read = provider.getSerializedValueForLabel
+    if (read === undefined) {
+      throw new Error('the local provider is expected to read values through getSerializedValueForLabel')
+    }
+    const original = read.bind(provider)
+    let reads = 0
+    provider.getSerializedValueForLabel = (...args: Parameters<typeof original>): ReturnType<typeof original> => {
+      reads += 1
+      return original(...args)
+    }
+    await new AgentControl('checkout', { label: 'production' }).run(async ({ config, label }) => {
+      expect(config).not.toBeNull()
+      expect(label).toBe('production')
+    })
+    expect(reads).toBe(1)
+  })
+
+  it("lets the callback's failure through, since it is the run failing and not the config", async () => {
+    useLocalVariables()
+    await expect(new AgentControl('checkout').run(async () => Promise.reject(new Error('the run failed')))).rejects.toThrow(
+      'the run failed'
+    )
+  })
+})
+
+describe('AgentControl.reportUnmatched', () => {
+  it("routes an adapter's own report through this control's policy", () => {
+    const message = 'Managed agent config sets a model, which this framework cannot switch; it is not applied.'
+    new AgentControl('checkout', { onUnmatched: 'ignore' }).reportUnmatched(message)
+    expect(warnings.messages).toEqual([])
+
+    new AgentControl('checkout').reportUnmatched(message)
+    expect(warnings.messages).toEqual([message])
+
+    // Deduplicated per process like every other report, so an adapter can call it per request.
+    new AgentControl('checkout').reportUnmatched(message)
+    expect(warnings.messages).toEqual([message])
+
+    expect(() => {
+      new AgentControl('checkout', { onUnmatched: 'error' }).reportUnmatched(message)
+    }).toThrow(UnmatchedConfigError)
+  })
+})
+
+describe('one resolution, two hooks', () => {
+  it('answers with the resolution the surrounding scope installed', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    const control = new AgentControl('checkout', { label: 'production' })
+    expect(control.currentResolution()).toBeNull()
+
+    const resolution = await control.resolution()
+    const inside = await useResolution(resolution, () => control.currentResolution())
+    // The seam for a framework that hands an adapter two hooks per run: resolving in each of them can
+    // send prompt A with model B while the telemetry attributes the request to B alone.
+    expect(inside).toBe(resolution)
+    expect(control.currentResolution()).toBeNull()
+  })
+
+  it('is installed by `run` too, so the common case needs no second call', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    const control = new AgentControl('checkout', { label: 'production' })
+    const inside = await control.run(async (resolution) => {
+      expect(control.currentResolution()).toBe(resolution)
+      return currentResolution('agent__checkout')
+    })
+    expect(inside?.config).toEqual({ model: 'openai:gpt-5.6-sol' })
+  })
+
+  it('keeps answering about each agent when a managed agent runs inside another', async () => {
+    useLocalVariables({
+      variables: {
+        ...publishedValue('agent__outer', { model: 'openai:gpt-5.6-sol' }).variables,
+        ...publishedValue('agent__inner', { model: 'anthropic:claude-fable-5-1' }).variables,
+      },
+    })
+    const outer = new AgentControl('outer', { label: 'production' })
+    const inner = new AgentControl('inner', { label: 'production' })
+    await useResolution(await outer.resolution(), async () => {
+      await useResolution(await inner.resolution(), () => {
+        // A handoff, a subagent, or a tool that runs another managed agent puts a second scope inside
+        // the first, and neither may start answering about the other.
+        expect(outer.currentResolution()?.config).toEqual({ model: 'openai:gpt-5.6-sol' })
+        expect(inner.currentResolution()?.config).toEqual({ model: 'anthropic:claude-fable-5-1' })
+      })
+      expect(inner.currentResolution()).toBeNull()
+    })
+  })
+
+  it('re-establishes the telemetry of a resolution carried in a framework’s own state', async () => {
+    useLocalVariables(publishedValue('agent__checkout', { model: 'openai:gpt-5.6-sol' }, 'production'))
+    const resolution = await new AgentControl('checkout', { label: 'production' }).resolution()
+    // Rebuilt from the resolution rather than held, so an adapter that carried it through its
+    // framework's per-run state still gets spans that say which version produced them.
+    expect(await useResolution(resolution, () => baggageFor('agent__checkout'))).toBe('production')
+  })
+
+  it('reports a run that fell back to code, which has no label or version to carry', async () => {
+    useLocalVariables()
+    const resolution = await new AgentControl('checkout').resolution()
+    expect(resolution.label).toBeNull()
+    expect(await useResolution(resolution, () => baggageFor('agent__checkout'))).toBe('<code_default>')
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/schema.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/schema.test.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto'
+
+import { describe, expect, it } from 'vite-plus/test'
+
+import { AGENT_CONFIG_JSON_SCHEMA, canonicalJson, MAX_MODEL_FACING_TEXT_LENGTH, SCHEMA_SHA256 } from '../index'
+
+describe('AGENT_CONFIG_JSON_SCHEMA', () => {
+  it('hashes to the digest every SDK pins', () => {
+    // The whole point of the constant: this package's literal and the Python one are provably the
+    // same document, so a variable created by either side is editable by the same Logfire UI.
+    const digest = createHash('sha256').update(canonicalJson(AGENT_CONFIG_JSON_SCHEMA)).digest('hex')
+    expect(digest).toBe(SCHEMA_SHA256)
+    expect(digest).toBe('e4c38488d6c46440dbf31939291e13fcd56814c1305bc9012cd2158733b0bbad')
+  })
+
+  it('is permissive about keys it does not name', () => {
+    // An `additionalProperties: false` anywhere would reject a key a newer UI writes at write time,
+    // which defeats the leniency every reader is built around.
+    const found: string[] = []
+    const walk = (node: unknown, path: string): void => {
+      if (Array.isArray(node)) {
+        node.forEach((item, index) => {
+          walk(item, `${path}[${String(index)}]`)
+        })
+        return
+      }
+      if (typeof node !== 'object' || node === null) {
+        return
+      }
+      for (const [key, value] of Object.entries(node)) {
+        if (key === 'additionalProperties' && value === false) {
+          found.push(path)
+        }
+        walk(value, `${path}.${key}`)
+      }
+    }
+    walk(AGENT_CONFIG_JSON_SCHEMA, '$')
+    expect(found).toEqual([])
+  })
+
+  it('caps model-facing text at the shared limit', () => {
+    expect(MAX_MODEL_FACING_TEXT_LENGTH).toBe(65_536)
+    expect(canonicalJson(AGENT_CONFIG_JSON_SCHEMA)).toContain('"maxLength":65536')
+  })
+})
+
+describe('canonicalJson', () => {
+  it('sorts object keys recursively and keeps array order', () => {
+    expect(canonicalJson({ b: 1, a: { d: [3, 1, 2], c: null } })).toBe('{"a":{"c":null,"d":[3,1,2]},"b":1}')
+  })
+
+  it('passes scalars through', () => {
+    expect(canonicalJson('x')).toBe('"x"')
+    expect(canonicalJson(null)).toBe('null')
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/settings.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/settings.test.ts
@@ -87,6 +87,16 @@ describe('applySettings', () => {
       expect(issues[1]?.message).toContain("publishes a 'model' section, which this agent framework has no way to apply")
     })
 
+    it('yields no patch for a settings section it cannot apply, whatever keys it lists', () => {
+      // Handing back the patch anyway would be this helper contradicting the declaration it was
+      // just given, and reporting each key again would bury the one report that matters.
+      const config = parseAgentConfig({ settings: { temperature: 0.4 } })
+      const support: AgentSupport = { sections: ['instructions'], settings: ['temperature'] }
+      const { settings, issues } = applySettings(config, { support })
+      expect(settings).toEqual({})
+      expect(issues.map((issue) => [issue.section, issue.reason])).toEqual([['settings', 'unsupported-section']])
+    })
+
     it('says nothing about a section the adapter declares', () => {
       const config = parseAgentConfig({ model: 'openai:gpt-5.6-sol' })
       expect(applySettings(config, { support: { sections: ['model'] } }).issues).toEqual([])

--- a/packages/logfire-node/src/agent-control/__test__/settings.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/settings.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { applySettings, parseAgentConfig, reportUnapplied, UnmatchedConfigError } from '../index'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('applySettings', () => {
+  it('returns only the keys the value actually set, so the result is a patch', () => {
+    const config = parseAgentConfig({ settings: { temperature: 0.2, thinking: 'high' } })
+    expect(applySettings(config)).toEqual({ temperature: 0.2, thinking: 'high' })
+  })
+
+  it('returns an empty patch when nothing is published, which merges to a no-op', () => {
+    expect(applySettings({})).toEqual({})
+    expect(applySettings(parseAgentConfig({ settings: {} }))).toEqual({})
+  })
+
+  it('keeps a falsy value, which is a setting and not an absence', () => {
+    const config = parseAgentConfig({ settings: { temperature: 0, parallel_tool_calls: false } })
+    expect(applySettings(config)).toEqual({ temperature: 0, parallel_tool_calls: false })
+  })
+
+  describe('a key this SDK has no field for', () => {
+    const config = parseAgentConfig({ settings: { service_tier: 'flex', temperature: 0.2 } })
+
+    it('is reported here, where the patch is applied, and the rest still applies', () => {
+      expect(applySettings(config)).toEqual({ temperature: 0.2 })
+      expect(warnings.messages).toEqual([
+        "Managed agent config sets 'service_tier', which this version of the SDK has no model setting for; that key is not applied.",
+      ])
+    })
+
+    it('says nothing under ignore', () => {
+      expect(applySettings(config, { onUnmatched: 'ignore' })).toEqual({ temperature: 0.2 })
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('fails the run under error', () => {
+      expect(() => applySettings(config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+    })
+  })
+})
+
+describe('reportUnapplied', () => {
+  it("warns for a key the adapter's own framework cannot lower", () => {
+    reportUnapplied(['top_k'])
+    expect(warnings.messages).toEqual([
+      "Managed agent config sets 'top_k', which this agent framework has no model setting for; that key is not applied.",
+    ])
+  })
+
+  it('is a no-op when the adapter applied everything', () => {
+    reportUnapplied([])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('says nothing under ignore and fails the run under error', () => {
+    reportUnapplied(['seed'], { onUnmatched: 'ignore' })
+    expect(warnings.messages).toEqual([])
+    expect(() => {
+      reportUnapplied(['seed'], { onUnmatched: 'error' })
+    }).toThrow(UnmatchedConfigError)
+  })
+})
+
+describe('a published timeout that is not a budget a request can be given', () => {
+  const config = parseAgentConfig({ settings: { timeout: -1, temperature: 0.2 } })
+
+  it('is dropped rather than clamped, and the rest of the patch still applies', () => {
+    // Clamping turns "no real limit" into a deadline nobody published, and rounding a negative one
+    // to `0` cancels the request before it is sent.
+    expect(applySettings(config)).toEqual({ temperature: 0.2 })
+    expect(warnings.messages[0]).toContain('sets a request timeout of -1 seconds')
+  })
+
+  it('goes through onUnmatched like every other key that is not applied', () => {
+    expect(applySettings(config, { onUnmatched: 'ignore' })).toEqual({ temperature: 0.2 })
+    expect(warnings.messages).toEqual([])
+    expect(() => applySettings(config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+  })
+
+  it('leaves a representable one alone, zero included', () => {
+    expect(applySettings(parseAgentConfig({ settings: { timeout: 0 } }))).toEqual({ timeout: 0 })
+    expect(applySettings(parseAgentConfig({ settings: { timeout: 30 } }))).toEqual({ timeout: 30 })
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/settings.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/settings.test.ts
@@ -1,66 +1,123 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { applySettings, parseAgentConfig, reportUnapplied, UnmatchedConfigError } from '../index'
+import { applySettings, parseAgentConfig } from '../index'
+import type { AgentSupport } from '../index'
 import { captureWarnings } from './helpers'
 
 const warnings = captureWarnings()
 
+/** An adapter that can lower two settings and apply no other section. */
+const SETTINGS_ONLY: AgentSupport = { sections: ['settings'], settings: ['temperature', 'max_tokens'] }
+
 describe('applySettings', () => {
   it('returns only the keys the value actually set, so the result is a patch', () => {
     const config = parseAgentConfig({ settings: { temperature: 0.2, thinking: 'high' } })
-    expect(applySettings(config)).toEqual({ temperature: 0.2, thinking: 'high' })
+    expect(applySettings(config)).toEqual({ settings: { temperature: 0.2, thinking: 'high' }, issues: [] })
   })
 
   it('returns an empty patch when nothing is published, which merges to a no-op', () => {
-    expect(applySettings({})).toEqual({})
-    expect(applySettings(parseAgentConfig({ settings: {} }))).toEqual({})
+    expect(applySettings({})).toEqual({ settings: {}, issues: [] })
+    expect(applySettings(parseAgentConfig({ settings: {} }))).toEqual({ settings: {}, issues: [] })
   })
 
   it('keeps a falsy value, which is a setting and not an absence', () => {
     const config = parseAgentConfig({ settings: { temperature: 0, parallel_tool_calls: false } })
-    expect(applySettings(config)).toEqual({ temperature: 0, parallel_tool_calls: false })
+    expect(applySettings(config).settings).toEqual({ temperature: 0, parallel_tool_calls: false })
+  })
+
+  it('reports nothing itself, whatever it could not apply', () => {
+    // The policy is applied once per request, by `AgentControl.report`. It used to be applied here,
+    // per key, which is why an adapter had to remember to call a second reporter for the keys *it*
+    // could not lower -- and a forgotten call was a silent drop.
+    const config = parseAgentConfig({ settings: { service_tier: 'flex' } })
+    expect(applySettings(config).issues).toHaveLength(1)
+    expect(warnings.messages).toEqual([])
   })
 
   describe('a key this SDK has no field for', () => {
     const config = parseAgentConfig({ settings: { service_tier: 'flex', temperature: 0.2 } })
 
-    it('is reported here, where the patch is applied, and the rest still applies', () => {
-      expect(applySettings(config)).toEqual({ temperature: 0.2 })
-      expect(warnings.messages).toEqual([
-        "Managed agent config sets 'service_tier', which this version of the SDK has no model setting for; that key is not applied.",
+    it('comes back as an issue, and the rest of the patch still applies', () => {
+      const { settings, issues } = applySettings(config)
+      expect(settings).toEqual({ temperature: 0.2 })
+      expect(issues.map((issue) => [issue.section, issue.reason, issue.setting])).toEqual([['settings', 'unknown-setting', 'service_tier']])
+      expect(issues[0]?.message).toBe(
+        "Managed agent config sets 'service_tier', which this version of the SDK has no model setting for; that key is not applied."
+      )
+    })
+  })
+
+  describe('a canonical key this adapter cannot lower', () => {
+    const config = parseAgentConfig({ settings: { temperature: 0.4, top_k: 40 } })
+
+    it('is dropped and reported, which this core could not do at all before', () => {
+      // There was no support filtering here: an adapter filtered the patch itself and then called a
+      // reporter of its own, so the two could disagree and a forgotten call said nothing.
+      const { settings, issues } = applySettings(config, { support: SETTINGS_ONLY })
+      expect(settings).toEqual({ temperature: 0.4 })
+      expect(issues.map((issue) => [issue.section, issue.reason, issue.setting])).toEqual([['settings', 'unsupported-setting', 'top_k']])
+      expect(issues[0]?.message).toContain("sets 'top_k', which this agent framework has no model setting for")
+    })
+
+    it('is applied when no support is declared, which says the adapter can lower all of them', () => {
+      expect(applySettings(config).settings).toEqual({ temperature: 0.4, top_k: 40 })
+      expect(applySettings(config, { support: null }).settings).toEqual({ temperature: 0.4, top_k: 40 })
+    })
+
+    it('is every canonical key when the declaration lists none', () => {
+      const { settings, issues } = applySettings(config, { support: { sections: ['settings'] } })
+      expect(settings).toEqual({})
+      expect(issues.map((issue) => issue.setting)).toEqual(['temperature', 'top_k'])
+    })
+  })
+
+  describe('a whole section this adapter cannot apply', () => {
+    it('is reported once, rather than being silently ignored', () => {
+      const config = parseAgentConfig({
+        instructions: ['Be brief.'],
+        model: 'openai:gpt-5.6-sol',
+        settings: { temperature: 0.4 },
+      })
+      const { settings, issues } = applySettings(config, { support: SETTINGS_ONLY })
+      expect(settings).toEqual({ temperature: 0.4 })
+      expect(issues.map((issue) => [issue.section, issue.reason])).toEqual([
+        ['instructions', 'unsupported-section'],
+        ['model', 'unsupported-section'],
       ])
+      expect(issues[1]?.message).toContain("publishes a 'model' section, which this agent framework has no way to apply")
     })
 
-    it('says nothing under ignore', () => {
-      expect(applySettings(config, { onUnmatched: 'ignore' })).toEqual({ temperature: 0.2 })
-      expect(warnings.messages).toEqual([])
+    it('says nothing about a section the adapter declares', () => {
+      const config = parseAgentConfig({ model: 'openai:gpt-5.6-sol' })
+      expect(applySettings(config, { support: { sections: ['model'] } }).issues).toEqual([])
     })
 
-    it('fails the run under error', () => {
-      expect(() => applySettings(config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+    it('says nothing when no support is declared, because nothing said it could not', () => {
+      expect(applySettings(parseAgentConfig({ model: 'openai:gpt-5.6-sol' })).issues).toEqual([])
     })
   })
-})
 
-describe('reportUnapplied', () => {
-  it("warns for a key the adapter's own framework cannot lower", () => {
-    reportUnapplied(['top_k'])
-    expect(warnings.messages).toEqual([
-      "Managed agent config sets 'top_k', which this agent framework has no model setting for; that key is not applied.",
-    ])
-  })
+  describe('a top-level key this release has no section for', () => {
+    it('is reported rather than dropped in silence', () => {
+      // The openness is deliberate -- it is what lets a future section be published against an older
+      // SDK -- but a drop nobody hears about is a silently degraded agent.
+      const config = parseAgentConfig({ instructions: ['Be brief.'], mcp_servers: [{ name: 'crm' }], skills: [] })
+      const { issues } = applySettings(config)
+      expect(issues.map((issue) => [issue.section, issue.reason])).toEqual([
+        ['mcp_servers', 'unknown-section'],
+        ['skills', 'unknown-section'],
+      ])
+      expect(issues[0]?.message).toContain("publishes a 'mcp_servers' section, which this version of the SDK has no section for")
+    })
 
-  it('is a no-op when the adapter applied everything', () => {
-    reportUnapplied([])
-    expect(warnings.messages).toEqual([])
-  })
+    it('is nothing for a config an adapter built itself, which has no published keys', () => {
+      expect(applySettings({ model: 'openai:gpt-5.6-sol' }).issues).toEqual([])
+    })
 
-  it('says nothing under ignore and fails the run under error', () => {
-    reportUnapplied(['seed'], { onUnmatched: 'ignore' })
-    expect(warnings.messages).toEqual([])
-    expect(() => {
-      reportUnapplied(['seed'], { onUnmatched: 'error' })
-    }).toThrow(UnmatchedConfigError)
+    it('does not reach the published value, so a baseline still serializes to the contract', () => {
+      const config = parseAgentConfig({ model: 'openai:gpt-5.6-sol', mcp_servers: [] })
+      expect(JSON.parse(JSON.stringify(config))).toEqual({ model: 'openai:gpt-5.6-sol' })
+    })
   })
 })
 
@@ -70,18 +127,22 @@ describe('a published timeout that is not a budget a request can be given', () =
   it('is dropped rather than clamped, and the rest of the patch still applies', () => {
     // Clamping turns "no real limit" into a deadline nobody published, and rounding a negative one
     // to `0` cancels the request before it is sent.
-    expect(applySettings(config)).toEqual({ temperature: 0.2 })
-    expect(warnings.messages[0]).toContain('sets a request timeout of -1 seconds')
+    const { settings, issues } = applySettings(config)
+    expect(settings).toEqual({ temperature: 0.2 })
+    expect(issues.map((issue) => [issue.reason, issue.setting])).toEqual([['unrepresentable-timeout', 'timeout']])
+    expect(issues[0]?.message).toContain('sets a request timeout of -1 seconds')
   })
 
-  it('goes through onUnmatched like every other key that is not applied', () => {
-    expect(applySettings(config, { onUnmatched: 'ignore' })).toEqual({ temperature: 0.2 })
-    expect(warnings.messages).toEqual([])
-    expect(() => applySettings(config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+  it('is judged in the canonical key order, so an issue lands in the same place in both cores', () => {
+    // Judging the timeout in a pass of its own would put it ahead of the keys an adapter cannot
+    // lower here and behind them in Python, for the same published value.
+    const both = parseAgentConfig({ settings: { timeout: -1, top_k: 40 } })
+    const { issues } = applySettings(both, { support: SETTINGS_ONLY })
+    expect(issues.map((issue) => issue.reason)).toEqual(['unsupported-setting', 'unrepresentable-timeout'])
   })
 
   it('leaves a representable one alone, zero included', () => {
-    expect(applySettings(parseAgentConfig({ settings: { timeout: 0 } }))).toEqual({ timeout: 0 })
-    expect(applySettings(parseAgentConfig({ settings: { timeout: 30 } }))).toEqual({ timeout: 30 })
+    expect(applySettings(parseAgentConfig({ settings: { timeout: 0 } })).settings).toEqual({ timeout: 0 })
+    expect(applySettings(parseAgentConfig({ settings: { timeout: 30 } })).settings).toEqual({ timeout: 30 })
   })
 })

--- a/packages/logfire-node/src/agent-control/__test__/spec.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/spec.test.ts
@@ -10,10 +10,11 @@
 /**
  * The cross-language vectors, run against this core.
  *
- * Three things have to give the same answer in Python and TypeScript, because a Logfire project is
+ * Everything that has to give the same answer in Python and TypeScript, because a Logfire project is
  * shared and the SDKs are not: which variable an agent's config lives in, what a code baseline says,
- * and what a published value parses to. `spec/` is where those answers live, and this is the half of
- * the agreement this package keeps. A change to a rule changes the file first, and both cores after.
+ * what a published value parses to, and what applying one does to a request. `spec/` is where those
+ * answers live, and this is the half of the agreement this package keeps. A change to a rule changes
+ * the file first, and both cores after.
  *
  * The vectors are the contract, not an illustration of it: every file in `spec/` is read here and
  * every vector in it is asserted, so a rule that stops holding fails a test rather than drifting.
@@ -27,8 +28,16 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vite-plus/test'
 
 import { UNRECOGNIZED_SETTINGS } from '../config'
-import { agentVariableName, buildBaseline, parseAgentConfig } from '../index'
-import type { InstructionBlock, ToolDef } from '../index'
+import {
+  agentVariableName,
+  applyInstructions,
+  applySettings,
+  applyToolDefinitions,
+  buildBaseline,
+  mergeSettings,
+  parseAgentConfig,
+} from '../index'
+import type { AgentSupport, ApplyIssue, CollisionScope, InstructionBlock, ToolDef } from '../index'
 import { resetWarnings } from '../warnings'
 import { captureWarnings } from './helpers'
 
@@ -120,11 +129,164 @@ function warnedBy(run: () => void): string[] {
  * failure prints.
  */
 const SPEC_SHA256: Record<string, string> = {
-  'README.md': '22f5a2680e26decc6caa43c55538a789ea5e455af188db3dbff4b682800a833c',
+  'README.md': '41b9ed72b6a4bac856fcaeece17278cae979627172bb95d880280dc6c1fb6bf5',
   'agent-name.json': '431a25d2745cc211d6489bb9d7ca1e2c47a6e3bbd8436125cf7e123c23c453df',
   'baseline.json': '589fb0f3ef6a3fd0a8d24fe91a105cb5feb3c5a33bbf23b180fc827d19dfab94',
   'config-parsing.json': '6e48cbef934dcc9950e3c33c2db7c83ff80df28171bdffb5c576d5fa36e41515',
+  'instructions-apply.json': '053111c38a39c1b807673df103919ff10627072c8c6a9b7bc6acaca552babcef',
+  'merge.json': 'f933baa835bf0f8f25635fe917ec5b44b60499b58c5a65830f0b910a6854e2eb',
+  'settings-apply.json': 'b4f874485892c0f0bb50c385acc2a0da4ff72adecb95db36a23aaf2f30281b1c',
+  'tools-apply.json': '64e27b93c29e66f7f6d387fe68a39483a535dbcd2145453c4c12c750ea5fa2ef',
 }
+
+/**
+ * Every issue as the fields it actually set, which is what the vectors compare.
+ *
+ * The message is left out on purpose: each core words it for its own users, and what has to match
+ * across the two is the decision and the path to what it was about.
+ */
+function issuesAsPaths(issues: readonly ApplyIssue[]): Record<string, unknown>[] {
+  // The vectors are the wire form, so the one camel-cased field is written back the way they write
+  // it. Every other field's name is already the same in both cores.
+  const names: Record<string, string> = { instructionId: 'instruction_id' }
+  return issues.map((issue) =>
+    Object.fromEntries(
+      Object.entries(issue)
+        .filter(([name, value]) => name !== 'message' && value !== undefined && value !== null)
+        .map(([name, value]) => [names[name] ?? name, value])
+    )
+  )
+}
+
+/**
+ * The `support` an apply vector declares, or `undefined` for an adapter that declares nothing.
+ *
+ * The vector's JSON is the wire form -- arrays, `accepts_additions` -- and this core's own is
+ * camel-cased, so the mapping belongs here rather than in each file's assertions.
+ */
+function supportOf(data: unknown): AgentSupport | undefined {
+  if (data === null || data === undefined) {
+    return undefined
+  }
+  const support = data as {
+    sections: AgentSupport['sections']
+    settings?: string[]
+    destinations?: { id: string; default?: boolean; accepts_additions?: boolean }[]
+  }
+  return {
+    sections: support.sections,
+    settings: support.settings ?? [],
+    destinations: (support.destinations ?? []).map((destination) => ({
+      id: destination.id,
+      default: destination.default ?? false,
+      acceptsAdditions: destination.accepts_additions ?? true,
+    })),
+  }
+}
+
+/** Each part as the vectors write one: `id` even when absent, `dynamic` only when it is set. */
+function partsAsJson(blocks: readonly InstructionBlock[]): Record<string, unknown>[] {
+  return blocks.map((block) => ({ id: block.id, text: block.text, ...(block.dynamic ? { dynamic: true } : {}) }))
+}
+
+/** Each tool as the vectors write one, leaving out what it does not carry. */
+function toolsAsJson(tools: readonly ToolDef[]): Record<string, unknown>[] {
+  return tools.map((tool) => ({
+    name: tool.name,
+    ...(tool.description === undefined ? {} : { description: tool.description }),
+    ...(Object.keys(tool.parametersJsonSchema).length === 0 ? {} : { parameters_json_schema: tool.parametersJsonSchema }),
+    ...(tool.toolset === undefined ? {} : { toolset: tool.toolset }),
+  }))
+}
+
+describe('spec/instructions-apply.json', () => {
+  it('applies every published instructions section the way both cores apply it', () => {
+    const all = vectors('instructions-apply.json')
+    expect(all).toHaveLength(1)
+    for (const vector of all) {
+      const input = expandRepeats(vector.input) as {
+        parts?: { id?: string | null; text: string; dynamic?: boolean }[]
+        config: unknown
+      }
+      const expected = expandRepeats(vector.expected) as { parts?: unknown[]; issues: unknown[] }
+      const parts: InstructionBlock[] = (input.parts ?? []).map((part) => ({
+        id: part.id ?? null,
+        text: part.text,
+        dynamic: part.dynamic ?? false,
+      }))
+      const applied = applyInstructions(parts, parseAgentConfig(input.config))
+      expect(partsAsJson(applied.blocks), vector.name).toEqual(expected.parts ?? [])
+      expect(issuesAsPaths(applied.issues), vector.name).toEqual(expected.issues)
+    }
+  })
+})
+
+describe('spec/tools-apply.json', () => {
+  it('applies every published tool_definitions section the way both cores apply it', () => {
+    const all = vectors('tools-apply.json')
+    expect(all).toHaveLength(2)
+    for (const vector of all) {
+      const input = expandRepeats(vector.input) as {
+        tools?: { name: string; description?: string; parameters_json_schema?: Record<string, unknown>; toolset?: string }[]
+        config: unknown
+        reserved?: string[]
+        collision_scope?: CollisionScope
+      }
+      const expected = expandRepeats(vector.expected) as {
+        tools?: unknown[]
+        routes?: Record<string, string>
+        issues: unknown[]
+      }
+      const tools: ToolDef[] = (input.tools ?? []).map((tool) => ({
+        name: tool.name,
+        parametersJsonSchema: tool.parameters_json_schema ?? {},
+        ...(tool.description === undefined ? {} : { description: tool.description }),
+        ...(tool.toolset === undefined ? {} : { toolset: tool.toolset }),
+      }))
+      const applied = applyToolDefinitions(tools, parseAgentConfig(input.config), {
+        reserved: input.reserved ?? [],
+        collisionScope: input.collision_scope ?? 'global',
+      })
+      expect(toolsAsJson(applied.tools), vector.name).toEqual(expected.tools ?? [])
+      if (expected.routes !== undefined) {
+        expect({ ...applied.routes }, vector.name).toEqual(expected.routes)
+      }
+      expect(issuesAsPaths(applied.issues), vector.name).toEqual(expected.issues)
+    }
+  })
+})
+
+describe('spec/settings-apply.json', () => {
+  it('applies every published settings section the way both cores apply it', () => {
+    const all = vectors('settings-apply.json')
+    expect(all).toHaveLength(8)
+    for (const vector of all) {
+      const input = expandRepeats(vector.input) as { config: unknown; support?: unknown }
+      const expected = expandRepeats(vector.expected) as { settings?: unknown; issues: unknown[] }
+      const applied = applySettings(parseAgentConfig(input.config), { support: supportOf(input.support) })
+      expect(applied.settings, vector.name).toEqual(expected.settings ?? {})
+      expect(issuesAsPaths(applied.issues), vector.name).toEqual(expected.issues)
+    }
+  })
+})
+
+describe('spec/merge.json', () => {
+  it('merges every set of layers the way both cores merge them', () => {
+    const all = vectors('merge.json')
+    expect(all).toHaveLength(6)
+    for (const vector of all) {
+      const input = vector.input as {
+        code?: Record<string, unknown>
+        published?: Record<string, unknown>
+        run_explicit?: Record<string, unknown>
+      }
+      const expected = vector.expected as { settings: Record<string, unknown>; sources: Record<string, string> }
+      const merged = mergeSettings(input.code, input.published, input.run_explicit)
+      expect({ ...merged.settings }, vector.name).toEqual(expected.settings)
+      expect(Object.fromEntries(merged.sources), vector.name).toEqual(expected.sources)
+    }
+  })
+})
 
 describe('the vendored spec/', () => {
   it('is byte-for-byte the canonical copy', () => {

--- a/packages/logfire-node/src/agent-control/__test__/spec.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/spec.test.ts
@@ -1,0 +1,231 @@
+/* eslint-disable vitest/valid-expect, vitest/no-conditional-expect -- see below */
+/*
+ * Every assertion in this file carries `vector.name` as its message, which is what makes a failure
+ * name the rule that stopped holding rather than a line number in a loop. Vitest supports that
+ * second argument to `expect`; the lint rule is modelled on Jest, which does not. The conditional
+ * assertions are the vectors' own two shapes -- a name that resolves to a variable and one that has
+ * no key at all -- asserted in one pass over the file, which is what "every vector in every file"
+ * means.
+ */
+/**
+ * The cross-language vectors, run against this core.
+ *
+ * Three things have to give the same answer in Python and TypeScript, because a Logfire project is
+ * shared and the SDKs are not: which variable an agent's config lives in, what a code baseline says,
+ * and what a published value parses to. `spec/` is where those answers live, and this is the half of
+ * the agreement this package keeps. A change to a rule changes the file first, and both cores after.
+ *
+ * The vectors are the contract, not an illustration of it: every file in `spec/` is read here and
+ * every vector in it is asserted, so a rule that stops holding fails a test rather than drifting.
+ */
+
+import { createHash } from 'node:crypto'
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vite-plus/test'
+
+import { UNRECOGNIZED_SETTINGS } from '../config'
+import { agentVariableName, buildBaseline, parseAgentConfig } from '../index'
+import type { InstructionBlock, ToolDef } from '../index'
+import { resetWarnings } from '../warnings'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+const SPEC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../spec')
+
+interface Vector {
+  name: string
+  input: unknown
+  expected?: unknown
+  warnings?: string[]
+  [key: string]: unknown
+}
+
+function vectors(file: string): Vector[] {
+  return JSON.parse(readFileSync(path.join(SPEC, file), 'utf8')) as Vector[]
+}
+
+/**
+ * Expand the vector files' `{repeat, times}` shorthand, which keeps the 64 KiB cases readable.
+ *
+ * Nothing about the contract depends on it: it is there so a vector about the budget is a line of
+ * JSON rather than 64 KiB of one letter.
+ */
+function expandRepeats(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(expandRepeats)
+  }
+  if (typeof value !== 'object' || value === null) {
+    return value
+  }
+  const entries = Object.entries(value)
+  if (entries.length === 2 && 'repeat' in value && 'times' in value) {
+    return (value as { repeat: string }).repeat.repeat((value as { times: number }).times)
+  }
+  return Object.fromEntries(entries.map(([key, item]) => [key, expandRepeats(item)]))
+}
+
+/**
+ * A distinctive fragment of each warning, mapped to the code the vectors name it by.
+ *
+ * Both cores word their warnings for their own users; what has to match is which decision was taken,
+ * which is why the vectors carry codes and this table is what turns one core's prose into them.
+ * Ordered, because one fragment is a prefix of another.
+ */
+const CODES: [string, string][] = [
+  ['selects invalid model', 'invalid-model'],
+  ['Managed instructions section contains', 'instructions-section-too-long'],
+  ["instructions section is invalid -- instructions=''", 'instructions-section-empty'],
+  ['instructions section has invalid container', 'instructions-invalid-container'],
+  ['Managed instruction entry contains', 'instruction-entry-too-long'],
+  ['has neither an `id` to address nor text to add', 'instruction-entry-empty'],
+  ['Managed instruction entry', 'instruction-entry-invalid'],
+  ['settings section has invalid container', 'settings-invalid-container'],
+  ['which this version of the SDK does not recognize', 'setting-value-not-recognized'],
+  ['has invalid value', 'setting-value-invalid'],
+  ['tool definitions section has invalid container', 'tool-definitions-invalid-container'],
+  ['tool definition override', 'tool-definition-invalid'],
+  ['The agent runs with a request timeout', 'baseline-timeout-not-representable'],
+  ['The agent runs with', 'baseline-value-not-describable'],
+  ['prefix is added automatically', 'prefix-added-automatically'],
+]
+
+function codeOf(message: string): string {
+  const found = CODES.find(([fragment]) => message.includes(fragment))
+  if (found === undefined) {
+    throw new Error(`no spec warning code covers ${JSON.stringify(message)}`)
+  }
+  return found[1]
+}
+
+/** Start each vector from a process that has not warned yet, and hand back what it warns. */
+function warnedBy(run: () => void): string[] {
+  resetWarnings()
+  warnings.messages.length = 0
+  run()
+  return warnings.messages.map(codeOf)
+}
+
+/**
+ * The SHA-256 of every vendored file, as it stands in the canonical copy.
+ *
+ * `spec/` is owned by the Python repository (`pydantic/logfire`), which is where a rule is changed
+ * first; the copy in this package is a vendored mirror so the vectors run offline here. A mirror
+ * with nothing pinning it is a mirror that drifts, and a drifted vector file is the one artifact
+ * that would let the two cores disagree while both of their suites stay green -- so re-vendoring is
+ * deliberately a two-line diff: copy the files across, then update these digests to the ones the
+ * failure prints.
+ */
+const SPEC_SHA256: Record<string, string> = {
+  'README.md': '22f5a2680e26decc6caa43c55538a789ea5e455af188db3dbff4b682800a833c',
+  'agent-name.json': '431a25d2745cc211d6489bb9d7ca1e2c47a6e3bbd8436125cf7e123c23c453df',
+  'baseline.json': '589fb0f3ef6a3fd0a8d24fe91a105cb5feb3c5a33bbf23b180fc827d19dfab94',
+  'config-parsing.json': '6e48cbef934dcc9950e3c33c2db7c83ff80df28171bdffb5c576d5fa36e41515',
+}
+
+describe('the vendored spec/', () => {
+  it('is byte-for-byte the canonical copy', () => {
+    for (const [file, digest] of Object.entries(SPEC_SHA256)) {
+      const actual = createHash('sha256')
+        .update(readFileSync(path.join(SPEC, file)))
+        .digest('hex')
+      expect(actual, `${file} differs from the canonical spec/ in the Python repository`).toBe(digest)
+    }
+  })
+
+  it('pins every file in the directory, so a new vector file cannot arrive unpinned', () => {
+    expect(readdirSync(SPEC).sort()).toEqual(Object.keys(SPEC_SHA256).sort())
+  })
+})
+
+describe('spec/agent-name.json', () => {
+  it('resolves every name to the variable both cores agree on', () => {
+    const all = vectors('agent-name.json')
+    expect(all).toHaveLength(19)
+    for (const vector of all) {
+      const input = vector.input as string
+      let variableName: string | undefined
+      const codes = warnedBy(() => {
+        try {
+          variableName = agentVariableName(input)
+        } catch {
+          variableName = undefined
+        }
+      })
+      if (vector['error'] === 'empty') {
+        expect(variableName, vector.name).toBeUndefined()
+      } else {
+        expect(variableName, vector.name).toBe(vector['variable_name'])
+        expect(input.trim(), vector.name).toBe(vector['display_name'])
+      }
+      expect(codes, vector.name).toEqual(vector['warning'] === undefined ? [] : [vector['warning']])
+    }
+  })
+})
+
+describe('spec/baseline.json', () => {
+  it('describes every agent the way both cores describe it', () => {
+    const all = vectors('baseline.json')
+    expect(all).toHaveLength(15)
+    for (const vector of all) {
+      const input = vector.input as {
+        blocks?: { text: string; id?: string; dynamic?: boolean }[]
+        model?: string
+        settings?: Record<string, unknown>
+        tools?: {
+          name: string
+          description?: string
+          parameters_json_schema?: Record<string, unknown>
+          toolset?: string
+        }[]
+      }
+      const instructions: InstructionBlock[] = (input.blocks ?? []).map((block) => ({
+        text: block.text,
+        id: block.id ?? null,
+        dynamic: block.dynamic ?? false,
+      }))
+      const tools: ToolDef[] = (input.tools ?? []).map((tool) => {
+        const def: ToolDef = { name: tool.name, parametersJsonSchema: tool.parameters_json_schema ?? {} }
+        if (tool.description !== undefined) {
+          def.description = tool.description
+        }
+        if (tool.toolset !== undefined) {
+          def.toolset = tool.toolset
+        }
+        return def
+      })
+      let baseline: unknown
+      const codes = warnedBy(() => {
+        baseline = buildBaseline({
+          instructions,
+          ...(input.model === undefined ? {} : { model: input.model }),
+          ...(input.settings === undefined ? {} : { settings: input.settings }),
+          tools,
+        })
+      })
+      expect(JSON.parse(JSON.stringify(baseline)), vector.name).toEqual(vector.expected)
+      expect(codes, vector.name).toEqual(vector.warnings ?? [])
+    }
+  })
+})
+
+describe('spec/config-parsing.json', () => {
+  it('parses every published value the way both cores parse it', () => {
+    const all = vectors('config-parsing.json')
+    expect(all).toHaveLength(30)
+    for (const vector of all) {
+      let config: ReturnType<typeof parseAgentConfig> | undefined
+      const codes = warnedBy(() => {
+        config = parseAgentConfig(expandRepeats(vector.input))
+      })
+      expect(JSON.parse(JSON.stringify(config)), vector.name).toEqual(expandRepeats(vector.expected))
+      expect(codes, vector.name).toEqual(vector.warnings)
+      if ('unrecognized_settings' in vector) {
+        expect(config?.settings?.[UNRECOGNIZED_SETTINGS], vector.name).toEqual(vector['unrecognized_settings'])
+      }
+    }
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/spec.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/spec.test.ts
@@ -129,13 +129,13 @@ function warnedBy(run: () => void): string[] {
  * failure prints.
  */
 const SPEC_SHA256: Record<string, string> = {
-  'README.md': '41b9ed72b6a4bac856fcaeece17278cae979627172bb95d880280dc6c1fb6bf5',
+  'README.md': 'e98e744cf2e55fde90a2882371288cec9daa584b268f36ec94e0147d8c295e58',
   'agent-name.json': '431a25d2745cc211d6489bb9d7ca1e2c47a6e3bbd8436125cf7e123c23c453df',
   'baseline.json': '589fb0f3ef6a3fd0a8d24fe91a105cb5feb3c5a33bbf23b180fc827d19dfab94',
   'config-parsing.json': '6e48cbef934dcc9950e3c33c2db7c83ff80df28171bdffb5c576d5fa36e41515',
   'instructions-apply.json': '053111c38a39c1b807673df103919ff10627072c8c6a9b7bc6acaca552babcef',
   'merge.json': 'f933baa835bf0f8f25635fe917ec5b44b60499b58c5a65830f0b910a6854e2eb',
-  'settings-apply.json': 'b4f874485892c0f0bb50c385acc2a0da4ff72adecb95db36a23aaf2f30281b1c',
+  'settings-apply.json': '65ff72964b022b895e5cf6749787bf29df68aeeeba04084dc082588e8dfdc836',
   'tools-apply.json': '64e27b93c29e66f7f6d387fe68a39483a535dbcd2145453c4c12c750ea5fa2ef',
 }
 
@@ -259,7 +259,7 @@ describe('spec/tools-apply.json', () => {
 describe('spec/settings-apply.json', () => {
   it('applies every published settings section the way both cores apply it', () => {
     const all = vectors('settings-apply.json')
-    expect(all).toHaveLength(8)
+    expect(all).toHaveLength(9)
     for (const vector of all) {
       const input = expandRepeats(vector.input) as { config: unknown; support?: unknown }
       const expected = expandRepeats(vector.expected) as { settings?: unknown; issues: unknown[] }

--- a/packages/logfire-node/src/agent-control/__test__/testing.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/testing.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vite-plus/test'
+
+import { AgentControl, buildBaseline, warnOnce } from '../index'
+import { resetAgentControl, resetProcessState, resetWarnings } from '../testing'
+import { captureWarnings, settle, storedConfigFor, useLocalVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('warnOnce', () => {
+  it('is exported for adapters, which had been copying it', () => {
+    warnOnce('an adapter said something')
+    warnOnce('an adapter said something')
+    expect(warnings.messages).toEqual(['an adapter said something'])
+  })
+})
+
+describe('the testing entry point', () => {
+  it('clears the warning memory, so a suite can assert a message more than once', () => {
+    warnOnce('said once')
+    warnOnce('said once')
+    expect(warnings.messages).toEqual(['said once'])
+
+    resetWarnings()
+    warnOnce('said once')
+    expect(warnings.messages).toEqual(['said once', 'said once'])
+  })
+
+  it('clears the publish guard, so a suite can assert a publish more than once', async () => {
+    useLocalVariables()
+    const baseline = buildBaseline({ model: 'openai:gpt-5.6-sol' })
+    new AgentControl('checkout').publishBaseline(baseline)
+    await settle()
+    expect(storedConfigFor('agent__checkout')).toBeDefined()
+
+    // Without the reset the second suite to publish this variable would silently write nothing, and
+    // its assertion would fail for a reason that has nothing to do with what it was testing.
+    useLocalVariables()
+    new AgentControl('checkout').publishBaseline(baseline)
+    await settle()
+    expect(storedConfigFor('agent__checkout')).toBeUndefined()
+
+    resetProcessState()
+    new AgentControl('checkout').publishBaseline(baseline)
+    await settle()
+    expect(storedConfigFor('agent__checkout')).toBeDefined()
+  })
+
+  it('clears both at once, which is what a `beforeEach` wants', async () => {
+    useLocalVariables()
+    warnOnce('said once')
+    new AgentControl('checkout').publishBaseline(buildBaseline({ model: 'openai:gpt-5.6-sol' }))
+    await settle()
+
+    resetAgentControl()
+    useLocalVariables()
+    warnOnce('said once')
+    new AgentControl('checkout').publishBaseline(buildBaseline({ model: 'openai:gpt-5.6-sol' }))
+    await settle()
+
+    expect(warnings.messages).toEqual(['said once', 'said once'])
+    expect(storedConfigFor('agent__checkout')).toBeDefined()
+  })
+
+  it('is reachable at the published subpath, not just from source', async () => {
+    // The `exports` map is what an adapter actually imports through, so a missing entry is a break
+    // that no source-relative test would ever catch.
+    const { createRequire } = await import('node:module')
+    const require = createRequire(import.meta.url)
+    const pkg = require('../../../package.json') as { exports: Record<string, Record<string, unknown>> }
+    expect(pkg.exports['./agent-control/testing']).toEqual({
+      import: {
+        types: './dist/agent-control/testing.d.ts',
+        default: './dist/agent-control/testing.js',
+      },
+      require: {
+        types: './dist/agent-control/testing.d.cts',
+        default: './dist/agent-control/testing.cjs',
+      },
+    })
+  })
+
+  it('does not leak the resets into the runtime entry point', async () => {
+    const index = await import('../index')
+    expect(Object.keys(index)).not.toContain('resetWarnings')
+    expect(Object.keys(index)).not.toContain('resetProcessState')
+    expect(Object.keys(index)).not.toContain('resetAgentControl')
+    vi.resetModules()
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/tools.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { applyToolDefinitions, toolKey, UnmatchedConfigError, withParameterDescriptions } from '../index'
+import { applyToolDefinitions, toolKey, withParameterDescriptions } from '../index'
 import type { ToolDef } from '../index'
 import { captureWarnings } from './helpers'
 
@@ -93,14 +93,15 @@ describe('applyToolDefinitions', () => {
   })
 
   it('reports a patch on a parameter the tool does not have, rather than ignoring it', () => {
-    const { tools, unapplied } = applyToolDefinitions(codeTools, {
+    const { tools, issues } = applyToolDefinitions(codeTools, {
       tool_definitions: [{ name: 'refund', parameters: { nonexistent: { description: 'Nothing.' } } }],
     })
     expect(tools[2]).toBe(codeTools[2])
     // From the Logfire UI, a patch naming a parameter the tool does not have looked exactly like one
     // that applied, which is the whole reason this is not silent.
-    expect(unapplied).toEqual([
+    expect(issues).toEqual([
       {
+        section: 'tool_definitions',
         reason: 'unknown-parameter',
         toolset: null,
         tool: 'refund',
@@ -110,17 +111,18 @@ describe('applyToolDefinitions', () => {
           'of that name; that patch applies to nothing.',
       },
     ])
-    expect(warnings.messages).toEqual([unapplied[0]?.message])
+    // Reported by nothing here: the policy is applied once per request, by `AgentControl.report`.
+    expect(warnings.messages).toEqual([])
   })
 
   describe('a rename onto a taken name', () => {
     it("is dropped, with the override's other patches kept", () => {
-      const { tools, routes } = applyToolDefinitions(codeTools, {
+      const { tools, routes, issues } = applyToolDefinitions(codeTools, {
         tool_definitions: [{ name: 'refund', new_name: 'search', description: 'Still applied.' }],
       })
       expect(tools[2]).toEqual({ ...codeTools[2], description: 'Still applied.' })
       expect(routes).toEqual({ search: 'search', refund: 'refund' })
-      expect(warnings.messages[0]).toBe(
+      expect(issues[0]?.message).toBe(
         "Managed tool definition override renames 'refund' to 'search', which is already advertised by " +
           "another tool; keeping the original name 'refund'."
       )
@@ -130,14 +132,14 @@ describe('applyToolDefinitions', () => {
       // A renamed tool stops answering to its code-side name, so that name is free for a later tool.
       // Every code-side name starts out taken, so this used to be refused: `docs/search` was still in
       // the namespace after the only tool holding it had renamed away.
-      const { tools, routes, unapplied } = applyToolDefinitions(codeTools.slice(1), {
+      const { tools, routes, issues } = applyToolDefinitions(codeTools.slice(1), {
         tool_definitions: [
           { name: 'search', new_name: 'lookup' },
           { name: 'refund', new_name: 'search' },
         ],
       })
       expect(tools.map((tool) => tool.name)).toEqual(['lookup', 'search'])
-      expect(unapplied).toEqual([])
+      expect(issues).toEqual([])
       expect(warnings.messages).toEqual([])
       expect(routes).toEqual({ lookup: 'search', search: 'refund' })
     })
@@ -150,24 +152,20 @@ describe('applyToolDefinitions', () => {
       // `refund` ahead of `docs/search`, so the second holder of `search` is not reached until after
       // the rename that would take it.
       const reordered = [codeTools[0], codeTools[2], codeTools[1]].filter((tool) => tool !== undefined)
-      const { tools, unapplied } = applyToolDefinitions(
-        reordered,
-        {
-          tool_definitions: [
-            { name: 'search', toolset: 'crm', new_name: 'lookup' },
-            { name: 'refund', new_name: 'search' },
-          ],
-        },
-        { onUnmatched: 'ignore' }
-      )
+      const { tools, issues } = applyToolDefinitions(reordered, {
+        tool_definitions: [
+          { name: 'search', toolset: 'crm', new_name: 'lookup' },
+          { name: 'refund', new_name: 'search' },
+        ],
+      })
       expect(tools.map((tool) => tool.name)).toEqual(['lookup', 'refund', 'search'])
-      expect(unapplied.map((entry) => [entry.reason, entry.tool])).toEqual([['rename-collision', 'refund']])
+      expect(issues.map((entry) => [entry.reason, entry.tool])).toEqual([['rename-collision', 'refund']])
     })
 
     it('does not free the original name for a later tool when the rename was refused', () => {
       // The refused rename keeps the original name, so it is still taken. Freeing it on the way to a
       // collision would advertise two tools under it.
-      const { tools, unapplied } = applyToolDefinitions(
+      const { tools, issues } = applyToolDefinitions(
         [
           { name: 'a', parametersJsonSchema: { type: 'object', properties: {} } },
           { name: 'b', parametersJsonSchema: { type: 'object', properties: {} } },
@@ -178,25 +176,24 @@ describe('applyToolDefinitions', () => {
             { name: 'a', new_name: 'b' },
             { name: 'c', new_name: 'a' },
           ],
-        },
-        { onUnmatched: 'ignore' }
+        }
       )
       expect(tools.map((tool) => tool.name)).toEqual(['a', 'b', 'c'])
-      expect(unapplied.map((entry) => [entry.reason, entry.tool])).toEqual([
+      expect(issues.map((entry) => [entry.reason, entry.tool])).toEqual([
         ['rename-collision', 'a'],
         ['rename-collision', 'c'],
       ])
     })
 
     it('is dropped when the collision is with a name an earlier rename produced', () => {
-      const { tools } = applyToolDefinitions(codeTools, {
+      const { tools, issues } = applyToolDefinitions(codeTools, {
         tool_definitions: [
           { name: 'search', toolset: 'crm', new_name: 'lookup' },
           { name: 'refund', new_name: 'lookup' },
         ],
       })
       expect(tools.map((tool) => tool.name)).toEqual(['lookup', 'search', 'refund'])
-      expect(warnings.messages[0]).toContain("renames 'refund' to 'lookup'")
+      expect(issues[0]?.message).toContain("renames 'refund' to 'lookup'")
     })
 
     it('leaves every tool reachable under a callable name', () => {
@@ -209,51 +206,56 @@ describe('applyToolDefinitions', () => {
     })
   })
 
-  describe('onUnmatched', () => {
+  describe('an override that matches no tool', () => {
     const config = {
       tool_definitions: [{ name: 'search', toolset: 'billing', description: 'Elsewhere.' }],
     }
 
-    it('warns by default, naming the toolset the entry was narrowed to', () => {
-      applyToolDefinitions(codeTools, config)
-      expect(warnings.messages).toEqual([
-        "Managed agent config patches tool 'search' from toolset 'billing', which no toolset advertises " +
-          'for this request; that override applies to nothing.',
+    it('names the toolset the entry was narrowed to', () => {
+      const { issues } = applyToolDefinitions(codeTools, config)
+      expect(issues.map((entry) => [entry.section, entry.reason, entry.toolset, entry.tool])).toEqual([
+        ['tool_definitions', 'unknown-tool', 'billing', 'search'],
       ])
+      expect(issues[0]?.message).toBe(
+        "Managed agent config patches tool 'search' from toolset 'billing', which no toolset advertises " +
+          'for this request; that override applies to nothing.'
+      )
     })
 
     it('names an unqualified entry without a toolset', () => {
-      applyToolDefinitions(codeTools, { tool_definitions: [{ name: 'nonexistent' }] })
-      expect(warnings.messages[0]).toContain("patches tool 'nonexistent', which no toolset advertises")
+      const { issues } = applyToolDefinitions(codeTools, { tool_definitions: [{ name: 'nonexistent' }] })
+      expect(issues[0]?.message).toContain("patches tool 'nonexistent', which no toolset advertises")
     })
 
-    it('says nothing under ignore', () => {
-      applyToolDefinitions(codeTools, config, { onUnmatched: 'ignore' })
+    it('is reported by nothing here', () => {
+      applyToolDefinitions(codeTools, config)
       expect(warnings.messages).toEqual([])
-    })
-
-    it('fails the run under error', () => {
-      expect(() => applyToolDefinitions(codeTools, config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
     })
   })
 
-  it('keeps the first of two overrides with the same name and toolset', () => {
-    const { tools } = applyToolDefinitions(codeTools, {
+  it('keeps the first of two overrides with the same name and toolset and reports the rest', () => {
+    // It used to warn straight from indexing, which made `'ignore'` warn anyway and `'error'` not
+    // throw at all -- the one decision the policy never governed.
+    const { tools, issues } = applyToolDefinitions(codeTools, {
       tool_definitions: [
         { name: 'refund', description: 'First wins.' },
         { name: 'refund', description: 'Second loses.' },
       ],
     })
     expect(tools[2]?.description).toBe('First wins.')
-    expect(warnings.messages[0]).toContain("names tool 'refund' more than once")
+    expect(issues.map((entry) => [entry.section, entry.reason, entry.toolset, entry.tool])).toEqual([
+      ['tool_definitions', 'duplicate-entry', null, 'refund'],
+    ])
+    expect(issues[0]?.message).toContain("names tool 'refund' more than once")
+    expect(warnings.messages).toEqual([])
   })
 
   it('matches a tool with no toolset against an unqualified override only', () => {
-    const { tools } = applyToolDefinitions(codeTools, {
+    const { tools, issues } = applyToolDefinitions(codeTools, {
       tool_definitions: [{ name: 'refund', toolset: 'crm', description: 'Wrong toolset.' }],
     })
     expect(tools[2]?.description).toBe('Issue a refund.')
-    expect(warnings.messages[0]).toContain("patches tool 'refund' from toolset 'crm'")
+    expect(issues[0]?.message).toContain("patches tool 'refund' from toolset 'crm'")
   })
 })
 
@@ -292,14 +294,14 @@ describe('routing identity', () => {
   })
 
   it('reserves names the adapter needs kept free, so a rename cannot take a handoff', () => {
-    const { tools, unapplied } = applyToolDefinitions(
+    const { tools, issues } = applyToolDefinitions(
       codeTools,
       { tool_definitions: [{ name: 'refund', new_name: 'transfer_to_billing', description: 'Still applied.' }] },
       { reserved: ['transfer_to_billing'] }
     )
     expect(tools[2]?.name).toBe('refund')
     expect(tools[2]?.description).toBe('Still applied.')
-    expect(unapplied.map((entry) => entry.reason)).toEqual(['rename-collision'])
+    expect(issues.map((entry) => entry.reason)).toEqual(['rename-collision'])
   })
 
   it("lets two toolsets each answer to a name when that is what the framework's runtime names mean", () => {
@@ -317,7 +319,7 @@ describe('routing identity', () => {
       { collisionScope: 'toolset' }
     )
     expect(scoped.tools.map((tool) => tool.name)).toEqual(['lookup', 'lookup', 'refund'])
-    expect(scoped.unapplied).toEqual([])
+    expect(scoped.issues).toEqual([])
     expect(scoped.reverse.get(toolKey('crm', 'lookup'))).toBe('search')
 
     // Under the default global scope the same rename is a genuine collision.
@@ -325,7 +327,7 @@ describe('routing identity', () => {
       tool_definitions: [{ name: 'search', toolset: 'crm', new_name: 'lookup' }],
     })
     expect(global.tools.map((tool) => tool.name)).toEqual(['search', 'lookup', 'refund'])
-    expect(global.unapplied.map((entry) => entry.reason)).toEqual(['rename-collision'])
+    expect(global.issues.map((entry) => entry.reason)).toEqual(['rename-collision'])
   })
 
   it('is a table about this request, not about `Object.prototype`', () => {
@@ -359,29 +361,26 @@ describe('routing identity', () => {
   })
 })
 
-describe('a rename collision goes through onUnmatched like every other decision', () => {
+describe('a rename collision comes back like every other decision', () => {
   const config = { tool_definitions: [{ name: 'refund', new_name: 'search' }] }
 
-  it('says nothing under ignore', () => {
-    // It used to warn unconditionally, so `'ignore'` still warned and `'error'` did not fail.
-    applyToolDefinitions(codeTools, config, { onUnmatched: 'ignore' })
+  it('is an issue rather than a warning of its own', () => {
+    // It used to warn unconditionally, so `'ignore'` still warned and `'error'` did not fail. Now
+    // every decision this section makes is one list for one reporter.
+    const { issues } = applyToolDefinitions(codeTools, config)
+    expect(issues.map((entry) => [entry.section, entry.reason, entry.tool])).toEqual([['tool_definitions', 'rename-collision', 'refund']])
     expect(warnings.messages).toEqual([])
-  })
-
-  it('fails the run under error', () => {
-    expect(() => applyToolDefinitions(codeTools, config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
   })
 })
 
 describe('a parameter patch that reaches nothing', () => {
   it('reports a tool with no top-level parameters to patch at all', () => {
-    const { unapplied } = applyToolDefinitions(
-      [{ name: 'raw', parametersJsonSchema: { type: 'string' } }],
-      { tool_definitions: [{ name: 'raw', parameters: { q: { description: 'Query.' } } }] },
-      { onUnmatched: 'ignore' }
-    )
-    expect(unapplied).toEqual([
+    const { issues } = applyToolDefinitions([{ name: 'raw', parametersJsonSchema: { type: 'string' } }], {
+      tool_definitions: [{ name: 'raw', parameters: { q: { description: 'Query.' } } }],
+    })
+    expect(issues).toEqual([
       {
+        section: 'tool_definitions',
         reason: 'no-patchable-schema',
         toolset: null,
         tool: 'raw',
@@ -395,48 +394,44 @@ describe('a parameter patch that reaches nothing', () => {
 
   it('reports nothing for an entry that asks for no change at all', () => {
     // `'no-patchable-schema'` is "no object schema to patch a description *into*", so an entry with no
-    // description is not a gap between Logfire and the agent -- and under `'error'` it used to fail
-    // the run for asking nothing. The same empty entry on a tool that does have properties was always
-    // silent, so this is the two paths agreeing.
-    const { unapplied } = applyToolDefinitions(
-      [{ name: 'raw', parametersJsonSchema: { type: 'string' } }],
-      { tool_definitions: [{ name: 'raw', parameters: { q: {} } }] },
-      { onUnmatched: 'error' }
-    )
-    expect(unapplied).toEqual([])
+    // description is not a gap between Logfire and the agent -- and it used to fail the run under
+    // `'error'` for asking nothing. The same empty entry on a tool that does have properties was
+    // always silent, so this is the two paths agreeing.
+    const { issues } = applyToolDefinitions([{ name: 'raw', parametersJsonSchema: { type: 'string' } }], {
+      tool_definitions: [{ name: 'raw', parameters: { q: {} } }],
+    })
+    expect(issues).toEqual([])
     expect(warnings.messages).toEqual([])
   })
 
   it('still reports a parameter this deployment does not have, patch or no patch', () => {
     // Not gated on a description: naming a parameter the tool has no property for is drift between
     // what the Logfire editor showed and what the agent advertises, whichever fields the entry sets.
-    const { unapplied } = applyToolDefinitions(
+    const { issues } = applyToolDefinitions(
       [{ name: 'ok', parametersJsonSchema: { type: 'object', properties: { q: { type: 'string' } } } }],
-      { tool_definitions: [{ name: 'ok', parameters: { nope: {} } }] },
-      { onUnmatched: 'ignore' }
+      { tool_definitions: [{ name: 'ok', parameters: { nope: {} } }] }
     )
-    expect(unapplied.map((entry) => [entry.reason, entry.parameter])).toEqual([['unknown-parameter', 'nope']])
+    expect(issues.map((entry) => [entry.reason, entry.parameter])).toEqual([['unknown-parameter', 'nope']])
   })
 
   it('reports a parameter whose schema is not an object to patch a description into', () => {
-    const { unapplied } = applyToolDefinitions(
-      [{ name: 'odd', parametersJsonSchema: { type: 'object', properties: { flag: true } } }],
-      { tool_definitions: [{ name: 'odd', parameters: { flag: { description: 'On or off.' } } }] },
-      { onUnmatched: 'ignore' }
-    )
-    expect(unapplied.map((entry) => [entry.reason, entry.parameter])).toEqual([['no-patchable-schema', 'flag']])
+    const { issues } = applyToolDefinitions([{ name: 'odd', parametersJsonSchema: { type: 'object', properties: { flag: true } } }], {
+      tool_definitions: [{ name: 'odd', parameters: { flag: { description: 'On or off.' } } }],
+    })
+    expect(issues.map((entry) => [entry.reason, entry.parameter])).toEqual([['no-patchable-schema', 'flag']])
   })
 
-  it('fails the run under error, which it could not do while it was silent', () => {
-    expect(() =>
-      applyToolDefinitions(codeTools, { tool_definitions: [{ name: 'refund', parameters: { nonexistent: {} } }] }, { onUnmatched: 'error' })
-    ).toThrow(UnmatchedConfigError)
+  it('comes back for one reporter to apply the policy to, which it could not do while it was silent', () => {
+    const { issues } = applyToolDefinitions(codeTools, {
+      tool_definitions: [{ name: 'refund', parameters: { nonexistent: {} } }],
+    })
+    expect(issues.map((entry) => [entry.reason, entry.parameter])).toEqual([['unknown-parameter', 'nonexistent']])
   })
 
   it('says nothing about a parameter entry that asks for no change', () => {
-    const { unapplied } = applyToolDefinitions(codeTools, {
+    const { issues } = applyToolDefinitions(codeTools, {
       tool_definitions: [{ name: 'search', toolset: 'crm', parameters: { q: {} } }],
     })
-    expect(unapplied).toEqual([])
+    expect(issues).toEqual([])
   })
 })

--- a/packages/logfire-node/src/agent-control/__test__/tools.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/tools.test.ts
@@ -126,6 +126,68 @@ describe('applyToolDefinitions', () => {
       )
     })
 
+    it('is allowed when an earlier rename freed the name it takes', () => {
+      // A renamed tool stops answering to its code-side name, so that name is free for a later tool.
+      // Every code-side name starts out taken, so this used to be refused: `docs/search` was still in
+      // the namespace after the only tool holding it had renamed away.
+      const { tools, routes, unapplied } = applyToolDefinitions(codeTools.slice(1), {
+        tool_definitions: [
+          { name: 'search', new_name: 'lookup' },
+          { name: 'refund', new_name: 'search' },
+        ],
+      })
+      expect(tools.map((tool) => tool.name)).toEqual(['lookup', 'search'])
+      expect(unapplied).toEqual([])
+      expect(warnings.messages).toEqual([])
+      expect(routes).toEqual({ lookup: 'search', search: 'refund' })
+    })
+
+    it('does not free a name a second tool still answers to', () => {
+      // Under the default global scope `crm/search` and `docs/search` both advertise `search`, so
+      // `crm/search` renaming away does not free it. Bookkeeping that only remembered whether a name
+      // was taken, rather than how many tools held it, let `refund` take it here and advertised two
+      // tools as `search`.
+      // `refund` ahead of `docs/search`, so the second holder of `search` is not reached until after
+      // the rename that would take it.
+      const reordered = [codeTools[0], codeTools[2], codeTools[1]].filter((tool) => tool !== undefined)
+      const { tools, unapplied } = applyToolDefinitions(
+        reordered,
+        {
+          tool_definitions: [
+            { name: 'search', toolset: 'crm', new_name: 'lookup' },
+            { name: 'refund', new_name: 'search' },
+          ],
+        },
+        { onUnmatched: 'ignore' }
+      )
+      expect(tools.map((tool) => tool.name)).toEqual(['lookup', 'refund', 'search'])
+      expect(unapplied.map((entry) => [entry.reason, entry.tool])).toEqual([['rename-collision', 'refund']])
+    })
+
+    it('does not free the original name for a later tool when the rename was refused', () => {
+      // The refused rename keeps the original name, so it is still taken. Freeing it on the way to a
+      // collision would advertise two tools under it.
+      const { tools, unapplied } = applyToolDefinitions(
+        [
+          { name: 'a', parametersJsonSchema: { type: 'object', properties: {} } },
+          { name: 'b', parametersJsonSchema: { type: 'object', properties: {} } },
+          { name: 'c', parametersJsonSchema: { type: 'object', properties: {} } },
+        ],
+        {
+          tool_definitions: [
+            { name: 'a', new_name: 'b' },
+            { name: 'c', new_name: 'a' },
+          ],
+        },
+        { onUnmatched: 'ignore' }
+      )
+      expect(tools.map((tool) => tool.name)).toEqual(['a', 'b', 'c'])
+      expect(unapplied.map((entry) => [entry.reason, entry.tool])).toEqual([
+        ['rename-collision', 'a'],
+        ['rename-collision', 'c'],
+      ])
+    })
+
     it('is dropped when the collision is with a name an earlier rename produced', () => {
       const { tools } = applyToolDefinitions(codeTools, {
         tool_definitions: [
@@ -329,6 +391,31 @@ describe('a parameter patch that reaches nothing', () => {
           'that patch applies to nothing.',
       },
     ])
+  })
+
+  it('reports nothing for an entry that asks for no change at all', () => {
+    // `'no-patchable-schema'` is "no object schema to patch a description *into*", so an entry with no
+    // description is not a gap between Logfire and the agent -- and under `'error'` it used to fail
+    // the run for asking nothing. The same empty entry on a tool that does have properties was always
+    // silent, so this is the two paths agreeing.
+    const { unapplied } = applyToolDefinitions(
+      [{ name: 'raw', parametersJsonSchema: { type: 'string' } }],
+      { tool_definitions: [{ name: 'raw', parameters: { q: {} } }] },
+      { onUnmatched: 'error' }
+    )
+    expect(unapplied).toEqual([])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('still reports a parameter this deployment does not have, patch or no patch', () => {
+    // Not gated on a description: naming a parameter the tool has no property for is drift between
+    // what the Logfire editor showed and what the agent advertises, whichever fields the entry sets.
+    const { unapplied } = applyToolDefinitions(
+      [{ name: 'ok', parametersJsonSchema: { type: 'object', properties: { q: { type: 'string' } } } }],
+      { tool_definitions: [{ name: 'ok', parameters: { nope: {} } }] },
+      { onUnmatched: 'ignore' }
+    )
+    expect(unapplied.map((entry) => [entry.reason, entry.parameter])).toEqual([['unknown-parameter', 'nope']])
   })
 
   it('reports a parameter whose schema is not an object to patch a description into', () => {

--- a/packages/logfire-node/src/agent-control/__test__/tools.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/tools.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { applyToolDefinitions, toolKey, UnmatchedConfigError, withParameterDescriptions } from '../index'
+import type { ToolDef } from '../index'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+const codeTools: ToolDef[] = [
+  {
+    name: 'search',
+    description: 'Search the CRM.',
+    parametersJsonSchema: {
+      type: 'object',
+      properties: { q: { type: 'string', description: 'Query.' }, limit: { type: 'integer' } },
+      required: ['q'],
+    },
+    toolset: 'crm',
+  },
+  {
+    name: 'search',
+    description: 'Search the docs.',
+    parametersJsonSchema: { type: 'object', properties: { q: { type: 'string' } } },
+    toolset: 'docs',
+  },
+  {
+    name: 'refund',
+    description: 'Issue a refund.',
+    parametersJsonSchema: { type: 'object', properties: {} },
+  },
+]
+
+describe('applyToolDefinitions', () => {
+  it('leaves the tools alone and still routes every one of them', () => {
+    const { tools, routes } = applyToolDefinitions(codeTools, {})
+    expect(tools).toEqual(codeTools)
+    expect(routes).toEqual({ search: 'search', refund: 'refund' })
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('patches description and parameter descriptions without touching the rest of the schema', () => {
+    const { tools } = applyToolDefinitions(codeTools, {
+      tool_definitions: [
+        { name: 'refund', description: 'Refund the customer, once approved.' },
+        {
+          name: 'search',
+          toolset: 'crm',
+          parameters: { q: { description: 'A customer name or email.' } },
+        },
+      ],
+    })
+    expect(tools[2]?.description).toBe('Refund the customer, once approved.')
+    expect(tools[0]?.parametersJsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        q: { type: 'string', description: 'A customer name or email.' },
+        limit: { type: 'integer' },
+      },
+      required: ['q'],
+    })
+    // Requiredness, types, and every other parameter are code-owned and untouched.
+    expect(tools[1]?.parametersJsonSchema).toBe(codeTools[1]?.parametersJsonSchema)
+  })
+
+  it('narrows a match to one toolset, letting two tools of the same name be patched apart', () => {
+    const { tools } = applyToolDefinitions(codeTools, {
+      tool_definitions: [
+        { name: 'search', toolset: 'crm', description: 'CRM search.' },
+        { name: 'search', toolset: 'docs', description: 'Docs search.' },
+      ],
+    })
+    expect(tools.map((tool) => tool.description)).toEqual(['CRM search.', 'Docs search.', 'Issue a refund.'])
+  })
+
+  it('lets a qualified override beat an unqualified one, without reporting the loser as unmatched', () => {
+    const { tools } = applyToolDefinitions(codeTools, {
+      tool_definitions: [
+        { name: 'search', description: 'Every search.' },
+        { name: 'search', toolset: 'crm', description: 'The CRM search.' },
+      ],
+    })
+    expect(tools.map((tool) => tool.description)).toEqual(['The CRM search.', 'Every search.', 'Issue a refund.'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('renames a tool and routes the new name back to the code-side one', () => {
+    const { tools, routes } = applyToolDefinitions(codeTools, {
+      tool_definitions: [{ name: 'refund', new_name: 'issue_refund' }],
+    })
+    expect(tools[2]?.name).toBe('issue_refund')
+    // Keyed by what the model is shown, so a call is routed by the name the model actually used.
+    expect(routes).toEqual({ search: 'search', issue_refund: 'refund' })
+  })
+
+  it('reports a patch on a parameter the tool does not have, rather than ignoring it', () => {
+    const { tools, unapplied } = applyToolDefinitions(codeTools, {
+      tool_definitions: [{ name: 'refund', parameters: { nonexistent: { description: 'Nothing.' } } }],
+    })
+    expect(tools[2]).toBe(codeTools[2])
+    // From the Logfire UI, a patch naming a parameter the tool does not have looked exactly like one
+    // that applied, which is the whole reason this is not silent.
+    expect(unapplied).toEqual([
+      {
+        reason: 'unknown-parameter',
+        toolset: null,
+        tool: 'refund',
+        parameter: 'nonexistent',
+        message:
+          "Managed agent config patches parameter 'nonexistent' of tool 'refund', which has no parameter " +
+          'of that name; that patch applies to nothing.',
+      },
+    ])
+    expect(warnings.messages).toEqual([unapplied[0]?.message])
+  })
+
+  describe('a rename onto a taken name', () => {
+    it("is dropped, with the override's other patches kept", () => {
+      const { tools, routes } = applyToolDefinitions(codeTools, {
+        tool_definitions: [{ name: 'refund', new_name: 'search', description: 'Still applied.' }],
+      })
+      expect(tools[2]).toEqual({ ...codeTools[2], description: 'Still applied.' })
+      expect(routes).toEqual({ search: 'search', refund: 'refund' })
+      expect(warnings.messages[0]).toBe(
+        "Managed tool definition override renames 'refund' to 'search', which is already advertised by " +
+          "another tool; keeping the original name 'refund'."
+      )
+    })
+
+    it('is dropped when the collision is with a name an earlier rename produced', () => {
+      const { tools } = applyToolDefinitions(codeTools, {
+        tool_definitions: [
+          { name: 'search', toolset: 'crm', new_name: 'lookup' },
+          { name: 'refund', new_name: 'lookup' },
+        ],
+      })
+      expect(tools.map((tool) => tool.name)).toEqual(['lookup', 'search', 'refund'])
+      expect(warnings.messages[0]).toContain("renames 'refund' to 'lookup'")
+    })
+
+    it('leaves every tool reachable under a callable name', () => {
+      const { tools, routes } = applyToolDefinitions(codeTools, {
+        tool_definitions: [{ name: 'refund', new_name: 'search' }],
+      })
+      for (const tool of tools) {
+        expect(routes[tool.name]).toBeDefined()
+      }
+    })
+  })
+
+  describe('onUnmatched', () => {
+    const config = {
+      tool_definitions: [{ name: 'search', toolset: 'billing', description: 'Elsewhere.' }],
+    }
+
+    it('warns by default, naming the toolset the entry was narrowed to', () => {
+      applyToolDefinitions(codeTools, config)
+      expect(warnings.messages).toEqual([
+        "Managed agent config patches tool 'search' from toolset 'billing', which no toolset advertises " +
+          'for this request; that override applies to nothing.',
+      ])
+    })
+
+    it('names an unqualified entry without a toolset', () => {
+      applyToolDefinitions(codeTools, { tool_definitions: [{ name: 'nonexistent' }] })
+      expect(warnings.messages[0]).toContain("patches tool 'nonexistent', which no toolset advertises")
+    })
+
+    it('says nothing under ignore', () => {
+      applyToolDefinitions(codeTools, config, { onUnmatched: 'ignore' })
+      expect(warnings.messages).toEqual([])
+    })
+
+    it('fails the run under error', () => {
+      expect(() => applyToolDefinitions(codeTools, config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+    })
+  })
+
+  it('keeps the first of two overrides with the same name and toolset', () => {
+    const { tools } = applyToolDefinitions(codeTools, {
+      tool_definitions: [
+        { name: 'refund', description: 'First wins.' },
+        { name: 'refund', description: 'Second loses.' },
+      ],
+    })
+    expect(tools[2]?.description).toBe('First wins.')
+    expect(warnings.messages[0]).toContain("names tool 'refund' more than once")
+  })
+
+  it('matches a tool with no toolset against an unqualified override only', () => {
+    const { tools } = applyToolDefinitions(codeTools, {
+      tool_definitions: [{ name: 'refund', toolset: 'crm', description: 'Wrong toolset.' }],
+    })
+    expect(tools[2]?.description).toBe('Issue a refund.')
+    expect(warnings.messages[0]).toContain("patches tool 'refund' from toolset 'crm'")
+  })
+})
+
+describe('withParameterDescriptions', () => {
+  it('returns the same object when there is nothing to patch', () => {
+    const schema = { type: 'object', properties: { q: { type: 'string' } } }
+    expect(withParameterDescriptions(schema, {})).toBe(schema)
+    expect(withParameterDescriptions(schema, { q: {} })).toBe(schema)
+  })
+
+  it('returns the same object for a schema with no properties to patch', () => {
+    const schema = { type: 'string' }
+    expect(withParameterDescriptions(schema, { q: { description: 'x' } })).toBe(schema)
+  })
+
+  it('leaves a non-object property entry alone', () => {
+    const schema = { type: 'object', properties: { q: 'not a schema' } }
+    expect(withParameterDescriptions(schema, { q: { description: 'x' } })).toBe(schema)
+  })
+})
+
+describe('routing identity', () => {
+  it('maps both directions on the `(toolset, name)` pair, not on a bare name', () => {
+    const { forward, reverse, routes } = applyToolDefinitions(codeTools, {
+      tool_definitions: [{ name: 'search', toolset: 'docs', new_name: 'lookup' }],
+    })
+    // Out: the name the code gave a tool, to the name it is advertised under.
+    expect(forward.get(toolKey('crm', 'search'))).toBe('search')
+    expect(forward.get(toolKey('docs', 'search'))).toBe('lookup')
+    // In: the name a call arrives under, back to the tool the code defined.
+    expect(reverse.get(toolKey('docs', 'lookup'))).toBe('search')
+    expect(reverse.get(toolKey(null, 'refund'))).toBe('refund')
+    // The flat table keeps the first of two tools advertising one name, which is why an adapter that
+    // allows that reads `reverse` instead.
+    expect(routes['search']).toBe('search')
+  })
+
+  it('reserves names the adapter needs kept free, so a rename cannot take a handoff', () => {
+    const { tools, unapplied } = applyToolDefinitions(
+      codeTools,
+      { tool_definitions: [{ name: 'refund', new_name: 'transfer_to_billing', description: 'Still applied.' }] },
+      { reserved: ['transfer_to_billing'] }
+    )
+    expect(tools[2]?.name).toBe('refund')
+    expect(tools[2]?.description).toBe('Still applied.')
+    expect(unapplied.map((entry) => entry.reason)).toEqual(['rename-collision'])
+  })
+
+  it("lets two toolsets each answer to a name when that is what the framework's runtime names mean", () => {
+    // The Claude Agent SDK advertises `mcp__<server>__<tool>`, so renaming the CRM's `search` to
+    // `lookup` cannot collide with the docs toolset's `lookup`: they are different runtime names.
+    const tools: ToolDef[] = [
+      { name: 'search', parametersJsonSchema: {}, toolset: 'crm' },
+      { name: 'lookup', parametersJsonSchema: {}, toolset: 'docs' },
+      // A tool with no toolset competes in its own namespace, the one keyed on nothing.
+      { name: 'refund', parametersJsonSchema: {} },
+    ]
+    const scoped = applyToolDefinitions(
+      tools,
+      { tool_definitions: [{ name: 'search', toolset: 'crm', new_name: 'lookup' }] },
+      { collisionScope: 'toolset' }
+    )
+    expect(scoped.tools.map((tool) => tool.name)).toEqual(['lookup', 'lookup', 'refund'])
+    expect(scoped.unapplied).toEqual([])
+    expect(scoped.reverse.get(toolKey('crm', 'lookup'))).toBe('search')
+
+    // Under the default global scope the same rename is a genuine collision.
+    const global = applyToolDefinitions(tools, {
+      tool_definitions: [{ name: 'search', toolset: 'crm', new_name: 'lookup' }],
+    })
+    expect(global.tools.map((tool) => tool.name)).toEqual(['search', 'lookup', 'refund'])
+    expect(global.unapplied.map((entry) => entry.reason)).toEqual(['rename-collision'])
+  })
+
+  it('is a table about this request, not about `Object.prototype`', () => {
+    // A tool the model calls `constructor` must be a name `routes` does not have, rather than an
+    // inherited function an adapter would go on to invoke.
+    const { routes } = applyToolDefinitions([{ name: 'refund', parametersJsonSchema: {} }], {})
+    expect('constructor' in routes).toBe(false)
+    expect('toString' in routes).toBe(false)
+  })
+})
+
+describe('a rename collision goes through onUnmatched like every other decision', () => {
+  const config = { tool_definitions: [{ name: 'refund', new_name: 'search' }] }
+
+  it('says nothing under ignore', () => {
+    // It used to warn unconditionally, so `'ignore'` still warned and `'error'` did not fail.
+    applyToolDefinitions(codeTools, config, { onUnmatched: 'ignore' })
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('fails the run under error', () => {
+    expect(() => applyToolDefinitions(codeTools, config, { onUnmatched: 'error' })).toThrow(UnmatchedConfigError)
+  })
+})
+
+describe('a parameter patch that reaches nothing', () => {
+  it('reports a tool with no top-level parameters to patch at all', () => {
+    const { unapplied } = applyToolDefinitions(
+      [{ name: 'raw', parametersJsonSchema: { type: 'string' } }],
+      { tool_definitions: [{ name: 'raw', parameters: { q: { description: 'Query.' } } }] },
+      { onUnmatched: 'ignore' }
+    )
+    expect(unapplied).toEqual([
+      {
+        reason: 'no-patchable-schema',
+        toolset: null,
+        tool: 'raw',
+        parameter: 'q',
+        message:
+          "Managed agent config patches parameter 'q' of tool 'raw', which has no top-level parameters; " +
+          'that patch applies to nothing.',
+      },
+    ])
+  })
+
+  it('reports a parameter whose schema is not an object to patch a description into', () => {
+    const { unapplied } = applyToolDefinitions(
+      [{ name: 'odd', parametersJsonSchema: { type: 'object', properties: { flag: true } } }],
+      { tool_definitions: [{ name: 'odd', parameters: { flag: { description: 'On or off.' } } }] },
+      { onUnmatched: 'ignore' }
+    )
+    expect(unapplied.map((entry) => [entry.reason, entry.parameter])).toEqual([['no-patchable-schema', 'flag']])
+  })
+
+  it('fails the run under error, which it could not do while it was silent', () => {
+    expect(() =>
+      applyToolDefinitions(codeTools, { tool_definitions: [{ name: 'refund', parameters: { nonexistent: {} } }] }, { onUnmatched: 'error' })
+    ).toThrow(UnmatchedConfigError)
+  })
+
+  it('says nothing about a parameter entry that asks for no change', () => {
+    const { unapplied } = applyToolDefinitions(codeTools, {
+      tool_definitions: [{ name: 'search', toolset: 'crm', parameters: { q: {} } }],
+    })
+    expect(unapplied).toEqual([])
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/tools.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/tools.test.ts
@@ -273,6 +273,28 @@ describe('routing identity', () => {
     expect('constructor' in routes).toBe(false)
     expect('toString' in routes).toBe(false)
   })
+
+  it('keeps a parameter called `__proto__` in the schema it patches', () => {
+    // A schema from JSON can carry `__proto__` as an ordinary own property. Rebuilding `properties`
+    // on a plain object would have assigned it to the prototype instead, so a code-defined
+    // parameter would vanish out of the schema the model is sent -- with nothing reported, because
+    // the entry that reached nothing was the tool's own parameter rather than a published one.
+    const schema = JSON.parse('{"type":"object","properties":{"__proto__":{"type":"string"},"city":{"type":"string"}}}') as Record<
+      string,
+      unknown
+    >
+    const patched = withParameterDescriptions(schema, { city: { description: 'City to look up.' } })
+    const properties = patched['properties'] as Record<string, unknown>
+    expect(Object.keys(properties)).toEqual(['__proto__', 'city'])
+    expect(properties['city']).toEqual({ type: 'string', description: 'City to look up.' })
+  })
+
+  it('patches a parameter called `__proto__` like any other', () => {
+    const schema = JSON.parse('{"type":"object","properties":{"__proto__":{"type":"string"}}}') as Record<string, unknown>
+    const patched = withParameterDescriptions(schema, { ['__proto__']: { description: 'Nothing special.' } })
+    const properties = patched['properties'] as Record<string, unknown>
+    expect(properties['__proto__']).toEqual({ type: 'string', description: 'Nothing special.' })
+  })
 })
 
 describe('a rename collision goes through onUnmatched like every other decision', () => {

--- a/packages/logfire-node/src/agent-control/__test__/units.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/units.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { isRepresentableTimeout, MAX_TIMEOUT_MILLISECONDS, MAX_TIMEOUT_SECONDS, toMilliseconds } from '../index'
+
+describe('isRepresentableTimeout', () => {
+  it('accepts a finite, non-negative budget a 32-bit timer can hold', () => {
+    expect(isRepresentableTimeout(0)).toBe(true)
+    expect(isRepresentableTimeout(0.0005)).toBe(true)
+    expect(isRepresentableTimeout(30)).toBe(true)
+    expect(isRepresentableTimeout(MAX_TIMEOUT_SECONDS)).toBe(true)
+  })
+
+  it('refuses everything that would make a request behave in a way nobody published', () => {
+    // Each of these is a different lie: cancelled before it was sent, never cancelled, or a delay
+    // that wraps a signed 32-bit timer into firing at once.
+    expect(isRepresentableTimeout(-1)).toBe(false)
+    expect(isRepresentableTimeout(Number.NaN)).toBe(false)
+    expect(isRepresentableTimeout(Number.POSITIVE_INFINITY)).toBe(false)
+    expect(isRepresentableTimeout(MAX_TIMEOUT_SECONDS + 1)).toBe(false)
+  })
+})
+
+describe('toMilliseconds', () => {
+  it('rounds half up, which is the rounding both cores agree on', () => {
+    expect(toMilliseconds(30)).toBe(30_000)
+    expect(toMilliseconds(0.0025)).toBe(3)
+    expect(toMilliseconds(MAX_TIMEOUT_SECONDS)).toBe(MAX_TIMEOUT_MILLISECONDS)
+  })
+
+  it('never rounds a positive budget down to "already expired"', () => {
+    // `AbortSignal.timeout(0)` fires immediately, so quantizing 0.5ms to 0 would turn a very short
+    // timeout into a request that cannot be made at all.
+    expect(toMilliseconds(0.0004)).toBe(1)
+    // An exact zero is passed through, because that is what it was published as.
+    expect(toMilliseconds(0)).toBe(0)
+  })
+
+  it('throws rather than guessing at a budget it cannot represent', () => {
+    // An adapter is expected to ask `isRepresentableTimeout` first and report the value under its
+    // policy; reaching here means it did not, and silently clamping would be the worse answer.
+    expect(() => toMilliseconds(-1)).toThrow(RangeError)
+    expect(() => toMilliseconds(-1)).toThrow(/not a representable request budget/u)
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/warnings.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/warnings.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test'
 
-import { UnmatchedConfigError } from '../index'
-import { droppedByProvider, repr, reportIssues, reportUnmatched, warnOnce } from '../warnings'
+import { droppedByProvider, reportIssues as reportIssuesFromIndex, UnmatchedConfigError } from '../index'
+import { droppedByProvider as droppedByProviderLocal, repr, reportIssues, reportUnmatched, warnOnce } from '../warnings'
 import type { ApplyIssue } from '../warnings'
 import { captureWarnings } from './helpers'
 
@@ -73,6 +73,13 @@ describe('reportIssues', () => {
     reportIssues('ignore', [first])
     reportIssues('error', [])
     expect(warnings.messages).toEqual([])
+  })
+
+  it('is part of the package, for an adapter that carries the policy and holds no control', () => {
+    // The same pair the Python core exports, so an adapter author reading either one finds the same
+    // two ways in: the method when there is a control to ask, the function when there is not.
+    expect(reportIssuesFromIndex).toBe(reportIssues)
+    expect(droppedByProvider).toBe(droppedByProviderLocal)
   })
 })
 

--- a/packages/logfire-node/src/agent-control/__test__/warnings.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/warnings.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vite-plus/test'
+
+import { UnmatchedConfigError } from '../index'
+import { repr, reportUnmatched, warnOnce } from '../warnings'
+import { captureWarnings } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('warnOnce', () => {
+  it('emits a message once per process, and a different one still gets through', () => {
+    warnOnce('first')
+    warnOnce('first')
+    warnOnce('second')
+    expect(warnings.messages).toEqual(['first', 'second'])
+  })
+})
+
+describe('reportUnmatched', () => {
+  it('carries the same message under every policy that says anything', () => {
+    const message = 'the entry reached nothing'
+    reportUnmatched('ignore', message)
+    expect(warnings.messages).toEqual([])
+    reportUnmatched('warn', message)
+    expect(warnings.messages).toEqual([message])
+    expect(() => {
+      reportUnmatched('error', message)
+    }).toThrow(new UnmatchedConfigError(message))
+  })
+})
+
+describe('repr', () => {
+  it('renders a value the way the message on the other SDK renders it', () => {
+    expect(repr('text')).toBe("'text'")
+    expect(repr("it's")).toBe("'it\\'s'")
+    expect(repr('a\\b')).toBe("'a\\\\b'")
+    expect(repr(null)).toBe('None')
+    expect(repr(undefined)).toBe('None')
+    expect(repr(true)).toBe('True')
+    expect(repr(false)).toBe('False')
+    expect(repr(42)).toBe('42')
+    expect(repr(1n)).toBe('1')
+    expect(repr({ a: 1 })).toBe('{"a":1}')
+    expect(repr([1, 'two'])).toBe('[1,"two"]')
+  })
+
+  it('falls back to a plain string for a value JSON cannot render', () => {
+    const circular: Record<string, unknown> = { name: 'loop' }
+    circular['self'] = circular
+    expect(repr(circular)).toBe('[object Object]')
+    // `JSON.stringify` returns `undefined` rather than throwing for a lone function.
+    expect(repr(() => 1)).toBe('() => 1')
+  })
+})

--- a/packages/logfire-node/src/agent-control/__test__/warnings.test.ts
+++ b/packages/logfire-node/src/agent-control/__test__/warnings.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test'
 
 import { UnmatchedConfigError } from '../index'
-import { repr, reportUnmatched, warnOnce } from '../warnings'
+import { droppedByProvider, repr, reportIssues, reportUnmatched, warnOnce } from '../warnings'
+import type { ApplyIssue } from '../warnings'
 import { captureWarnings } from './helpers'
 
 const warnings = captureWarnings()
@@ -25,6 +26,53 @@ describe('reportUnmatched', () => {
     expect(() => {
       reportUnmatched('error', message)
     }).toThrow(new UnmatchedConfigError(message))
+  })
+})
+
+describe('droppedByProvider', () => {
+  it('takes the two things every SDK warning shape carries, so the core knows none of them', () => {
+    // Discovered *after* the request, by an adapter reading its own SDK's warnings, which is why the
+    // core cannot find this one for itself.
+    const issue = droppedByProvider('top_k', 'unsupported by this model')
+    expect(issue).toEqual({
+      section: 'settings',
+      reason: 'dropped-by-provider',
+      setting: 'top_k',
+      message:
+        "Managed agent config sets 'top_k', which the provider did not apply -- unsupported by this " +
+        'model; that key had no effect on the request.',
+    })
+  })
+})
+
+describe('reportIssues', () => {
+  const first: ApplyIssue = { section: 'settings', reason: 'unknown-setting', setting: 'a', message: 'first' }
+  const second: ApplyIssue = { section: 'model', reason: 'unsupported-section', message: 'second' }
+
+  it('warns every issue, once per process per message', () => {
+    reportIssues('warn', [first, second])
+    reportIssues('warn', [first])
+    expect(warnings.messages).toEqual(['first', 'second'])
+  })
+
+  it('throws once, naming every issue and carrying them, rather than on the first', () => {
+    // `'error'` used to throw inside the first section's apply call, so the other sections were
+    // never planned: the strictest policy reported the least.
+    let thrown: unknown
+    try {
+      reportIssues('error', [first, second])
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toBeInstanceOf(UnmatchedConfigError)
+    expect((thrown as UnmatchedConfigError).message).toBe('first\nsecond')
+    expect((thrown as UnmatchedConfigError).issues).toEqual([first, second])
+  })
+
+  it('says nothing under ignore, and nothing at all for no issues', () => {
+    reportIssues('ignore', [first])
+    reportIssues('error', [])
+    expect(warnings.messages).toEqual([])
   })
 })
 

--- a/packages/logfire-node/src/agent-control/baseline.ts
+++ b/packages/logfire-node/src/agent-control/baseline.ts
@@ -1,0 +1,164 @@
+/**
+ * Building the code-side baseline: an `AgentConfig` that describes the agent as written.
+ *
+ * The baseline is published to the variable's `example`, which the Logfire UI shows as the thing a
+ * managed value is layered onto. Nothing ever resolves it -- which is exactly what lets it use the
+ * same fields to say *what exists* rather than *what to change*.
+ */
+
+import { canonicalSettings } from './config'
+import type { AgentConfig, InstructionBlockConfig, ParameterOverride, ToolDefinitionOverride } from './config'
+import type { InstructionBlock } from './instructions'
+import type { ToolDef } from './tools'
+
+/** What an adapter snapshots off one assembled request to describe the agent. */
+export interface BaselineInput {
+  /**
+   * The instruction blocks the framework assembled, before any managed value reached them.
+   *
+   * Snapshotted per block rather than as the joined prompt, because the seams are the whole reason
+   * the UI can offer an override at all: a baseline built from the joined text could only ever be
+   * copied wholesale, which -- since managed instructions *add* -- is how you get the agent's own
+   * text sent to the model twice with a frozen `Today is <date>` in the middle of it.
+   */
+  instructions?: readonly InstructionBlock[]
+  /** The model the agent would use, in `'provider:model'` form. */
+  model?: string | null
+  /**
+   * The settings the agent would run with, as a flat mapping.
+   *
+   * Filtered here to the canonical keys, and that filtering is load-bearing rather than tidiness: a
+   * framework's settings also carry provider-specific keys and things like extra headers and bodies
+   * -- exactly where authorization headers and signed request bodies live -- and a baseline is
+   * published to a variable every project member can read.
+   */
+  settings?: Readonly<Record<string, unknown>> | null
+  /** The tools the framework advertises, with their code-defined definitions. */
+  tools?: readonly ToolDef[]
+}
+
+/**
+ * Build the `AgentConfig` that describes the code-side agent.
+ *
+ * What comes back is a plain object whose keys are in contract order and whose unset fields are
+ * absent rather than `null`, so `JSON.stringify(baseline, null, 2)` is the exact `example` the
+ * reference implementation publishes.
+ *
+ * A dynamic block contributes only its seam -- its `id` and `dynamic: true`, never its text --
+ * because that text is this request's rendering, built from whatever the run carried (a tenant name,
+ * a user id, a retrieved document), and the baseline is readable by every member of the project. The
+ * seam is what the editor needs anyway: enough to show the block is there and that it is not yours
+ * to change.
+ *
+ * Two things are left out. A *static* block with blank text, which has nothing to describe. And a
+ * dynamic block with no `id`, which an editor could neither show nor address. Note which case is not
+ * on that list: a dynamic block with an `id` and blank text is published, because its text was never
+ * going to be published anyway, so blankness says nothing about whether the block is worth naming.
+ * An adapter whose framework renders dynamic text inside a binary it cannot read has only the seam
+ * to give, and the seam is the whole contribution.
+ *
+ * The snapshot is a sample, not a description. For instructions or a toolset that vary with the
+ * run's input, it is one point in time, which is why the reference implementation takes it from the
+ * first request in a process rather than from live traffic.
+ */
+export function buildBaseline(input: BaselineInput): AgentConfig {
+  const baseline: AgentConfig = {}
+
+  const instructions: InstructionBlockConfig[] = []
+  for (const block of input.instructions ?? []) {
+    // `dynamic` is decided first, and the blank-text guard applies only to the static branch. A
+    // dynamic block's text is never published, so whether it happens to be blank says nothing about
+    // whether the block is worth describing -- and an adapter whose framework renders its dynamic
+    // text inside a binary it cannot read (Codex, the Claude Agent SDK) has only the seam to give.
+    // Guarding on text first would erase from the baseline exactly the blocks whose existence the
+    // editor has no other way to learn about.
+    if (block.dynamic) {
+      // A dynamic block with nothing to key it on is left out entirely: an editor can neither show
+      // nor address it, and its text is not ours to publish.
+      if (block.id !== null) {
+        instructions.push(entry(block.id, undefined, true))
+      }
+      continue
+    }
+    if (block.text.trim() === '') {
+      continue
+    }
+    instructions.push(entry(block.id, block.text, false))
+  }
+  if (instructions.length > 0) {
+    baseline.instructions = instructions
+  }
+
+  if (input.model !== undefined && input.model !== null) {
+    baseline.model = input.model
+  }
+
+  const settings = input.settings === undefined || input.settings === null ? {} : canonicalSettings(input.settings)
+  if (Object.keys(settings).length > 0) {
+    baseline.settings = settings
+  }
+
+  const toolDefinitions = (input.tools ?? []).map(toolEntry)
+  if (toolDefinitions.length > 0) {
+    baseline.tool_definitions = toolDefinitions
+  }
+
+  return baseline
+}
+
+/** One instruction entry, with its keys in the order the contract declares them. */
+function entry(id: string | null, text: string | undefined, dynamic: boolean): InstructionBlockConfig {
+  const block: InstructionBlockConfig = {}
+  if (id !== null) {
+    block.id = id
+  }
+  if (text !== undefined) {
+    block.instructions = text
+  }
+  block.dynamic = dynamic
+  return block
+}
+
+/** One tool entry, with its keys in the order the contract declares them. */
+function toolEntry(tool: ToolDef): ToolDefinitionOverride {
+  const definition: ToolDefinitionOverride = { name: tool.name }
+  if (tool.description !== undefined && tool.description !== '') {
+    definition.description = tool.description
+  }
+  const parameters = parameterDescriptions(tool)
+  if (parameters !== undefined) {
+    definition.parameters = parameters
+  }
+  if (tool.toolset !== undefined && tool.toolset !== null) {
+    definition.toolset = tool.toolset
+  }
+  return definition
+}
+
+/**
+ * Every top-level parameter the editor may describe, documented in code or not.
+ *
+ * Only descriptions, because only descriptions are overridable: a baseline says what a managed value
+ * could change, and a parameter's name, type, and requiredness are not among them. But *every*
+ * parameter is listed, carrying its description when the code has one and an empty entry when it does
+ * not -- and the empty entry is the point. An undocumented parameter is exactly the one somebody
+ * wants to describe from Logfire, and a baseline that listed only the documented ones would hide it
+ * from the editor until it had been documented in code first.
+ */
+function parameterDescriptions(tool: ToolDef): Record<string, ParameterOverride> | undefined {
+  const properties = tool.parametersJsonSchema['properties']
+  if (typeof properties !== 'object' || properties === null || Array.isArray(properties)) {
+    return undefined
+  }
+  const parameters: Record<string, ParameterOverride> = {}
+  for (const [name, schema] of Object.entries(properties as Record<string, unknown>)) {
+    // A parameter whose schema is not an object -- JSON Schema's bare `true`, say -- still exists and
+    // is still describable, so it is listed with nothing to describe it yet rather than dropped.
+    const description =
+      typeof schema === 'object' && schema !== null && !Array.isArray(schema)
+        ? (schema as Record<string, unknown>)['description']
+        : undefined
+    parameters[name] = typeof description === 'string' ? { description } : {}
+  }
+  return Object.keys(parameters).length > 0 ? parameters : undefined
+}

--- a/packages/logfire-node/src/agent-control/config.ts
+++ b/packages/logfire-node/src/agent-control/config.ts
@@ -1,0 +1,541 @@
+/**
+ * The `AgentConfig` contract and the lenient parsing that turns a published value into it.
+ *
+ * # Why the field names are `snake_case`
+ *
+ * The types in this module are the *wire* shape: what is stored in the Logfire variable, what the
+ * Logfire UI edits, and what `AGENT_CONFIG_JSON_SCHEMA` validates. Renaming `tool_definitions` to
+ * `toolDefinitions` for the sake of TypeScript convention would put a translation layer between this
+ * package and the only artifact it exists to agree with, and give the two somewhere to drift. The
+ * adapter-facing types that never reach the wire -- `InstructionBlock`, `ToolDef`, every options bag
+ * -- are `camelCase`, because nothing outside this process ever sees them.
+ *
+ * # Why parsing is lenient
+ *
+ * A managed value is resolved on every run through the SDK's variable machinery, which falls back to
+ * the code default when parsing throws. So a strict parse does not mean "reject the bad field", it
+ * means "revert the agent's instructions, model, settings, and every tool override to code because
+ * one key was unfamiliar". Every parser here therefore degrades the narrowest unit that contains the
+ * problem -- one setting, one instruction entry, one tool override -- warns about exactly that unit,
+ * and keeps its siblings.
+ */
+
+import { z } from 'zod'
+
+import { codePointLength, MAX_MODEL_FACING_TEXT_LENGTH } from './schema'
+import { isRepresentableTimeout, MAX_TIMEOUT_SECONDS } from './units'
+import { repr, warnOnce } from './warnings'
+
+/**
+ * Where the settings keys a published value asked for and this release has no field for are kept.
+ *
+ * A symbol rather than a field because it is not part of the value: it is what the value asked for
+ * that this SDK could not do, which only `applySettings` has any use for. `JSON.stringify` ignores
+ * symbol-keyed properties outright, so a parsed config still serializes back to exactly the contract
+ * -- which matters, since a baseline is published by serializing one of these.
+ *
+ * Not exported from the package index: an adapter gets this reported for it by `applySettings`.
+ */
+export const UNRECOGNIZED_SETTINGS: unique symbol = Symbol('logfire.agentControl.unrecognizedSettings')
+
+/**
+ * Canonical model settings managed as one section of an `AgentConfig`.
+ *
+ * The keys are the contract: the settings every framework Agent Control drives has a knob for, under
+ * the names Pydantic AI's `ModelSettings` gives them, so a published value lowers into any SDK
+ * without translation and means the same thing to each. Unset keys keep their code-defined values.
+ * The model itself is the sibling `model` field on `AgentConfig`.
+ *
+ * Nothing else gets through. A key this SDK has no field for is dropped rather than forwarded -- a
+ * key it does not understand is not one it can lower into a request -- and remembered under
+ * `UNRECOGNIZED_SETTINGS` so `applySettings` can report it, since a newer UI's key that this SDK
+ * quietly did nothing with is exactly the kind of gap between what Logfire shows and what the agent
+ * does that has to be visible.
+ */
+export interface AgentConfigSettings {
+  max_tokens?: number
+  temperature?: number
+  top_p?: number
+  top_k?: number
+  seed?: number
+  presence_penalty?: number
+  frequency_penalty?: number
+  parallel_tool_calls?: boolean
+  timeout?: number
+  stop_sequences?: string[]
+  thinking?: boolean | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+  /** The published keys this release has no field for, in the order they were written. */
+  [UNRECOGNIZED_SETTINGS]?: readonly string[]
+}
+
+/** One entry in `AgentConfig.instructions`: a block to add, or a patch on a block the agent assembles. */
+export interface InstructionBlockConfig {
+  /**
+   * The id of the instruction block to address, or absent to add a block.
+   *
+   * The contract keeps `id` free-form and reserves only `'agent'` as the cross-framework name for the
+   * prompt as written; the rest of the namespace belongs to each adapter.
+   */
+  id?: string
+  /**
+   * The block's text, or `null` to drop the addressed block.
+   *
+   * `null` is how a block is disabled, which is why `''` is rejected rather than taken as a quiet way
+   * to blank one: an entry meaning "send nothing here" and an entry someone left half-filled should
+   * not look identical.
+   */
+  instructions?: string | null
+  /**
+   * Whether the addressed block is recomputed per request. Informational; ignored when applied.
+   *
+   * It earns its keep in a baseline, where it is how the Logfire UI can say that replacing a computed
+   * block -- today's date, the signed-in user -- would pin whatever it happened to evaluate to when
+   * the snapshot was taken.
+   */
+  dynamic?: boolean
+}
+
+/** A patch over one top-level parameter of a tool's LLM-facing definition. */
+export interface ParameterOverride {
+  /** Replacement description shown to the model; absent keeps the code-defined description. */
+  description?: string
+}
+
+/**
+ * A patch over a tool's LLM-facing definition.
+ *
+ * Overrides change only what the model is shown. Schema structure, validation, and execution remain
+ * code-defined.
+ */
+export interface ToolDefinitionOverride {
+  /** The tool's original code-side name, which is what this entry patches. */
+  name: string
+  /** Replacement name shown to the model; a call to it still routes back to the original tool. */
+  new_name?: string
+  /** Replacement description shown to the model. */
+  description?: string
+  /**
+   * Patches per top-level parameter name.
+   *
+   * Unknown parameter names are ignored: a parameter is part of the tool's code-defined shape, so a
+   * patch on one the tool does not have is the tool having changed, which the baseline shows.
+   */
+  parameters?: Record<string, ParameterOverride>
+  /**
+   * The toolset the tool came from: a baseline reports it, and an override narrows the match by it.
+   *
+   * An override that sets it applies only to that toolset's tool of this `name`, which is what lets
+   * two toolsets that both advertise a `search` be patched apart; an override without it matches by
+   * `name` alone, and when both match one tool the qualified entry wins.
+   */
+  toolset?: string
+}
+
+/**
+ * The schema contract shared with the Logfire Agent Control UI.
+ *
+ * Every managed value is a patch on the code-defined agent. A key present in the value is managed
+ * from Logfire; an absent key keeps code-defined behavior. Removing a key in Logfire is therefore a
+ * deliberate revert to code.
+ */
+export interface AgentConfig {
+  /**
+   * Instruction blocks to add to -- or swap out of -- the ones the agent assembles in code.
+   *
+   * A bare string is exactly one added block, and is kept as written rather than rewritten into the
+   * list form, so a published value stays the shape its author chose and successive versions stay
+   * readable as a diff.
+   */
+  instructions?: string | (string | InstructionBlockConfig)[]
+  /** A model string in `'provider:model'` form, such as `'anthropic:claude-fable-5-1'`. */
+  model?: string
+  /** Canonical model settings patch; see `AgentConfigSettings`. */
+  settings?: AgentConfigSettings
+  /** LLM-facing overlays, each naming the tool it patches; see `ToolDefinitionOverride`. */
+  tool_definitions?: ToolDefinitionOverride[]
+}
+
+/**
+ * A managed string that has to say something.
+ *
+ * `''` is never a meaningful managed value -- not "no model", not "no instructions", just a value
+ * someone left half-filled -- and absent already means "leave this to code". Rejecting it keeps the
+ * two apart at every level: the stored JSON schema won't accept the write, and a value that reaches
+ * an older SDK anyway degrades that one field instead of the whole config.
+ */
+const nonEmptyString = z.string().min(1)
+
+// Bounded in code points rather than with Zod's `.max()`, which counts UTF-16 code units: the budget
+// is a cross-language contract, and an astral character has to cost the same here as it does in the
+// Python core. In practice the section-level budget below refuses an oversized entry first; this is
+// what makes the bound a property of the entry schema rather than only of the loop around it.
+const instructionText = z
+  .string()
+  .min(1)
+  .refine((text) => codePointLength(text) <= MAX_MODEL_FACING_TEXT_LENGTH, {
+    message: `Text must contain at most ${String(MAX_MODEL_FACING_TEXT_LENGTH)} code points`,
+  })
+
+// Every object schema here strips unknown keys rather than rejecting or keeping them, which is the
+// same forward-compatibility rule the stored JSON schema follows: a key a newer UI writes must not
+// fail the entry that contains it, and must not be forwarded to a framework that has no idea what it
+// means either. `settings` is the one exception -- its unknown keys are remembered and reported,
+// because a setting someone published and this SDK did not apply is a gap the run should say aloud.
+const parameterOverrideSchema = z.object({ description: z.string().optional() })
+
+const toolDefinitionOverrideSchema = z.object({
+  name: nonEmptyString,
+  new_name: nonEmptyString.optional(),
+  description: z.string().optional(),
+  parameters: z.record(z.string(), parameterOverrideSchema).optional(),
+  toolset: z.string().optional(),
+})
+
+const instructionBlockSchema = z.object({
+  id: nonEmptyString.optional(),
+  instructions: instructionText.nullish(),
+  dynamic: z.boolean().optional(),
+})
+
+/**
+ * Per-key validators for the settings whose accepted values are open-ended.
+ *
+ * Split from `VERSIONED_SETTINGS` so a wrong type here reads as malformed rather than merely newer;
+ * the stored schema already rejects these at write time, so one arriving is a hand-edited value.
+ *
+ * A `Map` rather than an object literal, and that is not style. These are looked up by a key that
+ * came out of arbitrary JSON, and `PLAIN_SETTINGS['constructor']` on an object literal answers with
+ * `Object.prototype`'s -- a function with no `safeParse`, which turns one hostile or merely odd
+ * settings key into a `TypeError` thrown out of the parse, which the SDK's resolution then reads as
+ * "nothing is published" and reverts the entire config to code. A `Map` has no inherited entries to
+ * find. The same is true of `VERSIONED_SETTINGS` below.
+ */
+const PLAIN_SETTINGS = new Map<string, z.ZodType>([
+  ['max_tokens', z.number().int()],
+  ['temperature', z.number()],
+  ['top_p', z.number()],
+  ['top_k', z.number().int()],
+  ['seed', z.number().int()],
+  ['presence_penalty', z.number()],
+  ['frequency_penalty', z.number()],
+  ['parallel_tool_calls', z.boolean()],
+  ['timeout', z.number()],
+  ['stop_sequences', z.array(z.string())],
+])
+
+/**
+ * Per-key validators for the settings whose accepted values grow from release to release.
+ *
+ * A key that enumerates what *this* release knows about is the one that can be handed a value a
+ * newer UI wrote and this SDK cannot lower, which is a different failure from a structurally wrong
+ * value and gets a different warning. `thinking` is the only one today.
+ */
+const VERSIONED_SETTINGS = new Map<string, z.ZodType>([
+  ['thinking', z.union([z.boolean(), z.enum(['minimal', 'low', 'medium', 'high', 'xhigh'])])],
+])
+
+/** Every key an `AgentConfigSettings` has a field for, in the order the contract declares them. */
+export const CANONICAL_SETTINGS_KEYS = [...PLAIN_SETTINGS.keys(), ...VERSIONED_SETTINGS.keys()] as readonly (keyof AgentConfigSettings &
+  string)[]
+
+/**
+ * A framework's own settings reduced to the contract's canonical keys and describable values.
+ *
+ * What a baseline may say about the code side, and nothing more. Two filters, and both are
+ * load-bearing rather than tidiness:
+ *
+ * - **Keys.** A framework's settings also carry provider-specific ones and things like extra headers
+ *   and bodies -- exactly where authorization headers and signed request bodies live -- and a
+ *   baseline is published to a variable every member of the Logfire project can read. A key with no
+ *   field here is dropped in silence, because it is the agent's own setting rather than anything
+ *   anyone published.
+ * - **Values.** A value the contract has a key for but cannot hold is left out and warned about,
+ *   never approximated. A reasoning effort a framework spells `'max'` is not `'xhigh'`, and
+ *   publishing it as one describes the code as doing something it does not do, in the one artifact
+ *   the Logfire editor presents as the truth about the code. A timeout outside the representable
+ *   range goes the same way.
+ *
+ * The Python core reads these leniently and a *published* value strictly, because its two directions
+ * disagree about whether an `int` is a `float` and a tuple is a list. TypeScript has one number type
+ * and one sequence type, so the same validators serve both here; what does not change is that a code
+ * value the contract cannot hold is reported and omitted rather than coerced into the nearest thing
+ * that fits.
+ *
+ * Keys come back in the order the contract declares them, not the order the framework happened to
+ * hold them in, so the `example` this ends up in is byte-identical whichever SDK published it.
+ */
+export function canonicalSettings(settings: Readonly<Record<string, unknown>>): AgentConfigSettings {
+  const describable = new Map<string, unknown>()
+  for (const [name, value] of Object.entries(settings)) {
+    const validator = PLAIN_SETTINGS.get(name) ?? VERSIONED_SETTINGS.get(name)
+    if (validator === undefined || value === undefined || value === null) {
+      continue
+    }
+    if (name === 'timeout' && typeof value === 'number' && !isRepresentableTimeout(value)) {
+      warnOnce(
+        `The agent runs with a request timeout of ${repr(value)} seconds, which the Agent Control ` +
+          `contract cannot describe -- it has to be finite, not negative, and no larger than ` +
+          `${String(MAX_TIMEOUT_SECONDS)} seconds; leaving it out of the published baseline.`
+      )
+      continue
+    }
+    const result = validator.safeParse(value)
+    if (result.success) {
+      describable.set(name, result.data)
+    } else {
+      warnOnce(
+        `The agent runs with ${name}=${repr(value)}, which the Agent Control contract cannot describe; ` +
+          'leaving it out of the published baseline.'
+      )
+    }
+  }
+  const canonical: Record<string, unknown> = {}
+  for (const key of CANONICAL_SETTINGS_KEYS) {
+    if (describable.has(key)) {
+      canonical[key] = describable.get(key)
+    }
+  }
+  return canonical as AgentConfigSettings
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Validate the settings section, dropping each key this SDK cannot act on independently.
+ *
+ * Three outcomes per key, each with its own message because each is a different thing to fix: a key
+ * with no field here is *unrecognized* and remembered for `applySettings` to report; an enumerated
+ * key with a value this release does not know is *newer*; anything else that fails is *malformed*.
+ */
+function parseSettings(data: unknown): AgentConfigSettings | undefined {
+  if (!isPlainObject(data)) {
+    if (data === undefined || data === null) {
+      return undefined
+    }
+    warnOnce(
+      `Managed settings section has invalid container ${repr(data)}; ignoring that section and keeping the rest of the managed config.`
+    )
+    return undefined
+  }
+  const settings: Record<string, unknown> = {}
+  const unrecognized: string[] = []
+  for (const [name, value] of Object.entries(data)) {
+    const versioned = VERSIONED_SETTINGS.get(name)
+    if (versioned !== undefined) {
+      if (versioned.safeParse(value).success) {
+        settings[name] = value
+      } else {
+        warnOnce(
+          `Managed agent config sets ${repr(name)} to ${repr(value)}, which this version of the SDK does not ` +
+            'recognize; ignoring that setting and keeping the rest of the managed config.'
+        )
+      }
+      continue
+    }
+    const plain = PLAIN_SETTINGS.get(name)
+    if (plain === undefined) {
+      unrecognized.push(name)
+      continue
+    }
+    if (plain.safeParse(value).success) {
+      settings[name] = value
+    } else {
+      warnOnce(
+        `Managed agent config setting ${repr(name)} has invalid value ${repr(value)}; ignoring that setting ` +
+          'and keeping the rest of the managed config.'
+      )
+    }
+  }
+  const parsed = settings as AgentConfigSettings
+  if (unrecognized.length > 0) {
+    Object.defineProperty(parsed, UNRECOGNIZED_SETTINGS, {
+      value: Object.freeze(unrecognized),
+      enumerable: false,
+    })
+  }
+  return parsed
+}
+
+/**
+ * Render one rejected entry's failure -- offending field, value, and reason -- for a warning.
+ *
+ * `whole` names the entry itself, for a failure that is not about any one field (something that is
+ * not an object at all): the two sections share this renderer, so neither may be labelled with the
+ * other's noun.
+ */
+function entryErrors(error: z.ZodError, input: unknown, whole: string): string {
+  return error.issues
+    .map((issue) => `${issue.path.map(String).join('.') || whole}=${repr(getIn(input, issue.path))} (${issue.message})`)
+    .join('; ')
+}
+
+/**
+ * Follow a Zod issue's path into the value it was reported against.
+ *
+ * `Object(value)` rather than a traversability check, so a path that does not resolve comes back
+ * `undefined` instead of throwing: this only ever runs to build a warning about something that was
+ * already wrong, and a formatter that can throw would turn a dropped entry into a failed parse.
+ */
+function getIn(input: unknown, path: readonly PropertyKey[]): unknown {
+  let value = input
+  for (const key of path) {
+    value = (Object(value) as Record<PropertyKey, unknown>)[key]
+  }
+  return value
+}
+
+/**
+ * Validate the instructions section, dropping an entry that does not validate.
+ *
+ * An entry is the natural unit of degradation: each one adds or addresses exactly one block, so an
+ * entry this SDK cannot make sense of -- an empty string where text was meant, an entry that says
+ * neither what nor where, something that is neither a string nor an object -- can be left out while
+ * every other block still applies.
+ *
+ * A bare string is left whole: it is one block by definition, so there is no sibling to save by
+ * rescuing it, and preserving the shape keeps a published value looking the way its author wrote it.
+ */
+function parseInstructions(data: unknown): AgentConfig['instructions'] {
+  if (typeof data === 'string') {
+    if (codePointLength(data) > MAX_MODEL_FACING_TEXT_LENGTH) {
+      warnOnce(
+        `Managed instructions section contains ${String(codePointLength(data))} characters, exceeding the ` +
+          `${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character limit; ignoring that section and keeping the rest ` +
+          `of the managed config.`
+      )
+      return undefined
+    }
+    if (data.length === 0) {
+      warnOnce(
+        "Managed instructions section is invalid -- instructions=''; ignoring that section and keeping the rest of the managed config."
+      )
+      return undefined
+    }
+    return data
+  }
+  if (!Array.isArray(data)) {
+    if (data !== undefined && data !== null) {
+      warnOnce(
+        `Managed instructions section has invalid container ${repr(data)}; ignoring that section and ` +
+          'keeping the rest of the managed config.'
+      )
+    }
+    return undefined
+  }
+  const blocks: (string | InstructionBlockConfig)[] = []
+  // The bound is on the text this section adds to every model request, so it has to be the total
+  // across entries, not just each one: a section written as one string is capped, and the same text
+  // written as ten entries has to be capped too or the limit means nothing. Only text that actually
+  // survives is charged against it -- an entry dropped for being malformed adds nothing to the
+  // request, so charging it would let one bad entry shrink the budget for the good ones, and would
+  // make the entries a value keeps depend on the ones it does not.
+  let remaining = MAX_MODEL_FACING_TEXT_LENGTH
+  for (const entry of data as unknown[]) {
+    const text = typeof entry === 'string' ? entry : isPlainObject(entry) ? entry['instructions'] : undefined
+    const length = typeof text === 'string' ? codePointLength(text) : 0
+    if (typeof text === 'string' && length > remaining) {
+      warnOnce(
+        `Managed instruction entry contains ${String(length)} characters, which does not fit in the ` +
+          `${String(remaining)} remaining of the ${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character limit across all ` +
+          `entries; ignoring that entry and keeping the rest of the managed config.`
+      )
+      continue
+    }
+    const candidate = typeof entry === 'string' ? { instructions: entry } : entry
+    const result = instructionBlockSchema.safeParse(candidate)
+    if (!result.success) {
+      warnOnce(
+        `Managed instruction entry ${repr(entry)} is invalid -- ${entryErrors(result.error, candidate, 'entry')}; ` +
+          'ignoring that entry and keeping the rest of the managed config.'
+      )
+      continue
+    }
+    const block = result.data
+    if (block.id === undefined && (block.instructions === undefined || block.instructions === null)) {
+      warnOnce(
+        `Managed instruction entry ${repr(entry)} has neither an \`id\` to address nor text to add; ` +
+          'ignoring that entry and keeping the rest of the managed config.'
+      )
+      continue
+    }
+    remaining -= length
+    blocks.push(block as InstructionBlockConfig)
+  }
+  return blocks
+}
+
+/**
+ * Validate the tool overlays, dropping an override that does not validate.
+ *
+ * Each entry patches exactly one tool, so an entry this SDK cannot validate -- a missing or empty
+ * `name`, a field carrying a shape it does not know, something that is not an object at all -- can
+ * be left out while every other tool keeps its managed definition.
+ */
+function parseToolDefinitions(data: unknown): ToolDefinitionOverride[] | undefined {
+  if (!Array.isArray(data)) {
+    if (data !== undefined && data !== null) {
+      warnOnce(
+        `Managed tool definitions section has invalid container ${repr(data)}; ignoring that section and ` +
+          'keeping the rest of the managed config.'
+      )
+    }
+    return undefined
+  }
+  const overrides: ToolDefinitionOverride[] = []
+  for (const entry of data as unknown[]) {
+    const result = toolDefinitionOverrideSchema.safeParse(entry)
+    if (result.success) {
+      overrides.push(result.data as ToolDefinitionOverride)
+    } else {
+      warnOnce(
+        `Managed tool definition override ${repr(entry)} is invalid -- ` +
+          `${entryErrors(result.error, entry, 'override')}; ` +
+          'ignoring that override and keeping the rest of the managed config.'
+      )
+    }
+  }
+  return overrides
+}
+
+/**
+ * Turn a published value into an `AgentConfig`, degrading rather than failing.
+ *
+ * Never throws. That is the whole point: this runs inside the SDK's variable resolution, where a
+ * throw is indistinguishable from "nothing is published" and would revert every section of the
+ * config to code over one bad field. A value that is not an object at all is the one case with
+ * nothing to salvage, and comes back as an empty config.
+ */
+export function parseAgentConfig(data: unknown): AgentConfig {
+  if (!isPlainObject(data)) {
+    if (data !== undefined && data !== null) {
+      warnOnce(`Managed agent config is not an object -- ${repr(data)}; ignoring it and running on code.`)
+    }
+    return {}
+  }
+  const config: AgentConfig = {}
+  const instructions = parseInstructions(data['instructions'])
+  if (instructions !== undefined) {
+    config.instructions = instructions
+  }
+  const model = data['model']
+  if (model !== undefined && model !== null) {
+    if (nonEmptyString.safeParse(model).success) {
+      config.model = model as string
+    } else {
+      warnOnce(
+        `Managed agent config selects invalid model ${repr(model)}; ignoring that section and keeping the rest of the managed config.`
+      )
+    }
+  }
+  const settings = parseSettings(data['settings'])
+  if (settings !== undefined) {
+    config.settings = settings
+  }
+  const toolDefinitions = parseToolDefinitions(data['tool_definitions'])
+  if (toolDefinitions !== undefined) {
+    config.tool_definitions = toolDefinitions
+  }
+  return config
+}

--- a/packages/logfire-node/src/agent-control/config.ts
+++ b/packages/logfire-node/src/agent-control/config.ts
@@ -39,6 +39,22 @@ import { repr, warnOnce } from './warnings'
 export const UNRECOGNIZED_SETTINGS: unique symbol = Symbol('logfire.agentControl.unrecognizedSettings')
 
 /**
+ * Where the top-level keys a published value asked for and this release has no section for are kept.
+ *
+ * The same mechanism as `UNRECOGNIZED_SETTINGS`, one level up, and for the same reason: ignoring a
+ * key this release has no section for is what lets a future `mcp_servers` or `skills` section be
+ * published against an older SDK, and saying so is what stops the first person who does it from
+ * getting a silently degraded agent. A symbol, so a parsed config still serializes back to exactly
+ * the contract.
+ *
+ * Not exported from the package index: an adapter gets these reported for it by `applySettings`.
+ */
+export const UNRECOGNIZED_SECTIONS: unique symbol = Symbol('logfire.agentControl.unrecognizedSections')
+
+/** The top-level keys this release has a section for; everything else is remembered and reported. */
+const SECTION_KEYS: readonly string[] = ['instructions', 'model', 'settings', 'tool_definitions']
+
+/**
  * Canonical model settings managed as one section of an `AgentConfig`.
  *
  * The keys are the contract: the settings every framework Agent Control drives has a knob for, under
@@ -153,6 +169,8 @@ export interface AgentConfig {
   settings?: AgentConfigSettings
   /** LLM-facing overlays, each naming the tool it patches; see `ToolDefinitionOverride`. */
   tool_definitions?: ToolDefinitionOverride[]
+  /** The published top-level keys this release has no section for, in the order they were written. */
+  [UNRECOGNIZED_SECTIONS]?: readonly string[]
 }
 
 /**
@@ -536,6 +554,13 @@ export function parseAgentConfig(data: unknown): AgentConfig {
   const toolDefinitions = parseToolDefinitions(data['tool_definitions'])
   if (toolDefinitions !== undefined) {
     config.tool_definitions = toolDefinitions
+  }
+  const unrecognized = Object.keys(data).filter((name) => !SECTION_KEYS.includes(name))
+  if (unrecognized.length > 0) {
+    Object.defineProperty(config, UNRECOGNIZED_SECTIONS, {
+      value: Object.freeze(unrecognized),
+      enumerable: false,
+    })
   }
   return config
 }

--- a/packages/logfire-node/src/agent-control/control.ts
+++ b/packages/logfire-node/src/agent-control/control.ts
@@ -354,18 +354,24 @@ export class AgentControl {
    * update endpoint takes the whole definition and no revision or `If-Match`. Everything a client can
    * do to narrow that window is done, and it is worth being exact about what is and is not left:
    *
-   * - The variable is only ever *created* when the read says it is missing, so the common case for a
-   *   new agent involves no overwrite at all.
+   * - The provider is **refreshed from the server first**. `getVariableConfig` answers out of the
+   *   provider's cached config rather than fetching, so without this the existence check could be
+   *   answered by a cache that was never populated -- reporting a variable that does exist as
+   *   missing, taking the create path, and failing on a conflict that the once-per-process guard
+   *   then never retries -- and the read-modify-write below could be modifying state as old as the
+   *   polling interval.
+   * - The variable is only ever *created* when that refreshed read says it is missing, so the common
+   *   case for a new agent involves no overwrite at all.
    * - An existing variable is **re-read immediately before the write**, and the object written is
-   *   that fresh read with `example` replaced -- never one read earlier, and never one a caller passed
-   *   in. Whatever the UI saved up to that read is preserved: values, labels, rollout, description.
-   * - The write is skipped entirely when the fresh read already carries this `example`, which is the
+   *   that read with `example` replaced -- never one read earlier, and never one a caller passed in.
+   *   Whatever the UI saved up to the refresh is preserved: values, labels, rollout, description.
+   * - The write is skipped entirely when that read already carries this `example`, which is the
    *   steady state for a deployed agent, so the overwhelmingly common outcome is no write.
    * - It runs at most once per process per variable, off the request path.
    *
-   * What remains is one HTTP round trip: a value or label saved in the Logfire UI *between* the fresh
-   * read returning and the write landing is overwritten by the older state that read returned, and the
-   * UI reports success for the publish it just lost. Closing it needs an example-only `PATCH`, or a
+   * What remains is one HTTP round trip: a value or label saved in the Logfire UI *between* the
+   * refresh returning and the write landing is overwritten by the older state that refresh returned,
+   * and the UI reports success for the publish it just lost. Closing it needs an example-only `PATCH`, or a
    * conditional write on a revision or ETag, on the platform API:
    * https://github.com/pydantic/pydantic-ai-harness/issues/565. Until then, a deployment that cannot
    * tolerate that window sets `publishBaseline: false` and creates the variable in the UI, and a
@@ -407,6 +413,11 @@ export class AgentControl {
     if (provider instanceof NoOpVariableProvider) {
       return
     }
+    // `getVariableConfig` answers out of the provider's cached config and does not fetch, so both
+    // reads below are only as fresh as the last poll -- and before the first one there is no cache
+    // at all, which would report every existing variable as missing. `variablesPush` refreshes for
+    // the same reason before its own read-modify-write; this is that, once per process.
+    await provider.refresh?.(true)
     const existing = await provider.getVariableConfig?.(this.variableName)
     // `== null` rather than a strict pair: the provider interface types this as `VariableConfig |
     // undefined`, and a custom provider that answers `null` should still read as "no such variable".
@@ -422,8 +433,8 @@ export class AgentControl {
     // Deliberately its own read rather than reusing the one that decided the variable exists: the
     // value written back is the whole variable definition, so every moment between reading it and
     // writing it is a moment in which someone else's edit is inside the object about to be
-    // overwritten. Taking the read here makes that window one round trip instead of two, and makes
-    // "never write from a config read earlier" a property of the code rather than a rule to remember.
+    // overwritten. Taking the read here makes "never write from a config read earlier" a property of
+    // the code rather than a rule to remember.
     const fresh = await provider.getVariableConfig?.(this.variableName)
     // Vanished between the two reads, or already carries this baseline. Either way there is nothing
     // to write, and re-creating a variable someone just deleted is not this call's decision to make.

--- a/packages/logfire-node/src/agent-control/control.ts
+++ b/packages/logfire-node/src/agent-control/control.ts
@@ -16,8 +16,8 @@ import { parseAgentConfig } from './config'
 import type { AgentConfig } from './config'
 import { agentVariableName } from './names'
 import { AGENT_CONFIG_JSON_SCHEMA } from './schema'
-import { reportUnmatched as report, warnOnce } from './warnings'
-import type { OnUnmatched } from './warnings'
+import { reportIssues, reportUnmatched as report, warnOnce } from './warnings'
+import type { ApplyIssue, OnUnmatched } from './warnings'
 
 /**
  * The resolution outcomes that mean a published value was actually applied.
@@ -153,7 +153,13 @@ export interface AgentControlOptions {
    * without a targeting rule.
    */
   label?: string
-  /** What to do with a published entry that reaches nothing; passed on to the `apply*` helpers. */
+  /**
+   * What to do with a published entry that reaches nothing.
+   *
+   * Applied by `report`, which is the one place it is applied: the `apply*` helpers plan a request
+   * and hand back what they could not apply, so an adapter reports every section's issues together
+   * and `'error'` names all of them.
+   */
   onUnmatched?: OnUnmatched
   /**
    * Whether to publish the code-side baseline to the variable's `example`.
@@ -205,7 +211,7 @@ export class AgentControl {
   readonly variableName: string
   /** The label this control reads, or `undefined` to let the rollout choose. */
   readonly label: string | undefined
-  /** The policy this control passes to the `apply*` helpers by default. */
+  /** The policy `report` applies to a request's issues; see `OnUnmatched`. */
   readonly onUnmatched: OnUnmatched
 
   readonly #publishBaseline: boolean
@@ -287,13 +293,38 @@ export class AgentControl {
   }
 
   /**
-   * Report something this adapter could not apply, under this control's `onUnmatched` policy.
+   * Apply this control's `onUnmatched` policy to everything one request could not apply.
    *
-   * The `apply*` helpers report the entries *they* could not place, but they only see the section
-   * they were given. A whole section an adapter cannot act on at all -- a published `model` on a
-   * framework with no way to switch models, a `tool_definitions` section on one whose tools are
-   * fixed -- is the same gap between what Logfire shows and what the agent does, and has to reach the
-   * same policy rather than a `console.log` in the adapter.
+   * The `apply*` helpers plan and report nothing; this is where the policy the user configured is
+   * applied, once, to every section at once. Which is what makes their return value load-bearing: an
+   * adapter that plans three sections and forgets to report says nothing, visibly, rather than
+   * duplicating a warning that was already emitted.
+   *
+   * ```ts
+   * const instructions = applyInstructions(blocks, config);
+   * const tools = applyToolDefinitions(request.tools, config, { reserved });
+   * const settings = applySettings(config, { support: SUPPORT });
+   * control.report(...instructions.issues, ...tools.issues, ...settings.issues);
+   * ```
+   *
+   * Reporting after everything is planned is the point of collecting them: `'error'` used to throw
+   * inside the first section's apply call, so the strictest policy reported the least -- the other
+   * sections were never planned and their issues were never returned. One call throws one
+   * `UnmatchedConfigError`, naming every issue and carrying them on `issues`, which is what lets an
+   * adapter translate it into its own framework's error type without restating a message.
+   */
+  report(...issues: readonly ApplyIssue[]): void {
+    reportIssues(this.onUnmatched, issues)
+  }
+
+  /**
+   * Report something this adapter could not apply, as a message.
+   *
+   * `report` is the channel for anything the core planned, and anything an adapter can describe as an
+   * `ApplyIssue` -- including a section it cannot reach (`'unsupported-section'`) and a setting its
+   * provider dropped (`droppedByProvider`). This is the same policy for a message with no path to
+   * give, and applies it on its own so a message is not held back waiting for a request's other
+   * sections.
    *
    * Write the message the way the built-in ones read: name what was published, and say what did not
    * happen to it. `'warn'` deduplicates it per process, so it is safe to call per request.

--- a/packages/logfire-node/src/agent-control/control.ts
+++ b/packages/logfire-node/src/agent-control/control.ts
@@ -310,7 +310,9 @@ export class AgentControl {
    * disagreeing.
    */
   async #resolve(): Promise<{ resolved: ResolvedVariable<AgentConfig>; resolution: Resolution }> {
-    const resolved: ResolvedVariable<AgentConfig> = await this.#variable.get(this.label === undefined ? {} : { label: this.label })
+    const resolved: ResolvedVariable<AgentConfig> = this.#pinned(
+      await this.#variable.get(this.label === undefined ? {} : { label: this.label })
+    )
     const applied = APPLIED_REASONS.has(resolved.reason)
     if (!applied && NOTEWORTHY_REASONS.has(resolved.reason)) {
       warnOnce(
@@ -328,6 +330,40 @@ export class AgentControl {
         reason: resolved.reason,
       },
     }
+  }
+
+  /**
+   * Hold a pinned label to what it says, discarding a value the SDK resolved under another one.
+   *
+   * A label with nothing published does not stay pinned on the way down: `Variable.get` retries the
+   * read without the label and hands back whatever the rollout would have picked, so a control pinned
+   * to `staging` comes back holding `production`'s value under `reason: 'resolved'` -- applied, and
+   * reported as `production` by a control the deployment pinned to `staging`.
+   *
+   * Pinning a label is a statement about which value this process runs, so another label's value is
+   * not this control's value. It is the "nothing targeted at this label" outcome named in
+   * `APPLIED_REASONS`, and it lands where every one of those lands: the agent runs on code. Returned
+   * as a fresh code-default `ResolvedVariable` rather than by nulling the flat fields, so `run`'s
+   * baggage says `<code_default>` too and a span cannot be tagged with a label whose value the run
+   * never saw.
+   *
+   * Worth one warning: unlike a variable nobody has configured, someone wrote this label into a
+   * deployment and expects the agent to be running what is under it.
+   */
+  #pinned(resolved: ResolvedVariable<AgentConfig>): ResolvedVariable<AgentConfig> {
+    if (this.label === undefined || resolved.label === undefined || resolved.label === this.label) {
+      return resolved
+    }
+    warnOnce(
+      `Logfire managed variable '${this.variableName}' has nothing published under the pinned label ` +
+        `'${this.label}'; the project resolved '${resolved.label}' instead, which this control does not ` +
+        'apply. Running on the code-defined agent.'
+    )
+    return new ResolvedVariable<AgentConfig>({
+      name: this.variableName,
+      reason: 'code_default',
+      value: {} as AgentConfig,
+    })
   }
 
   /**

--- a/packages/logfire-node/src/agent-control/control.ts
+++ b/packages/logfire-node/src/agent-control/control.ts
@@ -1,0 +1,557 @@
+/**
+ * The variable behind one agent's managed config: reading the published value, publishing the
+ * baseline.
+ *
+ * Everything remote lives here. The helpers in `./instructions.ts`, `./tools.ts`, `./settings.ts`,
+ * and `./baseline.ts` are pure, so an adapter's tests never need a provider, and this class is the
+ * only thing that has to know a Logfire project exists.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+import { defineVar, getVariableProvider, NoOpVariableProvider, ResolvedVariable, Variable } from 'logfire/vars'
+import type { VariableConfig, VariableProvider, VariableResolutionReason } from 'logfire/vars'
+
+import { parseAgentConfig } from './config'
+import type { AgentConfig } from './config'
+import { agentVariableName } from './names'
+import { AGENT_CONFIG_JSON_SCHEMA } from './schema'
+import { reportUnmatched as report, warnOnce } from './warnings'
+import type { OnUnmatched } from './warnings'
+
+/**
+ * The resolution outcomes that mean a published value was actually applied.
+ *
+ * Every other reason -- no provider configured, no such variable, nothing targeted at this label, a
+ * value that failed validation, a provider that could not be reached -- means the agent runs on
+ * code, which `resolve` reports as `null` rather than as an empty config, so an adapter can tell
+ * "managed, and it says change nothing" apart from "not managed".
+ */
+const APPLIED_REASONS = new Set(['resolved', 'context_override'])
+
+/**
+ * Resolution outcomes worth saying something about.
+ *
+ * A variable that does not exist yet is the normal state of an agent nobody has configured, and a
+ * provider that is switched off is a deliberate choice; neither is news. A validation failure or an
+ * unreachable provider is: the agent is running on code while Logfire holds a value someone expects
+ * it to be running on.
+ */
+const NOTEWORTHY_REASONS = new Set(['validation_error', 'other_error'])
+
+/**
+ * Variables built in this process, by variable name.
+ *
+ * `defineVar` registers a variable in the SDK's module-level registry -- which is what puts it in
+ * `logfire vars push` -- and refuses a name that is already registered. Two `AgentControl`s for one
+ * agent is a perfectly ordinary thing for an adapter to end up with, and they should share one
+ * variable rather than the second one throwing, so the map is what makes the registration happen
+ * once.
+ */
+const variables = new Map<string, Variable<AgentConfig>>()
+
+/**
+ * Where a published baseline came from, which an adapter has to say because it changes what it means.
+ *
+ * - `'code'` is the agent *as written*: read off the agent object, its declared prompts, its declared
+ *   settings, its tool definitions. It describes every request the agent will make.
+ * - `'observed'` is one request, snapshotted because the framework offers nothing to read the agent
+ *   from until it runs. It describes the request it came from and nothing else, so a prompt or a tool
+ *   list assembled from the run's own input is a sample rather than a description -- and text that
+ *   came from a request is one tenant's, one user's, one retrieved document's, published into a
+ *   variable every member of the Logfire project can read.
+ *
+ * The distinction is not cosmetic: an adapter that can only observe should mark blocks it did not find
+ * in code as dynamic rather than publishing their rendered text, and the editor has to be able to tell
+ * a description of the code from a description of one request that happened first.
+ */
+export type BaselineSource = 'code' | 'observed'
+
+/** Options for `AgentControl.publishBaseline`. */
+export interface PublishBaselineOptions {
+  /**
+   * Whether the baseline describes the agent as written or one request that happened to come first.
+   *
+   * An adapter that reads its framework's agent object leaves this at `'code'`. One whose framework
+   * assembles its prompt or tool list from callables, so that the earliest anything can be read is a
+   * request, passes `'observed'` and says so, rather than letting a snapshot of one request stand in
+   * for a description of the code. A new process publishes again, so a changed deployment updates
+   * either kind.
+   */
+  source?: BaselineSource
+}
+
+/** What a newly created variable says about itself, which depends on what its example actually is. */
+const BASELINE_DESCRIPTIONS: Record<BaselineSource, string> = {
+  code:
+    'Agent Control config for this agent. The example is the agent as written, published by the SDK; ' +
+    'set a value here to change what the agent sends, and remove it to go back to the code.',
+  observed:
+    'Agent Control config for this agent. The example was snapshotted from one request, because this ' +
+    'framework offers nothing to read the agent from until it runs, so it describes that request rather ' +
+    'than every one. Set a value here to change what the agent sends, and remove it to go back to the code.',
+}
+
+/**
+ * Destinations a baseline publish has been attempted for in this process.
+ *
+ * Marked *before* the work starts, so concurrent first requests cannot schedule duplicate writes and
+ * a failure is not retried by every later run.
+ */
+const baselinePublishAttempted = new Set<string>()
+
+/**
+ * What one resolution of an agent's variable came back with.
+ *
+ * All four together, because an adapter needs more than the value: the `label` and `version` are what
+ * put a run's telemetry next to the thing someone saved in Logfire, and the `reason` is what tells
+ * "Logfire says change nothing" apart from "Logfire was never asked" when both hand back a `null`
+ * config.
+ */
+export interface Resolution {
+  /**
+   * The published config, or `null` when the agent is running on code.
+   *
+   * `null` rather than an empty config, so an adapter can tell a value that deliberately changes
+   * nothing apart from there being no value at all.
+   */
+  config: AgentConfig | null
+  /**
+   * The Logfire variable this was read from, which is also the key its scope is held under.
+   *
+   * `useResolution` and `currentResolution` are keyed on it, so a resolution carries the name of the
+   * agent it belongs to rather than an adapter having to pair the two up itself.
+   */
+  variableName: string
+  /** The label resolution selected, or `null` when none was. */
+  label: string | null
+  /** The version of that label's value, or `null` when nothing was resolved. */
+  version: number | null
+  /**
+   * How resolution ended.
+   *
+   * One of the Logfire SDK's `VariableResolutionReason` values, typed as `string` so a reason a newer
+   * SDK adds is something an adapter can log rather than something that fails its build.
+   *
+   * `'resolved'` and `'context_override'` are the two that mean `config` is non-`null`. Everything
+   * that means "running on code" reports `'code_default'` -- no provider configured, no such
+   * variable, and a variable with nothing targeted all land there, because to an agent they are one
+   * outcome -- except the two that are worth knowing about: `'validation_error'` for a value that
+   * would not parse and `'other_error'` for a provider that could not be reached, both of which also
+   * warn once per process.
+   */
+  reason: string
+}
+
+/** Options for `AgentControl`. */
+export interface AgentControlOptions {
+  /**
+   * The label to read, or absent to let the variable's rollout choose one.
+   *
+   * A deployment that pins a label is saying "this process runs the `production` value" regardless
+   * of what the rollout would have picked, which is how a staging deployment reads a staging value
+   * without a targeting rule.
+   */
+  label?: string
+  /** What to do with a published entry that reaches nothing; passed on to the `apply*` helpers. */
+  onUnmatched?: OnUnmatched
+  /**
+   * Whether to publish the code-side baseline to the variable's `example`.
+   *
+   * On by default because `example` is documentation for the Logfire editor and is never resolved or
+   * applied to a run, so a failed or stale publish cannot change agent behavior. Turn it off when the
+   * variables token is intentionally read-only, or when code must not write variable metadata.
+   */
+  publishBaseline?: boolean
+}
+
+/**
+ * Manage one agent's config through one `agent__<name>` Logfire variable.
+ *
+ * The variable holds an `AgentConfig`. Each present section -- `instructions`, `model`, `settings`,
+ * or `tool_definitions` -- is managed from Logfire, while an absent section keeps the code-defined
+ * behavior. Removing a section in Logfire is a deliberate revert to code.
+ *
+ * ```ts
+ * const control = new AgentControl('checkout_assistant', { label: 'production' });
+ * control.publishBaseline(buildBaseline({ instructions: codeBlocks, model, tools }));
+ *
+ * return await control.run(async ({ config }) => {
+ *   const blocks = config === null ? codeBlocks : applyInstructions(codeBlocks, config).blocks;
+ *   return runTheAgent(blocks);
+ * });
+ * ```
+ *
+ * Everything inside `run` carries the resolved label on its spans, so a trace says which published
+ * version drove it. `resolution()` and `resolve()` are there for an adapter whose framework gives it
+ * no single scope to wrap.
+ *
+ * The agent name is required and never inferred. The reference implementation can derive one from a
+ * framework's own agent name, and that derivation is lossy -- `checkout-assistant` and
+ * `checkout_assistant` normalize onto the same variable -- so a core that has no framework to ask
+ * takes the name it will use rather than guessing at one.
+ */
+export class AgentControl {
+  /**
+   * The agent's name as given, trimmed, which is what telemetry and the Logfire UI display.
+   *
+   * Kept verbatim otherwise -- punctuation and capitals and all -- because it is what a person
+   * recognizes the agent by. The variable is keyed on `variableName`, which is this name normalized,
+   * so the display name can be changed to read better without moving the agent to a different config,
+   * as long as it still normalizes to the same key.
+   */
+  readonly name: string
+  /** The Logfire variable holding the config: `agent__` plus the normalized name. */
+  readonly variableName: string
+  /** The label this control reads, or `undefined` to let the rollout choose. */
+  readonly label: string | undefined
+  /** The policy this control passes to the `apply*` helpers by default. */
+  readonly onUnmatched: OnUnmatched
+
+  readonly #publishBaseline: boolean
+  readonly #variable: Variable<AgentConfig>
+
+  constructor(name: string, options: AgentControlOptions = {}) {
+    // Before anything is assigned, because a name with nothing to key on is not an agent this class
+    // can back: `agentVariableName` throws, naming the rule and what it needs.
+    this.variableName = agentVariableName(name)
+    this.name = name.trim()
+    this.label = options.label
+    this.onUnmatched = options.onUnmatched ?? 'warn'
+    this.#publishBaseline = options.publishBaseline ?? true
+    this.#variable = agentVariable(this.variableName)
+  }
+
+  /**
+   * Resolve the variable and report what came back, whether or not anything was published.
+   *
+   * The full outcome, not just the value: which `label` was selected, which `version` of it, and the
+   * `reason` resolution ended on. An adapter wants all four together -- to put the label and version
+   * on its own telemetry, and to tell "Logfire says change nothing" apart from "Logfire was never
+   * asked" when both hand back a `null` config.
+   *
+   * Never throws on a network problem, a missing variable, or a value that fails validation: all
+   * three mean the agent keeps running exactly as its code defines it, which is the behavior a
+   * managed config has to degrade to if it is going to be safe to depend on. That is the SDK's
+   * contract and not a guard here -- resolution reports a failed read, a thrown read, and a provider
+   * missing the method entirely as a `reason`, never as a rejection -- so there is deliberately no
+   * `catch` around it to go stale and never run. The two reasons worth knowing about, a value that
+   * would not validate and a provider that could not be reached, warn once per process.
+   *
+   * The value is parsed leniently, so what comes back may be less than what was published: a
+   * malformed setting or an unparseable tool override is dropped, with a warning naming it, while
+   * its siblings apply. A parse never fails as a whole, so a value that reaches here is never lost to
+   * one bad field.
+   */
+  async resolution(): Promise<Resolution> {
+    return (await this.#resolve()).resolution
+  }
+
+  /**
+   * The published config for this agent, or `null` when it is running on code.
+   *
+   * Sugar over `resolution()` for an adapter that only wants the value; identical in every other
+   * respect, including the warnings.
+   */
+  async resolve(): Promise<AgentConfig | null> {
+    return (await this.resolution()).config
+  }
+
+  /**
+   * Resolve once, then run `fn` with the outcome inside the resolution's telemetry context.
+   *
+   * This is the form to reach for when the agent run is a unit you can wrap, because it fixes
+   * something `resolve()` cannot: every span the callback opens carries the selected label as
+   * OpenTelemetry baggage, under the SDK's own `logfire.variables.<variable name>` key (with
+   * `<code_default>` when nothing was selected). So a trace says which published version the run was
+   * actually driven by, which is the difference between "this agent regressed" and "this agent
+   * regressed on the value someone saved at 14:02".
+   *
+   * The baggage is the Logfire SDK's mechanism, not one invented here: it is
+   * `ResolvedVariable.withContext`, the same entry the SDK writes for any managed variable, so a
+   * project's existing baggage configuration picks it up with nothing further to set. The `version`
+   * is reported on the `Resolution` rather than as a second baggage key, because a key no other
+   * Logfire SDK writes is one nothing else would know to read.
+   *
+   * One resolve serves the whole callback: the config `fn` is handed and the label the spans carry
+   * cannot disagree, however long the run lasts or how many times a rollout would have re-rolled.
+   */
+  async run<T>(fn: (resolution: Resolution) => Promise<T>): Promise<T> {
+    const { resolved, resolution } = await this.#resolve()
+    // The scope as well as the telemetry context: an adapter whose framework hands it a second hook
+    // inside this callback reads `control.currentResolution()` there and gets this one resolution,
+    // rather than resolving again and risking prompt A with model B.
+    return scope.run(new Map(scope.getStore()).set(this.variableName, resolution), async () =>
+      resolved.withContext(async () => fn(resolution))
+    )
+  }
+
+  /**
+   * Report something this adapter could not apply, under this control's `onUnmatched` policy.
+   *
+   * The `apply*` helpers report the entries *they* could not place, but they only see the section
+   * they were given. A whole section an adapter cannot act on at all -- a published `model` on a
+   * framework with no way to switch models, a `tool_definitions` section on one whose tools are
+   * fixed -- is the same gap between what Logfire shows and what the agent does, and has to reach the
+   * same policy rather than a `console.log` in the adapter.
+   *
+   * Write the message the way the built-in ones read: name what was published, and say what did not
+   * happen to it. `'warn'` deduplicates it per process, so it is safe to call per request.
+   */
+  reportUnmatched(message: string): void {
+    report(this.onUnmatched, message)
+  }
+
+  /**
+   * Resolve the backing variable once, keeping the SDK's own object alongside the flat outcome.
+   *
+   * `run` needs the `ResolvedVariable` itself for its baggage context, and `resolution` needs only
+   * the flat shape; doing both from one place is what stops the two from ever resolving twice and
+   * disagreeing.
+   */
+  async #resolve(): Promise<{ resolved: ResolvedVariable<AgentConfig>; resolution: Resolution }> {
+    const resolved: ResolvedVariable<AgentConfig> = await this.#variable.get(this.label === undefined ? {} : { label: this.label })
+    const applied = APPLIED_REASONS.has(resolved.reason)
+    if (!applied && NOTEWORTHY_REASONS.has(resolved.reason)) {
+      warnOnce(
+        `Logfire managed variable '${this.variableName}' could not be resolved (${resolved.reason}); ` +
+          'running on the code-defined agent.'
+      )
+    }
+    return {
+      resolved,
+      resolution: {
+        config: applied ? resolved.value : null,
+        variableName: this.variableName,
+        label: resolved.label ?? null,
+        version: resolved.version ?? null,
+        reason: resolved.reason,
+      },
+    }
+  }
+
+  /**
+   * Publish a baseline as the variable's `example`, creating the variable if needed.
+   *
+   * Returns immediately. The write is a remote round trip and the baseline is documentation for the
+   * Logfire editor that no run ever reads, so making a model request wait on it would trade something
+   * that matters for something that does not. Failures are warned about and never thrown: this is
+   * called from the middle of an agent run, and a variable's metadata not being up to date must not be
+   * what takes that run down.
+   *
+   * At most once per process per variable, and the guard is marked *before* the work starts, so
+   * concurrent first requests cannot schedule duplicate writes and a failure is not retried by every
+   * later run. That is also what makes the caller's job easy: call it on every request and let this
+   * decide.
+   *
+   * If the variable does not exist, it is created with `AGENT_CONFIG_JSON_SCHEMA` as its stored
+   * schema, which is what makes the Logfire UI able to edit it -- the backend validates every value
+   * written against that schema, so whichever side creates the variable first fixes the contract.
+   *
+   * ## A lost update is still possible here, and cannot be closed from this side
+   *
+   * Updating an existing variable is read-modify-write, because the API offers nothing narrower: the
+   * update endpoint takes the whole definition and no revision or `If-Match`. Everything a client can
+   * do to narrow that window is done, and it is worth being exact about what is and is not left:
+   *
+   * - The variable is only ever *created* when the read says it is missing, so the common case for a
+   *   new agent involves no overwrite at all.
+   * - An existing variable is **re-read immediately before the write**, and the object written is
+   *   that fresh read with `example` replaced -- never one read earlier, and never one a caller passed
+   *   in. Whatever the UI saved up to that read is preserved: values, labels, rollout, description.
+   * - The write is skipped entirely when the fresh read already carries this `example`, which is the
+   *   steady state for a deployed agent, so the overwhelmingly common outcome is no write.
+   * - It runs at most once per process per variable, off the request path.
+   *
+   * What remains is one HTTP round trip: a value or label saved in the Logfire UI *between* the fresh
+   * read returning and the write landing is overwritten by the older state that read returned, and the
+   * UI reports success for the publish it just lost. Closing it needs an example-only `PATCH`, or a
+   * conditional write on a revision or ETag, on the platform API:
+   * https://github.com/pydantic/pydantic-ai-harness/issues/565. Until then, a deployment that cannot
+   * tolerate that window sets `publishBaseline: false` and creates the variable in the UI, and a
+   * successful baseline write is **not** evidence that managed values survived it.
+   *
+   * @param baseline What to publish, from `buildBaseline`.
+   * @param options `source` says whether `baseline` describes the agent as written or one request
+   * that happened to come first; see `BaselineSource`.
+   */
+  publishBaseline(baseline: AgentConfig, options: PublishBaselineOptions = {}): void {
+    if (!this.#publishBaseline) {
+      return
+    }
+    if (baselinePublishAttempted.has(this.variableName)) {
+      return
+    }
+    baselinePublishAttempted.add(this.variableName)
+    const source = options.source ?? 'code'
+    let example: string
+    try {
+      example = JSON.stringify(baseline, null, 2)
+    } catch (error) {
+      this.#publishFailed(error)
+      return
+    }
+    this.#publish(example, source).catch((error: unknown) => {
+      this.#publishFailed(error)
+    })
+  }
+
+  #publishFailed(error: unknown): void {
+    warnOnce(`Failed to publish the code baseline for Logfire managed variable '${this.variableName}': ` + describe(error))
+  }
+
+  async #publish(example: string, source: BaselineSource): Promise<void> {
+    const provider: VariableProvider = getVariableProvider()
+    // A provider with no write path is one there is nothing to publish into: the no-op provider
+    // stands in for "variables are switched off", and a custom read-only one is saying the same.
+    if (provider instanceof NoOpVariableProvider) {
+      return
+    }
+    const existing = await provider.getVariableConfig?.(this.variableName)
+    // `== null` rather than a strict pair: the provider interface types this as `VariableConfig |
+    // undefined`, and a custom provider that answers `null` should still read as "no such variable".
+    if (existing == null) {
+      const config: VariableConfig = {
+        ...this.#variable.toConfig(),
+        example,
+        description: BASELINE_DESCRIPTIONS[source],
+      }
+      await provider.createVariable?.(config)
+      return
+    }
+    // Deliberately its own read rather than reusing the one that decided the variable exists: the
+    // value written back is the whole variable definition, so every moment between reading it and
+    // writing it is a moment in which someone else's edit is inside the object about to be
+    // overwritten. Taking the read here makes that window one round trip instead of two, and makes
+    // "never write from a config read earlier" a property of the code rather than a rule to remember.
+    const fresh = await provider.getVariableConfig?.(this.variableName)
+    // Vanished between the two reads, or already carries this baseline. Either way there is nothing
+    // to write, and re-creating a variable someone just deleted is not this call's decision to make.
+    if (fresh == null || fresh.example === example) {
+      return
+    }
+    await provider.updateVariable?.(this.variableName, { ...fresh, example })
+  }
+
+  /**
+   * This agent's resolution for the surrounding run scope, or `null` outside one.
+   *
+   * Sugar over `currentResolution` for this control's own variable, which is what an adapter almost
+   * always wants: it holds the control already, and it should not have to know that the scope is keyed
+   * on a variable name.
+   */
+  currentResolution(): Resolution | null {
+    return currentResolution(this.variableName)
+  }
+}
+
+/**
+ * The resolutions in scope, per variable, for the current asynchronous execution.
+ *
+ * A `Map` rather than one value because agents nest: a handoff, a subagent, or a tool that runs
+ * another managed agent puts a second control's scope inside the first, and `currentResolution` for
+ * either of them has to keep answering about *that* one rather than about whichever was entered last.
+ */
+const scope = new AsyncLocalStorage<ReadonlyMap<string, Resolution>>()
+
+/**
+ * Make one resolution the answer for its agent, and report it, for the whole of `fn`.
+ *
+ * The seam for a framework that resolves in one place and does the work in another. An adapter with
+ * one hook around the run does not need it -- `AgentControl.run` already is that scope -- but an
+ * adapter whose framework hands it two hooks per run, an instruction callable and a model wrapper,
+ * has to make them agree. Resolving in each of them means a value published between the two, or a
+ * rollout that lands differently on two reads, can send prompt A with model B while the telemetry
+ * attributes the request to B alone. Resolving once and installing it here means both hooks read the
+ * same value:
+ *
+ * ```ts
+ * const resolution = await control.resolution(); // resolved once, at the run seam
+ * await useResolution(resolution, async () => {
+ *   // ... anywhere inside, including a hook the framework calls back into:
+ *   const same = control.currentResolution(); // the one this run resolved
+ * });
+ * ```
+ *
+ * Entering also re-establishes the resolution's telemetry, exactly as `AgentControl.run` does, so
+ * spans inside `fn` carry the label and version that produced them. Nesting is fine: an inner scope
+ * shadows an outer one for that agent, and the outer one comes back when `fn` returns.
+ *
+ * The **unit of resolution** is a decision each adapter documents, because frameworks differ in what
+ * they offer. Where there is a run seam -- something that brackets a whole agent run -- resolve once
+ * per run, so every span of the run agrees on the version that produced it and a value published
+ * mid-run takes effect on the next run. Where there is only a per-model-request hook, resolution is
+ * per request, and a rollout can move between two requests of one run. Both are supportable; what is
+ * not is implying the first while doing the second.
+ */
+export async function useResolution<T>(resolution: Resolution, fn: () => Promise<T> | T): Promise<T> {
+  // Rebuilt rather than held: what the telemetry context *is* is the name, label, and version, and an
+  // adapter that carried a `Resolution` through its framework's own per-run state no longer has the
+  // SDK object that produced it.
+  const resolved = new ResolvedVariable<AgentConfig | null>({
+    name: resolution.variableName,
+    value: resolution.config,
+    // `Resolution.reason` is widened to `string` so a reason a newer SDK adds does not fail an
+    // adapter's build; it only ever holds one the SDK gave us.
+    reason: resolution.reason as VariableResolutionReason,
+    ...(resolution.label === null ? {} : { label: resolution.label }),
+    ...(resolution.version === null ? {} : { version: resolution.version }),
+  })
+  const resolutions = new Map(scope.getStore()).set(resolution.variableName, resolution)
+  return scope.run(resolutions, async () => resolved.withContext(fn))
+}
+
+/**
+ * The resolution installed for `variableName` by the innermost enclosing scope, if any.
+ *
+ * `null` means no scope is open for that agent here -- an adapter's hook reached outside a run, or a
+ * run that never resolved -- which is not an error: it means the same thing an unresolved config
+ * does, run the agent as written.
+ */
+export function currentResolution(variableName: string): Resolution | null {
+  return scope.getStore()?.get(variableName) ?? null
+}
+
+/**
+ * The variable for one agent, registered with the SDK on first use.
+ *
+ * The codec is what ties the three halves of the contract together: `jsonSchema` is what
+ * `toConfig()` stores on a newly created variable, `parse` is the lenient reader, and the default is
+ * the empty config -- the only code-side default there is, since the agent itself is what a
+ * published value is layered onto and a second place to say that would only be somewhere for the two
+ * to disagree.
+ */
+function agentVariable(variableName: string): Variable<AgentConfig> {
+  const existing = variables.get(variableName)
+  if (existing !== undefined) {
+    return existing
+  }
+  const options = {
+    default: {} as AgentConfig,
+    description: 'Agent Control configuration: instructions, model, settings, and tool definition overrides.',
+    codec: {
+      jsonSchema: AGENT_CONFIG_JSON_SCHEMA,
+      parse: parseAgentConfig,
+    },
+  }
+  let variable: Variable<AgentConfig>
+  try {
+    variable = defineVar<AgentConfig>(variableName, options)
+  } catch {
+    // The name is registered, but not by us -- an application that defined this variable itself.
+    // Theirs stays the registered one; ours reads the same name through the same provider.
+    variable = new Variable<AgentConfig>(variableName, options)
+  }
+  variables.set(variableName, variable)
+  return variable
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/** Clear this module's process-wide state. Intended for tests only. */
+export function resetProcessState(): void {
+  variables.clear()
+  baselinePublishAttempted.clear()
+}

--- a/packages/logfire-node/src/agent-control/index.ts
+++ b/packages/logfire-node/src/agent-control/index.ts
@@ -22,7 +22,7 @@ export { AgentControl, currentResolution, useResolution } from './control'
 export type { AgentControlOptions, BaselineSource, PublishBaselineOptions, Resolution } from './control'
 
 export { applyInstructions, instructionEntries } from './instructions'
-export type { AppliedInstructions, ApplyInstructionsOptions, InstructionBlock } from './instructions'
+export type { AppliedInstructions, InstructionBlock } from './instructions'
 
 export { mergeSettings } from './merge'
 export type { Provenance, SettingsLayer, SettingSource } from './merge'
@@ -32,13 +32,15 @@ export { AGENT_VARIABLE_PREFIX, agentVariableName, normalizeAgentName } from './
 export { AGENT_CONFIG_JSON_SCHEMA, canonicalJson, MAX_MODEL_FACING_TEXT_LENGTH, SCHEMA_SHA256 } from './schema'
 export type { JsonSchema } from './schema'
 
-export { applySettings, reportUnapplied } from './settings'
-export type { ApplySettingsOptions } from './settings'
+export { applySettings } from './settings'
+export type { AppliedSettings, ApplySettingsOptions } from './settings'
+
+export type { AgentSupport, Destination, Section } from './support'
 
 export { applyToolDefinitions, toolKey, withParameterDescriptions } from './tools'
 export type { AppliedTools, ApplyToolDefinitionsOptions, CollisionScope, ToolDef, ToolKey } from './tools'
 
 export { isRepresentableTimeout, MAX_TIMEOUT_MILLISECONDS, MAX_TIMEOUT_SECONDS, toMilliseconds } from './units'
 
-export { UnmatchedConfigError, warnOnce } from './warnings'
-export type { OnUnmatched, UnappliedEntry, UnappliedReason } from './warnings'
+export { droppedByProvider, UnmatchedConfigError, warnOnce } from './warnings'
+export type { ApplyIssue, ApplyIssueReason, OnUnmatched } from './warnings'

--- a/packages/logfire-node/src/agent-control/index.ts
+++ b/packages/logfire-node/src/agent-control/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Logfire Agent Control, without an agent framework.
+ *
+ * An agent's Agent Control config is one Logfire variable holding an `AgentConfig`. This package
+ * owns that contract -- the types, the stored JSON schema, and the variable plumbing -- plus the
+ * pure helpers that apply a published value to whatever an agent framework happens to call its
+ * instructions, its tools, and its settings.
+ *
+ * The split is the point. `AgentControl` is the only thing that talks to Logfire; `applyInstructions`,
+ * `applyToolDefinitions`, `applySettings`, and `buildBaseline` are pure functions over plain data.
+ * An adapter for a new framework is: enumerate a baseline, install the framework's hook, call two
+ * pure helpers. See the README for a worked one.
+ */
+
+export { buildBaseline } from './baseline'
+export type { BaselineInput } from './baseline'
+
+export type { AgentConfig, AgentConfigSettings, InstructionBlockConfig, ParameterOverride, ToolDefinitionOverride } from './config'
+export { canonicalSettings, CANONICAL_SETTINGS_KEYS, parseAgentConfig } from './config'
+
+export { AgentControl, currentResolution, useResolution } from './control'
+export type { AgentControlOptions, BaselineSource, PublishBaselineOptions, Resolution } from './control'
+
+export { applyInstructions, instructionEntries } from './instructions'
+export type { AppliedInstructions, ApplyInstructionsOptions, InstructionBlock } from './instructions'
+
+export { mergeSettings } from './merge'
+export type { Provenance, SettingsLayer, SettingSource } from './merge'
+
+export { AGENT_VARIABLE_PREFIX, agentVariableName, normalizeAgentName } from './names'
+
+export { AGENT_CONFIG_JSON_SCHEMA, canonicalJson, MAX_MODEL_FACING_TEXT_LENGTH, SCHEMA_SHA256 } from './schema'
+export type { JsonSchema } from './schema'
+
+export { applySettings, reportUnapplied } from './settings'
+export type { ApplySettingsOptions } from './settings'
+
+export { applyToolDefinitions, toolKey, withParameterDescriptions } from './tools'
+export type { AppliedTools, ApplyToolDefinitionsOptions, CollisionScope, ToolDef, ToolKey } from './tools'
+
+export { isRepresentableTimeout, MAX_TIMEOUT_MILLISECONDS, MAX_TIMEOUT_SECONDS, toMilliseconds } from './units'
+
+export { UnmatchedConfigError, warnOnce } from './warnings'
+export type { OnUnmatched, UnappliedEntry, UnappliedReason } from './warnings'

--- a/packages/logfire-node/src/agent-control/index.ts
+++ b/packages/logfire-node/src/agent-control/index.ts
@@ -42,5 +42,5 @@ export type { AppliedTools, ApplyToolDefinitionsOptions, CollisionScope, ToolDef
 
 export { isRepresentableTimeout, MAX_TIMEOUT_MILLISECONDS, MAX_TIMEOUT_SECONDS, toMilliseconds } from './units'
 
-export { droppedByProvider, UnmatchedConfigError, warnOnce } from './warnings'
+export { droppedByProvider, reportIssues, UnmatchedConfigError, warnOnce } from './warnings'
 export type { ApplyIssue, ApplyIssueReason, OnUnmatched } from './warnings'

--- a/packages/logfire-node/src/agent-control/instructions.ts
+++ b/packages/logfire-node/src/agent-control/instructions.ts
@@ -123,6 +123,82 @@ function overridesById(config: AgentConfig): Map<string, string | null> {
 }
 
 /**
+ * Which entries do not fit the section's budget, decided in the order the value published them.
+ *
+ * The bound is on what this section adds to every model request, so it is the total across entries
+ * and not just each one: the same text written as one entry and as ten has to cost the same, or the
+ * limit means nothing. A typed caller reaching `applyInstructions` directly -- an adapter with its
+ * own config, a test -- used to go through a per-entry check alone, so two entries at the limit both
+ * applied and the request carried twice it.
+ *
+ * Charged in `instructionEntries` order rather than in the order the entries are *applied*, which is
+ * replacements first and then additions. `parseInstructions` charges a published value in published
+ * order, and the two have to agree: with a 40,000-character addition published before a
+ * 40,000-character replacement, block order keeps the replacement while the parser keeps the
+ * addition, so the same value would apply differently depending on whether it arrived as JSON or as
+ * a typed config. Hence a pass of its own before anything is applied.
+ *
+ * Only text that survives is charged, as in the parser: an entry refused for the budget adds nothing
+ * to the request, so charging it would let one oversized entry shrink the budget for the good ones
+ * and make the entries a value keeps depend on the ones it does not. An entry that reaches no block,
+ * addresses a dynamic one, or only removes text adds nothing either, so none of them is charged.
+ *
+ * Returns the remaining budget at the point each refused entry was measured, keyed by instruction id
+ * for a replacement and by index into `added` for an addition, so the message can say how much room
+ * was actually left rather than quoting the whole limit.
+ */
+function spendBudget(
+  blocks: readonly InstructionBlock[],
+  config: AgentConfig,
+  overrides: ReadonlyMap<string, string | null>
+): { ids: Map<string, number>; additions: Map<number, number> } {
+  const byId = new Map<string, InstructionBlock>()
+  for (const block of blocks) {
+    if (block.id !== null && !byId.has(block.id)) {
+      byId.set(block.id, block)
+    }
+  }
+  const ids = new Map<string, number>()
+  const additions = new Map<number, number>()
+  const charged = new Set<string>()
+  let remaining = MAX_MODEL_FACING_TEXT_LENGTH
+  let index = -1
+  for (const entry of instructionEntries(config)) {
+    let text: string
+    if (entry.id === undefined) {
+      if (typeof entry.instructions !== 'string') {
+        continue
+      }
+      index += 1
+      text = entry.instructions
+    } else {
+      // Only the first entry naming an id is applied, so only the first is charged.
+      if (charged.has(entry.id)) {
+        continue
+      }
+      charged.add(entry.id)
+      const replacement = overrides.get(entry.id)
+      const block = byId.get(entry.id)
+      if (typeof replacement !== 'string' || block === undefined || block.dynamic) {
+        continue
+      }
+      text = replacement
+    }
+    const length = codePointLength(text)
+    if (length > remaining) {
+      if (entry.id === undefined) {
+        additions.set(index, remaining)
+      } else {
+        ids.set(entry.id, remaining)
+      }
+      continue
+    }
+    remaining -= length
+  }
+  return { ids, additions }
+}
+
+/**
  * Where an added block goes: before the first dynamic block, or at the end when there is none.
  *
  * Frameworks that care about prompt caching group static text ahead of dynamic text so the provider
@@ -182,14 +258,7 @@ export function applyInstructions(
   const unapplied: UnappliedEntry[] = []
   const matched = new Set<string>()
   const result: InstructionBlock[] = []
-  // The bound is on what this section adds to every model request, so it is the total across entries
-  // and not just each one: the same text written as one entry and as ten has to cost the same, or the
-  // limit means nothing. `parseInstructions` already charges a published value this way; a typed
-  // caller reaching `applyInstructions` directly -- an adapter with its own config, a test -- went
-  // through a per-entry check only, and two 65,536-character entries both applied. Only text that
-  // survives is charged, as in the parser: an entry refused here adds nothing to the request, so
-  // charging it would let one oversized entry shrink the budget for the good ones.
-  let remaining = MAX_MODEL_FACING_TEXT_LENGTH
+  const budget = spendBudget(blocks, config, overrides)
   for (const block of blocks) {
     if (block.id === null || !overrides.has(block.id)) {
       result.push(block)
@@ -214,13 +283,12 @@ export function applyInstructions(
     if (replacement === null) {
       continue
     }
-    const length = codePointLength(replacement)
-    if (length > remaining) {
-      unapplied.push(oversized(replacement, remaining, block.id))
+    const refusedAt = budget.ids.get(block.id)
+    if (refusedAt !== undefined) {
+      unapplied.push(oversized(replacement, refusedAt, block.id))
       result.push(block)
       continue
     }
-    remaining -= length
     result.push({ ...block, text: replacement })
   }
   for (const id of overrides.keys()) {
@@ -236,15 +304,14 @@ export function applyInstructions(
   }
 
   const additions: InstructionBlock[] = []
-  for (const text of added) {
-    const length = codePointLength(text)
-    if (length > remaining) {
-      unapplied.push(oversized(text, remaining))
+  added.forEach((text, index) => {
+    const refusedAt = budget.additions.get(index)
+    if (refusedAt !== undefined) {
+      unapplied.push(oversized(text, refusedAt))
     } else {
-      remaining -= length
       additions.push({ id: null, text, dynamic: false })
     }
-  }
+  })
   result.splice(insertionIndex(result), 0, ...additions)
   return { blocks: result, unapplied: reportUnappliedEntries(onUnmatched, unapplied) }
 }

--- a/packages/logfire-node/src/agent-control/instructions.ts
+++ b/packages/logfire-node/src/agent-control/instructions.ts
@@ -9,8 +9,8 @@
 
 import type { AgentConfig, InstructionBlockConfig } from './config'
 import { codePointLength, MAX_MODEL_FACING_TEXT_LENGTH } from './schema'
-import { reportUnappliedEntries, repr, warnOnce } from './warnings'
-import type { OnUnmatched, UnappliedEntry } from './warnings'
+import { repr } from './warnings'
+import type { ApplyIssue } from './warnings'
 
 /**
  * One instruction block as a framework assembles it, and as this package hands it back.
@@ -41,33 +41,21 @@ export interface InstructionBlock {
   dynamic: boolean
 }
 
-/** Options for `applyInstructions`. */
-export interface ApplyInstructionsOptions {
-  /**
-   * What to do with a published entry this request did not apply.
-   *
-   * Every decision `applyInstructions` makes goes through it -- an unknown id, a dynamic one, and
-   * text past the budget alike -- so `'ignore'` silences all three and `'error'` fails on all three.
-   */
-  onUnmatched?: OnUnmatched
-}
-
 /** What `applyInstructions` returns: the blocks to send, and what reached nothing. */
 export interface AppliedInstructions {
   /** The blocks to send, with published text swapped in, removed, or added. */
   blocks: InstructionBlock[]
   /**
-   * Every published instruction entry this request did not apply; see `UnappliedEntry`.
+   * Every published instruction entry this request did not apply; see `ApplyIssue`.
    *
-   * Already reported under the caller's `onUnmatched` policy before it is returned, so this is for an
-   * adapter that wants to do something *else* with them -- put them on a span, count them -- rather
-   * than the way they are surfaced.
+   * Reported by nothing here. Hand these to `AgentControl.report`, with the other sections' issues,
+   * and the policy the user configured is applied to all of it at once.
    */
-  unapplied: readonly UnappliedEntry[]
+  issues: readonly ApplyIssue[]
 }
 
 /** One entry whose text is past the budget, refused rather than truncated. */
-function oversized(text: string, remaining: number, instructionId?: string): UnappliedEntry {
+function oversized(text: string, remaining: number, instructionId?: string): ApplyIssue {
   const where = instructionId === undefined ? '' : `for instruction block ${repr(instructionId)} `
   const limit =
     remaining === MAX_MODEL_FACING_TEXT_LENGTH
@@ -75,6 +63,7 @@ function oversized(text: string, remaining: number, instructionId?: string): Una
       : `which does not fit in the ${String(remaining)} remaining of the ${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character ` +
         `limit across all entries on what this section may add to `
   return {
+    section: 'instructions',
     reason: 'oversized-text',
     ...(instructionId === undefined ? {} : { instructionId }),
     message:
@@ -101,25 +90,35 @@ export function instructionEntries(config: AgentConfig): InstructionBlockConfig[
 }
 
 /**
- * Index entries by key, keeping the first of any duplicates with a warning.
+ * Index entries by key, keeping the first of any duplicates and naming the rest.
  *
  * A published value can name the same block twice -- by a hand edit, or by a UI bug. Keeping the
  * first is what keeps the run predictable and lets the ignored entry be named, rather than the last
  * writer silently winning depending on how the JSON happened to be ordered.
+ *
+ * Deliberately not warned from here: this is an apply-time decision about a value, so it belongs
+ * under the caller's `onUnmatched` policy like every other one -- warning directly, as this used to,
+ * meant `'ignore'` still warned and `'error'` did not throw.
  */
-function overridesById(config: AgentConfig): Map<string, string | null> {
+function overridesById(config: AgentConfig): { overrides: Map<string, string | null>; duplicates: ApplyIssue[] } {
   const overrides = new Map<string, string | null>()
+  const duplicates: ApplyIssue[] = []
   for (const entry of instructionEntries(config)) {
     if (entry.id === undefined) {
       continue
     }
     if (overrides.has(entry.id)) {
-      warnOnce(`Managed agent config names instruction id ${repr(entry.id)} more than once; keeping the first entry and ignoring the rest.`)
+      duplicates.push({
+        section: 'instructions',
+        reason: 'duplicate-entry',
+        instructionId: entry.id,
+        message: `Managed agent config names instruction id ${repr(entry.id)} more than once; keeping the first entry and ignoring the rest.`,
+      })
       continue
     }
     overrides.set(entry.id, entry.instructions ?? null)
   }
-  return overrides
+  return { overrides, duplicates }
 }
 
 /**
@@ -227,35 +226,32 @@ function insertionIndex(blocks: readonly InstructionBlock[]): number {
  *   about the managed value says which was meant.
  * - An entry with **no `id`** adds a static block at the end of the static group; see
  *   `insertionIndex`.
- * - An `id` that **matches no block** applies nothing and is reported under `onUnmatched`, per call
- *   rather than once, because an agent whose instructions vary with its input can carry a block on
- *   one request and not the next.
+ * - An `id` that **matches no block** applies nothing and is reported, per call rather than once,
+ *   because an agent whose instructions vary with its input can carry a block on one request and not
+ *   the next.
  * - Text **past the contract's budget** is refused rather than truncated: half a prompt is not a
  *   smaller version of the prompt.
+ * - The second and later entries naming one `id` are kept out and reported (`'duplicate-entry'`).
  *
- * All three decisions come back as `UnappliedEntry` records on `unapplied`, already reported under
- * `onUnmatched`, so an adapter can put them on a span or count them without parsing a message.
+ * Every one of those decisions comes back as an `ApplyIssue` on `issues` and is reported by nothing
+ * here: hand them to `AgentControl.report` along with the other sections', which is what lets
+ * `'error'` fail once naming all of it rather than on whichever section was applied first.
  *
  * Added blocks come back with `id: null` and `dynamic: false`: they are new text, nothing addresses
  * them yet, and they are fixed by construction. Each added entry becomes its own block rather than
  * being joined into one, so an adapter can attribute them individually; joining them is a
  * `map(...).join('\n\n')` away for a framework that wants one string.
  */
-export function applyInstructions(
-  blocks: readonly InstructionBlock[],
-  config: AgentConfig,
-  options: ApplyInstructionsOptions = {}
-): AppliedInstructions {
-  const onUnmatched = options.onUnmatched ?? 'warn'
-  const overrides = overridesById(config)
+export function applyInstructions(blocks: readonly InstructionBlock[], config: AgentConfig): AppliedInstructions {
+  const { overrides, duplicates } = overridesById(config)
   const added = instructionEntries(config)
     .filter((entry) => entry.id === undefined && typeof entry.instructions === 'string')
     .map((entry) => entry.instructions as string)
   if (overrides.size === 0 && added.length === 0) {
-    return { blocks: [...blocks], unapplied: [] }
+    return { blocks: [...blocks], issues: duplicates }
   }
 
-  const unapplied: UnappliedEntry[] = []
+  const issues: ApplyIssue[] = [...duplicates]
   const matched = new Set<string>()
   const result: InstructionBlock[] = []
   const budget = spendBudget(blocks, config, overrides)
@@ -268,7 +264,8 @@ export function applyInstructions(
     // a key nothing carries.
     matched.add(block.id)
     if (block.dynamic) {
-      unapplied.push({
+      issues.push({
+        section: 'instructions',
         reason: 'dynamic-id',
         instructionId: block.id,
         message:
@@ -285,7 +282,7 @@ export function applyInstructions(
     }
     const refusedAt = budget.ids.get(block.id)
     if (refusedAt !== undefined) {
-      unapplied.push(oversized(replacement, refusedAt, block.id))
+      issues.push(oversized(replacement, refusedAt, block.id))
       result.push(block)
       continue
     }
@@ -293,7 +290,8 @@ export function applyInstructions(
   }
   for (const id of overrides.keys()) {
     if (!matched.has(id)) {
-      unapplied.push({
+      issues.push({
+        section: 'instructions',
         reason: 'unknown-id',
         instructionId: id,
         message:
@@ -307,11 +305,11 @@ export function applyInstructions(
   added.forEach((text, index) => {
     const refusedAt = budget.additions.get(index)
     if (refusedAt !== undefined) {
-      unapplied.push(oversized(text, refusedAt))
+      issues.push(oversized(text, refusedAt))
     } else {
       additions.push({ id: null, text, dynamic: false })
     }
   })
   result.splice(insertionIndex(result), 0, ...additions)
-  return { blocks: result, unapplied: reportUnappliedEntries(onUnmatched, unapplied) }
+  return { blocks: result, issues }
 }

--- a/packages/logfire-node/src/agent-control/instructions.ts
+++ b/packages/logfire-node/src/agent-control/instructions.ts
@@ -1,0 +1,234 @@
+/**
+ * Applying the `instructions` section to a framework's assembled instruction blocks.
+ *
+ * Instructions are the one section that composes with the agent rather than patching it, which is
+ * why they need a helper at all: an entry with no `id` *adds* a block, and an entry with an `id`
+ * *swaps out* a block the framework already assembled. Getting the two confused is the difference
+ * between a prompt that reads well and one sent to the model twice.
+ */
+
+import type { AgentConfig, InstructionBlockConfig } from './config'
+import { codePointLength, MAX_MODEL_FACING_TEXT_LENGTH } from './schema'
+import { reportUnappliedEntries, repr, warnOnce } from './warnings'
+import type { OnUnmatched, UnappliedEntry } from './warnings'
+
+/**
+ * One instruction block as a framework assembles it, and as this package hands it back.
+ *
+ * The three fields are everything a managed config needs to know about a block and, per the adapter
+ * reports, everything every surveyed framework can supply: what addresses it, what it says, and
+ * whether it is recomputed. An adapter maps its own parts onto these, calls `applyInstructions`, and
+ * maps the result back; nothing else about its instruction model has to be modelled here.
+ */
+export interface InstructionBlock {
+  /**
+   * The key a managed config addresses this block by, or `null` when nothing can address it.
+   *
+   * A framework gives ids to the blocks it can name and `null` to the ones it cannot -- a callable
+   * that returns text, an anonymous contribution. A `null` block passes through untouched.
+   */
+  id: string | null
+  /** The block's text. */
+  text: string
+  /**
+   * Whether the framework recomputes this block per request.
+   *
+   * Load-bearing twice over. A dynamic block cannot be addressed -- replacing it would pin one
+   * rendering forever and dropping it would remove the computation -- and it is what decides where
+   * an added block goes, since providers cache a request's stable prefix and an added block must not
+   * move that boundary.
+   */
+  dynamic: boolean
+}
+
+/** Options for `applyInstructions`. */
+export interface ApplyInstructionsOptions {
+  /**
+   * What to do with a published entry this request did not apply.
+   *
+   * Every decision `applyInstructions` makes goes through it -- an unknown id, a dynamic one, and
+   * text past the budget alike -- so `'ignore'` silences all three and `'error'` fails on all three.
+   */
+  onUnmatched?: OnUnmatched
+}
+
+/** What `applyInstructions` returns: the blocks to send, and what reached nothing. */
+export interface AppliedInstructions {
+  /** The blocks to send, with published text swapped in, removed, or added. */
+  blocks: InstructionBlock[]
+  /**
+   * Every published instruction entry this request did not apply; see `UnappliedEntry`.
+   *
+   * Already reported under the caller's `onUnmatched` policy before it is returned, so this is for an
+   * adapter that wants to do something *else* with them -- put them on a span, count them -- rather
+   * than the way they are surfaced.
+   */
+  unapplied: readonly UnappliedEntry[]
+}
+
+/** One entry whose text is past the budget, refused rather than truncated. */
+function oversized(text: string, instructionId?: string): UnappliedEntry {
+  const where = instructionId === undefined ? '' : `for instruction block ${repr(instructionId)} `
+  return {
+    reason: 'oversized-text',
+    ...(instructionId === undefined ? {} : { instructionId }),
+    message:
+      `Managed agent config publishes instruction text ${where}of ${String(codePointLength(text))} characters, ` +
+      `past the ${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character limit on what one managed entry may add to ` +
+      `every model request; that entry is not applied.`,
+  }
+}
+
+/**
+ * The `instructions` section as a list of entries, whichever of its two shapes was written.
+ *
+ * A bare string is exactly one added block, so the two shapes only ever differ in how they read in
+ * the Logfire editor.
+ */
+export function instructionEntries(config: AgentConfig): InstructionBlockConfig[] {
+  const { instructions } = config
+  if (instructions === undefined) {
+    return []
+  }
+  if (typeof instructions === 'string') {
+    return [{ instructions }]
+  }
+  return instructions.map((entry) => (typeof entry === 'string' ? { instructions: entry } : entry))
+}
+
+/**
+ * Index entries by key, keeping the first of any duplicates with a warning.
+ *
+ * A published value can name the same block twice -- by a hand edit, or by a UI bug. Keeping the
+ * first is what keeps the run predictable and lets the ignored entry be named, rather than the last
+ * writer silently winning depending on how the JSON happened to be ordered.
+ */
+function overridesById(config: AgentConfig): Map<string, string | null> {
+  const overrides = new Map<string, string | null>()
+  for (const entry of instructionEntries(config)) {
+    if (entry.id === undefined) {
+      continue
+    }
+    if (overrides.has(entry.id)) {
+      warnOnce(`Managed agent config names instruction id ${repr(entry.id)} more than once; keeping the first entry and ignoring the rest.`)
+      continue
+    }
+    overrides.set(entry.id, entry.instructions ?? null)
+  }
+  return overrides
+}
+
+/**
+ * Where an added block goes: before the first dynamic block, or at the end when there is none.
+ *
+ * Frameworks that care about prompt caching group static text ahead of dynamic text so the provider
+ * can cache the stable prefix, so this lands an added block at the end of the static group -- after
+ * the last static block and before the first dynamic one -- and moves no existing block. On input
+ * that is not grouped that way, landing before the first dynamic block is still the choice that
+ * cannot push cached text past the boundary.
+ */
+function insertionIndex(blocks: readonly InstructionBlock[]): number {
+  const firstDynamic = blocks.findIndex((block) => block.dynamic)
+  return firstDynamic === -1 ? blocks.length : firstDynamic
+}
+
+/**
+ * Apply a managed config's `instructions` section to a request's assembled blocks.
+ *
+ * Pure: it reads `blocks` and returns a new list, so an adapter can call it from whatever hook its
+ * framework gives it and hand the result straight back.
+ *
+ * - An entry **with an `id`** replaces that block's text, or removes the block when `instructions` is
+ *   `null`. The block's position and its `dynamic` flag are carried over untouched -- re-flagging a
+ *   replaced block would move the provider's cache boundary for every request, a silent cost
+ *   regression in exchange for nothing.
+ * - An entry that addresses a **dynamic** block is refused and reported: its text is recomputed per
+ *   request, so replacing it pins one rendering and dropping it removes the computation, and nothing
+ *   about the managed value says which was meant.
+ * - An entry with **no `id`** adds a static block at the end of the static group; see
+ *   `insertionIndex`.
+ * - An `id` that **matches no block** applies nothing and is reported under `onUnmatched`, per call
+ *   rather than once, because an agent whose instructions vary with its input can carry a block on
+ *   one request and not the next.
+ * - Text **past the contract's budget** is refused rather than truncated: half a prompt is not a
+ *   smaller version of the prompt.
+ *
+ * All three decisions come back as `UnappliedEntry` records on `unapplied`, already reported under
+ * `onUnmatched`, so an adapter can put them on a span or count them without parsing a message.
+ *
+ * Added blocks come back with `id: null` and `dynamic: false`: they are new text, nothing addresses
+ * them yet, and they are fixed by construction. Each added entry becomes its own block rather than
+ * being joined into one, so an adapter can attribute them individually; joining them is a
+ * `map(...).join('\n\n')` away for a framework that wants one string.
+ */
+export function applyInstructions(
+  blocks: readonly InstructionBlock[],
+  config: AgentConfig,
+  options: ApplyInstructionsOptions = {}
+): AppliedInstructions {
+  const onUnmatched = options.onUnmatched ?? 'warn'
+  const overrides = overridesById(config)
+  const added = instructionEntries(config)
+    .filter((entry) => entry.id === undefined && typeof entry.instructions === 'string')
+    .map((entry) => entry.instructions as string)
+  if (overrides.size === 0 && added.length === 0) {
+    return { blocks: [...blocks], unapplied: [] }
+  }
+
+  const unapplied: UnappliedEntry[] = []
+  const matched = new Set<string>()
+  const result: InstructionBlock[] = []
+  for (const block of blocks) {
+    if (block.id === null || !overrides.has(block.id)) {
+      result.push(block)
+      continue
+    }
+    // Addressed, and refused for a reason of its own: reported as the dynamic case and not again as
+    // a key nothing carries.
+    matched.add(block.id)
+    if (block.dynamic) {
+      unapplied.push({
+        reason: 'dynamic-id',
+        instructionId: block.id,
+        message:
+          `Managed agent config addresses instruction block ${repr(block.id)}, which the agent recomputes ` +
+          'per request; a managed value would pin or remove that computation, so it is not applied ' +
+          'and the block keeps what the code produces.',
+      })
+      result.push(block)
+      continue
+    }
+    const replacement = overrides.get(block.id) ?? null
+    if (replacement === null) {
+      continue
+    }
+    if (codePointLength(replacement) > MAX_MODEL_FACING_TEXT_LENGTH) {
+      unapplied.push(oversized(replacement, block.id))
+      result.push(block)
+      continue
+    }
+    result.push({ ...block, text: replacement })
+  }
+  for (const id of overrides.keys()) {
+    if (!matched.has(id)) {
+      unapplied.push({
+        reason: 'unknown-id',
+        instructionId: id,
+        message:
+          `Managed agent config addresses instruction block ${repr(id)}, which this request does not ` +
+          'assemble; that entry applies to nothing.',
+      })
+    }
+  }
+
+  const additions: InstructionBlock[] = []
+  for (const text of added) {
+    if (codePointLength(text) > MAX_MODEL_FACING_TEXT_LENGTH) {
+      unapplied.push(oversized(text))
+    } else {
+      additions.push({ id: null, text, dynamic: false })
+    }
+  }
+  result.splice(insertionIndex(result), 0, ...additions)
+  return { blocks: result, unapplied: reportUnappliedEntries(onUnmatched, unapplied) }
+}

--- a/packages/logfire-node/src/agent-control/instructions.ts
+++ b/packages/logfire-node/src/agent-control/instructions.ts
@@ -67,15 +67,19 @@ export interface AppliedInstructions {
 }
 
 /** One entry whose text is past the budget, refused rather than truncated. */
-function oversized(text: string, instructionId?: string): UnappliedEntry {
+function oversized(text: string, remaining: number, instructionId?: string): UnappliedEntry {
   const where = instructionId === undefined ? '' : `for instruction block ${repr(instructionId)} `
+  const limit =
+    remaining === MAX_MODEL_FACING_TEXT_LENGTH
+      ? `past the ${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character limit on what this section may add to `
+      : `which does not fit in the ${String(remaining)} remaining of the ${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character ` +
+        `limit across all entries on what this section may add to `
   return {
     reason: 'oversized-text',
     ...(instructionId === undefined ? {} : { instructionId }),
     message:
       `Managed agent config publishes instruction text ${where}of ${String(codePointLength(text))} characters, ` +
-      `past the ${String(MAX_MODEL_FACING_TEXT_LENGTH)}-character limit on what one managed entry may add to ` +
-      `every model request; that entry is not applied.`,
+      `${limit}every model request; that entry is not applied.`,
   }
 }
 
@@ -178,6 +182,14 @@ export function applyInstructions(
   const unapplied: UnappliedEntry[] = []
   const matched = new Set<string>()
   const result: InstructionBlock[] = []
+  // The bound is on what this section adds to every model request, so it is the total across entries
+  // and not just each one: the same text written as one entry and as ten has to cost the same, or the
+  // limit means nothing. `parseInstructions` already charges a published value this way; a typed
+  // caller reaching `applyInstructions` directly -- an adapter with its own config, a test -- went
+  // through a per-entry check only, and two 65,536-character entries both applied. Only text that
+  // survives is charged, as in the parser: an entry refused here adds nothing to the request, so
+  // charging it would let one oversized entry shrink the budget for the good ones.
+  let remaining = MAX_MODEL_FACING_TEXT_LENGTH
   for (const block of blocks) {
     if (block.id === null || !overrides.has(block.id)) {
       result.push(block)
@@ -202,11 +214,13 @@ export function applyInstructions(
     if (replacement === null) {
       continue
     }
-    if (codePointLength(replacement) > MAX_MODEL_FACING_TEXT_LENGTH) {
-      unapplied.push(oversized(replacement, block.id))
+    const length = codePointLength(replacement)
+    if (length > remaining) {
+      unapplied.push(oversized(replacement, remaining, block.id))
       result.push(block)
       continue
     }
+    remaining -= length
     result.push({ ...block, text: replacement })
   }
   for (const id of overrides.keys()) {
@@ -223,9 +237,11 @@ export function applyInstructions(
 
   const additions: InstructionBlock[] = []
   for (const text of added) {
-    if (codePointLength(text) > MAX_MODEL_FACING_TEXT_LENGTH) {
-      unapplied.push(oversized(text))
+    const length = codePointLength(text)
+    if (length > remaining) {
+      unapplied.push(oversized(text, remaining))
     } else {
+      remaining -= length
       additions.push({ id: null, text, dynamic: false })
     }
   }

--- a/packages/logfire-node/src/agent-control/merge.ts
+++ b/packages/logfire-node/src/agent-control/merge.ts
@@ -1,0 +1,96 @@
+/**
+ * Merging code, published, and per-run settings, and remembering which layer won each key.
+ *
+ * The contract's precedence is one sentence -- code < published < the values a run passed explicitly
+ * -- and three adapters have now implemented it by *diffing* the framework's effective settings
+ * against the agent's own to guess which keys the run asked for. That guess is wrong in exactly the
+ * case that matters: code `temperature: 0.2`, published `0.8`, and a run that passes `0.2`
+ * explicitly is indistinguishable from a run that passed nothing, so the published value wins a key
+ * the caller overrode. It cannot be fixed by diffing harder, only by capturing the explicit keys at
+ * the boundary that has them and merging with that knowledge, which is what this module takes in.
+ */
+
+/**
+ * Which layer a merged setting's value came from.
+ *
+ * `'code'` is the agent as written, `'published'` is the managed config, and `'run'` is a value the
+ * caller passed explicitly for this one run. They are ordered: a later layer overrides an earlier
+ * one, and nothing else does.
+ */
+export type SettingSource = 'code' | 'published' | 'run'
+
+/**
+ * A merged settings patch, and which layer each key came from.
+ *
+ * The provenance is not decoration. An adapter that has to lower one merged value into a
+ * provider-specific place -- `providerOptions.openai.parallelToolCalls`, a request timeout composed
+ * with a caller's own deadline -- needs to know whether the value it is about to write came from the
+ * run or from the published config, because those two want opposite treatment: a run's value
+ * replaces what is there, a published one must not stamp over a run's.
+ */
+export interface Provenance {
+  /** The merged patch: every key that has a value, with the winning layer's value. */
+  readonly settings: Record<string, unknown>
+  /**
+   * The winning layer per key mentioned by any layer.
+   *
+   * A superset of `settings`'s keys: a key here but not there is one a run explicitly *cleared*,
+   * which an adapter has to be able to tell from a key nobody ever set -- the first means "send no
+   * value for this", the second means "whatever the framework does by default".
+   *
+   * A `Map` rather than an object because the keys come from a framework's settings and, through the
+   * published layer, from JSON: `sources['constructor']` on a plain object answers about
+   * `Object.prototype`, and no lookup here should ever be able to.
+   */
+  readonly sources: ReadonlyMap<string, SettingSource>
+}
+
+/** One layer's settings, or nothing when that layer has none. */
+export type SettingsLayer = Readonly<Record<string, unknown>> | null | undefined
+
+/**
+ * Merge the three settings layers in contract order, keeping a record of who won.
+ *
+ * Each argument is a flat mapping of that layer's settings. `code` and `published` are read as
+ * patches, so an `undefined` or `null` value in them is "this layer does not set that key" and is
+ * skipped: neither layer has any way to express "explicitly no value", and treating one there as
+ * such would let a framework that spells its unset settings out as `undefined` erase the layer under
+ * it.
+ *
+ * `runExplicit` is different, and it is the whole reason this function exists: it holds only the keys
+ * the caller set *at the call site for this run*, so an `undefined` in it is a deliberate "send no
+ * value for this key" and clears whatever the layers under it had. An adapter that cannot see which
+ * keys a run set explicitly -- a hook handed one already-merged settings object -- should pass
+ * nothing here and document the weaker contract rather than diff its way to a guess.
+ *
+ * Keys outside the contract's canonical eleven pass through untouched, so an adapter can merge its
+ * framework's whole settings object rather than splitting the canonical keys out first: a
+ * provider-specific key only `code` carries simply survives with `'code'` provenance.
+ */
+export function mergeSettings(code?: SettingsLayer, published?: SettingsLayer, runExplicit?: SettingsLayer): Provenance {
+  const settings: Record<string, unknown> = {}
+  const sources = new Map<string, SettingSource>()
+  for (const [layer, source] of [
+    [code, 'code'],
+    [published, 'published'],
+  ] as const) {
+    for (const [key, value] of Object.entries(layer ?? {})) {
+      if (value === undefined || value === null) {
+        continue
+      }
+      settings[key] = value
+      sources.set(key, source)
+    }
+  }
+  for (const [key, value] of Object.entries(runExplicit ?? {})) {
+    sources.set(key, 'run')
+    // `Reflect.deleteProperty` rather than `delete settings[key]`: the key comes from a caller's
+    // settings object, and a computed `delete` is what the repository's lint rules keep out.
+    if (value === undefined || value === null) {
+      Reflect.deleteProperty(settings, key)
+    } else {
+      settings[key] = value
+    }
+  }
+  return { settings, sources }
+}

--- a/packages/logfire-node/src/agent-control/merge.ts
+++ b/packages/logfire-node/src/agent-control/merge.ts
@@ -68,7 +68,11 @@ export type SettingsLayer = Readonly<Record<string, unknown>> | null | undefined
  * provider-specific key only `code` carries simply survives with `'code'` provenance.
  */
 export function mergeSettings(code?: SettingsLayer, published?: SettingsLayer, runExplicit?: SettingsLayer): Provenance {
-  const settings: Record<string, unknown> = {}
+  // Null-prototype, like `sources` is a `Map`: the keys come from a framework's settings and,
+  // through the published layer, from JSON, so `settings[key] =` on a plain object would let a
+  // `__proto__` key replace the prototype rather than become an entry -- and `sources` would then
+  // report a key the merged patch does not carry.
+  const settings = Object.create(null) as Record<string, unknown>
   const sources = new Map<string, SettingSource>()
   for (const [layer, source] of [
     [code, 'code'],

--- a/packages/logfire-node/src/agent-control/names.ts
+++ b/packages/logfire-node/src/agent-control/names.ts
@@ -1,0 +1,72 @@
+/**
+ * One rule for turning an agent's name into the Logfire variable its config lives in.
+ *
+ * Both cores and the Logfire UI have to land on the same variable for the same agent, or a Pydantic
+ * AI agent and a Mastra agent called `checkout-assistant` quietly hold two different configs while
+ * the UI shows one. The rule is therefore stated once, here, with cross-language vectors in
+ * `spec/agent-name.json`, rather than reimplemented per language.
+ */
+
+import { warnOnce } from './warnings'
+
+/** The one naming rule the SDKs and the Logfire UI share: an agent's config lives at `agent__<key>`. */
+export const AGENT_VARIABLE_PREFIX = 'agent__'
+
+/**
+ * Reduce an agent's display name to the key its variable is built from.
+ *
+ * Trim, lowercase, turn every character outside `[a-z0-9_]` into `_`, collapse runs of `_`, and
+ * strip `_` from both ends. The result is the *key*, not the variable name; see `agentVariableName`.
+ *
+ * Lowercasing is the part worth justifying, because it is the lossy one. The rule exists to make two
+ * SDKs agree with the Logfire UI, and the UI's own rule -- the one the Pydantic AI harness already
+ * applies to an agent's telemetry name -- lowercases. Diverging from it would mean an agent named
+ * `Checkout Assistant` in one service and `checkout_assistant` in another shows up as two configs in
+ * a UI that only ever renders one name for them. It is lossy in the other direction too:
+ * `checkout-assistant`, `Checkout Assistant`, and `checkout_assistant` are one key, so two genuinely
+ * different agents whose names differ only in punctuation or case share a config. Give them
+ * explicit, distinct names when that is not what you want.
+ *
+ * The character class is deliberately ASCII: `café` keys as `caf` and a name with no ASCII in it at
+ * all keys as `''`. Transliterating instead would be a per-language table, which is the one thing a
+ * cross-language rule cannot afford.
+ *
+ * Returns the empty string for a name with nothing usable in it -- whitespace, punctuation, or a
+ * script with no ASCII in it -- which callers turn into an error rather than a variable.
+ */
+export function normalizeAgentName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9_]/gu, '_')
+    .replaceAll(/_+/gu, '_')
+    .replaceAll(/^_+|_+$/gu, '')
+}
+
+/**
+ * The Logfire variable holding the config for the agent called `name`.
+ *
+ * `agent__` plus `normalizeAgentName(name)`. The prefix is added here, so passing a name that
+ * already carries it is a mistake the caller is warned about rather than one that produces
+ * `agent__agent__checkout`.
+ *
+ * @throws If `name` has nothing a key can be made of.
+ */
+export function agentVariableName(name: string): string {
+  let stripped = name.trim()
+  if (stripped.toLowerCase().startsWith(AGENT_VARIABLE_PREFIX)) {
+    warnOnce(`The '${AGENT_VARIABLE_PREFIX}' prefix is added automatically; pass the bare agent name rather than '${name}'.`)
+    stripped = stripped.slice(AGENT_VARIABLE_PREFIX.length)
+  }
+  const key = normalizeAgentName(stripped)
+  if (key === '') {
+    throw new Error(
+      `Agent name '${name}' has nothing a variable key can be made of. The config is stored under ` +
+        '`agent__<key>`, where the key is the name lowercased with everything outside `[a-z0-9_]` turned ' +
+        'into `_`, so a name has to contain at least one ASCII letter, digit, or underscore.'
+    )
+  }
+  // `key` is a non-empty `[a-z0-9_]` string and the prefix starts with a letter, so the result is
+  // always a valid identifier: there is nothing left here for a validity check to catch.
+  return `${AGENT_VARIABLE_PREFIX}${key}`
+}

--- a/packages/logfire-node/src/agent-control/schema.ts
+++ b/packages/logfire-node/src/agent-control/schema.ts
@@ -226,10 +226,16 @@ export const AGENT_CONFIG_JSON_SCHEMA: JsonSchema = {
 /**
  * The SHA-256 of `AGENT_CONFIG_JSON_SCHEMA` in its canonical form.
  *
- * Canonical means the JSON with object keys sorted recursively and no whitespace, which is exactly
- * Python's `json.dumps(schema, sort_keys=True, separators=(',', ':'))`. Sorting is what makes the
- * digest comparable across SDKs: neither side's literal has to be written in the other's key order
- * for the two to be provably the same document.
+ * Canonical means the JSON with object keys sorted recursively, no whitespace, and non-ASCII
+ * characters emitted rather than escaped -- exactly Python's
+ * `json.dumps(schema, sort_keys=True, separators=(',', ':'), ensure_ascii=False)`, encoded as UTF-8,
+ * and exactly what `JSON.stringify` does here. Sorting is what makes the digest comparable across
+ * SDKs: neither side's literal has to be written in the other's key order for the two to be provably
+ * the same document. `ensure_ascii=False` is what makes it comparable across *languages*: `json.dumps`
+ * escapes non-ASCII by default and `JSON.stringify` does not, so the first non-ASCII character in a
+ * description or a sample value would otherwise give the two copies different digests for the same
+ * schema. The schema is ASCII today, so that clause is currently invisible on both sides; it is
+ * stated so it stays that way.
  *
  * It is a constant rather than something computed at import time so that a change to the schema
  * shows up as a diff on this line -- a value someone has to look at and update deliberately --

--- a/packages/logfire-node/src/agent-control/schema.ts
+++ b/packages/logfire-node/src/agent-control/schema.ts
@@ -1,0 +1,262 @@
+/**
+ * The stored JSON schema for an `agent__<name>` variable, and the digest that pins it.
+ *
+ * This module is a contract, not code that does anything: the schema below is byte-for-byte the one
+ * the reference implementation stores, so a variable created by this package and one created by the
+ * Python SDK or the Logfire UI are the same object.
+ */
+
+/**
+ * The cap on any single piece of text a managed config can put in front of a model.
+ *
+ * 64 KiB of text is already roughly 16K tokens for typical English prose. It accommodates
+ * substantial instructions while preventing one managed entry from adding megabytes to every model
+ * request.
+ */
+export const MAX_MODEL_FACING_TEXT_LENGTH = 65_536
+
+/**
+ * The length of `text` in Unicode code points, which is what the budget is counted in.
+ *
+ * Deliberately not `String.length`, which counts UTF-16 code units and would give an emoji or a CJK
+ * extension character twice the weight the Python core gives it -- so the same published value would
+ * fit one core's budget and not the other's. `[...text].length` iterates code points, which is what
+ * Python's `len` counts.
+ */
+export function codePointLength(text: string): number {
+  // Spreading a string is exactly what is wanted here, and exactly what the lint rule warns about:
+  // it splits into code points rather than grapheme clusters. Code points are the unit the
+  // cross-language budget is stated in, so this is the counting rule, not a bug in it.
+  // eslint-disable-next-line @typescript-eslint/no-misused-spread -- code points are the unit here.
+  return [...text].length
+}
+
+/** A JSON Schema document, as the Logfire variables API stores and returns it. */
+export type JsonSchema = Record<string, unknown>
+
+/**
+ * The stored JSON schema for an `agent__<name>` variable, shared with the Logfire Agent Control UI.
+ *
+ * The Logfire UI holds a copy of this, and whichever side creates the variable first is the one
+ * whose schema is persisted. The schema is not cosmetic: the Logfire backend validates every new
+ * version of the value against it, so anything this schema rejects cannot be written at all. That is
+ * also why it is maintained by hand rather than generated from the Zod types in `./config.ts` --
+ * generated output describes *this* release on *this* Zod version, while the stored schema is a
+ * long-lived contract between a Logfire project and every SDK version that will ever write to it.
+ *
+ * It is permissive at every level for the same reason `parseAgentConfig` is lenient: an
+ * `additionalProperties: false` anywhere would reject a key a newer UI writes at *write* time, which
+ * is worse than an older SDK ignoring it at read time. For the same reason the fields whose accepted
+ * values grow from release to release (`thinking`) are typed rather than enumerated, and `settings`
+ * names the canonical keys for the editor's benefit while leaving unnamed ones writable.
+ *
+ * The constraints it does keep are structural rather than versioned, and each one closes a hole a
+ * permissive schema would otherwise leave open. Every `minLength: 1` says that `''` is a half-filled
+ * field, never a value, and `model: ''` in particular takes an agent down on every request.
+ * `tool_definitions` items require a `name` because an overlay that names no tool cannot be applied
+ * to anything, so accepting it would only let the UI save a row that silently does nothing.
+ *
+ * Any edit here changes the contract and must be made in every SDK at once; `SCHEMA_SHA256` is what
+ * makes an accidental one fail a test instead of reaching a project.
+ */
+export const AGENT_CONFIG_JSON_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    instructions: {
+      description:
+        'Instruction blocks added to the ones the agent assembles in code, not a replacement for ' +
+        'them. A bare string is one added block. An entry with an `id` swaps out the block the ' +
+        'agent already sends under that key instead of adding one.',
+      anyOf: [
+        {
+          type: 'string',
+          minLength: 1,
+          maxLength: MAX_MODEL_FACING_TEXT_LENGTH,
+        },
+        {
+          type: 'array',
+          items: {
+            anyOf: [
+              {
+                type: 'string',
+                minLength: 1,
+                maxLength: MAX_MODEL_FACING_TEXT_LENGTH,
+              },
+              {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'string',
+                    minLength: 1,
+                    description:
+                      'The id of the instruction block to address, as the baseline lists it. Omit to add a ' +
+                      'block instead. A block the baseline marks dynamic cannot be addressed: replacing it ' +
+                      'would pin one rendering and dropping it would remove the computation, so either is ' +
+                      'ignored.',
+                  },
+                  instructions: {
+                    anyOf: [
+                      {
+                        type: 'string',
+                        minLength: 1,
+                        maxLength: MAX_MODEL_FACING_TEXT_LENGTH,
+                      },
+                      {
+                        type: 'null',
+                      },
+                    ],
+                    description: 'The text to send, or null to drop the addressed block.',
+                  },
+                  dynamic: {
+                    type: 'boolean',
+                    description:
+                      'Whether the block is recomputed per request. Set on the code-side baseline and ignored ' +
+                      'on input -- but a block marked true is not addressable, so an editor should offer no ' +
+                      'override for it.',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    model: {
+      type: 'string',
+      minLength: 1,
+      description: "A model string in 'provider:model' form, such as 'anthropic:claude-fable-5-1'.",
+    },
+    settings: {
+      type: 'object',
+      description: 'Model settings patch. Only the keys named here are applied; a key an SDK does not know is ignored.',
+      properties: {
+        max_tokens: {
+          type: 'integer',
+        },
+        temperature: {
+          type: 'number',
+        },
+        top_p: {
+          type: 'number',
+        },
+        top_k: {
+          type: 'integer',
+        },
+        seed: {
+          type: 'integer',
+        },
+        presence_penalty: {
+          type: 'number',
+        },
+        frequency_penalty: {
+          type: 'number',
+        },
+        parallel_tool_calls: {
+          type: 'boolean',
+        },
+        timeout: {
+          type: 'number',
+        },
+        stop_sequences: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        thinking: {
+          anyOf: [
+            {
+              type: 'boolean',
+            },
+            {
+              type: 'string',
+            },
+          ],
+          description: "Enabled/disabled, or an effort level: 'minimal', 'low', 'medium', 'high', 'xhigh'.",
+        },
+      },
+    },
+    tool_definitions: {
+      type: 'array',
+      description:
+        'LLM-facing overlays, each naming the tool it patches by its code-side name. Parameter ' +
+        'names, types, requiredness, validation, and implementation stay code-defined. The ' +
+        'baseline also says which `toolset` each tool came from.',
+      items: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: {
+            type: 'string',
+            minLength: 1,
+            description: "The tool's code-side name, which is what this entry patches.",
+          },
+          new_name: {
+            type: 'string',
+            minLength: 1,
+            description: 'Name shown to the model; a call to it routes back to the original tool.',
+          },
+          description: {
+            type: 'string',
+          },
+          parameters: {
+            type: 'object',
+            description: 'Patches per top-level parameter name.',
+            additionalProperties: {
+              type: 'object',
+              properties: {
+                description: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+          toolset: {
+            type: 'string',
+            description:
+              'The toolset the tool came from: the baseline reports it, and on an override it narrows ' +
+              "the match to that toolset's tool of this name.",
+          },
+        },
+      },
+    },
+  },
+}
+
+/**
+ * The SHA-256 of `AGENT_CONFIG_JSON_SCHEMA` in its canonical form.
+ *
+ * Canonical means the JSON with object keys sorted recursively and no whitespace, which is exactly
+ * Python's `json.dumps(schema, sort_keys=True, separators=(',', ':'))`. Sorting is what makes the
+ * digest comparable across SDKs: neither side's literal has to be written in the other's key order
+ * for the two to be provably the same document.
+ *
+ * It is a constant rather than something computed at import time so that a change to the schema
+ * shows up as a diff on this line -- a value someone has to look at and update deliberately --
+ * instead of silently agreeing with itself.
+ */
+export const SCHEMA_SHA256 = 'e4c38488d6c46440dbf31939291e13fcd56814c1305bc9012cd2158733b0bbad'
+
+/**
+ * Serialize a JSON value with object keys sorted recursively and no whitespace.
+ *
+ * `JSON.stringify` preserves insertion order and offers no way to sort nested keys, so the canonical
+ * form has to be built by hand. Arrays keep their order -- it is part of the value -- and only
+ * objects are reordered.
+ */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeys(value))
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys)
+  }
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+  // `Object.entries` already hands back a fresh array, so sorting it in place mutates nothing the
+  // caller holds. An object cannot hold one key twice, so the comparator has no equal case to answer for.
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : 1))
+  return Object.fromEntries(entries.map(([key, item]) => [key, sortKeys(item)]))
+}

--- a/packages/logfire-node/src/agent-control/settings.ts
+++ b/packages/logfire-node/src/agent-control/settings.ts
@@ -1,0 +1,93 @@
+/**
+ * Applying the `settings` section, and reporting the keys an adapter could not lower.
+ *
+ * There are two ways a published setting fails to reach the model, and they are found in different
+ * places. A key *this SDK* has no field for is found when the value is parsed, and is reported by
+ * `applySettings`. A key this SDK understands but the *adapter's framework* has no knob for is only
+ * known to the adapter, which reports it with `reportUnapplied`. Both are the same gap between what
+ * Logfire shows and what the agent does, so both go through the same `onUnmatched` policy.
+ */
+
+import { CANONICAL_SETTINGS_KEYS, UNRECOGNIZED_SETTINGS } from './config'
+import type { AgentConfig, AgentConfigSettings } from './config'
+import { isRepresentableTimeout, MAX_TIMEOUT_SECONDS } from './units'
+import { reportUnmatched, repr } from './warnings'
+import type { OnUnmatched } from './warnings'
+
+/** Options for `applySettings` and `reportUnapplied`. */
+export interface ApplySettingsOptions {
+  /** What to do with a published settings key that is not applied. */
+  onUnmatched?: OnUnmatched
+}
+
+/**
+ * The canonical settings a managed config sets, as a patch to merge over the code-defined ones.
+ *
+ * Only keys the value actually set are present, so the result is a patch and not a set of defaults:
+ * an adapter merges it over whatever its framework is already running with, and every key it does
+ * not contain keeps its code-defined value.
+ *
+ * Also reports, under `onUnmatched`, every `settings` key the published value carried that this
+ * release has no field for -- reported here, at the point the patch is applied, rather than at parse
+ * time, because parsing runs inside the SDK's variable resolution where a throw would be swallowed
+ * into a fallback to code instead of failing the run.
+ *
+ * A published `timeout` that is not a representable request budget -- negative, not finite, or past
+ * `MAX_TIMEOUT_SECONDS` -- is dropped and reported here too. Dropped rather than clamped, because
+ * clamping turns "no real limit" into a deadline nobody published, and rounding a negative one to
+ * `0` cancels the request before it is sent.
+ *
+ * Returns an empty object when no `settings` section is published, which merges to a no-op.
+ */
+export function applySettings(config: AgentConfig, options: ApplySettingsOptions = {}): AgentConfigSettings {
+  const onUnmatched = options.onUnmatched ?? 'warn'
+  const settings = config.settings
+  if (settings === undefined) {
+    return {}
+  }
+  for (const name of settings[UNRECOGNIZED_SETTINGS] ?? []) {
+    reportUnmatched(
+      onUnmatched,
+      `Managed agent config sets ${repr(name)}, which this version of the SDK has no model setting for; that key is not applied.`
+    )
+  }
+  const applied: AgentConfigSettings = {}
+  for (const key of CANONICAL_SETTINGS_KEYS) {
+    const value = settings[key]
+    if (value === undefined) {
+      continue
+    }
+    if (key === 'timeout' && typeof value === 'number' && !isRepresentableTimeout(value)) {
+      reportUnmatched(
+        onUnmatched,
+        `Managed agent config sets a request timeout of ${repr(value)} seconds, which is not a budget a ` +
+          `request can be given -- it has to be finite, not negative, and no larger than ${String(MAX_TIMEOUT_SECONDS)} ` +
+          `seconds; that key is not applied.`
+      )
+      continue
+    }
+    ;(applied as Record<string, unknown>)[key] = value
+  }
+  return applied
+}
+
+/**
+ * Report settings keys the adapter's framework has no knob for.
+ *
+ * `applySettings` hands back the canonical patch without knowing what the framework on the other
+ * side can do with it. An adapter that cannot lower `top_k`, or whose framework has no `seed`, calls
+ * this with those key names so the same `onUnmatched` policy governs them -- otherwise a published
+ * setting would be silently dropped at the last step, which is the one thing this contract is meant
+ * not to do.
+ *
+ * Reporting nothing is a no-op, so an adapter can call it unconditionally with whatever it skipped.
+ */
+export function reportUnapplied(keys: Iterable<string>, options: ApplySettingsOptions = {}): void {
+  const onUnmatched = options.onUnmatched ?? 'warn'
+  for (const name of keys) {
+    reportUnmatched(
+      onUnmatched,
+      `Managed agent config sets ${repr(name)}, which this agent framework has no model setting for; that key is not applied.`
+    )
+  }
+}

--- a/packages/logfire-node/src/agent-control/settings.ts
+++ b/packages/logfire-node/src/agent-control/settings.ts
@@ -1,55 +1,132 @@
 /**
- * Applying the `settings` section, and reporting the keys an adapter could not lower.
+ * Applying the `settings` section, and saying which sections and keys this adapter could not apply.
  *
- * There are two ways a published setting fails to reach the model, and they are found in different
- * places. A key *this SDK* has no field for is found when the value is parsed, and is reported by
- * `applySettings`. A key this SDK understands but the *adapter's framework* has no knob for is only
- * known to the adapter, which reports it with `reportUnapplied`. Both are the same gap between what
- * Logfire shows and what the agent does, so both go through the same `onUnmatched` policy.
+ * There are three ways a published setting fails to reach the model, and they used to be found in
+ * three different places. A key *this SDK* has no field for is found when the value is parsed. A key
+ * this SDK understands but the *adapter's framework* has no knob for is known only to the adapter,
+ * which had to filter the patch itself and then remember to call a separate reporter -- and a
+ * forgotten call was a silent drop, the exact failure this contract exists to prevent. A `timeout`
+ * that is not a request budget is found here. All three are the same gap between what Logfire shows
+ * and what the agent does, so all three now come back on one result, for one reporter to apply one
+ * policy to.
  */
 
-import { CANONICAL_SETTINGS_KEYS, UNRECOGNIZED_SETTINGS } from './config'
+import { CANONICAL_SETTINGS_KEYS, UNRECOGNIZED_SECTIONS, UNRECOGNIZED_SETTINGS } from './config'
 import type { AgentConfig, AgentConfigSettings } from './config'
+import type { AgentSupport, Section } from './support'
 import { isRepresentableTimeout, MAX_TIMEOUT_SECONDS } from './units'
-import { reportUnmatched, repr } from './warnings'
-import type { OnUnmatched } from './warnings'
+import { repr } from './warnings'
+import type { ApplyIssue } from './warnings'
 
-/** Options for `applySettings` and `reportUnapplied`. */
+/** Options for `applySettings`. */
 export interface ApplySettingsOptions {
-  /** What to do with a published settings key that is not applied. */
-  onUnmatched?: OnUnmatched
+  /**
+   * What this adapter can apply; see `AgentSupport`.
+   *
+   * Absent says it can apply every section and every canonical setting, which is the right answer
+   * for an adapter that has not been taught to declare yet and the wrong one for any that has.
+   */
+  support?: AgentSupport | null | undefined
+}
+
+/** What `applySettings` returns: the patch to merge, and what reached nothing. */
+export interface AppliedSettings {
+  /** The canonical settings patch: every key that was published and can be applied. */
+  settings: AgentConfigSettings
+  /**
+   * Every published key, and every whole section, this request did not apply; see `ApplyIssue`.
+   *
+   * Reported by nothing here; hand them to `AgentControl.report` with the rest. The shape is the same
+   * as the other two sections' so an adapter treats all three alike, which is what it could not do
+   * while this one returned a bare patch and a reporter of its own.
+   */
+  issues: readonly ApplyIssue[]
+}
+
+/**
+ * What this release, and this adapter, cannot do with the sections a value carries.
+ *
+ * Two decisions about the config as a whole rather than about any one entry: a top-level key this
+ * release has no section for, and a section it does have and the adapter declared it cannot apply.
+ *
+ * The first is the other half of the openness that makes a future `mcp_servers` or `skills` section
+ * readable by an older SDK. Unknown keys are ignored on purpose -- refusing them would make the day a
+ * section is added the day every older SDK stops resolving -- but an ignored key that nobody hears
+ * about is how the first person to publish one gets a silently degraded agent.
+ */
+function sectionIssues(config: AgentConfig, support: AgentSupport | null | undefined): ApplyIssue[] {
+  const issues: ApplyIssue[] = (config[UNRECOGNIZED_SECTIONS] ?? []).map((name) => ({
+    section: name,
+    reason: 'unknown-section' as const,
+    message:
+      `Managed agent config publishes a ${repr(name)} section, which this version of the SDK has no ` +
+      'section for; that section is not applied.',
+  }))
+  if (support === undefined || support === null) {
+    return issues
+  }
+  const published: [Section, unknown][] = [
+    ['instructions', config.instructions],
+    ['model', config.model],
+    ['settings', config.settings],
+    ['tool_definitions', config.tool_definitions],
+  ]
+  for (const [name, value] of published) {
+    if (value !== undefined && !support.sections.includes(name)) {
+      issues.push({
+        section: name,
+        reason: 'unsupported-section',
+        message:
+          `Managed agent config publishes a ${repr(name)} section, which this agent framework has no ` +
+          'way to apply; that section is not applied.',
+      })
+    }
+  }
+  return issues
 }
 
 /**
  * The canonical settings a managed config sets, as a patch to merge over the code-defined ones.
  *
- * Only keys the value actually set are present, so the result is a patch and not a set of defaults:
- * an adapter merges it over whatever its framework is already running with, and every key it does
- * not contain keeps its code-defined value.
+ * Only keys the value actually set are present, so `settings` is a patch and not a set of defaults:
+ * an adapter merges it over whatever its framework is already running with, and every key it does not
+ * contain keeps its code-defined value.
  *
- * Also reports, under `onUnmatched`, every `settings` key the published value carried that this
- * release has no field for -- reported here, at the point the patch is applied, rather than at parse
- * time, because parsing runs inside the SDK's variable resolution where a throw would be swallowed
- * into a fallback to code instead of failing the run.
+ * Five kinds of published thing come back on `issues` rather than being silently dropped:
  *
- * A published `timeout` that is not a representable request budget -- negative, not finite, or past
- * `MAX_TIMEOUT_SECONDS` -- is dropped and reported here too. Dropped rather than clamped, because
- * clamping turns "no real limit" into a deadline nobody published, and rounding a negative one to
- * `0` cancels the request before it is sent.
+ * - a key this release has no field for (`'unknown-setting'`), which a newer Logfire UI can write;
+ * - a key this adapter cannot lower into its framework (`'unsupported-setting'`), which it names
+ *   through `AgentSupport.settings`;
+ * - a `timeout` that is not a representable request budget (`'unrepresentable-timeout'`) -- negative,
+ *   not finite, or past `MAX_TIMEOUT_SECONDS`. Dropped rather than clamped, because clamping turns
+ *   "no real limit" into a deadline nobody published, and rounding a negative one to `0` cancels the
+ *   request before it is sent;
+ * - a top-level key this release has no section for (`'unknown-section'`);
+ * - a section this adapter declared it cannot apply (`'unsupported-section'`).
  *
- * Returns an empty object when no `settings` section is published, which merges to a no-op.
+ * The last two are about the whole config rather than about settings, and they are here because this
+ * is the helper every adapter can call with the whole config and its own support declaration,
+ * whatever hooks its framework gives it: an adapter that never calls `applyInstructions` would
+ * otherwise have nowhere to learn that an `instructions` section was published at an agent that
+ * cannot apply one.
+ *
+ * Nothing is reported here, and nothing throws: parsing and applying both run where a throw would be
+ * swallowed into a fallback to code, so the policy is applied once, later, by `AgentControl.report`.
  */
-export function applySettings(config: AgentConfig, options: ApplySettingsOptions = {}): AgentConfigSettings {
-  const onUnmatched = options.onUnmatched ?? 'warn'
+export function applySettings(config: AgentConfig, options: ApplySettingsOptions = {}): AppliedSettings {
+  const { support } = options
+  const issues = sectionIssues(config, support)
   const settings = config.settings
   if (settings === undefined) {
-    return {}
+    return { settings: {}, issues }
   }
   for (const name of settings[UNRECOGNIZED_SETTINGS] ?? []) {
-    reportUnmatched(
-      onUnmatched,
-      `Managed agent config sets ${repr(name)}, which this version of the SDK has no model setting for; that key is not applied.`
-    )
+    issues.push({
+      section: 'settings',
+      reason: 'unknown-setting',
+      setting: name,
+      message: `Managed agent config sets ${repr(name)}, which this version of the SDK has no model setting for; that key is not applied.`,
+    })
   }
   const applied: AgentConfigSettings = {}
   for (const key of CANONICAL_SETTINGS_KEYS) {
@@ -58,36 +135,27 @@ export function applySettings(config: AgentConfig, options: ApplySettingsOptions
       continue
     }
     if (key === 'timeout' && typeof value === 'number' && !isRepresentableTimeout(value)) {
-      reportUnmatched(
-        onUnmatched,
-        `Managed agent config sets a request timeout of ${repr(value)} seconds, which is not a budget a ` +
+      issues.push({
+        section: 'settings',
+        reason: 'unrepresentable-timeout',
+        setting: key,
+        message:
+          `Managed agent config sets a request timeout of ${repr(value)} seconds, which is not a budget a ` +
           `request can be given -- it has to be finite, not negative, and no larger than ${String(MAX_TIMEOUT_SECONDS)} ` +
-          `seconds; that key is not applied.`
-      )
+          `seconds; that key is not applied.`,
+      })
+      continue
+    }
+    if (support !== undefined && support !== null && !(support.settings ?? []).includes(key)) {
+      issues.push({
+        section: 'settings',
+        reason: 'unsupported-setting',
+        setting: key,
+        message: `Managed agent config sets ${repr(key)}, which this agent framework has no model setting for; that key is not applied.`,
+      })
       continue
     }
     ;(applied as Record<string, unknown>)[key] = value
   }
-  return applied
-}
-
-/**
- * Report settings keys the adapter's framework has no knob for.
- *
- * `applySettings` hands back the canonical patch without knowing what the framework on the other
- * side can do with it. An adapter that cannot lower `top_k`, or whose framework has no `seed`, calls
- * this with those key names so the same `onUnmatched` policy governs them -- otherwise a published
- * setting would be silently dropped at the last step, which is the one thing this contract is meant
- * not to do.
- *
- * Reporting nothing is a no-op, so an adapter can call it unconditionally with whatever it skipped.
- */
-export function reportUnapplied(keys: Iterable<string>, options: ApplySettingsOptions = {}): void {
-  const onUnmatched = options.onUnmatched ?? 'warn'
-  for (const name of keys) {
-    reportUnmatched(
-      onUnmatched,
-      `Managed agent config sets ${repr(name)}, which this agent framework has no model setting for; that key is not applied.`
-    )
-  }
+  return { settings: applied, issues }
 }

--- a/packages/logfire-node/src/agent-control/settings.ts
+++ b/packages/logfire-node/src/agent-control/settings.ts
@@ -104,6 +104,9 @@ function sectionIssues(config: AgentConfig, support: AgentSupport | null | undef
  * - a top-level key this release has no section for (`'unknown-section'`);
  * - a section this adapter declared it cannot apply (`'unsupported-section'`).
  *
+ * An adapter that declares it cannot apply the `settings` section at all gets an empty patch and the
+ * one `'unsupported-section'` issue, whatever its `AgentSupport.settings` says.
+ *
  * The last two are about the whole config rather than about settings, and they are here because this
  * is the helper every adapter can call with the whole config and its own support declaration,
  * whatever hooks its framework gives it: an adapter that never calls `applyInstructions` would
@@ -117,7 +120,11 @@ export function applySettings(config: AgentConfig, options: ApplySettingsOptions
   const { support } = options
   const issues = sectionIssues(config, support)
   const settings = config.settings
-  if (settings === undefined) {
+  if (settings === undefined || (support !== undefined && support !== null && !support.sections.includes('settings'))) {
+    // An adapter that declared it cannot apply the section has already been told so, once, by
+    // `sectionIssues`. Handing it the patch anyway would be this function contradicting that
+    // declaration, and reporting every key in it a second time would bury the one report that
+    // matters under a list of keys the adapter was never going to reach.
     return { settings: {}, issues }
   }
   for (const name of settings[UNRECOGNIZED_SETTINGS] ?? []) {

--- a/packages/logfire-node/src/agent-control/spec/README.md
+++ b/packages/logfire-node/src/agent-control/spec/README.md
@@ -8,7 +8,7 @@ change to a rule is a change to the file first, and to both cores after.
 
 The canonical copy of this directory lives in the `pydantic/logfire` repository at
 `tests/agent_control/spec/`; every other SDK vendors it and pins the same digest, which each core's
-test suite asserts. Prose for all three rules lives in the Agent Control documentation under
+test suite asserts. The prose for these rules lives in the Agent Control documentation under
 **Contract**; this directory is the machine-readable half.
 
 | File | What it pins | Applied by |

--- a/packages/logfire-node/src/agent-control/spec/README.md
+++ b/packages/logfire-node/src/agent-control/spec/README.md
@@ -1,13 +1,14 @@
 # Cross-language conformance vectors
 
-Three things in Agent Control have to give the same answer in every language, because a Logfire
+Everything in Agent Control that has to give the same answer in every language, because a Logfire
 project is shared and the SDKs are not: which variable an agent's config lives in, what a code
-baseline says, and what a published value parses to. Each is one algorithm with vectors here, and
-each core has a test that reads the file and asserts against it. A change to a rule is a change to
-the file first, and to both cores after.
+baseline says, what a published value parses to, and what applying one does to a request. Each is one
+algorithm with vectors here, and each core has a test that reads the file and asserts against it. A
+change to a rule is a change to the file first, and to both cores after.
 
-Prose for all three lives in
-[`python/logfire-agent-control/README.md`](../python/logfire-agent-control/README.md) under
+The canonical copy of this directory lives in the `pydantic/logfire` repository at
+`tests/agent_control/spec/`; every other SDK vendors it and pins the same digest, which each core's
+test suite asserts. Prose for all three rules lives in the Agent Control documentation under
 **Contract**; this directory is the machine-readable half.
 
 | File | What it pins | Applied by |
@@ -15,6 +16,10 @@ Prose for all three lives in
 | `agent-name.json` | Agent name -> `agent__<key>` variable name, and which names have no key at all | `agent_variable_name` / `agentVariableName` |
 | `baseline.json` | The code baseline built from one snapshot of an agent | `build_baseline` / `buildBaseline` |
 | `config-parsing.json` | What a published value parses to, and what it warns about on the way | `AgentConfig` parsing / `parseAgentConfig` |
+| `instructions-apply.json` | What a published `instructions` section does to the parts a request assembles | `apply_instructions` / `applyInstructions` |
+| `tools-apply.json` | Matching, narrowing, renaming, parameter patching, and the routing maps | `apply_tool_definitions` / `applyToolDefinitions` |
+| `settings-apply.json` | The canonical patch, the adapter's support declaration, timeout representability, and the unrecognized key and section reports | `apply_settings` / `applySettings` |
+| `merge.json` | code < published < explicit-run precedence, the `sources` map, and clearing from the run layer only | `merge_settings` / `mergeSettings` |
 
 ## Reading a vector file
 
@@ -70,6 +75,33 @@ what has to match is which decision was taken.
 | `setting-value-invalid` | A setting carried a value of the wrong JSON type |
 | `tool-definitions-invalid-container` | `tool_definitions` was not an array |
 | `tool-definition-invalid` | One override failed validation |
-| `duplicate-key` | The same instruction `id`, or the same `(toolset, name)`, was written twice |
+| `duplicate-key` | The same instruction `id`, or the same `(toolset, name)`, was written twice (raised when a value is *applied*, not when it is parsed, so no vector here carries it) |
 | `baseline-value-not-describable` | A code-side setting value the contract cannot hold, left out of the baseline |
 | `baseline-timeout-not-representable` | A code-side `timeout` outside the representable range |
+
+### The apply files
+
+`instructions-apply.json`, `tools-apply.json` and `settings-apply.json` share one shape: `input` is
+what a request carries (`parts`, `tools`, or nothing but the `config`), the published `config`, and
+the adapter's `support` declaration when it has one; `expected` is what the helper returns.
+
+`support` is the adapter's own capability, never a model's: `sections` are the sections it can apply
+at all and `settings` the canonical keys it can lower. `null` -- or an absent key -- says the adapter
+applies everything, which is what an adapter that has not been taught to declare yet is doing.
+
+**Issues compare by their set fields, with the message left out.** Each expected issue lists every
+field the core sets on it and nothing else, because every core words its messages for its own users
+while the decision and its path have to match. `section` is one of the four section names, except on
+`unknown-section`, where it is the unrecognized top-level key itself.
+
+Unset things are left out rather than spelled as null: a part carries `dynamic` only when it is
+`true`, a tool carries `description`, `toolset` and `parameters_json_schema` only when it has them,
+and an `expected` with no `settings`, `routes` or `parts` key is asserting the empty one. The one
+exception is a part's `id`, which is written even when `null`, because an added part having no id is
+the assertion.
+
+### `merge.json`
+
+`input` has a `code`, `published` and `run_explicit` layer, each optional. `expected` is the merged
+`settings` and the `sources` map naming the layer that won each key -- which is a superset of
+`settings`, since a key a run cleared is owned by the run and carries no value.

--- a/packages/logfire-node/src/agent-control/spec/README.md
+++ b/packages/logfire-node/src/agent-control/spec/README.md
@@ -1,0 +1,75 @@
+# Cross-language conformance vectors
+
+Three things in Agent Control have to give the same answer in every language, because a Logfire
+project is shared and the SDKs are not: which variable an agent's config lives in, what a code
+baseline says, and what a published value parses to. Each is one algorithm with vectors here, and
+each core has a test that reads the file and asserts against it. A change to a rule is a change to
+the file first, and to both cores after.
+
+Prose for all three lives in
+[`python/logfire-agent-control/README.md`](../python/logfire-agent-control/README.md) under
+**Contract**; this directory is the machine-readable half.
+
+| File | What it pins | Applied by |
+|---|---|---|
+| `agent-name.json` | Agent name -> `agent__<key>` variable name, and which names have no key at all | `agent_variable_name` / `agentVariableName` |
+| `baseline.json` | The code baseline built from one snapshot of an agent | `build_baseline` / `buildBaseline` |
+| `config-parsing.json` | What a published value parses to, and what it warns about on the way | `AgentConfig` parsing / `parseAgentConfig` |
+
+## Reading a vector file
+
+Each file is a JSON array of vectors. Every vector has a `name`, which is a sentence describing the
+decision it pins, and is what a failing test should print.
+
+**Long strings are compressed.** Any object of exactly the form `{"repeat": "a", "times": 65536}`,
+anywhere in a vector's `input` or `expected`, stands for that string repeated that many times. A
+consumer expands them recursively before use. It is only there to keep the 64 KiB budget cases
+readable; nothing about the contract depends on it.
+
+**Numbers compare by value.** `1` and `1.0` are the same number; JSON and the two languages disagree
+about which one to print, and none of them disagrees about the value.
+
+**Objects compare by content, not key order.**
+
+### `agent-name.json`
+
+`input` is the name as a user wrote it. A vector has either:
+
+- `variable_name`, plus the `display_name` the core keeps for telemetry (the input, trimmed) -- and
+  optionally `warning: "prefix-added-automatically"` when the name already carried `agent__`; or
+- `error: "empty"`, when the name has nothing a key can be made of, which the core raises on.
+
+### `baseline.json`
+
+`input` is what an adapter snapshots -- `blocks`, `model`, `settings`, `tools` -- with each block
+`{text, id?, dynamic?}` and each tool `{name, description?, parameters_json_schema?, toolset?}`.
+`expected` is the resulting config serialized the way it is published: contract field names, and
+unset fields absent rather than null. `warnings` lists the codes below when the baseline had to leave
+something out.
+
+### `config-parsing.json`
+
+`input` is the stored value as JSON. `expected` is the parsed config, serialized the same way.
+`warnings` is the ordered list of codes the parse emitted, and `unrecognized_settings` (when present)
+is what the parse remembered for the adapter to report at apply time.
+
+Warnings are compared as **codes**, not prose: each core words its warnings for its own users, and
+what has to match is which decision was taken.
+
+| Code | The decision it names |
+|---|---|
+| `invalid-model` | `model` was not a non-empty string; only that section is dropped |
+| `instructions-section-too-long` | A bare-string `instructions` section past the code-point budget |
+| `instructions-section-empty` | `instructions: ""` |
+| `instructions-invalid-container` | `instructions` was neither a string nor an array |
+| `instruction-entry-too-long` | One entry did not fit in the budget left by the entries that survived before it |
+| `instruction-entry-invalid` | One entry failed validation |
+| `instruction-entry-empty` | One entry had neither an `id` to address nor text to add |
+| `settings-invalid-container` | `settings` was not an object |
+| `setting-value-not-recognized` | An enumerated setting carried a value only a newer contract knows |
+| `setting-value-invalid` | A setting carried a value of the wrong JSON type |
+| `tool-definitions-invalid-container` | `tool_definitions` was not an array |
+| `tool-definition-invalid` | One override failed validation |
+| `duplicate-key` | The same instruction `id`, or the same `(toolset, name)`, was written twice |
+| `baseline-value-not-describable` | A code-side setting value the contract cannot hold, left out of the baseline |
+| `baseline-timeout-not-representable` | A code-side `timeout` outside the representable range |

--- a/packages/logfire-node/src/agent-control/spec/agent-name.json
+++ b/packages/logfire-node/src/agent-control/spec/agent-name.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "a hyphenated name is the canonical example",
+    "input": "checkout-assistant",
+    "display_name": "checkout-assistant",
+    "variable_name": "agent__checkout_assistant"
+  },
+  {
+    "name": "spaces and capitals reach the same variable as the hyphenated name",
+    "input": "Checkout Assistant",
+    "display_name": "Checkout Assistant",
+    "variable_name": "agent__checkout_assistant"
+  },
+  {
+    "name": "the already-normalized form is a fixed point",
+    "input": "checkout_assistant",
+    "display_name": "checkout_assistant",
+    "variable_name": "agent__checkout_assistant"
+  },
+  {
+    "name": "surrounding whitespace is trimmed from both the display name and the key",
+    "input": "  checkout  ",
+    "display_name": "checkout",
+    "variable_name": "agent__checkout"
+  },
+  {
+    "name": "the key lowercases, the display name does not",
+    "input": "CHECKOUT",
+    "display_name": "CHECKOUT",
+    "variable_name": "agent__checkout"
+  },
+  {
+    "name": "punctuation of every kind becomes an underscore",
+    "input": "checkout.assistant",
+    "display_name": "checkout.assistant",
+    "variable_name": "agent__checkout_assistant"
+  },
+  {
+    "name": "a slash is punctuation like any other, not a namespace separator",
+    "input": "billing/refunds",
+    "display_name": "billing/refunds",
+    "variable_name": "agent__billing_refunds"
+  },
+  {
+    "name": "runs of replaced characters collapse to one underscore",
+    "input": "a -- b",
+    "display_name": "a -- b",
+    "variable_name": "agent__a_b"
+  },
+  {
+    "name": "underscores are stripped from both ends",
+    "input": "_leading_and_trailing_",
+    "display_name": "_leading_and_trailing_",
+    "variable_name": "agent__leading_and_trailing"
+  },
+  {
+    "name": "a leading digit is fine, because the prefix is what starts the identifier",
+    "input": "2fa",
+    "display_name": "2fa",
+    "variable_name": "agent__2fa"
+  },
+  {
+    "name": "non-ASCII letters are not transliterated, they are replaced",
+    "input": "café",
+    "display_name": "café",
+    "variable_name": "agent__caf"
+  },
+  {
+    "name": "an emoji is replaced like any other non-key character",
+    "input": "checkout 🛒",
+    "display_name": "checkout 🛒",
+    "variable_name": "agent__checkout"
+  },
+  {
+    "name": "the prefix is added automatically, so passing it is a warning and not a doubled prefix",
+    "input": "agent__checkout",
+    "display_name": "agent__checkout",
+    "variable_name": "agent__checkout",
+    "warning": "prefix-added-automatically"
+  },
+  {
+    "name": "the prefix is recognized case-insensitively, since the key lowercases anyway",
+    "input": "Agent__Checkout",
+    "display_name": "Agent__Checkout",
+    "variable_name": "agent__checkout",
+    "warning": "prefix-added-automatically"
+  },
+  {
+    "name": "an empty name has no key",
+    "input": "",
+    "error": "empty"
+  },
+  {
+    "name": "whitespace only has no key",
+    "input": "   ",
+    "error": "empty"
+  },
+  {
+    "name": "punctuation only has no key",
+    "input": "---",
+    "error": "empty"
+  },
+  {
+    "name": "a name with no ASCII in it at all has no key",
+    "input": "日本語",
+    "error": "empty"
+  },
+  {
+    "name": "the bare prefix leaves nothing behind it",
+    "input": "agent__",
+    "error": "empty",
+    "warning": "prefix-added-automatically"
+  }
+]

--- a/packages/logfire-node/src/agent-control/spec/baseline.json
+++ b/packages/logfire-node/src/agent-control/spec/baseline.json
@@ -1,0 +1,350 @@
+[
+  {
+    "name": "one prompt, one tool, one setting: the shape every adapter starts from",
+    "input": {
+      "blocks": [
+        {
+          "text": "You are a concise checkout assistant.",
+          "id": "agent"
+        }
+      ],
+      "model": "anthropic:claude-fable-5-1",
+      "settings": {
+        "temperature": 0.1
+      },
+      "tools": [
+        {
+          "name": "get_weather",
+          "description": "Get the current weather for a city.",
+          "parameters_json_schema": {
+            "type": "object",
+            "properties": {
+              "city": {
+                "type": "string",
+                "description": "City to look up."
+              }
+            },
+            "required": [
+              "city"
+            ]
+          },
+          "toolset": "<agent>"
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "id": "agent",
+          "instructions": "You are a concise checkout assistant.",
+          "dynamic": false
+        }
+      ],
+      "model": "anthropic:claude-fable-5-1",
+      "settings": {
+        "temperature": 0.1
+      },
+      "tool_definitions": [
+        {
+          "name": "get_weather",
+          "description": "Get the current weather for a city.",
+          "parameters": {
+            "city": {
+              "description": "City to look up."
+            }
+          },
+          "toolset": "<agent>"
+        }
+      ]
+    }
+  },
+  {
+    "name": "an undocumented parameter is listed with an empty entry, so it can be described from Logfire",
+    "input": {
+      "tools": [
+        {
+          "name": "refund_order",
+          "parameters_json_schema": {
+            "type": "object",
+            "properties": {
+              "order_id": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "number",
+                "description": "Amount in cents."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "refund_order",
+          "parameters": {
+            "order_id": {},
+            "amount": {
+              "description": "Amount in cents."
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "a tool with no parameters at all has no parameters key",
+    "input": {
+      "tools": [
+        {
+          "name": "ping",
+          "parameters_json_schema": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "ping"
+        }
+      ]
+    }
+  },
+  {
+    "name": "a schema with no properties object is not guessed at",
+    "input": {
+      "tools": [
+        {
+          "name": "raw",
+          "parameters_json_schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "raw"
+        }
+      ]
+    }
+  },
+  {
+    "name": "a parameter whose schema is not an object still exists, and is still describable",
+    "input": {
+      "tools": [
+        {
+          "name": "odd",
+          "parameters_json_schema": {
+            "type": "object",
+            "properties": {
+              "flag": true
+            }
+          }
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "odd",
+          "parameters": {
+            "flag": {}
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "a dynamic block carries its seam and never its text",
+    "input": {
+      "blocks": [
+        {
+          "text": "You are a concise checkout assistant.",
+          "id": "agent"
+        },
+        {
+          "text": "Today is 2026-09-09.",
+          "id": "agent:today",
+          "dynamic": true
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "id": "agent",
+          "instructions": "You are a concise checkout assistant.",
+          "dynamic": false
+        },
+        {
+          "id": "agent:today",
+          "dynamic": true
+        }
+      ]
+    }
+  },
+  {
+    "name": "a dynamic block with nothing to key it on is left out entirely",
+    "input": {
+      "blocks": [
+        {
+          "text": "Tenant: acme",
+          "dynamic": true
+        }
+      ]
+    },
+    "expected": {}
+  },
+  {
+    "name": "a blank static block is left out; a blank dynamic one with an id is not",
+    "input": {
+      "blocks": [
+        {
+          "text": "   ",
+          "id": "agent:empty"
+        },
+        {
+          "text": "",
+          "id": "agent:rendered",
+          "dynamic": true
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "id": "agent:rendered",
+          "dynamic": true
+        }
+      ]
+    }
+  },
+  {
+    "name": "a static block with no id is published as unaddressable rather than dropped",
+    "input": {
+      "blocks": [
+        {
+          "text": "Escalate anything over $500."
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": "Escalate anything over $500.",
+          "dynamic": false
+        }
+      ]
+    }
+  },
+  {
+    "name": "toolset is present when known and absent when not, never guessed",
+    "input": {
+      "tools": [
+        {
+          "name": "search",
+          "toolset": "crm"
+        },
+        {
+          "name": "lookup"
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "search",
+          "toolset": "crm"
+        },
+        {
+          "name": "lookup"
+        }
+      ]
+    }
+  },
+  {
+    "name": "settings are filtered to the canonical keys, so no header or provider option is published",
+    "input": {
+      "settings": {
+        "temperature": 0.2,
+        "max_tokens": 1024,
+        "extra_headers": {
+          "authorization": "Bearer sk-secret"
+        },
+        "openai_service_tier": "flex"
+      }
+    },
+    "expected": {
+      "settings": {
+        "max_tokens": 1024,
+        "temperature": 0.2
+      }
+    }
+  },
+  {
+    "name": "an effort level the contract has no word for is omitted, never approximated",
+    "input": {
+      "settings": {
+        "thinking": "max",
+        "temperature": 0.3
+      }
+    },
+    "expected": {
+      "settings": {
+        "temperature": 0.3
+      }
+    },
+    "warnings": [
+      "baseline-value-not-describable"
+    ]
+  },
+  {
+    "name": "a timeout outside the representable range is omitted and reported",
+    "input": {
+      "settings": {
+        "timeout": -1,
+        "max_tokens": 512
+      }
+    },
+    "expected": {
+      "settings": {
+        "max_tokens": 512
+      }
+    },
+    "warnings": [
+      "baseline-timeout-not-representable"
+    ]
+  },
+  {
+    "name": "code-side values are read leniently, so an int for a float describes the agent fine",
+    "input": {
+      "settings": {
+        "temperature": 1,
+        "stop_sequences": [
+          "STOP",
+          "HALT"
+        ]
+      }
+    },
+    "expected": {
+      "settings": {
+        "temperature": 1.0,
+        "stop_sequences": [
+          "STOP",
+          "HALT"
+        ]
+      }
+    }
+  },
+  {
+    "name": "an empty agent describes nothing rather than describing emptiness",
+    "input": {},
+    "expected": {}
+  }
+]

--- a/packages/logfire-node/src/agent-control/spec/config-parsing.json
+++ b/packages/logfire-node/src/agent-control/spec/config-parsing.json
@@ -1,0 +1,534 @@
+[
+  {
+    "name": "a value with every section in play parses whole",
+    "input": {
+      "instructions": [
+        "Escalate anything over $500 to a human.",
+        {
+          "id": "agent",
+          "instructions": "You are a refund specialist."
+        },
+        {
+          "id": "toolset:legacy_crm"
+        }
+      ],
+      "model": "anthropic:claude-fable-5-1",
+      "settings": {
+        "temperature": 0.4,
+        "max_tokens": 2048,
+        "thinking": "high"
+      },
+      "tool_definitions": [
+        {
+          "name": "get_weather",
+          "new_name": "lookup_weather"
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": "Escalate anything over $500 to a human."
+        },
+        {
+          "id": "agent",
+          "instructions": "You are a refund specialist."
+        },
+        {
+          "id": "toolset:legacy_crm"
+        }
+      ],
+      "model": "anthropic:claude-fable-5-1",
+      "settings": {
+        "max_tokens": 2048,
+        "temperature": 0.4,
+        "thinking": "high"
+      },
+      "tool_definitions": [
+        {
+          "name": "get_weather",
+          "new_name": "lookup_weather"
+        }
+      ]
+    },
+    "warnings": []
+  },
+  {
+    "name": "a bare string is kept as a bare string, not rewritten into the list form",
+    "input": {
+      "instructions": "Be concise."
+    },
+    "expected": {
+      "instructions": "Be concise."
+    },
+    "warnings": []
+  },
+  {
+    "name": "an invalid model costs only the model section",
+    "input": {
+      "model": 42,
+      "settings": {
+        "temperature": 0.4
+      }
+    },
+    "expected": {
+      "settings": {
+        "temperature": 0.4
+      }
+    },
+    "warnings": [
+      "invalid-model"
+    ]
+  },
+  {
+    "name": "the empty string is never a model, and costs only the model section",
+    "input": {
+      "model": "",
+      "instructions": "Be concise."
+    },
+    "expected": {
+      "instructions": "Be concise."
+    },
+    "warnings": [
+      "invalid-model"
+    ]
+  },
+  {
+    "name": "a null model is simply absent, and says nothing",
+    "input": {
+      "model": null,
+      "instructions": "Be concise."
+    },
+    "expected": {
+      "instructions": "Be concise."
+    },
+    "warnings": []
+  },
+  {
+    "name": "the empty string is never instruction text either",
+    "input": {
+      "instructions": "",
+      "model": "openai:gpt-5.6-sol"
+    },
+    "expected": {
+      "model": "openai:gpt-5.6-sol"
+    },
+    "warnings": [
+      "instructions-section-empty"
+    ]
+  },
+  {
+    "name": "an entry whose text is the empty string is dropped, and its siblings are not",
+    "input": {
+      "instructions": [
+        {
+          "id": "agent",
+          "instructions": ""
+        },
+        "Be concise."
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": "Be concise."
+        }
+      ]
+    },
+    "warnings": [
+      "instruction-entry-invalid"
+    ]
+  },
+  {
+    "name": "a section one character past the budget is dropped whole",
+    "input": {
+      "instructions": {
+        "repeat": "a",
+        "times": 65537
+      }
+    },
+    "expected": {},
+    "warnings": [
+      "instructions-section-too-long"
+    ]
+  },
+  {
+    "name": "a section exactly at the budget is kept",
+    "input": {
+      "instructions": {
+        "repeat": "a",
+        "times": 65536
+      }
+    },
+    "expected": {
+      "instructions": {
+        "repeat": "a",
+        "times": 65536
+      }
+    },
+    "warnings": []
+  },
+  {
+    "name": "the budget is the total across entries, not per entry",
+    "input": {
+      "instructions": [
+        {
+          "repeat": "a",
+          "times": 65526
+        },
+        {
+          "repeat": "b",
+          "times": 11
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": {
+            "repeat": "a",
+            "times": 65526
+          }
+        }
+      ]
+    },
+    "warnings": [
+      "instruction-entry-too-long"
+    ]
+  },
+  {
+    "name": "only entries that survive are charged against the budget",
+    "input": {
+      "instructions": [
+        {
+          "id": 42,
+          "instructions": {
+            "repeat": "a",
+            "times": 40000
+          }
+        },
+        {
+          "repeat": "b",
+          "times": 40000
+        }
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": {
+            "repeat": "b",
+            "times": 40000
+          }
+        }
+      ]
+    },
+    "warnings": [
+      "instruction-entry-invalid"
+    ]
+  },
+  {
+    "name": "text is measured in code points, so an astral character weighs one and not two",
+    "input": {
+      "instructions": {
+        "repeat": "𝄞",
+        "times": 65536
+      }
+    },
+    "expected": {
+      "instructions": {
+        "repeat": "𝄞",
+        "times": 65536
+      }
+    },
+    "warnings": []
+  },
+  {
+    "name": "one code point past the budget in astral characters is still one code point past it",
+    "input": {
+      "instructions": {
+        "repeat": "𝄞",
+        "times": 65537
+      }
+    },
+    "expected": {},
+    "warnings": [
+      "instructions-section-too-long"
+    ]
+  },
+  {
+    "name": "an entry that says neither what nor where is dropped",
+    "input": {
+      "instructions": [
+        {},
+        "Be concise."
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": "Be concise."
+        }
+      ]
+    },
+    "warnings": [
+      "instruction-entry-empty"
+    ]
+  },
+  {
+    "name": "an entry that is not a string or an object is dropped, and its siblings are not",
+    "input": {
+      "instructions": [
+        7,
+        "Be concise."
+      ]
+    },
+    "expected": {
+      "instructions": [
+        {
+          "instructions": "Be concise."
+        }
+      ]
+    },
+    "warnings": [
+      "instruction-entry-invalid"
+    ]
+  },
+  {
+    "name": "an instructions section that is neither a string nor a list is dropped whole",
+    "input": {
+      "instructions": {
+        "id": "agent"
+      },
+      "model": "openai:gpt-5.6-sol"
+    },
+    "expected": {
+      "model": "openai:gpt-5.6-sol"
+    },
+    "warnings": [
+      "instructions-invalid-container"
+    ]
+  },
+  {
+    "name": "a settings value of the wrong JSON type is dropped, and its siblings are not",
+    "input": {
+      "settings": {
+        "temperature": "hot",
+        "max_tokens": 2048
+      }
+    },
+    "expected": {
+      "settings": {
+        "max_tokens": 2048
+      }
+    },
+    "warnings": [
+      "setting-value-invalid"
+    ]
+  },
+  {
+    "name": "a number written as a string is not coerced, because the stored schema says number",
+    "input": {
+      "settings": {
+        "temperature": "0.4",
+        "max_tokens": 2048
+      }
+    },
+    "expected": {
+      "settings": {
+        "max_tokens": 2048
+      }
+    },
+    "warnings": [
+      "setting-value-invalid"
+    ]
+  },
+  {
+    "name": "an integer is a number, because JSON writes 1 for 1.0",
+    "input": {
+      "settings": {
+        "temperature": 1
+      }
+    },
+    "expected": {
+      "settings": {
+        "temperature": 1.0
+      }
+    },
+    "warnings": []
+  },
+  {
+    "name": "a fraction is not an integer, so a fractional max_tokens is dropped",
+    "input": {
+      "settings": {
+        "max_tokens": 1.5
+      }
+    },
+    "expected": {
+      "settings": {}
+    },
+    "warnings": [
+      "setting-value-invalid"
+    ]
+  },
+  {
+    "name": "a number is not a boolean, so 1 does not enable parallel tool calls",
+    "input": {
+      "settings": {
+        "parallel_tool_calls": 1
+      }
+    },
+    "expected": {
+      "settings": {}
+    },
+    "warnings": [
+      "setting-value-invalid"
+    ]
+  },
+  {
+    "name": "an effort level a newer contract accepts is dropped as newer, not as malformed",
+    "input": {
+      "settings": {
+        "thinking": "extreme",
+        "temperature": 0.4
+      }
+    },
+    "expected": {
+      "settings": {
+        "temperature": 0.4
+      }
+    },
+    "warnings": [
+      "setting-value-not-recognized"
+    ]
+  },
+  {
+    "name": "a settings key this release has no field for is kept out of the patch and remembered",
+    "input": {
+      "settings": {
+        "service_tier": "flex",
+        "temperature": 0.4
+      }
+    },
+    "expected": {
+      "settings": {
+        "temperature": 0.4
+      }
+    },
+    "warnings": [],
+    "unrecognized_settings": [
+      "service_tier"
+    ]
+  },
+  {
+    "name": "a settings section that is not an object is dropped whole",
+    "input": {
+      "settings": [
+        1,
+        2
+      ],
+      "model": "openai:gpt-5.6-sol"
+    },
+    "expected": {
+      "model": "openai:gpt-5.6-sol"
+    },
+    "warnings": [
+      "settings-invalid-container"
+    ]
+  },
+  {
+    "name": "a tool override with no name is dropped, and its siblings are not",
+    "input": {
+      "tool_definitions": [
+        {
+          "new_name": "lookup"
+        },
+        {
+          "name": "search",
+          "description": "Search."
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "search",
+          "description": "Search."
+        }
+      ]
+    },
+    "warnings": [
+      "tool-definition-invalid"
+    ]
+  },
+  {
+    "name": "an override renaming to the empty string is dropped, since '' is never a value",
+    "input": {
+      "tool_definitions": [
+        {
+          "name": "search",
+          "new_name": ""
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": []
+    },
+    "warnings": [
+      "tool-definition-invalid"
+    ]
+  },
+  {
+    "name": "a tool_definitions section that is not a list is dropped whole",
+    "input": {
+      "tool_definitions": {
+        "name": "search"
+      },
+      "model": "openai:gpt-5.6-sol"
+    },
+    "expected": {
+      "model": "openai:gpt-5.6-sol"
+    },
+    "warnings": [
+      "tool-definitions-invalid-container"
+    ]
+  },
+  {
+    "name": "an unknown key inside an override costs nothing",
+    "input": {
+      "tool_definitions": [
+        {
+          "name": "search",
+          "colour": "blue"
+        }
+      ]
+    },
+    "expected": {
+      "tool_definitions": [
+        {
+          "name": "search"
+        }
+      ]
+    },
+    "warnings": []
+  },
+  {
+    "name": "an unknown top-level key costs nothing",
+    "input": {
+      "model": "openai:gpt-5.6-sol",
+      "future_section": {
+        "anything": true
+      }
+    },
+    "expected": {
+      "model": "openai:gpt-5.6-sol"
+    },
+    "warnings": []
+  },
+  {
+    "name": "an empty value is a value that changes nothing",
+    "input": {},
+    "expected": {},
+    "warnings": []
+  }
+]

--- a/packages/logfire-node/src/agent-control/spec/instructions-apply.json
+++ b/packages/logfire-node/src/agent-control/spec/instructions-apply.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "two entries for one id keep the first and report the second",
+    "input": {
+      "parts": [{ "id": "agent", "text": "Main." }],
+      "config": { "instructions": [{ "id": "agent", "instructions": "A" }, { "id": "agent", "instructions": "B" }] }
+    },
+    "expected": {
+      "parts": [{ "id": "agent", "text": "A" }],
+      "issues": [{ "section": "instructions", "reason": "duplicate-entry", "instruction_id": "agent" }]
+    }
+  }
+]

--- a/packages/logfire-node/src/agent-control/spec/merge.json
+++ b/packages/logfire-node/src/agent-control/spec/merge.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "published beats code, an explicit run value beats published",
+    "input": {
+      "code": { "temperature": 0.2, "max_tokens": 100 },
+      "published": { "temperature": 0.8 },
+      "run_explicit": { "max_tokens": 500 }
+    },
+    "expected": {
+      "settings": { "temperature": 0.8, "max_tokens": 500 },
+      "sources": { "temperature": "published", "max_tokens": "run" }
+    }
+  },
+  {
+    "name": "an explicitly null run value clears the key and still records that the run owns it",
+    "input": {
+      "code": { "temperature": 0.2 },
+      "published": { "temperature": 0.8 },
+      "run_explicit": { "temperature": null }
+    },
+    "expected": { "settings": {}, "sources": { "temperature": "run" } }
+  },
+  {
+    "name": "a null published value does not clear a code value: only a run can clear",
+    "input": { "code": { "temperature": 0.2 }, "published": { "temperature": null } },
+    "expected": { "settings": { "temperature": 0.2 }, "sources": { "temperature": "code" } }
+  },
+  {
+    "name": "a null code value is the layer not setting the key, so the published one still applies",
+    "input": { "code": { "temperature": null }, "published": { "temperature": 0.8 } },
+    "expected": { "settings": { "temperature": 0.8 }, "sources": { "temperature": "published" } }
+  },
+  {
+    "name": "a key outside the canonical settings passes through with the layer that set it",
+    "input": { "code": { "service_tier": "flex" }, "published": { "temperature": 0.8 } },
+    "expected": {
+      "settings": { "service_tier": "flex", "temperature": 0.8 },
+      "sources": { "service_tier": "code", "temperature": "published" }
+    }
+  },
+  {
+    "name": "no layer sets anything, so nothing is merged and nothing is owned",
+    "input": {},
+    "expected": { "settings": {}, "sources": {} }
+  }
+]

--- a/packages/logfire-node/src/agent-control/spec/settings-apply.json
+++ b/packages/logfire-node/src/agent-control/spec/settings-apply.json
@@ -1,0 +1,69 @@
+[
+  {
+    "name": "a canonical setting this adapter cannot lower is dropped and reported",
+    "input": {
+      "config": { "settings": { "temperature": 0.4, "top_k": 40 } },
+      "support": { "sections": ["settings"], "settings": ["temperature"] }
+    },
+    "expected": {
+      "settings": { "temperature": 0.4 },
+      "issues": [{ "section": "settings", "reason": "unsupported-setting", "setting": "top_k" }]
+    }
+  },
+  {
+    "name": "no support declared is the adapter saying it can lower every canonical setting",
+    "input": { "config": { "settings": { "temperature": 0.4, "top_k": 40 } }, "support": null },
+    "expected": { "settings": { "temperature": 0.4, "top_k": 40 }, "issues": [] }
+  },
+  {
+    "name": "a key this version of the contract has no field for is reported, not forwarded",
+    "input": { "config": { "settings": { "temperature": 0.4, "reasoning_budget": 1024 } }, "support": null },
+    "expected": {
+      "settings": { "temperature": 0.4 },
+      "issues": [{ "section": "settings", "reason": "unknown-setting", "setting": "reasoning_budget" }]
+    }
+  },
+  {
+    "name": "a timeout that is not a request budget is dropped rather than clamped",
+    "input": { "config": { "settings": { "timeout": -1 } }, "support": null },
+    "expected": {
+      "settings": {},
+      "issues": [{ "section": "settings", "reason": "unrepresentable-timeout", "setting": "timeout" }]
+    }
+  },
+  {
+    "name": "issues come back in the order the canonical settings are declared, whatever order the value wrote them in",
+    "input": {
+      "config": { "settings": { "timeout": -1, "top_k": 40 } },
+      "support": { "sections": ["settings"], "settings": ["temperature"] }
+    },
+    "expected": {
+      "settings": {},
+      "issues": [
+        { "section": "settings", "reason": "unsupported-setting", "setting": "top_k" },
+        { "section": "settings", "reason": "unrepresentable-timeout", "setting": "timeout" }
+      ]
+    }
+  },
+  {
+    "name": "a section this adapter cannot apply is reported once, not silently ignored",
+    "input": {
+      "config": { "model": "openai:gpt-5.6-sol" },
+      "support": { "sections": ["instructions", "settings"], "settings": [] }
+    },
+    "expected": { "issues": [{ "section": "model", "reason": "unsupported-section" }] }
+  },
+  {
+    "name": "every section the adapter declares is applied without a word about it",
+    "input": {
+      "config": { "instructions": ["Be brief."], "model": "openai:gpt-5.6-sol", "settings": { "temperature": 0.4 } },
+      "support": { "sections": ["instructions", "model", "settings"], "settings": ["temperature"] }
+    },
+    "expected": { "settings": { "temperature": 0.4 }, "issues": [] }
+  },
+  {
+    "name": "a top-level key this SDK version has no section for is reported, not dropped in silence",
+    "input": { "config": { "instructions": ["Be brief."], "mcp_servers": [{ "name": "crm" }] }, "support": null },
+    "expected": { "issues": [{ "section": "mcp_servers", "reason": "unknown-section" }] }
+  }
+]

--- a/packages/logfire-node/src/agent-control/spec/settings-apply.json
+++ b/packages/logfire-node/src/agent-control/spec/settings-apply.json
@@ -54,6 +54,17 @@
     "expected": { "issues": [{ "section": "model", "reason": "unsupported-section" }] }
   },
   {
+    "name": "a settings section the adapter cannot apply yields no patch, whatever keys it can lower",
+    "input": {
+      "config": { "settings": { "temperature": 0.4 } },
+      "support": { "sections": ["instructions"], "settings": ["temperature"] }
+    },
+    "expected": {
+      "settings": {},
+      "issues": [{ "section": "settings", "reason": "unsupported-section" }]
+    }
+  },
+  {
     "name": "every section the adapter declares is applied without a word about it",
     "input": {
       "config": { "instructions": ["Be brief."], "model": "openai:gpt-5.6-sol", "settings": { "temperature": 0.4 } },

--- a/packages/logfire-node/src/agent-control/spec/tools-apply.json
+++ b/packages/logfire-node/src/agent-control/spec/tools-apply.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "two overrides for one tool keep the first and report the second",
+    "input": {
+      "tools": [{ "name": "get_weather" }],
+      "config": {
+        "tool_definitions": [
+          { "name": "get_weather", "description": "First." },
+          { "name": "get_weather", "description": "Last." }
+        ]
+      }
+    },
+    "expected": {
+      "tools": [{ "name": "get_weather", "description": "First." }],
+      "routes": { "get_weather": "get_weather" },
+      "issues": [{ "section": "tool_definitions", "reason": "duplicate-entry", "tool": "get_weather" }]
+    }
+  },
+  {
+    "name": "one toolset's tool and another's are separate keys, so neither is a duplicate of the other",
+    "input": {
+      "tools": [{ "name": "search", "toolset": "crm" }, { "name": "search", "toolset": "docs" }],
+      "config": {
+        "tool_definitions": [
+          { "name": "search", "toolset": "crm", "description": "CRM." },
+          { "name": "search", "toolset": "docs", "description": "Docs." }
+        ]
+      }
+    },
+    "expected": {
+      "tools": [
+        { "name": "search", "description": "CRM.", "toolset": "crm" },
+        { "name": "search", "description": "Docs.", "toolset": "docs" }
+      ],
+      "issues": []
+    }
+  }
+]

--- a/packages/logfire-node/src/agent-control/support.ts
+++ b/packages/logfire-node/src/agent-control/support.ts
@@ -1,0 +1,108 @@
+/**
+ * What an adapter can do with a published config, declared as data rather than inferred.
+ *
+ * Two facts about an agent are known only to its adapter and are needed everywhere else: which
+ * sections and settings it can actually apply, and how faithfully it can tell an explicit per-run
+ * setting from a default. Both used to be prose -- a README footnote, an `if` in a hook -- and the
+ * Logfire editor inferred the first by reading the variable's `example`, which cannot tell "this
+ * adapter cannot apply `tool_definitions`" from "this agent has no tools".
+ *
+ * `AgentSupport` is that knowledge as one value: built by the adapter, published with the baseline,
+ * and read by the editor. It describes the **adapter**, and only the adapter. What a particular model
+ * does with a setting the adapter forwarded is deliberately not here -- it goes out of date the week
+ * a provider ships, it belongs to whatever curates model metadata, and every framework Agent Control
+ * drives already has its own reasoning for settings a model will not take.
+ */
+
+/** The four sections of an `AgentConfig`, which are also the four things an adapter may not be able to apply. */
+export type Section = 'instructions' | 'model' | 'settings' | 'tool_definitions'
+
+/**
+ * One named sink an adapter can put instruction text into.
+ *
+ * A framework with one prompt has one destination; a framework with several -- a CLI preset and a
+ * system prompt, a session prefix and a per-turn prefix -- has one per sink, and a published addition
+ * says which of them it means rather than an index into a list only the adapter can see.
+ *
+ * Declared here and consumed where instructions are applied, so the editor learns the sinks from the
+ * same value that tells it which sections exist.
+ */
+export interface Destination {
+  /** The name a published addition routes to, and the name the editor offers. */
+  readonly id: string
+  /**
+   * Whether an addition that names no destination lands here.
+   *
+   * At most one destination should say `true`. An adapter with a single sink can leave it out and let
+   * the first destination be the fallback, which is what one sink means anyway.
+   */
+  readonly default?: boolean
+  /**
+   * Whether published text may be added to this sink at all. Defaults to `true`.
+   *
+   * `false` is for a sink an adapter can rewrite but not grow -- a fixed-shape preset, a field with
+   * one slot -- where the editor should offer editing and not "add a block".
+   */
+  readonly acceptsAdditions?: boolean
+}
+
+/**
+ * What this adapter can apply, declared once and carried with the baseline.
+ *
+ * An adapter builds one of these and passes it to the apply helpers, which use it to say -- rather
+ * than silently do nothing about -- a published section or setting this framework cannot lower. The
+ * Logfire editor reads the same value to grey out what it would be pointless to publish.
+ *
+ * Nothing here is about a model. A published `temperature` a reasoning model refuses, or a
+ * `presence_penalty` a provider rejects outright, reaches that provider and fails the request unless
+ * the adapter's own reasoning drops it first: that is the adapter's table to get right, and Agent
+ * Control carries none of it.
+ */
+export interface AgentSupport {
+  /**
+   * The sections this adapter can apply at all.
+   *
+   * A published section outside this list is reported once, rather than silently doing nothing, which
+   * is the difference between an editor that greys a section out and one that offers an edit that
+   * will never take effect.
+   */
+  readonly sections: readonly Section[]
+  /**
+   * The named instruction sinks; see `Destination`.
+   *
+   * Also what the editor offers "add a block" for. Absent means the adapter has one unnamed sink,
+   * which is every framework with a single prompt.
+   */
+  readonly destinations?: readonly Destination[]
+  /**
+   * The canonical setting keys this adapter can lower into its framework.
+   *
+   * An empty list declares that it can lower none of them, so an adapter that applies settings has to
+   * say which. Passing no support at all to `applySettings` is the other way to say "all of them",
+   * for an adapter that has not been taught to declare yet.
+   */
+  readonly settings?: readonly string[]
+  /**
+   * How faithfully this adapter can tell an explicit per-run setting from a default.
+   *
+   * - `'exact'`: it sees the keys the caller set for this run, so the contract's precedence -- code,
+   *   then published, then the run -- holds exactly.
+   * - `'inferred'`: it diffs the framework's effective settings against the defaults, so a run that
+   *   re-sets a value that happens to be the default loses to the published one.
+   * - `'code-wins'`: there is no run layer to read, or the framework writes its own values last, so a
+   *   code-side value beats a published one and cannot be made not to from outside.
+   *
+   * Nothing verifies this; it is a declaration, and a wrong one is a wrong hint in the editor about
+   * when a published value will win. Defaults to `'exact'`.
+   */
+  readonly precedence?: 'exact' | 'inferred' | 'code-wins'
+  /**
+   * What one resolved config covers, which is what the editor tells a user about when a change takes
+   * effect.
+   *
+   * `'run'` is a whole agent run, `'request'` is one model request inside it, and `'session'` is a
+   * conversation the framework snapshots once -- where a published change reaches the next session
+   * rather than the next request. Defaults to `'run'`.
+   */
+  readonly resolutionUnit?: 'run' | 'request' | 'session'
+}

--- a/packages/logfire-node/src/agent-control/testing.ts
+++ b/packages/logfire-node/src/agent-control/testing.ts
@@ -12,7 +12,7 @@
  * point is what says so in a way a reviewer can see at the import line.
  *
  * ```ts
- * import { resetAgentControl } from '@pydantic/logfire-agent-control/testing';
+ * import { resetAgentControl } from '@pydantic/logfire-node/agent-control/testing'
  *
  * beforeEach(resetAgentControl);
  * ```

--- a/packages/logfire-node/src/agent-control/testing.ts
+++ b/packages/logfire-node/src/agent-control/testing.ts
@@ -1,0 +1,38 @@
+/**
+ * Test-only entry point: reset the process-wide state this package keeps.
+ *
+ * Two guards make Agent Control quiet in production and awkward in a test suite. Warnings are
+ * emitted once per process per message, and a baseline is published once per process per variable.
+ * Both are deliberate -- a config resolved on every run would otherwise bury its own signal, and a
+ * failed publish would otherwise retry forever -- and both mean the second test to exercise a path
+ * sees nothing happen.
+ *
+ * So these are exported, from their own subpath rather than the index. An adapter's suite needs them
+ * in a `beforeEach`; an adapter's *runtime* has no business calling either, and a separate entry
+ * point is what says so in a way a reviewer can see at the import line.
+ *
+ * ```ts
+ * import { resetAgentControl } from '@pydantic/logfire-agent-control/testing';
+ *
+ * beforeEach(resetAgentControl);
+ * ```
+ */
+
+import { resetProcessState } from './control'
+import { resetWarnings } from './warnings'
+
+export { resetProcessState } from './control'
+export { resetWarnings } from './warnings'
+
+/**
+ * Reset every once-per-process guard at once.
+ *
+ * The two are almost always wanted together -- a test that asserts a publish happens needs the
+ * publish guard cleared, and a test that asserts what was warned needs the warning memory cleared --
+ * so this is the one to reach for, and the individual resets are there for a suite that wants to
+ * hold one guard across several tests on purpose.
+ */
+export function resetAgentControl(): void {
+  resetWarnings()
+  resetProcessState()
+}

--- a/packages/logfire-node/src/agent-control/tools.ts
+++ b/packages/logfire-node/src/agent-control/tools.ts
@@ -1,0 +1,405 @@
+/**
+ * Applying the `tool_definitions` section to the tools a framework advertises to the model.
+ *
+ * Overrides change only what the model is shown. Parameter names, types, requiredness, validation,
+ * and the implementation behind a tool stay code-defined, which is why the result carries routing
+ * tables: a renamed tool has to be callable under its new name and still run the old one.
+ */
+
+import type { AgentConfig, ParameterOverride, ToolDefinitionOverride } from './config'
+import type { JsonSchema } from './schema'
+import { reportUnappliedEntries, repr, warnOnce } from './warnings'
+import type { OnUnmatched, UnappliedEntry, UnappliedReason } from './warnings'
+
+/**
+ * One tool's LLM-facing definition as a framework advertises it, and as this package hands it back.
+ *
+ * Unlike `ToolDefinitionOverride`, which is the wire shape of a *patch*, this is the tool itself, and
+ * it never reaches the wire -- so its fields are named the way a TypeScript adapter would name them.
+ */
+export interface ToolDef {
+  /** The tool's name as the model sees it. On input, its code-side name. */
+  name: string
+  /** The tool's description as the model sees it. */
+  description?: string
+  /** The tool's parameters as a JSON Schema object. */
+  parametersJsonSchema: JsonSchema
+  /**
+   * The toolset this tool came from, or `null`/absent when the framework has no such grouping.
+   *
+   * It is what an override narrows its match by, so an adapter should report it as one stable string
+   * per toolset -- an id where the framework has one, its label otherwise -- and use the same value
+   * when building a baseline, so the value the Logfire editor shows is exactly the value an override
+   * can be written against.
+   */
+  toolset?: string | null
+}
+
+/**
+ * Where two advertised tool names actually collide, which is a property of the framework.
+ *
+ * A rename is only safe if the core can tell whether the new name is already taken, and "taken" is
+ * not the same question everywhere:
+ *
+ * - `'global'` (the default): every tool is advertised into one flat namespace, so any two tools with
+ *   the same advertised name collide. Almost every framework -- the AI SDK, Mastra, OpenAI Agents,
+ *   LangChain -- works this way.
+ * - `'toolset'`: the runtime name a tool is advertised under already carries its toolset, as the
+ *   Claude Agent SDK's `mcp__<server>__<tool>` does, so two servers may each advertise a `search`,
+ *   and renaming one of them to `lookup` does not collide with another server's `lookup`.
+ *
+ * Getting this wrong is not cosmetic in either direction: too wide drops a legal rename, too narrow
+ * advertises two tools under one name and makes a call unroutable.
+ */
+export type CollisionScope = 'global' | 'toolset'
+
+/**
+ * The identity a tool is matched and routed by: its toolset and its name, as one string.
+ *
+ * A string rather than a tuple because it is a `Map` key, and two tuples with the same contents are
+ * two different keys. Build one with `toolKey` and never by hand: the encoding is this module's, and
+ * the only thing it guarantees is that `toolKey` round-trips through a `Map` lookup.
+ */
+export type ToolKey = string
+
+/**
+ * The key `(toolset, name)` is looked up under, with `null` and absent meaning the same thing.
+ *
+ * An adapter reading `forward` or `reverse` calls this with the toolset it knows the tool by and the
+ * name it is asking about; an adapter whose framework has no toolsets passes `null`.
+ */
+export function toolKey(toolset: string | null | undefined, name: string): ToolKey {
+  return JSON.stringify([toolset ?? null, name])
+}
+
+function splitToolKey(key: ToolKey): [string | null, string] {
+  return JSON.parse(key) as [string | null, string]
+}
+
+function describeToolKey(key: ToolKey): string {
+  const [toolset, name] = splitToolKey(key)
+  return toolset === null ? `tool ${repr(name)}` : `tool ${repr(name)} from toolset ${repr(toolset)}`
+}
+
+/** What `applyToolDefinitions` returns: the tools to advertise, and where a call comes back to. */
+export interface AppliedTools {
+  /** The tools to advertise, in the order they were given, with managed definitions applied. */
+  tools: ToolDef[]
+  /**
+   * Advertised name to code-side name, for every tool.
+   *
+   * Total rather than rename-only so a dispatcher can look up any name the model calls without
+   * special-casing the tools that were not renamed. Frameworks differ on whether the implementation
+   * should see its old name or the new one, so the mapping is handed over rather than applied here.
+   *
+   * Flat, and therefore exact only under `collisionScope: 'global'`, where an advertised name
+   * identifies a tool by itself. An adapter that passes `'toolset'` has said that two toolsets may
+   * advertise the same name, so it routes through `reverse` instead; this mapping keeps the first of
+   * such a pair.
+   *
+   * A null-prototype object, so a tool the model calls `constructor` or `toString` is a name this
+   * table does not have rather than an inherited function an adapter would go on to invoke.
+   */
+  routes: Record<string, string>
+  /**
+   * `toolKey(toolset, code-side name)` to the name that tool is advertised under.
+   *
+   * The direction an adapter needs on the way *out*: rewriting a `toolChoice`, an active-tools list,
+   * or a replayed history entry that names a tool by the name the code gave it. Keyed on the pair
+   * rather than the bare name so a framework with toolsets rewrites exactly the one it means.
+   */
+  forward: ReadonlyMap<ToolKey, string>
+  /**
+   * `toolKey(toolset, advertised name)` to the tool's code-side name.
+   *
+   * The direction an adapter needs on the way *in*: a call arrives under an advertised name, and
+   * under `collisionScope: 'toolset'` the adapter also knows which toolset it came from, which is
+   * what keeps two servers' identically named tools distinguishable.
+   */
+  reverse: ReadonlyMap<ToolKey, string>
+  /**
+   * Every published tool entry, or part of one, this request did not apply; see `UnappliedEntry`.
+   *
+   * Already reported under the caller's `onUnmatched` policy before it is returned.
+   */
+  unapplied: readonly UnappliedEntry[]
+}
+
+/** Options for `applyToolDefinitions`. */
+export interface ApplyToolDefinitionsOptions {
+  /**
+   * What to do with a published entry this request did not apply.
+   *
+   * Every decision `applyToolDefinitions` makes goes through it, a dropped rename included: a rename
+   * refused for colliding is as much a gap between what Logfire shows and what the agent does as an
+   * override naming a tool that is not there.
+   */
+  onUnmatched?: OnUnmatched
+  /**
+   * Advertised names this adapter needs kept free.
+   *
+   * An OpenAI Agents handoff, a provider-defined tool the framework adds after this call, anything
+   * outside the editable list. A rename onto one of them is refused like any other collision. Read as
+   * taken in every namespace, which is exact for a framework with one and deliberately conservative
+   * for a framework with several.
+   */
+  reserved?: Iterable<string>
+  /** Where two advertised names collide; see `CollisionScope`. */
+  collisionScope?: CollisionScope
+}
+
+/**
+ * Index overrides by the `(toolset, name)` each one patches, keeping the first of any duplicates.
+ *
+ * An entry without a `toolset` is keyed under `null`, so the same `name` can carry one unqualified
+ * entry and one per toolset side by side; only two entries with the same pair collide.
+ */
+function overridesByKey(config: AgentConfig): Map<ToolKey, ToolDefinitionOverride> {
+  const overrides = new Map<ToolKey, ToolDefinitionOverride>()
+  for (const override of config.tool_definitions ?? []) {
+    const key = toolKey(override.toolset, override.name)
+    if (overrides.has(key)) {
+      warnOnce(`Managed agent config names ${describeToolKey(key)} more than once; keeping the first entry and ignoring the rest.`)
+      continue
+    }
+    overrides.set(key, override)
+  }
+  return overrides
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parameterEntry(
+  reason: Extract<UnappliedReason, 'unknown-parameter' | 'no-patchable-schema'>,
+  tool: ToolDef,
+  parameter: string,
+  because: string
+): UnappliedEntry {
+  return {
+    reason,
+    toolset: tool.toolset ?? null,
+    tool: tool.name,
+    parameter,
+    message:
+      `Managed agent config patches parameter ${repr(parameter)} of ` +
+      `${describeToolKey(toolKey(tool.toolset, tool.name))}, which ${because}; that patch applies to nothing.`,
+  }
+}
+
+/** What `patchParameters` found: the schema to send, and the patches that reached nothing. */
+interface PatchedParameters {
+  schema: JsonSchema
+  /** Names the schema has no top-level property for. */
+  unknown: string[]
+  /** Names whose property schema is not an object to patch a description into. */
+  unpatchable: string[]
+  /** Whether the tool has no top-level parameters at all, which makes every patch a miss. */
+  noProperties: boolean
+}
+
+/**
+ * Patch top-level parameter descriptions while preserving all other schema structure.
+ *
+ * Own-property lookups throughout: both sides of this come from JSON, so a parameter called
+ * `constructor` must be a name the schema does not have rather than an inherited function.
+ */
+function patchParameters(schema: JsonSchema, parameters: Record<string, ParameterOverride>): PatchedParameters {
+  const properties = schema['properties']
+  const unknown: string[] = []
+  const unpatchable: string[] = []
+  if (!isRecord(properties)) {
+    return { schema, unknown, unpatchable, noProperties: true }
+  }
+  const newProperties: Record<string, unknown> = {}
+  let changed = false
+  for (const [name, propertySchema] of Object.entries(properties)) {
+    const description = Object.hasOwn(parameters, name) ? parameters[name]?.description : undefined
+    if (description !== undefined && isRecord(propertySchema)) {
+      newProperties[name] = { ...propertySchema, description }
+      changed = true
+    } else {
+      newProperties[name] = propertySchema
+    }
+  }
+  for (const [name, override] of Object.entries(parameters)) {
+    if (!Object.hasOwn(properties, name)) {
+      unknown.push(name)
+    } else if (override.description !== undefined && !isRecord(properties[name])) {
+      unpatchable.push(name)
+    }
+  }
+  return {
+    schema: changed ? { ...schema, properties: newProperties } : schema,
+    unknown,
+    unpatchable,
+    noProperties: false,
+  }
+}
+
+/**
+ * Patch top-level parameter descriptions, for an adapter holding a schema of its own.
+ *
+ * Returns the original object when nothing changed, so an adapter that compares by identity can tell
+ * a patched schema from an untouched one. Reporting is the caller's here: `applyToolDefinitions` is
+ * what turns a patch that reached nothing into an `UnappliedEntry` under a policy.
+ */
+export function withParameterDescriptions(schema: JsonSchema, parameters: Record<string, ParameterOverride>): JsonSchema {
+  return patchParameters(schema, parameters).schema
+}
+
+/** Apply the LLM-facing parts of one override, returning the original definition for a no-op. */
+function applyOverride(tool: ToolDef, override: ToolDefinitionOverride): { tool: ToolDef; unapplied: UnappliedEntry[] } {
+  const patched: ToolDef = { ...tool }
+  const unapplied: UnappliedEntry[] = []
+  let changed = false
+  if (override.new_name !== undefined && override.new_name !== tool.name) {
+    patched.name = override.new_name
+    changed = true
+  }
+  if (override.description !== undefined && override.description !== tool.description) {
+    patched.description = override.description
+    changed = true
+  }
+  if (override.parameters !== undefined) {
+    const result = patchParameters(tool.parametersJsonSchema, override.parameters)
+    if (result.schema !== tool.parametersJsonSchema) {
+      patched.parametersJsonSchema = result.schema
+      changed = true
+    }
+    const missing = result.noProperties ? Object.keys(override.parameters) : result.unknown
+    const because = result.noProperties ? 'has no top-level parameters' : 'has no parameter of that name'
+    const reason = result.noProperties ? 'no-patchable-schema' : 'unknown-parameter'
+    for (const name of missing) {
+      unapplied.push(parameterEntry(reason, tool, name, because))
+    }
+    for (const name of result.unpatchable) {
+      unapplied.push(parameterEntry('no-patchable-schema', tool, name, 'describes that parameter with no schema object'))
+    }
+  }
+  return { tool: changed ? patched : tool, unapplied }
+}
+
+/** The set of advertised names this tool competes in; see `CollisionScope`. */
+function namespaceOf(tool: ToolDef, scope: CollisionScope): string | null {
+  return scope === 'toolset' ? (tool.toolset ?? null) : null
+}
+
+/** The names already taken in one namespace, created empty the first time it is asked for. */
+function namesTakenIn(taken: Map<string | null, Set<string>>, namespace: string | null): Set<string> {
+  const existing = taken.get(namespace)
+  if (existing !== undefined) {
+    return existing
+  }
+  const names = new Set<string>()
+  taken.set(namespace, names)
+  return names
+}
+
+/**
+ * Apply a managed config's `tool_definitions` section to the tools a request advertises.
+ *
+ * Pure: it reads `tools` and returns new definitions plus the routing tables for them.
+ *
+ * - A tool is matched by `name`, narrowed to one toolset's tool of that name when the override sets
+ *   `toolset`. An override narrowed to a toolset beats one that only names the tool, so a config can
+ *   say "every `search`" and "the CRM's `search`" at once and the specific entry wins where both
+ *   apply. The unqualified entry is then outranked, not unmatched -- it still reached the tool it
+ *   named -- so only an entry that matched no tool at all is reported.
+ * - A rename onto a name that is already taken is **dropped** while that override's other patches
+ *   still apply, so every tool keeps a name the model can call. What counts as taken is
+ *   `collisionScope` plus `reserved`, and renames resolve in input order, so the tool that was there
+ *   first keeps the name.
+ * - Parameter descriptions are patched in place and every other piece of schema structure is
+ *   preserved. A patch on a parameter the tool does not have, or on one whose schema is not an object
+ *   to patch a description into, applies nothing -- a parameter is part of the tool's code-defined
+ *   shape, and the baseline is what says which ones exist -- and is reported rather than dropped in
+ *   silence.
+ * - An override that matches nothing is reported per call rather than once, because tool availability
+ *   is dynamic: a framework can advertise different tools from one step to the next, and a report
+ *   from one listing is a report about that listing.
+ *
+ * Every one of those decisions goes through `onUnmatched` and comes back on `unapplied`.
+ */
+export function applyToolDefinitions(
+  tools: readonly ToolDef[],
+  config: AgentConfig,
+  options: ApplyToolDefinitionsOptions = {}
+): AppliedTools {
+  const onUnmatched = options.onUnmatched ?? 'warn'
+  const collisionScope = options.collisionScope ?? 'global'
+  const reserved = new Set(options.reserved ?? [])
+  const overrides = overridesByKey(config)
+
+  // A namespace is the set of advertised names that compete: one for the whole request, or one per
+  // toolset. Every code-side name starts out taken, so a rename onto a tool later in the list is a
+  // collision rather than a name that is free until that tool is reached.
+  const taken = new Map<string | null, Set<string>>()
+  for (const tool of tools) {
+    namesTakenIn(taken, namespaceOf(tool, collisionScope)).add(tool.name)
+  }
+
+  const unapplied: UnappliedEntry[] = []
+  const matched = new Set<ToolKey>()
+  const applied: ToolDef[] = []
+  // Null-prototype, so `'constructor' in routes` is a question about this request's tools rather than
+  // about `Object.prototype`, and a tool named `__proto__` becomes an entry rather than a new
+  // prototype.
+  const routes = Object.create(null) as Record<string, string>
+  const forward = new Map<ToolKey, string>()
+  const reverse = new Map<ToolKey, string>()
+
+  for (const tool of tools) {
+    const qualified = toolKey(tool.toolset, tool.name)
+    const unqualified = toolKey(null, tool.name)
+    for (const key of [qualified, unqualified]) {
+      if (overrides.has(key)) {
+        matched.add(key)
+      }
+    }
+    const override = overrides.get(qualified) ?? overrides.get(unqualified)
+    let patched = tool
+    if (override !== undefined) {
+      const result = applyOverride(tool, override)
+      patched = result.tool
+      unapplied.push(...result.unapplied)
+    }
+    const names = namesTakenIn(taken, namespaceOf(tool, collisionScope))
+    if (patched.name !== tool.name && (names.has(patched.name) || reserved.has(patched.name))) {
+      unapplied.push({
+        reason: 'rename-collision',
+        toolset: tool.toolset ?? null,
+        tool: tool.name,
+        message:
+          `Managed tool definition override renames ${repr(tool.name)} to ${repr(patched.name)}, ` +
+          `which is already advertised by another tool; keeping the original name ${repr(tool.name)}.`,
+      })
+      patched = { ...patched, name: tool.name }
+    } else {
+      names.add(patched.name)
+    }
+    applied.push(patched)
+    if (!Object.hasOwn(routes, patched.name)) {
+      routes[patched.name] = tool.name
+    }
+    forward.set(qualified, patched.name)
+    reverse.set(toolKey(tool.toolset, patched.name), tool.name)
+  }
+
+  for (const key of overrides.keys()) {
+    if (matched.has(key)) {
+      continue
+    }
+    const [toolset, name] = splitToolKey(key)
+    unapplied.push({
+      reason: 'unknown-tool',
+      toolset,
+      tool: name,
+      message:
+        `Managed agent config patches ${describeToolKey(key)}, which no toolset advertises for ` +
+        'this request; that override applies to nothing.',
+    })
+  }
+  return { tools: applied, routes, forward, reverse, unapplied: reportUnappliedEntries(onUnmatched, unapplied) }
+}

--- a/packages/logfire-node/src/agent-control/tools.ts
+++ b/packages/logfire-node/src/agent-control/tools.ts
@@ -130,9 +130,14 @@ export interface ApplyToolDefinitionsOptions {
   /**
    * What to do with a published entry this request did not apply.
    *
-   * Every decision `applyToolDefinitions` makes goes through it, a dropped rename included: a rename
-   * refused for colliding is as much a gap between what Logfire shows and what the agent does as an
-   * override naming a tool that is not there.
+   * Every *request-level* decision goes through it -- an unknown tool, an unknown parameter, a
+   * parameter with no schema to patch, and a dropped rename alike -- so `'ignore'` silences all four
+   * and `'error'` fails on all four: a rename refused for colliding is as much a gap between what
+   * Logfire shows and what the agent does as an override naming a tool that is not there.
+   *
+   * Not what the *value* itself is malformed about. A config naming the same tool twice is the same
+   * on every request in the process, so it warns once from indexing and takes no policy, like the
+   * parser's other value-level warnings; see `UnappliedReason`.
    */
   onUnmatched?: OnUnmatched
   /**
@@ -272,7 +277,17 @@ function applyOverride(tool: ToolDef, override: ToolDefinitionOverride): { tool:
       patched.parametersJsonSchema = result.schema
       changed = true
     }
-    const missing = result.noProperties ? Object.keys(override.parameters) : result.unknown
+    // `'no-patchable-schema'` is "no object schema to patch a description *into*", so an entry
+    // carrying no description asks for nothing and is not a gap between Logfire and the agent worth
+    // reporting -- let alone worth failing the run under `onUnmatched: 'error'`. Gated the way
+    // `patchParameters` already gates its per-property `unpatchable` case. `unknown` is deliberately
+    // not gated: naming a parameter this deployment does not have is drift whether or not the entry
+    // goes on to patch it.
+    const missing = result.noProperties
+      ? Object.entries(override.parameters)
+          .filter(([, entry]) => entry.description !== undefined)
+          .map(([name]) => name)
+      : result.unknown
     const because = result.noProperties ? 'has no top-level parameters' : 'has no parameter of that name'
     const reason = result.noProperties ? 'no-patchable-schema' : 'unknown-parameter'
     for (const name of missing) {
@@ -290,15 +305,38 @@ function namespaceOf(tool: ToolDef, scope: CollisionScope): string | null {
   return scope === 'toolset' ? (tool.toolset ?? null) : null
 }
 
-/** The names already taken in one namespace, created empty the first time it is asked for. */
-function namesTakenIn(taken: Map<string | null, Set<string>>, namespace: string | null): Set<string> {
+/**
+ * How many tools answer to each name in one namespace, created empty the first time it is asked for.
+ *
+ * Counted rather than a `Set` because a name can genuinely be held twice: under the default global
+ * scope, `crm/search` and `docs/search` both advertise `search`. A rename has to put its code-side
+ * name back down before checking -- otherwise a tool cannot rename into a name an earlier rename
+ * freed -- and a set cannot tell "the only holder let go" from "one of two holders let go", which
+ * would let a later rename take a name another tool still answers to.
+ */
+function namesTakenIn(taken: Map<string | null, Map<string, number>>, namespace: string | null): Map<string, number> {
   const existing = taken.get(namespace)
   if (existing !== undefined) {
     return existing
   }
-  const names = new Set<string>()
+  const names = new Map<string, number>()
   taken.set(namespace, names)
   return names
+}
+
+/** Record one more tool answering to `name`. */
+function claim(names: Map<string, number>, name: string): void {
+  names.set(name, (names.get(name) ?? 0) + 1)
+}
+
+/** Record one fewer tool answering to `name`, dropping the key when the last holder lets go. */
+function release(names: Map<string, number>, name: string): void {
+  const count = (names.get(name) ?? 0) - 1
+  if (count > 0) {
+    names.set(name, count)
+  } else {
+    names.delete(name)
+  }
 }
 
 /**
@@ -339,9 +377,9 @@ export function applyToolDefinitions(
   // A namespace is the set of advertised names that compete: one for the whole request, or one per
   // toolset. Every code-side name starts out taken, so a rename onto a tool later in the list is a
   // collision rather than a name that is free until that tool is reached.
-  const taken = new Map<string | null, Set<string>>()
+  const taken = new Map<string | null, Map<string, number>>()
   for (const tool of tools) {
-    namesTakenIn(taken, namespaceOf(tool, collisionScope)).add(tool.name)
+    claim(namesTakenIn(taken, namespaceOf(tool, collisionScope)), tool.name)
   }
 
   const unapplied: UnappliedEntry[] = []
@@ -370,19 +408,29 @@ export function applyToolDefinitions(
       unapplied.push(...result.unapplied)
     }
     const names = namesTakenIn(taken, namespaceOf(tool, collisionScope))
-    if (patched.name !== tool.name && (names.has(patched.name) || reserved.has(patched.name))) {
-      unapplied.push({
-        reason: 'rename-collision',
-        toolset: tool.toolset ?? null,
-        tool: tool.name,
-        message:
-          `Managed tool definition override renames ${repr(tool.name)} to ${repr(patched.name)}, ` +
-          `which is already advertised by another tool; keeping the original name ${repr(tool.name)}.`,
-      })
-      patched = { ...patched, name: tool.name }
-    } else {
-      names.add(patched.name)
+    if (patched.name !== tool.name) {
+      // A renamed tool stops answering to its code-side name, so that name is free for a later tool to
+      // rename into and must not count against this rename either. Released for the check and claimed
+      // again below by whichever name wins: the new one on a rename that lands, the original on one
+      // that collides. Leaving it held would refuse the valid `a -> x` then `b -> a`; releasing it
+      // without claiming again would let a refused `a -> b` free `a` for a later `c -> a` and
+      // advertise two tools under it.
+      release(names, tool.name)
+      if (names.has(patched.name) || reserved.has(patched.name)) {
+        unapplied.push({
+          reason: 'rename-collision',
+          toolset: tool.toolset ?? null,
+          tool: tool.name,
+          message:
+            `Managed tool definition override renames ${repr(tool.name)} to ${repr(patched.name)}, ` +
+            `which is already advertised by another tool; keeping the original name ${repr(tool.name)}.`,
+        })
+        patched = { ...patched, name: tool.name }
+      }
+      claim(names, patched.name)
     }
+    // A tool that did not rename still holds the name the fill above claimed for it, so there is
+    // nothing to release and nothing to claim again.
     applied.push(patched)
     if (!Object.hasOwn(routes, patched.name)) {
       routes[patched.name] = tool.name

--- a/packages/logfire-node/src/agent-control/tools.ts
+++ b/packages/logfire-node/src/agent-control/tools.ts
@@ -8,8 +8,8 @@
 
 import type { AgentConfig, ParameterOverride, ToolDefinitionOverride } from './config'
 import type { JsonSchema } from './schema'
-import { reportUnappliedEntries, repr, warnOnce } from './warnings'
-import type { OnUnmatched, UnappliedEntry, UnappliedReason } from './warnings'
+import { repr } from './warnings'
+import type { ApplyIssue, ApplyIssueReason } from './warnings'
 
 /**
  * One tool's LLM-facing definition as a framework advertises it, and as this package hands it back.
@@ -118,28 +118,15 @@ export interface AppliedTools {
    */
   reverse: ReadonlyMap<ToolKey, string>
   /**
-   * Every published tool entry, or part of one, this request did not apply; see `UnappliedEntry`.
+   * Every published tool entry, or part of one, this request did not apply; see `ApplyIssue`.
    *
-   * Already reported under the caller's `onUnmatched` policy before it is returned.
+   * Reported by nothing here; hand them to `AgentControl.report` with the rest.
    */
-  unapplied: readonly UnappliedEntry[]
+  issues: readonly ApplyIssue[]
 }
 
 /** Options for `applyToolDefinitions`. */
 export interface ApplyToolDefinitionsOptions {
-  /**
-   * What to do with a published entry this request did not apply.
-   *
-   * Every *request-level* decision goes through it -- an unknown tool, an unknown parameter, a
-   * parameter with no schema to patch, and a dropped rename alike -- so `'ignore'` silences all four
-   * and `'error'` fails on all four: a rename refused for colliding is as much a gap between what
-   * Logfire shows and what the agent does as an override naming a tool that is not there.
-   *
-   * Not what the *value* itself is malformed about. A config naming the same tool twice is the same
-   * on every request in the process, so it warns once from indexing and takes no policy, like the
-   * parser's other value-level warnings; see `UnappliedReason`.
-   */
-  onUnmatched?: OnUnmatched
   /**
    * Advertised names this adapter needs kept free.
    *
@@ -158,18 +145,33 @@ export interface ApplyToolDefinitionsOptions {
  *
  * An entry without a `toolset` is keyed under `null`, so the same `name` can carry one unqualified
  * entry and one per toolset side by side; only two entries with the same pair collide.
+ *
+ * The duplicates come back rather than being warned from here: it is an apply-time decision about a
+ * value, so it belongs under the caller's `onUnmatched` policy like every other one -- warning
+ * directly, as this used to, meant `'ignore'` still warned and `'error'` did not throw.
  */
-function overridesByKey(config: AgentConfig): Map<ToolKey, ToolDefinitionOverride> {
+function overridesByKey(config: AgentConfig): {
+  overrides: Map<ToolKey, ToolDefinitionOverride>
+  duplicates: ApplyIssue[]
+} {
   const overrides = new Map<ToolKey, ToolDefinitionOverride>()
+  const duplicates: ApplyIssue[] = []
   for (const override of config.tool_definitions ?? []) {
     const key = toolKey(override.toolset, override.name)
     if (overrides.has(key)) {
-      warnOnce(`Managed agent config names ${describeToolKey(key)} more than once; keeping the first entry and ignoring the rest.`)
+      const [toolset, name] = splitToolKey(key)
+      duplicates.push({
+        section: 'tool_definitions',
+        reason: 'duplicate-entry',
+        toolset,
+        tool: name,
+        message: `Managed agent config names ${describeToolKey(key)} more than once; keeping the first entry and ignoring the rest.`,
+      })
       continue
     }
     overrides.set(key, override)
   }
-  return overrides
+  return { overrides, duplicates }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -177,12 +179,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parameterEntry(
-  reason: Extract<UnappliedReason, 'unknown-parameter' | 'no-patchable-schema'>,
+  reason: Extract<ApplyIssueReason, 'unknown-parameter' | 'no-patchable-schema'>,
   tool: ToolDef,
   parameter: string,
   because: string
-): UnappliedEntry {
+): ApplyIssue {
   return {
+    section: 'tool_definitions',
     reason,
     toolset: tool.toolset ?? null,
     tool: tool.name,
@@ -252,16 +255,16 @@ function patchParameters(schema: JsonSchema, parameters: Record<string, Paramete
  *
  * Returns the original object when nothing changed, so an adapter that compares by identity can tell
  * a patched schema from an untouched one. Reporting is the caller's here: `applyToolDefinitions` is
- * what turns a patch that reached nothing into an `UnappliedEntry` under a policy.
+ * what turns a patch that reached nothing into an `ApplyIssue` under a policy.
  */
 export function withParameterDescriptions(schema: JsonSchema, parameters: Record<string, ParameterOverride>): JsonSchema {
   return patchParameters(schema, parameters).schema
 }
 
 /** Apply the LLM-facing parts of one override, returning the original definition for a no-op. */
-function applyOverride(tool: ToolDef, override: ToolDefinitionOverride): { tool: ToolDef; unapplied: UnappliedEntry[] } {
+function applyOverride(tool: ToolDef, override: ToolDefinitionOverride): { tool: ToolDef; issues: ApplyIssue[] } {
   const patched: ToolDef = { ...tool }
-  const unapplied: UnappliedEntry[] = []
+  const issues: ApplyIssue[] = []
   let changed = false
   if (override.new_name !== undefined && override.new_name !== tool.name) {
     patched.name = override.new_name
@@ -291,13 +294,13 @@ function applyOverride(tool: ToolDef, override: ToolDefinitionOverride): { tool:
     const because = result.noProperties ? 'has no top-level parameters' : 'has no parameter of that name'
     const reason = result.noProperties ? 'no-patchable-schema' : 'unknown-parameter'
     for (const name of missing) {
-      unapplied.push(parameterEntry(reason, tool, name, because))
+      issues.push(parameterEntry(reason, tool, name, because))
     }
     for (const name of result.unpatchable) {
-      unapplied.push(parameterEntry('no-patchable-schema', tool, name, 'describes that parameter with no schema object'))
+      issues.push(parameterEntry('no-patchable-schema', tool, name, 'describes that parameter with no schema object'))
     }
   }
-  return { tool: changed ? patched : tool, unapplied }
+  return { tool: changed ? patched : tool, issues }
 }
 
 /** The set of advertised names this tool competes in; see `CollisionScope`. */
@@ -362,17 +365,20 @@ function release(names: Map<string, number>, name: string): void {
  *   is dynamic: a framework can advertise different tools from one step to the next, and a report
  *   from one listing is a report about that listing.
  *
- * Every one of those decisions goes through `onUnmatched` and comes back on `unapplied`.
+ * - Two overrides naming one `(toolset, name)` keep the first and report the rest
+ *   (`'duplicate-entry'`).
+ *
+ * Every one of those decisions comes back as an `ApplyIssue` on `issues`, and is reported by nothing
+ * here: hand them to `AgentControl.report` along with the other sections'.
  */
 export function applyToolDefinitions(
   tools: readonly ToolDef[],
   config: AgentConfig,
   options: ApplyToolDefinitionsOptions = {}
 ): AppliedTools {
-  const onUnmatched = options.onUnmatched ?? 'warn'
   const collisionScope = options.collisionScope ?? 'global'
   const reserved = new Set(options.reserved ?? [])
-  const overrides = overridesByKey(config)
+  const { overrides, duplicates } = overridesByKey(config)
 
   // A namespace is the set of advertised names that compete: one for the whole request, or one per
   // toolset. Every code-side name starts out taken, so a rename onto a tool later in the list is a
@@ -382,7 +388,7 @@ export function applyToolDefinitions(
     claim(namesTakenIn(taken, namespaceOf(tool, collisionScope)), tool.name)
   }
 
-  const unapplied: UnappliedEntry[] = []
+  const issues: ApplyIssue[] = [...duplicates]
   const matched = new Set<ToolKey>()
   const applied: ToolDef[] = []
   // Null-prototype, so `'constructor' in routes` is a question about this request's tools rather than
@@ -405,7 +411,7 @@ export function applyToolDefinitions(
     if (override !== undefined) {
       const result = applyOverride(tool, override)
       patched = result.tool
-      unapplied.push(...result.unapplied)
+      issues.push(...result.issues)
     }
     const names = namesTakenIn(taken, namespaceOf(tool, collisionScope))
     if (patched.name !== tool.name) {
@@ -417,7 +423,8 @@ export function applyToolDefinitions(
       // advertise two tools under it.
       release(names, tool.name)
       if (names.has(patched.name) || reserved.has(patched.name)) {
-        unapplied.push({
+        issues.push({
+          section: 'tool_definitions',
           reason: 'rename-collision',
           toolset: tool.toolset ?? null,
           tool: tool.name,
@@ -444,7 +451,8 @@ export function applyToolDefinitions(
       continue
     }
     const [toolset, name] = splitToolKey(key)
-    unapplied.push({
+    issues.push({
+      section: 'tool_definitions',
       reason: 'unknown-tool',
       toolset,
       tool: name,
@@ -453,5 +461,5 @@ export function applyToolDefinitions(
         'this request; that override applies to nothing.',
     })
   }
-  return { tools: applied, routes, forward, reverse, unapplied: reportUnappliedEntries(onUnmatched, unapplied) }
+  return { tools: applied, routes, forward, reverse, issues }
 }

--- a/packages/logfire-node/src/agent-control/tools.ts
+++ b/packages/logfire-node/src/agent-control/tools.ts
@@ -212,7 +212,11 @@ function patchParameters(schema: JsonSchema, parameters: Record<string, Paramete
   if (!isRecord(properties)) {
     return { schema, unknown, unpatchable, noProperties: true }
   }
-  const newProperties: Record<string, unknown> = {}
+  // Null-prototype, for the same reason `routes` is: both sides of this come from JSON, so a
+  // parameter genuinely called `__proto__` is an own key on the way in, and `newProperties[name] =`
+  // on a plain object would set the prototype instead of that key -- dropping a code-defined
+  // parameter out of the schema the model is sent.
+  const newProperties = Object.create(null) as Record<string, unknown>
   let changed = false
   for (const [name, propertySchema] of Object.entries(properties)) {
     const description = Object.hasOwn(parameters, name) ? parameters[name]?.description : undefined

--- a/packages/logfire-node/src/agent-control/units.ts
+++ b/packages/logfire-node/src/agent-control/units.ts
@@ -1,0 +1,65 @@
+/**
+ * What the contract's one dimensioned setting means, and how to convert it without surprises.
+ *
+ * `timeout` is the only canonical setting carrying a unit, and it is the only one an adapter has to
+ * convert before it can be used: `AbortSignal.timeout`, `fetch` wrappers, and most CLI flags want
+ * integer milliseconds. Left to each adapter, that conversion has already drifted three ways -- one
+ * truncating, one rounding, one passing a fraction of a millisecond straight into an API that throws
+ * on it -- so the range and the rounding are defined here, once, and the cores share these rules.
+ */
+
+/**
+ * The largest delay a timer can be given: `2 ** 31 - 1` ms, about 24.9 days.
+ *
+ * Not an opinion about sensible timeouts, but the smallest ceiling the targets share. Browsers,
+ * Node, and `AbortSignal.timeout` all take a signed 32-bit millisecond delay, and a larger one
+ * silently wraps or fires immediately -- which is the failure mode a managed setting must never
+ * introduce, since it turns "no real limit" into "cancel at once".
+ */
+export const MAX_TIMEOUT_MILLISECONDS: number = 2 ** 31 - 1
+
+/** `MAX_TIMEOUT_MILLISECONDS` as the seconds the contract states timeouts in. */
+export const MAX_TIMEOUT_SECONDS: number = MAX_TIMEOUT_MILLISECONDS / 1000
+
+/**
+ * Whether a published `timeout` is a request budget an adapter can actually install.
+ *
+ * A timeout is representable when it is a finite, non-negative number of seconds no larger than
+ * `MAX_TIMEOUT_SECONDS`. Everything else -- a negative budget, a `NaN` that compares false against
+ * every deadline, an `Infinity` or an oversized value that wraps a 32-bit timer -- is refused rather
+ * than clamped, because each of them would make a request behave in a way nobody published: silently
+ * unlimited, or cancelled before it was sent.
+ *
+ * `0` is representable and means exactly what it says: a budget of no time at all.
+ */
+export function isRepresentableTimeout(seconds: number): boolean {
+  return Number.isFinite(seconds) && seconds >= 0 && seconds <= MAX_TIMEOUT_SECONDS
+}
+
+/**
+ * A representable `timeout` in the integer milliseconds most SDKs and timers want.
+ *
+ * Rounded half up -- `Math.floor(seconds * 1000 + 0.5)` -- which is the one rounding this core and
+ * the Python one agree on for non-negative values, so both return the same integer for the same
+ * published value. (`Math.round` agrees for these inputs; it is spelled out because Python's own
+ * `round` does not, rounding halves to even.)
+ *
+ * A *positive* budget never rounds down to `0`: anything under half a millisecond comes back as `1`.
+ * Zero milliseconds means "already expired" to a timer, so rounding a small positive budget into it
+ * would turn a very short timeout into a request that cannot be made at all. An exact `0` is passed
+ * through, since that is what it was published as.
+ *
+ * @throws If `seconds` is not representable; see `isRepresentableTimeout`, which is what an adapter
+ * should call first so the value is reported under its `onUnmatched` policy rather than thrown at
+ * conversion time.
+ */
+export function toMilliseconds(seconds: number): number {
+  if (!isRepresentableTimeout(seconds)) {
+    throw new RangeError(
+      `Timeout ${String(seconds)} is not a representable request budget: it has to be a finite, ` +
+        `non-negative number of seconds no larger than ${String(MAX_TIMEOUT_SECONDS)}.`
+    )
+  }
+  const milliseconds = Math.floor(seconds * 1000 + 0.5)
+  return seconds > 0 ? Math.max(milliseconds, 1) : milliseconds
+}

--- a/packages/logfire-node/src/agent-control/warnings.ts
+++ b/packages/logfire-node/src/agent-control/warnings.ts
@@ -283,6 +283,11 @@ export function droppedByProvider(setting: string, detail: string): ApplyIssue {
  * `'error'` throws after every section has been planned, naming all of it, rather than on the first
  * entry of the first section -- which used to mean the strictest policy reported the least.
  *
+ * `AgentControl.report` is this with the policy read off the control, and is what an adapter built on
+ * one should call. This is the same thing for an adapter that carries the policy itself -- one whose
+ * framework has its own notion of a managed capability, and so never holds an `AgentControl` to ask.
+ * Either way, an adapter with its own error type translates it without restating a message.
+ *
  * Throws `UnmatchedConfigError`, naming every issue, when `policy` is `'error'`.
  */
 export function reportIssues(policy: OnUnmatched, issues: readonly ApplyIssue[]): void {

--- a/packages/logfire-node/src/agent-control/warnings.ts
+++ b/packages/logfire-node/src/agent-control/warnings.ts
@@ -1,0 +1,195 @@
+/**
+ * Reporting for managed values that this process could not act on.
+ *
+ * Two kinds of thing get reported here, and they differ in who is at fault. A *drop* is a value this
+ * SDK could not make sense of -- a malformed setting, an entry that says nothing -- and is always a
+ * warning, because the alternative is failing the whole config and reverting the agent to code over
+ * one bad field. An *unmatched* entry is a perfectly valid value that reached nothing in this
+ * deployment, and what happens to it is the caller's `onUnmatched` policy.
+ */
+
+/** What to do with a published entry that reaches nothing in this deployment. */
+export type OnUnmatched = 'ignore' | 'warn' | 'error'
+
+/**
+ * Thrown by `onUnmatched: 'error'` for an entry that reached nothing.
+ *
+ * A distinct class rather than a bare `Error` so an adapter can let it through its own error
+ * handling deliberately: the run is being failed on purpose, by configuration, and should not be
+ * caught by a `catch` meant for a model or tool failure.
+ */
+export class UnmatchedConfigError extends Error {
+  override name = 'UnmatchedConfigError'
+}
+
+/**
+ * Messages already emitted in this process, keyed by the message itself.
+ *
+ * Deduplicating on the message rather than on the field costs nothing in clarity -- each message
+ * names its subject and the offending value -- and still lets a *different* unrecognized value
+ * surface later, which a per-field guard would swallow.
+ */
+const warned = new Set<string>()
+
+/**
+ * Surface a dropped or unapplied managed value once per process.
+ *
+ * A drop means Logfire shows one thing and the agent does another, which has to be visible. But the
+ * config is resolved on every single run, so warning per drop would bury that signal under its own
+ * repetition.
+ */
+export function warnOnce(message: string): void {
+  if (warned.has(message)) {
+    return
+  }
+  warned.add(message)
+  console.warn(message)
+}
+
+/**
+ * Apply an `onUnmatched` policy to one published entry that reached nothing.
+ *
+ * Called where the entry would have been applied -- `applySettings`, `applyInstructions`,
+ * `applyToolDefinitions` -- and never from parsing. Parsing runs inside the SDK's variable
+ * resolution, which turns a throw into a fallback to the code-defined agent, so an `'error'` raised
+ * there would be swallowed and un-manage the whole config instead of stopping the run.
+ *
+ * The message is the same under every policy, so a warning someone chose to tolerate reads like the
+ * error they would have gotten by not tolerating it.
+ */
+export function reportUnmatched(policy: OnUnmatched, message: string): void {
+  if (policy === 'error') {
+    throw new UnmatchedConfigError(message)
+  }
+  if (policy === 'warn') {
+    warnOnce(message)
+  }
+}
+
+/**
+ * Render a value the way the reference implementation's Python `!r` does, for warning text.
+ *
+ * Warnings name the offending value, and the two SDKs' messages are compared against each other, so
+ * strings are single-quoted rather than JSON's double-quoted and `null`/`undefined` read as Python's
+ * `None`. Anything structural falls back to JSON, which both sides agree on.
+ */
+export function repr(value: unknown): string {
+  if (typeof value === 'string') {
+    return `'${value.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'`
+  }
+  if (value === null || value === undefined) {
+    return 'None'
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'True' : 'False'
+  }
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value)
+  }
+  try {
+    // Asserted because `JSON.stringify` is typed as returning `string` while it genuinely returns
+    // `undefined` for a function or a symbol -- which is exactly the kind of odd value a warning has
+    // to be able to name.
+    const json = JSON.stringify(value) as string | undefined
+    return json ?? describeUnserializable(value)
+  } catch {
+    return describeUnserializable(value)
+  }
+}
+
+/**
+ * Name a value JSON could not render: a function, a symbol, something circular.
+ *
+ * Lint would rather this were not `String` of an `unknown`, and in general it is right, since a plain
+ * object renders as `[object Object]`. Here that is the answer: the value has already failed to
+ * serialize, and a warning that names it however it names itself beats one that drops it.
+ */
+function describeUnserializable(value: unknown): string {
+  return String(value)
+}
+
+/** Clear the once-per-process warning memory. Intended for tests only. */
+export function resetWarnings(): void {
+  warned.clear()
+}
+
+/**
+ * Why one published entry did not reach the request, as a stable string an adapter can branch on.
+ *
+ * Instructions:
+ *
+ * - `'unknown-id'` -- an `id` this request assembles no block under.
+ * - `'dynamic-id'` -- an `id` only a block the framework recomputes per request carries, which cannot
+ *   be replaced or dropped without pinning or removing that computation.
+ * - `'oversized-text'` -- text past the contract's per-request budget, which is refused rather than
+ *   truncated: half a prompt is not a smaller version of the prompt.
+ *
+ * Tools:
+ *
+ * - `'unknown-tool'` -- a `name` (narrowed by `toolset` when the entry sets one) no advertised tool
+ *   has.
+ * - `'unknown-parameter'` -- a `parameters` key the tool's schema has no top-level property for.
+ * - `'no-patchable-schema'` -- the tool, or that one property, has no object schema to patch a
+ *   description into at all.
+ * - `'rename-collision'` -- a `new_name` another advertised tool, or a name the adapter reserved,
+ *   already answers to. The rename is dropped and the tool keeps its code-side name; the same entry's
+ *   other patches still apply.
+ *
+ * These are the runtime decisions: what a *valid* published value did not reach in *this*
+ * deployment, on *this* request. They are deliberately not the parser's compatibility warnings -- an
+ * entry a newer UI wrote that this release cannot understand -- which are about the value rather than
+ * the request, warn once per process from parsing, and never take an `onUnmatched` policy.
+ */
+export type UnappliedReason =
+  | 'unknown-id'
+  | 'dynamic-id'
+  | 'oversized-text'
+  | 'unknown-tool'
+  | 'unknown-parameter'
+  | 'no-patchable-schema'
+  | 'rename-collision'
+
+/**
+ * One published entry that reached nothing, with the path that says which one.
+ *
+ * Returned by the apply helpers so an adapter can do more than repeat the message: count them,
+ * attach them to a span, decide per section, or feed the tool ones back into its own routing. The
+ * fields are a path, and only the ones that apply to `reason` are set -- `tool` and `parameter` on a
+ * parameter patch, `instructionId` on an instruction entry -- so an adapter never has to parse
+ * `message` to learn what an entry was about.
+ *
+ * The helpers report every entry they return under the caller's `onUnmatched` policy before returning
+ * it, so an adapter that only wants the configured behavior can ignore these entirely and one that
+ * wants both does not get the message twice.
+ */
+export interface UnappliedEntry {
+  /** Why it was not applied; see `UnappliedReason`. */
+  readonly reason: UnappliedReason
+  /** What the policy reports: what was published, and what was not applied. */
+  readonly message: string
+  /** The instruction `id` the entry addressed, for the instruction reasons. */
+  readonly instructionId?: string
+  /** The toolset the entry named or the tool came from, when either has one. */
+  readonly toolset?: string | null
+  /** The code-side tool name the entry named, for the tool reasons. */
+  readonly tool?: string
+  /** The parameter the entry patched, for `'unknown-parameter'` and `'no-patchable-schema'`. */
+  readonly parameter?: string
+}
+
+/**
+ * Apply one `onUnmatched` policy to every entry that reached nothing, and hand them back.
+ *
+ * One call site per helper, so the policy governs *all* of a section's decisions rather than the
+ * subset that happened to be routed through it: a rename dropped for colliding is as much a gap
+ * between what Logfire shows and what the agent does as an override naming a tool that is not there,
+ * and `'ignore'` has to silence both while `'error'` has to fail on both.
+ *
+ * Throws `UnmatchedConfigError` on the first entry when `policy` is `'error'`.
+ */
+export function reportUnappliedEntries(policy: OnUnmatched, entries: readonly UnappliedEntry[]): readonly UnappliedEntry[] {
+  for (const entry of entries) {
+    reportUnmatched(policy, entry.message)
+  }
+  return entries
+}

--- a/packages/logfire-node/src/agent-control/warnings.ts
+++ b/packages/logfire-node/src/agent-control/warnings.ts
@@ -8,18 +8,52 @@
  * deployment, and what happens to it is the caller's `onUnmatched` policy.
  */
 
-/** What to do with a published entry that reaches nothing in this deployment. */
+/**
+ * What to do with a published entry that reaches nothing in this deployment.
+ *
+ * The policy is applied in one place, by `AgentControl.report`, rather than inside each apply helper:
+ * an adapter plans every section and then reports, so `'error'` fails on everything the request would
+ * have got wrong rather than on whichever section happened to be planned first.
+ */
 export type OnUnmatched = 'ignore' | 'warn' | 'error'
 
 /**
- * Thrown by `onUnmatched: 'error'` for an entry that reached nothing.
+ * Thrown by `onUnmatched: 'error'` for everything one request could not apply.
  *
- * A distinct class rather than a bare `Error` so an adapter can let it through its own error
- * handling deliberately: the run is being failed on purpose, by configuration, and should not be
- * caught by a `catch` meant for a model or tool failure.
+ * A distinct class rather than a bare `Error` so an adapter can let it through its own error handling
+ * deliberately: the run is being failed on purpose, by configuration, and should not be caught by a
+ * `catch` meant for a model or tool failure. It also lets an adapter translate it into its own
+ * framework's error type without restating a single message:
+ *
+ * ```ts
+ * try {
+ *   control.report(...issues)
+ * } catch (error) {
+ *   if (error instanceof UnmatchedConfigError) {
+ *     throw new MyFrameworkError(error.message)
+ *   }
+ *   throw error
+ * }
+ * ```
+ *
+ * Thrown once for a whole request, with every issue's message in `message` and the issues themselves
+ * on `issues`, so an adapter that reports a kind it has never heard of still reports it faithfully.
  */
 export class UnmatchedConfigError extends Error {
   override name = 'UnmatchedConfigError'
+
+  /**
+   * Every issue this request could not apply, in the order they were planned.
+   *
+   * Empty for the string channel -- `AgentControl.reportUnmatched` -- which carries a message and no
+   * path.
+   */
+  readonly issues: readonly ApplyIssue[]
+
+  constructor(message: string, issues: readonly ApplyIssue[] = []) {
+    super(message)
+    this.issues = issues
+  }
 }
 
 /**
@@ -135,12 +169,34 @@ export function resetWarnings(): void {
  *   already answers to. The rename is dropped and the tool keeps its code-side name; the same entry's
  *   other patches still apply.
  *
+ * Settings:
+ *
+ * - `'unknown-setting'` -- a `settings` key this release has no field for, which a newer Logfire UI
+ *   can write.
+ * - `'unsupported-setting'` -- a canonical key this adapter declared it cannot lower; see
+ *   `AgentSupport.settings`.
+ * - `'unrepresentable-timeout'` -- a `timeout` that is not a request budget: negative, not finite, or
+ *   past `MAX_TIMEOUT_SECONDS`.
+ *
+ * Any section:
+ *
+ * - `'unknown-section'` -- a top-level key this release has no section for. Every section is optional
+ *   and unknown keys cost nothing, which is what lets a future section be written against an older
+ *   SDK -- but the drop has to be audible, or the first person to publish one gets a silently
+ *   degraded agent.
+ * - `'unsupported-section'` -- a section this release understands and this adapter cannot apply; see
+ *   `AgentSupport.sections`.
+ * - `'duplicate-entry'` -- the same instruction `id`, or the same `(toolset, name)`, written twice.
+ *   The first is applied and the rest are not.
+ * - `'dropped-by-provider'` -- a setting the adapter did forward and the provider or its SDK dropped;
+ *   see `droppedByProvider`.
+ *
  * These are the runtime decisions: what a *valid* published value did not reach in *this*
  * deployment, on *this* request. They are deliberately not the parser's compatibility warnings -- an
  * entry a newer UI wrote that this release cannot understand -- which are about the value rather than
  * the request, warn once per process from parsing, and never take an `onUnmatched` policy.
  */
-export type UnappliedReason =
+export type ApplyIssueReason =
   | 'unknown-id'
   | 'dynamic-id'
   | 'oversized-text'
@@ -148,48 +204,97 @@ export type UnappliedReason =
   | 'unknown-parameter'
   | 'no-patchable-schema'
   | 'rename-collision'
+  | 'unknown-setting'
+  | 'unsupported-setting'
+  | 'unrepresentable-timeout'
+  | 'unknown-section'
+  | 'unsupported-section'
+  | 'duplicate-entry'
+  | 'dropped-by-provider'
 
 /**
  * One published entry that reached nothing, with the path that says which one.
  *
- * Returned by the apply helpers so an adapter can do more than repeat the message: count them,
- * attach them to a span, decide per section, or feed the tool ones back into its own routing. The
- * fields are a path, and only the ones that apply to `reason` are set -- `tool` and `parameter` on a
- * parameter patch, `instructionId` on an instruction entry -- so an adapter never has to parse
- * `message` to learn what an entry was about.
+ * Returned by the apply helpers, which report nothing themselves: an adapter collects the issues of
+ * every section it planned and hands them to `AgentControl.report` once. That is what makes the
+ * return value load-bearing rather than a duplicate of a warning already emitted, and what lets
+ * `'error'` fail on everything a request got wrong instead of on the first section planned.
  *
- * The helpers report every entry they return under the caller's `onUnmatched` policy before returning
- * it, so an adapter that only wants the configured behavior can ignore these entirely and one that
- * wants both does not get the message twice.
+ * The fields are a path, and only the ones that apply to `reason` are set -- `tool` and `parameter`
+ * on a parameter patch, `instructionId` on an instruction entry, `setting` on a settings key -- so an
+ * adapter never has to parse `message` to learn what an issue was about.
  */
-export interface UnappliedEntry {
-  /** Why it was not applied; see `UnappliedReason`. */
-  readonly reason: UnappliedReason
+export interface ApplyIssue {
+  /**
+   * Which section of the config the issue is about.
+   *
+   * One of the four `Section` names, except for `'unknown-section'`, where it is the unrecognized
+   * top-level key itself: a key this release has no section for has no section name to give, and
+   * naming the key is what makes the report actionable. Typed as a plain string for that reason, in
+   * both cores.
+   */
+  readonly section: string
+  /** Why it was not applied; see `ApplyIssueReason`. */
+  readonly reason: ApplyIssueReason
   /** What the policy reports: what was published, and what was not applied. */
   readonly message: string
   /** The instruction `id` the entry addressed, for the instruction reasons. */
   readonly instructionId?: string
+  /** The instruction destination the entry named, when it named one. */
+  readonly destination?: string
   /** The toolset the entry named or the tool came from, when either has one. */
   readonly toolset?: string | null
   /** The code-side tool name the entry named, for the tool reasons. */
   readonly tool?: string
   /** The parameter the entry patched, for `'unknown-parameter'` and `'no-patchable-schema'`. */
   readonly parameter?: string
+  /** The canonical settings key the issue is about, for the settings reasons. */
+  readonly setting?: string
 }
 
 /**
- * Apply one `onUnmatched` policy to every entry that reached nothing, and hand them back.
+ * One setting the adapter forwarded and the provider, or its own SDK, did not apply.
  *
- * One call site per helper, so the policy governs *all* of a section's decisions rather than the
- * subset that happened to be routed through it: a rename dropped for colliding is as much a gap
- * between what Logfire shows and what the agent does as an override naming a tool that is not there,
- * and `'ignore'` has to silence both while `'error'` has to fail on both.
+ * The one issue the core cannot find for itself: it is discovered *after* the request, by an adapter
+ * reading whatever its framework reports -- the Vercel AI SDK's `result.warnings`, a provider's own
+ * "unsupported parameter" note. Those shapes differ per SDK and the core knows none of them, so it
+ * takes the two things every one of them carries: which canonical setting, and what the SDK said
+ * about it.
  *
- * Throws `UnmatchedConfigError` on the first entry when `policy` is `'error'`.
+ * ```ts
+ * control.report(...result.warnings.map((w) => droppedByProvider('top_k', w.details)))
+ * ```
  */
-export function reportUnappliedEntries(policy: OnUnmatched, entries: readonly UnappliedEntry[]): readonly UnappliedEntry[] {
-  for (const entry of entries) {
-    reportUnmatched(policy, entry.message)
+export function droppedByProvider(setting: string, detail: string): ApplyIssue {
+  return {
+    section: 'settings',
+    reason: 'dropped-by-provider',
+    setting,
+    message:
+      `Managed agent config sets ${repr(setting)}, which the provider did not apply -- ${detail}; ` +
+      'that key had no effect on the request.',
   }
-  return entries
+}
+
+/**
+ * Apply one `onUnmatched` policy to every issue a request's planning produced.
+ *
+ * One call for a whole request, which is the point: the apply helpers plan and report nothing, so
+ * `'error'` throws after every section has been planned, naming all of it, rather than on the first
+ * entry of the first section -- which used to mean the strictest policy reported the least.
+ *
+ * Throws `UnmatchedConfigError`, naming every issue, when `policy` is `'error'`.
+ */
+export function reportIssues(policy: OnUnmatched, issues: readonly ApplyIssue[]): void {
+  if (issues.length === 0) {
+    return
+  }
+  if (policy === 'error') {
+    throw new UnmatchedConfigError(issues.map((issue) => issue.message).join('\n'), issues)
+  }
+  if (policy === 'warn') {
+    for (const issue of issues) {
+      warnOnce(issue.message)
+    }
+  }
 }

--- a/packages/logfire-node/vite.config.ts
+++ b/packages/logfire-node/vite.config.ts
@@ -12,9 +12,11 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
       resolver: 'tsc',
     },
     deps: {
-      neverBundle: [/^@opentelemetry/u, /^node:/u, 'logfire', 'logfire/datasets', 'logfire/evals', 'logfire/vars', 'picocolors'],
+      neverBundle: [/^@opentelemetry/u, /^node:/u, 'logfire', 'logfire/datasets', 'logfire/evals', 'logfire/vars', 'picocolors', 'zod'],
     },
     entry: {
+      'agent-control/index': 'src/agent-control/index.ts',
+      'agent-control/testing': 'src/agent-control/testing.ts',
       datasets: 'src/datasets.ts',
       index: 'src/index.ts',
       vars: 'src/vars.ts',
@@ -22,7 +24,7 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     format: ['esm', 'cjs'],
     hooks: {
       'build:done': () => {
-        copyCjsDeclarations(['datasets', 'index', 'vars'])
+        copyCjsDeclarations(['agent-control/index', 'agent-control/testing', 'datasets', 'index', 'vars'])
       },
     },
     minify: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,6 +553,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@opentelemetry/api':
         specifier: 'catalog:'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,15 @@ const generatedAndExternalFiles = ['node_modules/**', '.pnpm-store/**', 'pnpm-lo
 
 export default defineConfig({
   fmt: {
-    ignorePatterns: ['CHANGELOG.md', '.changeset/*.md', ...generatedAndExternalFiles],
+    ignorePatterns: [
+      'CHANGELOG.md',
+      '.changeset/*.md',
+      // Cross-language conformance vectors vendored from the Python repository, which owns them.
+      // They are pinned byte-for-byte by a digest test, so reformatting them here would fail that
+      // test and, worse, make a real drift indistinguishable from a formatting pass.
+      'packages/logfire-node/src/agent-control/spec/**',
+      ...generatedAndExternalFiles,
+    ],
     overrides: [
       {
         files: ['examples/cf-worker/**', 'examples/cf-producer-worker/**', 'examples/cf-tail-worker/**'],


### PR DESCRIPTION
## What this is

Agent Control lets someone change what a running agent does — its instructions, its model, its model settings, the names and descriptions its tools are advertised under — from the Logfire UI, without a deploy.

An agent's configuration lives in one managed variable named `agent__<name>`, holding a document called an `AgentConfig`. Every value in it is a *patch* on the agent as written: a section that is present is managed from Logfire, a section that is absent keeps its code-defined behavior, and deleting a section in Logfire is a deliberate revert to code. If Logfire is unreachable, if nothing has been published, or if a published value cannot be understood, the agent runs on its code — the one thing a remote configuration must never do is take the agent down.

This PR is that mechanism with **no agent framework attached**.

## Why framework-neutral

A Logfire project is shared and the SDKs are not. One person edits one config in the UI, and it has to drive a Mastra agent, an AI SDK agent, a Codex session, and a Pydantic AI agent identically — which only holds if the variable name, the baseline, and the parse are one set of rules rather than one per integration. So the contract and the plumbing live here, once, and an adapter is a thin thing on top: enumerate a baseline, install the framework's hook, call two pure helpers.

That split is also what makes an adapter testable. `AgentControl` is the only thing that talks to Logfire; `applyInstructions`, `applyToolDefinitions`, `applySettings`, and `buildBaseline` are pure functions over plain data, so an adapter's own tests never need a Logfire project.

### Registration is a report, not a write

`AgentControl` never creates or updates a variable. Every agent reports what it says in code on one `agent_control_config_hint` span per process, and Logfire promotes that into a config — for an agent it has none for, or as an offer to refresh a stored baseline the code has moved on from — when someone asks it to. The span name and every `agent_control.*` attribute on it are shared byte for byte with the Pydantic AI capability, which is what the platform indexes. `logfire vars push` is still how a deployment creates the variable from code deliberately.

### The public API

```ts
import {
  AgentControl,          // one agent's variable: resolve, report a baseline, report issues
  applyInstructions,     // published instructions -> the blocks to send
  applyToolDefinitions,  // published overlays -> the tools to advertise, plus routing tables
  applySettings,         // published settings -> a patch to merge
  mergeSettings,         // code < published < run, with per-key provenance
  buildBaseline,         // the agent as written, reported on a hint span
  useResolution,         // one resolution across two hooks in one run
  currentResolution,
  parseAgentConfig,
  canonicalSettings,
  agentVariableName,
  normalizeAgentName,
  toolKey,
  withParameterDescriptions,
  reportUnapplied,
  warnOnce,
  isRepresentableTimeout,
  toMilliseconds,
  AGENT_CONFIG_JSON_SCHEMA,
  SCHEMA_SHA256,
  canonicalJson,
  UnmatchedConfigError,
} from '@pydantic/logfire-node/agent-control'

import { resetAgentControl } from '@pydantic/logfire-node/agent-control/testing'
```

Wire types (`AgentConfig`, `ToolDefinitionOverride`) are `snake_case`, because they are what gets stored, edited in the UI, and validated by the schema. Adapter-facing types (`InstructionBlock`, `ToolDef`, every options bag) are `camelCase`, because nothing outside the process ever sees them.

## Placement: a `/agent-control` subpath, not a new package

This repository already splits feature areas from runtimes, and it splits them the other way round from how a new package would: **every `packages/*` entry is a runtime** (Node, browser, Cloudflare Workers, the manual API), while **every feature area is a subpath** — `logfire/vars`, `logfire/datasets`, `logfire/evals`, `@pydantic/logfire-node/vars`. Agent Control is a feature layered directly on `vars`, so it belongs where `vars` users already look; a package would have had to depend on `@pydantic/logfire-node` to reach the very thing it exists to use, and would have added a publish target, an npm trusted-publisher setup, and a second changeset stream for a module with no independent runtime story. The docs follow the same shape: `docs/managed-variables.md` is a feature page next to four package pages, and `docs/agent-control.md` sits beside it.

The three arguments that could have pushed the other way all check out in favor of the subpath:

- **Bundle size.** It is a separate rollup entry (`dist/agent-control/index.js`), `sideEffects` is already `false`, and the main entry does not reference the agent-control chunk at all. I built `logfire-node` with and without the two new entries: `dist/index.js` stays 18,040 bytes, differing by one byte of minified identifier assignment and nothing else.
- **Browser and Workers builds.** Putting it in `logfire-node` rather than in `logfire` keeps it out of `@pydantic/logfire-browser` and `@pydantic/logfire-cf-workers` by construction, which is right: it uses `node:async_hooks` and is Node-only in practice.
- **Changesets.** `@pydantic/logfire-node` already versions `vars` and `datasets` this way, and the adapters are separate packages regardless, so they get their own semver where it matters.

The only new dependency is `zod`, and it is already in the tree transitively: `logfire` depends on it, and `@pydantic/logfire-node` depends on `logfire`. It is declared on the catalog version and added to `neverBundle`.

## What the stacked adapter PRs will add

Three TypeScript adapters, stacked on this branch, each its own package so a project that uses one does not install the other two:

1. **Mastra** — instructions and tools off the agent object, one run seam.
2. **Vercel AI SDK** — a middleware over `generateText`/`streamText`, where the settings provenance from `mergeSettings` is what keeps a published value from stamping over a value the call site passed.
3. **OpenAI Codex SDK** — the case that motivated publishing a dynamic block's seam with no text: Codex assembles part of its prompt inside a binary the adapter cannot read, so the adapter can publish that a block exists and nothing more.

Five Python adapters plus the same core land in `pydantic/logfire` in parallel.

## Contracts this pins, and who else pins them

**The stored JSON schema.** `AGENT_CONFIG_JSON_SCHEMA` is byte-for-byte the reference implementation's. The Logfire backend validates every written value against whatever schema the variable was created with, so whichever side creates the variable first fixes the contract for everyone — which makes it a cross-repo artifact rather than an implementation detail. Its digest, `e4c38488d6c46440dbf31939291e13fcd56814c1305bc9012cd2158733b0bbad`, is already pinned by the Logfire UI (`platform` #27570), by `pydantic-ai-harness` #331, and by the Python core. It must not change; `SCHEMA_SHA256` and a test on it are what make an accidental edit fail here rather than reach a project.

**The conformance vectors.** `spec/` pins the three rules that have to give the same answer in every language: agent name → variable key (19 vectors), what a code baseline says (15), and what a published value parses to, warnings included (30). The Python repository is canonical for those files; the copy here is vendored so the vectors can run offline, and `spec.test.ts` pins each file's sha256 — plus asserts that the directory contains nothing unpinned, so a new vector file cannot arrive without a digest. A comment on the digest table says where the canonical copy lives and that re-vendoring means copying the files across and updating the digests, never editing them here. `packages/logfire-node/src/agent-control/spec/**` is excluded from `vp fmt` for the same reason: a reformatting pass would be indistinguishable from real drift.

## Tests

218 tests (`packages/logfire-node` goes from 124 to 342), all offline. The Logfire SDK's own `LocalVariableProvider` implements the same `VariableProvider` interface the remote one does, so resolution is exercised against the real seam with no network and no recorded fixtures to drift; the hint span is read back off a real `InMemorySpanExporter`, so what is asserted is the name and the attributes that actually got exported rather than the arguments a spy saw.

The core resolves through `logfire/vars` (`defineVar`, `Variable.get`, `getVariableProvider`) rather than a hand-rolled `fetch` client, so the SDK's authentication, base-URL resolution, retry and caching are the ones in play, and there is no second place for a token or a base URL to be resolved. It calls no write method at all: `createVariable` and `updateVariable` are never reached, which a test asserts by interposing on the provider.

The repository has no coverage gate today — `coverage:evals` is disabled during the Vite+ migration, per `AGENTS.md` — so this matches the standard as it stands rather than introducing one package with a threshold of its own. The suite it ports was held at 100% statements, branches, functions, and lines.

## Gates

Everything CI runs, from the root, green: `vp install --frozen-lockfile`, `vp run --filter "./packages/*" build`, `vp check` (510 files formatted, 319 files lint- and type-clean), `vp run --filter "./packages/*" typecheck`, `vp run --filter "./packages/*" test`, and `node scripts/create-npm-token.test.mjs`. `examples/node/agent-control.ts` runs end-to-end against a local variables config and its `typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTCke3iTd1KUvgqwpXxE9f

