### PR TITLE
Report a Contains mismatch that JSON.stringify cannot represent

### DIFF
--- a/.changeset/contains-repr-total.md
+++ b/.changeset/contains-repr-total.md
@@ -1,0 +1,11 @@
+---
+'logfire': patch
+---
+
+Stop a `Contains` mismatch reason from failing or flattening on a value `JSON.stringify` cannot represent.
+
+`truncatedRepr` read `.length` off the result outside its own try, so an output property whose
+value is `undefined` reported an evaluator failure instead of the mismatch it had found. A `BigInt`
+anywhere in the output threw, and the `String(value)` fallback rendered the whole object as
+`[object Object]`, losing every other field. Both now go through `attributeJsonReplacer`, the same
+replacer the attribute seam applies.

--- a/packages/logfire-api/src/evals/__test__/builtins.test.ts
+++ b/packages/logfire-api/src/evals/__test__/builtins.test.ts
@@ -278,6 +278,23 @@ describe('built-in evaluator edge cases', () => {
     })
   })
 
+  it('Contains reports a mismatch that JSON.stringify cannot represent', () => {
+    // An own property whose value is `undefined` passes the key check and fails the value
+    // comparison, so the reason has to render `undefined`. `JSON.stringify(undefined)` is
+    // `undefined`, not a string, and the length check reads `.length` outside the try.
+    expect(new Contains({ value: { a: 1 } }).evaluate(ctx({ a: undefined }))).toEqual({
+      reason: 'Output has different value for key "a": undefined != 1',
+      value: false,
+    })
+
+    // A BigInt throws inside `JSON.stringify`, and the old fallback of `String(value)` rendered
+    // the whole object as `[object Object]`, losing every field including the ones that are fine.
+    expect(new Contains({ value: 'missing' }).evaluate(ctx({ model: 'gpt', tokens: 9007199254740993n }))).toEqual({
+      reason: 'Output {"model":"gpt","tokens":"9007199254740993"} does not contain provided value as a key',
+      value: false,
+    })
+  })
+
   it('Contains does not leave a lone surrogate when truncating a reason', () => {
     // repr is '"' + value + '"' and the string limit is 100, so the head cut lands
     // at repr index 50, putting an emoji's halves either side of it.

--- a/packages/logfire-api/src/evals/builtins/Contains.ts
+++ b/packages/logfire-api/src/evals/builtins/Contains.ts
@@ -1,6 +1,7 @@
 import type { EvaluationReason, EvaluatorContext } from '../types'
 
 import { ceilCodePointBoundary, floorCodePointBoundary } from '../../formatter'
+import { attributeJsonReplacer } from '../../serializeAttributes'
 import { Evaluator } from '../Evaluator'
 import { registerEvaluator } from '../registry'
 import { deepEqual } from './Equals'
@@ -190,19 +191,25 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function truncatedRepr(value: unknown, maxLength: number): string {
-  let repr: string
-  if (typeof value === 'string') {
-    repr = JSON.stringify(value)
-  } else {
-    try {
-      repr = JSON.stringify(value)
-    } catch {
-      repr = String(value)
-    }
-  }
+  // `JSON.stringify` is not total, and both of its gaps arrive here as the evaluated output. It
+  // hands back `undefined` rather than a string for `undefined`, a function or a symbol, and the
+  // length check below reads `.length` outside the try, so an absent property took the evaluator
+  // down instead of reporting the mismatch. It also throws on a BigInt at any depth, where
+  // `String(value)` flattened a whole object to `[object Object]` and lost the diagnostic; the
+  // shared replacer carries the value instead.
+  const repr = stringifyRepr(value)
   if (repr.length <= maxLength) {
     return repr
   }
   const half = Math.floor(maxLength / 2)
   return `${repr.slice(0, floorCodePointBoundary(repr, half))}...${repr.slice(ceilCodePointBoundary(repr, repr.length - half))}`
+}
+
+function stringifyRepr(value: unknown): string {
+  try {
+    const serialized: unknown = JSON.stringify(value, attributeJsonReplacer)
+    return typeof serialized === 'string' ? serialized : String(value)
+  } catch {
+    return String(value)
+  }
 }


### PR DESCRIPTION
`truncatedRepr` in `Contains.ts` builds the repr that every mismatch reason embeds. It treats `JSON.stringify` as total, and both of the ways it is not reach that call as the evaluated output.

```ts
let repr: string
if (typeof value === 'string') {
  repr = JSON.stringify(value)
} else {
  try {
    repr = JSON.stringify(value)
  } catch {
    repr = String(value)
  }
}
if (repr.length <= maxLength) {
```

**An output property whose value is `undefined` crashes the evaluator.** `JSON.stringify(undefined)` returns `undefined`, not a string, and `repr.length` is read outside the try. An own property with an `undefined` value passes the key check on line 128 and fails the value comparison on line 132, which is exactly the path that then needs the repr:

```
new Contains({ value: { a: 1 } }).evaluate({ output: { a: undefined } })
  -> TypeError: Cannot read properties of undefined (reading 'length')
```

The evaluator had already worked out the answer. Instead of `false` with a reason, the case records an evaluator failure.

**A BigInt anywhere in the output erases the whole diagnostic.** `JSON.stringify` throws, the catch falls back to `String(value)`, and an object becomes `[object Object]`:

```
new Contains({ value: 'missing' }).evaluate({ output: { model: 'gpt', tokens: 9007199254740993n } })
  -> "Output [object Object] does not contain provided value as a key"
```

The `model` field was fine and went with it. Same shape as ef5e6e3, in a call site that sweep did not reach.

Both go through `attributeJsonReplacer`, which ef5e6e3 exported for exactly this, and the result is read with the `typeof serialized === 'string'` check the attribute seam uses. The `typeof value === 'string'` branch is deleted rather than converted: `JSON.stringify` on a string cannot throw, so it did the same thing as the `else` it sat next to.

The reason now reads `Output {"model":"gpt","tokens":"9007199254740993"}`, with the exact value rather than the rounded double a `Number` conversion would give.

Not touching the half-and-half cut below it. Per 7ffee54 that mirrors pydantic-evals' `_truncated_repr`, which is a different helper from `truncate_string` with different arithmetic.

One note on the local gate: `pnpm run typecheck` fails here on `vite.shared.ts(13)`, `Buffer<ArrayBufferLike> is not assignable to string`. Not from this diff, it reproduces on a clean checkout of `main`, and lint, test and build all pass.

Built this with Claude Code's help and reviewed the diff myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
