### PR TITLE
Add `@pydantic/logfire-agent-control-codex-sdk`, the Agent Control adapter for the OpenAI Codex SDK

### DIFF
--- a/.changeset/agent-control-codex-sdk.md
+++ b/.changeset/agent-control-codex-sdk.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-agent-control-codex-sdk': minor
+---
+
+Add `@pydantic/logfire-agent-control-codex-sdk`, the Agent Control adapter for the OpenAI Codex SDK: wrap the options you already pass to `new Codex(...)` and `startThread(...)`, give the agent a name, and its developer instructions, its base prompt, its model, and its reasoning effort become editable from the Logfire UI without a deploy. Codex assembles its prompt and defines its tools inside the `codex` binary, so the two writable instruction blocks lower onto real config keys while the blocks Codex computes per session are published as seams, and a published tool definition or sampling setting is reported through `onUnmatched` rather than dropped where nobody would see it. The published config is applied per thread, at thread start, because that is the last moment Codex accepts any of it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository is the Pydantic Logfire JavaScript SDK monorepo. It provides Ope
 - `packages/logfire-cf-workers` publishes `@pydantic/logfire-cf-workers`, which adapts Logfire to Cloudflare Workers.
 - `packages/otel-cf-workers` publishes `@pydantic/otel-cf-workers`, the lower-level Cloudflare Workers OpenTelemetry implementation used by the Logfire wrapper.
 - `packages/logfire-browser` publishes `@pydantic/logfire-browser`, which adapts Logfire to browser tracing.
+- `packages/logfire-agent-control-codex-sdk` publishes `@pydantic/logfire-agent-control-codex-sdk`, the Agent Control adapter for the OpenAI Codex SDK. It is a package rather than a subpath of `@pydantic/logfire-node` because it takes `@openai/codex-sdk` as a peer dependency, and ESM-only because that peer publishes no `require` condition.
 - `packages/logfire-session-replay` publishes `@pydantic/logfire-session-replay`, the optional standalone rrweb recorder used by the browser package's session replay integration.
 - `vite.shared.ts` holds the build helpers every package config imports: `packageDefines()` stamps `PACKAGE_VERSION` and `PACKAGE_TIMESTAMP` from the package's own `package.json`, and `copyCjsDeclarations()` emits the `.d.cts` files.
 - `vite.config.ts` and `tsconfig.base.json` at the repository root hold the shared format, lint, task, and TypeScript configuration.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -140,7 +140,7 @@ The stored JSON schema is pinned by `SCHEMA_SHA256`, and the cross-language rule
 
 The core is framework-neutral on purpose: it knows about instruction blocks, tool definitions, and settings, and about no framework's spelling of them. An adapter is what maps one framework onto those three: it enumerates a baseline, installs the framework's hook, and calls the pure helpers.
 
-TypeScript adapters for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Codex SDK** are in progress, each as its own package, because a project that uses one has no reason to install the other two. Until they land, the paragraph below is how to drive Agent Control from any framework directly.
+TypeScript adapters are each their own package, because a project that uses one has no reason to install the other two: [`@pydantic/logfire-agent-control-codex-sdk`](frameworks/codex-sdk.md) for the **OpenAI Codex SDK**, with **Mastra** and the **Vercel AI SDK** in progress. The paragraph below is how to drive Agent Control from a framework no adapter covers yet.
 
 Python users get the same contract from [`logfire`](https://logfire.pydantic.dev/docs/) and [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness). A config published from the Logfire UI drives every one of them, because the variable name, the baseline, and the parse are the same three rules in both languages.
 

--- a/docs/frameworks/codex-sdk.md
+++ b/docs/frameworks/codex-sdk.md
@@ -1,0 +1,77 @@
+---
+title: OpenAI Codex SDK
+description: Use @pydantic/logfire-agent-control-codex-sdk to change a Codex agent's instructions, model, and reasoning effort from Logfire.
+---
+
+# OpenAI Codex SDK
+
+[Agent Control](../agent-control.md) lets someone change what a running agent does from the Logfire UI, without a deploy. `@pydantic/logfire-agent-control-codex-sdk` is the adapter for the [Codex SDK](https://developers.openai.com/codex/sdk): it makes a Codex agent's developer instructions, its base prompt, its model, and its reasoning effort editable from Logfire.
+
+Codex is a process wrapper rather than an in-process agent framework, and that decides what an adapter can offer. Everything the model sees is assembled inside the `codex` binary from `config.toml`, the `-c key=value` overrides the SDK forwards, and files on disk — so the prompt and the model are manageable, and the tools, which the binary defines and never sends from the client, are not.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-agent-control-codex-sdk @openai/codex-sdk @pydantic/logfire-node
+```
+
+Both `@openai/codex-sdk` and `@pydantic/logfire-node` are peer dependencies, so your project owns the versions: the adapter has to use the copy of the SDK your code builds threads with, and the copy of Logfire your code configured.
+
+## Usage
+
+Wrap the options you already pass to `new Codex(...)` and `startThread(...)`, and give the agent a name:
+
+```ts
+import { agentControl } from '@pydantic/logfire-agent-control-codex-sdk'
+import * as logfire from '@pydantic/logfire-node'
+
+logfire.configure()
+
+const managed = agentControl({
+  name: 'ci_fixer',
+  codex: { config: { developer_instructions: 'Fix CI without changing public APIs.' } },
+  thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'medium', sandboxMode: 'workspace-write' },
+})
+
+const answer = await managed.run(async (thread) => {
+  const turn = await thread.run('Diagnose and fix the failing CI job.')
+  return turn.finalResponse
+})
+```
+
+`name` is required and is never inferred: it is what picks out the `agent__<name>` variable, and Codex has no agent name of its own to derive one from.
+
+`run` is the form to reach for. It starts the thread with the published config applied and holds the resolution's telemetry context open for the callback, so every span your own code opens around the turn carries the label the config was resolved under. `startThread`, `resumeThread`, and `resolveOptions` apply the same config without that scope, and `baseline()` returns the document describing your code without publishing it.
+
+On construction, the agent as written is published to the variable's `example`, which is what the Logfire editor shows a managed value being layered onto. Pass `publishBaseline: false` when the token is intentionally read-only.
+
+## What is editable
+
+| Published                                                        | Applies as                                                    | Support                                                                                             |
+| ---------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `instructions` entry with id `developer_instructions`            | `-c developer_instructions=`                                  | Yes                                                                                                 |
+| `instructions` entry with no id                                  | joined onto the developer message                             | Yes                                                                                                 |
+| `instructions` entry with id `base_instructions`                 | `-c model_instructions_file=` pointing at a private temp file | Yes, and it replaces Codex's _entire_ built-in system prompt                                        |
+| `model`                                                          | the `--model` slug plus `-c model_provider=`                  | Yes                                                                                                 |
+| `settings.thinking`                                              | `-c model_reasoning_effort=`                                  | `minimal`, `low`, `medium`, `high`, `xhigh`; the provider has the last word per model               |
+| `agents_md`, `host_skills`, `permissions`, `environment_context` | —                                                             | No. Codex assembles them per session; they are published as seams so the editor can show they exist |
+| every other `settings` key                                       | —                                                             | No. Codex exposes a reasoning effort, not a sampler                                                 |
+| `tool_definitions`                                               | —                                                             | No. Codex defines its tools inside its own binary                                                   |
+
+Everything in the last three rows is reported through the control's `onUnmatched` policy rather than dropped in silence, so Logfire never shows a value the agent is quietly ignoring.
+
+## When the config applies
+
+**Per thread, at thread start.** There is no per-request hook to install and no per-turn config, so the published value is read once — when `run` / `startThread` / `resumeThread` / `resolveOptions` is called — and lowered into the options that start the `codex` process. A second turn on a `Thread` you kept runs on what that thread was started with.
+
+Resuming is the one place where Codex and the contract disagree. `resumeThread` re-sends every override, and Codex takes the model and the reasoning effort but replays the developer message it persisted with the session, so a **changed instruction reaches new threads only**.
+
+Per-call overrides win over the published config, which wins over the options the agent was constructed with. The model is the one value that is more than a per-key merge: a published `ollama:qwen3` sets both the slug and `model_provider`, and if the call passes its own `model`, the published provider is dropped along with the model it qualified rather than left behind to send that model somewhere it has never been heard of.
+
+See the [package README](https://github.com/pydantic/logfire-js/blob/main/packages/logfire-agent-control-codex-sdk/README.md) for the full table, the baseline, and the known limits.
+
+## Related Guides
+
+- [Agent Control](../agent-control.md)
+- [Managed Variables](../managed-variables.md)
+- [Node.js](../packages/node.md)

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -49,6 +49,10 @@
           {
             "label": "Vercel AI SDK",
             "slug": "frameworks/vercel-ai"
+          },
+          {
+            "label": "OpenAI Codex SDK",
+            "slug": "frameworks/codex-sdk"
           }
         ]
       },

--- a/packages/logfire-agent-control-codex-sdk/.gitignore
+++ b/packages/logfire-agent-control-codex-sdk/.gitignore
@@ -1,0 +1,25 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+*.tgz

--- a/packages/logfire-agent-control-codex-sdk/README.md
+++ b/packages/logfire-agent-control-codex-sdk/README.md
@@ -1,0 +1,239 @@
+# `@pydantic/logfire-agent-control-codex-sdk`
+
+Agent Control lets someone change what a running [Codex SDK](https://developers.openai.com/codex/sdk)
+agent does — its developer instructions, its base prompt, its model, its reasoning effort — from the
+Logfire UI, without a deploy.
+
+The agent's configuration lives in one Logfire variable named `agent__<name>`. Every value in it is a
+_patch_ on the agent as written: a section that is present is managed from Logfire, a section that is
+absent keeps what your code does, and deleting a section in Logfire is a deliberate revert to code.
+If Logfire is unreachable, if nothing has been published, or if a published value cannot be
+understood, the agent runs exactly as your code defines it.
+
+**Prerequisites.** Node 20+, ESM, the `codex` CLI on the machine, and a Logfire project. Both
+`@openai/codex-sdk` and `@pydantic/logfire-node` are peer dependencies you install yourself — the
+first because this package must use the copy of the SDK your code builds threads with, the second
+because Logfire's variable provider is a module-level singleton and a second copy of it would read a
+different one. Nothing here reads an environment variable of its own: the Logfire SDK's own
+configuration decides where the variable is read from — `logfire.configure({ apiKey })` or
+`LOGFIRE_API_KEY` / `LOGFIRE_TOKEN`, with `LOGFIRE_BASE_URL` naming the region.
+
+```bash
+npm install @pydantic/logfire-agent-control-codex-sdk @openai/codex-sdk @pydantic/logfire-node
+```
+
+## Quick start
+
+Wrap the options you already pass to `new Codex(...)` and `startThread(...)`, and give the agent a
+name:
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+import { agentControl } from '@pydantic/logfire-agent-control-codex-sdk'
+
+logfire.configure()
+
+const managed = agentControl({
+  name: 'ci_fixer',
+  codex: { config: { developer_instructions: 'Fix CI without changing public APIs.' } },
+  thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'medium', sandboxMode: 'workspace-write' },
+})
+
+const answer = await managed.run(async (thread) => {
+  const turn = await thread.run('Diagnose and fix the failing CI job.')
+  return turn.finalResponse
+})
+```
+
+`run` is the form to reach for: it starts the thread with the published config applied and holds the
+resolution's telemetry context open for the callback, so every span your code opens around the turn
+carries the label the config was resolved under — the difference between "this agent regressed" and
+"this agent regressed on the value someone published at 14:02". The `codex` child process itself is
+not something this package can instrument.
+
+`name` is required and is not derived from anything: it is what picks out the variable, and Codex has
+no agent name of its own to take one from. It is normalized to the variable key by the core's rule —
+lowercased, everything outside `[a-z0-9_]` replaced with `_` — so `ci_fixer`, `CI Fixer`, and
+`ci-fixer` are all `agent__ci_fixer`.
+
+## The factory
+
+```ts
+agentControl(options: CodexAgentControlOptions): ManagedCodex
+```
+
+Constructs nothing of the SDK's: it holds your options, publishes the baseline once, and hands back a
+`ManagedCodex`. Your own `CodexOptions` and `ThreadOptions` objects are never mutated — every call
+copies them before applying anything.
+
+| Option            | Meaning                                                                                                                                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` (required) | Picks out the `agent__<name>` variable.                                                                                                                                                              |
+| `codex`           | The options you would have passed to `new Codex(...)`.                                                                                                                                               |
+| `thread`          | The options you would have passed to `startThread(...)` / `resumeThread(...)`.                                                                                                                       |
+| `label`           | Read this label instead of letting the variable's rollout choose one.                                                                                                                                |
+| `onUnmatched`     | What to do about a published entry that reaches nothing: `'warn'` (default, once per distinct message per process), `'ignore'`, or `'error'`, which throws `UnmatchedConfigError` and fails the run. |
+| `publishBaseline` | `false` when the Logfire token is read-only, or code must not write variable metadata.                                                                                                               |
+
+`ManagedCodex` has four ways to run and one to look:
+
+| Method                         | Returns                                                       | Resolution's telemetry context   |
+| ------------------------------ | ------------------------------------------------------------- | -------------------------------- |
+| `run(fn, overrides?)`          | whatever `fn` returns                                         | open for the whole of `fn`       |
+| `startThread(overrides?)`      | the SDK's `Thread`                                            | closed before you use the thread |
+| `resumeThread(id, overrides?)` | the SDK's `Thread`                                            | closed before you use the thread |
+| `resolveOptions(overrides?)`   | `{ codex, thread }`, for code that builds its own `Codex`     | closed before you build it       |
+| `baseline()`                   | the `AgentConfig` describing your code, without publishing it | —                                |
+
+`control` is the underlying `AgentControl`, exposed for its `name`, `variableName`, `label`, and
+`onUnmatched`.
+
+## What becomes editable in Logfire
+
+| Source / canonical field                                                                                                                                    | Block id or runtime mapping                                      | Support         | Conditions and unmatched behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `codex.config.developer_instructions`                                                                                                                       | `developer_instructions` → `-c developer_instructions=`          | **Yes**         | Rewrites the developer message. Removing the block sends `developer_instructions=""`, which Codex reads as none — a dropped flag would instead expose the `developer_instructions` in the machine's `config.toml`.                                                                                                                                                                                                                                                                                             |
+| An entry with no `id`                                                                                                                                       | joined onto `developer_instructions`                             | **Yes**         | Appended after your own text, in the order published; nothing moves ahead of it, so a cached prompt prefix stays cached. Works for an agent whose code sets no developer instructions at all.                                                                                                                                                                                                                                                                                                                  |
+| `codex.config.model_instructions_file`                                                                                                                      | `base_instructions` → `-c model_instructions_file=<temp file>`   | **Conditional** | Published text replaces Codex's **entire** built-in system prompt, including the parts that tell it how to use `apply_patch` and its shell. It is written to a private temp file, since Codex takes a path. Shown in the baseline only when your code already sets `model_instructions_file`; publish it by id otherwise. Removing the block stops this package from overriding the prompt, but cannot reset one set in `config.toml` — Codex has no key for that, so the gap is reported under `onUnmatched`. |
+| Codex's own prompt pieces                                                                                                                                   | `agents_md`, `host_skills`, `permissions`, `environment_context` | **No**          | Assembled inside the binary per session from the repository and the machine. They are in the baseline as seams so the editor can show they exist; an entry addressing one is reported and not applied. `AGENTS.md` is editable by committing to it.                                                                                                                                                                                                                                                            |
+| `model`                                                                                                                                                     | `--model` slug, plus `-c model_provider=`                        | **Yes**         | `openai:gpt-5.6-sol` is the model and `openai` the provider entry it is looked up under; a bare `gpt-5.6-sol` leaves your provider alone. A provider other than the default must exist in your `config.toml` `model_providers` table, and Codex only speaks the Responses API. A per-call `overrides.model` wins, and then the published provider is **not** applied either — see [Precedence](#precedence).                                                                                                   |
+| `settings.thinking`                                                                                                                                         | `-c model_reasoning_effort=`                                     | **Conditional** | `minimal`, `low`, `medium`, `high`, `xhigh` apply. `thinking: true` / `false` has no Codex meaning and is reported. Codex's own `max`, `ultra`, and `persistent` are outside the contract: set them in your code and they stay, but they are not published as a baseline. Codex forwards the effort verbatim and the provider has the last word on it, per model: `gpt-5.6-sol` answers `minimal` with a 400 naming the values it does take.                                                                   |
+| `settings.max_tokens`, `temperature`, `top_p`, `top_k`, `seed`, `presence_penalty`, `frequency_penalty`, `parallel_tool_calls`, `stop_sequences`, `timeout` | —                                                                | **No**          | Codex has no config key for any of them; each published key is reported under `onUnmatched`. It is a coding-agent runtime: what it exposes is reasoning effort, not a sampler.                                                                                                                                                                                                                                                                                                                                 |
+| `tool_definitions` (rename, description, parameter descriptions)                                                                                            | —                                                                | **No**          | Codex defines its tools inside its own binary. `shell`, `apply_patch`, `update_plan`, web search, and MCP tools are never sent by a client, so there is nothing to reword; each override is reported.                                                                                                                                                                                                                                                                                                          |
+
+`'warn'` (the default) prints each distinct report once per process, `'error'` turns it into a thrown
+`UnmatchedConfigError`, and `'ignore'` says nothing.
+
+## Resolution, baseline, precedence
+
+### When the config applies
+
+**Per thread, at thread start.** Codex is a process wrapper: everything the model sees is assembled
+inside the `codex` binary from `config.toml`, the `-c key=value` overrides the SDK forwards, and files
+on disk. There is no per-request hook to install and no per-turn config, so the published value is
+read once, when `run` / `startThread` / `resumeThread` / `resolveOptions` is called, and lowered into
+the options that start the process.
+
+A turn on an already-started thread runs with what its thread was started with. That includes a
+`Thread` you keep: `await thread.run(...)` a second time is a second turn on the options the first
+resolution produced, and reusing a `Thread` never re-reads the config. Call `run` again — or start a
+new thread — to pick up a change.
+
+Resuming re-sends every override as a flag on the new process, but a **changed developer block does
+not reach the model on a resumed session**: `codex exec resume` replays the developer message the
+session already persisted, and the `-c developer_instructions=` this package sends is ignored.
+Observed against codex-cli 0.153.4 and pinned by `live-tests/codex.live.ts`, which starts a session
+under one published instruction, publishes another, resumes, and gets the first one back. So a
+published change is something _new threads_ pick up; `resumeThread` still applies a published model
+and reasoning effort, which the CLI does take per turn.
+
+### Precedence
+
+Code < published < the options you pass to this call. `agentControl({ thread })` is the code layer,
+the Logfire value is the published layer, and `run(fn, overrides)` / `startThread(overrides)` /
+`resumeThread(id, overrides)` / `resolveOptions(overrides)` are the per-call layer. Because those
+overrides are a bag you pass at the call site, this adapter knows exactly which keys a call set —
+there is no diffing and no guessing — and a call that explicitly passes the same value its code
+declares still beats a published one.
+
+The one place that is more than a per-key merge is the model, because Codex splits it in two. A
+published `ollama:qwen3` sets both the slug and `model_provider`; if the same call passes its own
+`model`, the published model loses, and its provider is dropped with it rather than left behind to
+send your model to somebody else's endpoint.
+
+### The baseline
+
+On construction, the agent as written is published to the variable's `example` — what the Logfire
+editor shows a managed value being layered onto — and, if the variable does not exist yet, it is
+created with the contract's JSON schema, which is what makes it editable at all. Everything a Codex
+agent is, it is at construction, so this needs no first request and the baseline is `source: 'code'`
+rather than a snapshot of one run.
+
+What it contains: the two writable blocks (`base_instructions` only when your code replaced the
+built-in prompt, read off the file you pointed at), the four Codex-owned blocks as ids with no text,
+the model, and the reasoning effort. The model and effort are read from `thread` first and from
+`codex.config` otherwise, since an agent may pin either in either place; `thread` wins because that is
+the order Codex applies them in. A provider is published only when your code pins one — an
+unqualified slug is published unqualified, because the provider a bare slug resolves to lives in a
+`config.toml` this package cannot read, and inventing `openai` would describe an identity the run need
+not have.
+
+What it does not contain: the config keys you set for anything else (`mcp_servers`, `sandbox_mode`,
+`model_verbosity`), any text Codex computes inside the binary, and any `tool_definitions` section —
+a section describing none of Codex's tools would read as "this agent has no tools".
+
+Publishing is at most once per process per variable, off the request path, and never fails a run.
+Updating an existing variable is read-modify-write over the whole definition, so a value or label
+saved in the Logfire UI inside that one round trip can be overwritten; pass `publishBaseline: false`
+and create the variable in the UI if you cannot tolerate that window.
+
+## Renames, permissions, and history
+
+**Tool renames do not exist here.** A `tool_definitions` entry is reported and nothing is renamed, so
+the question of whether your code, your hooks, or a resumed session see the old name or the new one
+does not arise. Codex's session history is written by the binary and is never rewritten by this
+package.
+
+The one tool control Codex does have is allow-listing (`mcp_servers.<id>.enabled_tools`, per-tool
+`approval_mode`), which is not part of this contract: set it in your own `codex.config` and it is
+carried through untouched, like every other key this contract says nothing about.
+
+## Known limits
+
+- **Per thread, not per turn**, and a reused `Thread` does not re-read the config — see above.
+- **Your `codex.configOverrides` win.** Raw `-c` strings are passed to the CLI after the structured
+  `config` this package writes, and the last `-c` for a key wins, so a raw `developer_instructions=…`
+  there beats a published one. Set instructions through `config`, not `configOverrides`.
+- **A removed base prompt cannot be reset.** Removing `base_instructions` stops this package from
+  sending `model_instructions_file`, but Codex has no config value that resets one — an empty value is
+  a path it fails the run trying to read — so a `model_instructions_file` in the machine's own
+  `config.toml` still replaces the built-in prompt. That gap is reported under `onUnmatched` rather
+  than papered over.
+- **A published base prompt is written to a temp file** (mode 0600, in a per-process directory removed
+  at exit) because Codex takes it as a path rather than as text. One file per distinct prompt, written
+  once and never rewritten, so a `codex` process reading it never sees a half-written file.
+- **Codex's model is invisible when your code names one in neither `thread` nor `codex.config`.** It
+  falls back to `config.toml`, which this package does not read, so the baseline names no model and
+  publishing one is how you get it back.
+- **The `codex` process is not instrumented.** Only the spans your own code opens carry the resolved
+  label.
+- **Node only, ESM only.**
+
+## Compared with an in-process agent framework
+
+If you are choosing where to run an agent you want to manage from Logfire, this is the difference in
+one line: **on the Codex SDK, Agent Control is a managed prompt and a model switch; on a framework
+that hands an adapter the agent itself — Mastra, the Vercel AI SDK, Pydantic AI — it is the whole
+feature.**
+
+Those frameworks give an adapter an agent object with its own instructions, tools, model, and model
+settings, plus a per-request hook — so all four sections apply per model request, a renamed tool
+routes back to your function, tool descriptions and parameter descriptions are editable, and
+`temperature` and the rest lower onto real fields. Codex gives an adapter a command line. What you
+gain here is hot-swapping the model, the reasoning effort, and the developer instructions (or the
+whole system prompt) without a redeploy. What you do not gain is any control over tool wording or
+sampling.
+
+## Development
+
+This package lives in the [`logfire-js`](https://github.com/pydantic/logfire-js) monorepo and uses its
+toolchain. From the repository root:
+
+```bash
+vp install
+vp run @pydantic/logfire-agent-control-codex-sdk#test        # offline, what CI runs
+vp run @pydantic/logfire-agent-control-codex-sdk#typecheck
+vp check                                                     # format and lint, whole repo
+```
+
+The offline suite runs against a local variables provider and a stand-in `codex` binary
+(`test-fixtures/fake-codex.ts`) that records the argv it was started with — so the mapping from a
+published value to real CLI flags is asserted end to end, with no API key and no model.
+
+`live-tests/` is the other half, and it is not in the default `vp test` include, so CI never runs it:
+it drives a real `codex` against a real model to settle the three claims a recorder cannot, because
+Codex assembles its prompt inside a binary that no JS HTTP recorder sits in front of. See
+[`live-tests/README.md`](live-tests/README.md).
+
+Where this README states what the `codex` binary itself does with a flag, it was checked against
+codex-cli 0.153.4 with `codex debug prompt-input` or by a test in `live-tests/`.

--- a/packages/logfire-agent-control-codex-sdk/README.md
+++ b/packages/logfire-agent-control-codex-sdk/README.md
@@ -16,7 +16,8 @@ first because this package must use the copy of the SDK your code builds threads
 because Logfire's variable provider is a module-level singleton and a second copy of it would read a
 different one. Nothing here reads an environment variable of its own: the Logfire SDK's own
 configuration decides where the variable is read from — `logfire.configure({ apiKey })` or
-`LOGFIRE_API_KEY` / `LOGFIRE_TOKEN`, with `LOGFIRE_BASE_URL` naming the region.
+`LOGFIRE_API_KEY`, with `LOGFIRE_BASE_URL` naming the region. An API key is what remote variables
+need; `LOGFIRE_TOKEN` is the write token for spans and does not resolve one.
 
 ```bash
 npm install @pydantic/logfire-agent-control-codex-sdk @openai/codex-sdk @pydantic/logfire-node

--- a/packages/logfire-agent-control-codex-sdk/README.md
+++ b/packages/logfire-agent-control-codex-sdk/README.md
@@ -8,7 +8,9 @@ The agent's configuration lives in one Logfire variable named `agent__<name>`. E
 _patch_ on the agent as written: a section that is present is managed from Logfire, a section that is
 absent keeps what your code does, and deleting a section in Logfire is a deliberate revert to code.
 If Logfire is unreachable, if nothing has been published, or if a published value cannot be
-understood, the agent runs exactly as your code defines it.
+understood at all, the agent runs exactly as your code defines it. Below that, leniency is per
+section: an entry or a setting this release cannot make sense of costs only itself, and the rest of
+the published value still applies.
 
 **Prerequisites.** Node 20+, ESM, the `codex` CLI on the machine, and a Logfire project. Both
 `@openai/codex-sdk` and `@pydantic/logfire-node` are peer dependencies you install yourself — the

--- a/packages/logfire-agent-control-codex-sdk/live-tests/README.md
+++ b/packages/logfire-agent-control-codex-sdk/live-tests/README.md
@@ -1,0 +1,48 @@
+# Live tests
+
+Three assertions about a real `codex` process talking to a real model. **CI never runs them**: the
+file is `codex.live.ts` rather than `*.test.ts` and sits behind its own `vite.live.config.ts`, so the
+default `vp test` include cannot pick it up — the same way `@pydantic/logfire-session-replay` keeps
+its Playwright specs out with `.pw.ts`.
+
+## Why these are live rather than recorded
+
+Every other integration in this repository can be pinned with a recorded HTTP exchange. This one
+cannot: the Codex SDK does not make HTTP requests, it spawns the `codex` binary, and the binary makes
+them from its own process with its own credentials. There is no fetch to intercept from JavaScript,
+so a recorder here would record nothing and prove less than the offline suite already does.
+
+What the offline suite in `src/__test__` proves is the whole mapping from a published value to the
+argv a `codex` process is started with, against a stand-in binary. What it cannot prove is what the
+_model_ then sees, since the prompt is assembled inside the binary. These three tests are exactly the
+claims that live on the far side of that line:
+
+1. **A published `developer_instructions` block changes what the model is told**, and a published
+   `settings.thinking` is accepted by the provider rather than rejected on the request.
+2. **`codex exec resume` does not re-inject a changed developer block** into a session that already
+   persisted one. This is why the README says a published change is something new threads pick up.
+3. **A published `model` whose provider id is not `openai` reaches that provider.** The test writes a
+   `CODEX_HOME` holding one extra `model_providers` entry and no `auth.json`, so nothing but that
+   entry can serve the turn.
+
+## Running them
+
+```bash
+vp run @pydantic/logfire-agent-control-codex-sdk#test:live
+```
+
+Requirements:
+
+- A logged-in Codex account (`codex login`, which writes `auth.json` into `$CODEX_HOME` or `~/.codex`). Without it every test in the file skips. The CLI binary itself comes from the `@openai/codex-sdk` devDependency, so nothing has to be on `PATH`.
+- `OPENAI_API_KEY` in the environment for the third test only; without it that one skips. Pass it
+  through the environment rather than putting it on a command line.
+
+Each test runs one turn on a small model, in a fresh temporary working directory, with a prompt whose
+only job is to echo one word back — no repository is read and nothing is written.
+
+Two environment variables adjust the run:
+
+| Variable                  | Default       | Why you would set it                                                                                                                                               |
+| ------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CODEX_LIVE_MODEL`        | `gpt-5.6-sol` | An account that cannot reach the default.                                                                                                                          |
+| `CODEX_LIVE_SANDBOX_MODE` | `read-only`   | A container that refuses the user namespace Codex's sandbox needs. Set it to the mode that machine's own `config.toml` uses and let the container be the boundary. |

--- a/packages/logfire-agent-control-codex-sdk/live-tests/README.md
+++ b/packages/logfire-agent-control-codex-sdk/live-tests/README.md
@@ -38,7 +38,8 @@ Requirements:
   through the environment rather than putting it on a command line.
 
 Each test runs one turn on a small model, in a fresh temporary working directory, with a prompt whose
-only job is to echo one word back — no repository is read and nothing is written.
+only job is to echo one word back — except the resumed-session test, which needs two: one to start the
+session and one on the resume. No repository is read and nothing is written.
 
 Two environment variables adjust the run:
 

--- a/packages/logfire-agent-control-codex-sdk/live-tests/codex.live.ts
+++ b/packages/logfire-agent-control-codex-sdk/live-tests/codex.live.ts
@@ -156,13 +156,16 @@ describe.skipIf(!LOGGED_IN)('a live Codex turn', () => {
     // The session's own developer message wins. A published change is a new-thread affair.
     expect(answer.trim()).toBe(PUBLISHED_CODEWORD)
   })
+})
 
-  it.skipIf(OPENAI_API_KEY === undefined)('sends a published non-`openai` provider id to that provider', async () => {
+describe.skipIf(OPENAI_API_KEY === undefined)('a live turn on a provider the machine defines itself', () => {
+  it('sends a published non-`openai` provider id to that provider', async () => {
     // `model_provider` indexes into the `model_providers` table of the machine's `config.toml`, a
     // file this package never reads -- so "a published `ollama:qwen3` reaches Ollama" was, until
     // this test, an argument from the flag rather than an observation. A `CODEX_HOME` holding one
     // extra provider entry and no `auth.json` makes the observation: nothing but that entry can
-    // serve the turn, and the ChatGPT login the other tests run on is not reachable from here.
+    // serve the turn. That is also why this one is not under the login guard the others are: it
+    // brings its own Codex home and its own credential, so a machine with only an API key runs it.
     const home = scratchDirectory()
     writeFileSync(
       join(home, 'config.toml'),

--- a/packages/logfire-agent-control-codex-sdk/live-tests/codex.live.ts
+++ b/packages/logfire-agent-control-codex-sdk/live-tests/codex.live.ts
@@ -1,0 +1,201 @@
+/**
+ * The live suite: this adapter, a real `codex` process, and a real model.
+ *
+ * The offline suite in `src/__test__` proves the mapping from a published value to the flags a
+ * `codex` process is started with, against a stand-in binary that records its argv. What it cannot
+ * prove is what the *model* then sees, because the prompt is assembled inside the binary and sent
+ * from there. Three claims this package makes are about exactly that, and each of the tests below
+ * exists to settle one of them:
+ *
+ * 1. a published `developer_instructions` block really does change what the model is told, and a
+ *    published `settings.thinking` is really accepted by the provider rather than 400'd;
+ * 2. `codex exec resume` does *not* re-inject a changed developer block into a session that already
+ *    persisted one -- which is why the README tells you to treat a published change as something new
+ *    threads pick up;
+ * 3. a published `model` whose provider id is not `openai` reaches that provider, rather than being
+ *    a flag Codex parses and ignores.
+ *
+ * This file is deliberately not a `.test.ts` and is not in the default `vp test` include, so CI
+ * never runs it: it needs a `codex` on the machine, a logged-in account, and (for the third test) an
+ * OpenAI API key. See `live-tests/README.md`.
+ */
+
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { CodexOptions, SandboxMode, ThreadOptions } from '@openai/codex-sdk'
+import { configureVariables } from '@pydantic/logfire-node/vars'
+import { resetAgentControl } from '@pydantic/logfire-node/agent-control/testing'
+import { beforeEach, describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../src/index'
+
+/**
+ * Whether the machine has a Codex account these turns can run on.
+ *
+ * The binary itself is not in question -- `@openai/codex-sdk` vendors one and the SDK resolves it
+ * without any help -- so the thing that decides whether a live turn is possible is `codex login`,
+ * which writes an `auth.json` into the Codex home.
+ */
+function isLoggedIn(): boolean {
+  return existsSync(join(process.env['CODEX_HOME'] ?? join(homedir(), '.codex'), 'auth.json'))
+}
+
+const LOGGED_IN = isLoggedIn()
+const OPENAI_API_KEY = process.env['OPENAI_API_KEY']
+
+/**
+ * The model every test here runs on.
+ *
+ * A small current model rather than the flagship the README names: these turns exist to prove a
+ * flag arrives, not to measure an agent. Override it when a machine's account cannot reach this one.
+ */
+const MODEL = process.env['CODEX_LIVE_MODEL'] ?? 'gpt-5.6-sol'
+
+/**
+ * The sandbox every test here runs under.
+ *
+ * `read-only` by default, because nothing in this suite has any business writing to the machine.
+ * Codex's sandbox is a user namespace, which some containers refuse to create; where it cannot
+ * start, set this to the mode that machine's own `config.toml` uses and let the container be the
+ * boundary instead.
+ */
+const SANDBOX_MODE = (process.env['CODEX_LIVE_SANDBOX_MODE'] ?? 'read-only') as SandboxMode
+
+/** Two codewords no model has an opinion about, so the answer says which prompt reached it. */
+const PUBLISHED_CODEWORD = 'ALPHA7'
+const CODE_CODEWORD = 'OMEGA2'
+
+/** An instruction whose only effect is to make the model repeat one word back. */
+function codewordRule(codeword: string): string {
+  return `Do not run any commands. When asked for the codeword, reply with exactly ${codeword} and nothing else.`
+}
+
+/** The prompt that asks for it. */
+const ASK = 'What is the codeword?'
+
+/** Publish `value` for `agent__<name>` in a local variables config, the way the UI would. */
+function publish(name: string, value: unknown): void {
+  configureVariables({
+    instrument: false,
+    config: {
+      variables: {
+        [`agent__${name}`]: {
+          name: `agent__${name}`,
+          labels: { production: { version: 1, serialized_value: JSON.stringify(value) } },
+          rollout: { labels: { production: 1 } },
+          overrides: [],
+        },
+      },
+    },
+  })
+}
+
+/** A distinct agent name per test, so no two share a variable. */
+let counter = 0
+function uniqueName(): string {
+  counter += 1
+  return `live_codex_${String(counter)}`
+}
+
+/** A scratch directory to run the turn in, so no test touches a repository. */
+function scratchDirectory(): string {
+  return mkdtempSync(join(tmpdir(), 'agent-control-live-'))
+}
+
+/** The thread options every test starts from. */
+function threadOptions(): ThreadOptions {
+  return { model: MODEL, sandboxMode: SANDBOX_MODE, skipGitRepoCheck: true, workingDirectory: scratchDirectory() }
+}
+
+beforeEach(() => {
+  resetAgentControl()
+})
+
+describe.skipIf(!LOGGED_IN)('a live Codex turn', () => {
+  it('answers with the published developer instructions, not the ones in the code', async () => {
+    const name = uniqueName()
+    publish(name, {
+      instructions: [{ id: 'developer_instructions', instructions: codewordRule(PUBLISHED_CODEWORD) }],
+      // Lowered to `-c model_reasoning_effort=low` and sent to the provider on the same request, so
+      // a turn that completes at all is a `thinking` the provider accepted.
+      settings: { thinking: 'low' },
+    })
+    const managed = agentControl({
+      name,
+      codex: { config: { developer_instructions: codewordRule(CODE_CODEWORD) } },
+      thread: threadOptions(),
+      publishBaseline: false,
+    })
+
+    const answer = await managed.run(async (thread) => (await thread.run(ASK)).finalResponse)
+
+    expect(answer.trim()).toBe(PUBLISHED_CODEWORD)
+  })
+
+  it('does not re-inject a changed developer block into a session it already persisted one for', async () => {
+    // The one claim in the README that could not be read off Codex's source: `resumeThread` re-sends
+    // every `-c` flag, so the *question* is whether the binary prefers the flag or the developer
+    // message it wrote into the session file. The first turn is deliberately not about the codeword,
+    // so an answer of ALPHA7 on resume cannot be the model repeating its own earlier reply.
+    const started = uniqueName()
+    publish(started, { instructions: [{ id: 'developer_instructions', instructions: codewordRule(PUBLISHED_CODEWORD) }] })
+    const options = threadOptions()
+    const first = agentControl({ name: started, thread: options, publishBaseline: false })
+    const thread = await first.startThread()
+    await thread.run('Reply with exactly READY and nothing else.')
+    const id = thread.id
+    expect(id).not.toBeNull()
+
+    const resumed = uniqueName()
+    publish(resumed, { instructions: [{ id: 'developer_instructions', instructions: codewordRule(CODE_CODEWORD) }] })
+    const second = agentControl({ name: resumed, thread: options, publishBaseline: false })
+    const answer = (await (await second.resumeThread(id as string)).run(ASK)).finalResponse
+
+    // The session's own developer message wins. A published change is a new-thread affair.
+    expect(answer.trim()).toBe(PUBLISHED_CODEWORD)
+  })
+
+  it.skipIf(OPENAI_API_KEY === undefined)('sends a published non-`openai` provider id to that provider', async () => {
+    // `model_provider` indexes into the `model_providers` table of the machine's `config.toml`, a
+    // file this package never reads -- so "a published `ollama:qwen3` reaches Ollama" was, until
+    // this test, an argument from the flag rather than an observation. A `CODEX_HOME` holding one
+    // extra provider entry and no `auth.json` makes the observation: nothing but that entry can
+    // serve the turn, and the ChatGPT login the other tests run on is not reachable from here.
+    const home = scratchDirectory()
+    writeFileSync(
+      join(home, 'config.toml'),
+      [
+        '[model_providers.openai_direct]',
+        'name = "OpenAI direct"',
+        'base_url = "https://api.openai.com/v1"',
+        'env_key = "OPENAI_API_KEY"',
+        'wire_api = "responses"',
+        '',
+      ].join('\n'),
+      'utf8'
+    )
+
+    const name = uniqueName()
+    publish(name, {
+      instructions: [{ id: 'developer_instructions', instructions: codewordRule(PUBLISHED_CODEWORD) }],
+      model: `openai_direct:${MODEL}`,
+    })
+    // `env` replaces the child's environment wholesale rather than adding to it, so everything the
+    // CLI needs is named here and nothing else leaks in.
+    const codex: CodexOptions = {
+      env: {
+        CODEX_HOME: home,
+        HOME: home,
+        OPENAI_API_KEY: OPENAI_API_KEY ?? '',
+        PATH: process.env['PATH'] ?? '',
+      },
+    }
+    const managed = agentControl({ name, codex, thread: threadOptions(), publishBaseline: false })
+
+    const answer = await managed.run(async (thread) => (await thread.run(ASK)).finalResponse)
+
+    expect(answer.trim()).toBe(PUBLISHED_CODEWORD)
+  })
+})

--- a/packages/logfire-agent-control-codex-sdk/live-tests/tsconfig.json
+++ b/packages/logfire-agent-control-codex-sdk/live-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["*.ts"],
+  "compilerOptions": {
+    "declaration": false,
+    "isolatedDeclarations": false,
+    "types": ["node"]
+  }
+}

--- a/packages/logfire-agent-control-codex-sdk/package.json
+++ b/packages/logfire-agent-control-codex-sdk/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@pydantic/logfire-agent-control-codex-sdk",
+  "description": "Logfire Agent Control for the OpenAI Codex SDK - https://pydantic.dev/logfire",
+  "author": {
+    "name": "The Pydantic Team",
+    "email": "engineering@pydantic.dev",
+    "url": "https://pydantic.dev"
+  },
+  "repository": {
+    "url": "git+https://github.com/pydantic/logfire-js.git",
+    "directory": "packages/logfire-agent-control-codex-sdk"
+  },
+  "sideEffects": false,
+  "homepage": "https://pydantic.dev/logfire",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "logfire",
+    "agent",
+    "agent-control",
+    "codex",
+    "observability",
+    "prompt-management"
+  ],
+  "version": "0.0.0",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "dev": "vp pack --watch",
+    "build": "vp pack",
+    "lint": "vp lint",
+    "preview": "vp preview",
+    "typecheck": "tsc && tsc --project live-tests/tsconfig.json",
+    "prepack": "cp ../../LICENSE .",
+    "postpublish": "rm LICENSE",
+    "test": "vp test",
+    "test:live": "vp test --config vite.live.config.ts"
+  },
+  "devDependencies": {
+    "@openai/codex-sdk": "catalog:",
+    "@pydantic/logfire-node": "workspace:*",
+    "@types/node": "^22.5.1",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@openai/codex-sdk": ">=0.153.4 <1",
+    "@pydantic/logfire-node": "workspace:^0.18.24"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
+}

--- a/packages/logfire-agent-control-codex-sdk/package.json
+++ b/packages/logfire-agent-control-codex-sdk/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@openai/codex-sdk": ">=0.153.4 <1",
-    "@pydantic/logfire-node": "workspace:^0.18.24"
+    "@pydantic/logfire-node": "workspace:^"
   },
   "engines": {
     "node": ">=20"

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/baseline.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/baseline.test.ts
@@ -1,0 +1,177 @@
+/**
+ * What the Logfire editor is shown: the baseline this adapter publishes for a Codex agent.
+ *
+ * The exact JSON matters more here than in most tests. It is the document someone edits, so a block
+ * that is missing from it is a block nobody knows they can change, and a block whose text is
+ * published is text that anyone who can read the project can read.
+ */
+
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import { captureWarnings, settle, storedConfig, tempFile, uniqueName, useLocalVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('the published baseline', () => {
+  it('describes the writable blocks, the Codex-owned ones as seams, the model, and the effort', async () => {
+    const name = uniqueName()
+    useLocalVariables()
+    const managed = agentControl({
+      name,
+      codex: { config: { developer_instructions: 'Fix CI without changing public APIs.' } },
+      thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'medium', sandboxMode: 'workspace-write' },
+    })
+
+    const baseline = {
+      instructions: [
+        { id: 'developer_instructions', instructions: 'Fix CI without changing public APIs.', dynamic: false },
+        { id: 'host_skills', dynamic: true },
+        { id: 'permissions', dynamic: true },
+        { id: 'agents_md', dynamic: true },
+        { id: 'environment_context', dynamic: true },
+      ],
+      model: 'gpt-5.6-sol',
+      settings: { thinking: 'medium' },
+    }
+    expect(managed.baseline()).toEqual(baseline)
+    // No `tool_definitions`: Codex's tools are defined in the binary, and a section describing none
+    // of them would read as "this agent has no tools".
+    expect(Object.keys(managed.baseline())).toEqual(['instructions', 'model', 'settings'])
+
+    await settle()
+    const stored = storedConfig(`agent__${name}`)
+    expect(stored?.example).toBe(JSON.stringify(baseline, null, 2))
+    // Created with the contract's schema, which is what makes the variable editable in Logfire.
+    expect(stored?.json_schema).toBeDefined()
+  })
+
+  it('publishes the base prompt only when the code replaced it, and reads it off disk', () => {
+    const file = tempFile('base.md', 'You are a release bot.')
+    const managed = agentControl({
+      name: uniqueName(),
+      codex: { config: { model_instructions_file: file } },
+      publishBaseline: false,
+    })
+    expect(managed.baseline().instructions).toContainEqual({
+      id: 'base_instructions',
+      instructions: 'You are a release bot.',
+      dynamic: false,
+    })
+
+    // Nothing replaced it, so the built-in prompt is not offered as an empty box to overwrite.
+    const builtIn = agentControl({ name: uniqueName(), publishBaseline: false })
+    expect(JSON.stringify(builtIn.baseline())).not.toContain('base_instructions')
+  })
+
+  it('says so when the base prompt cannot be read, and publishes the rest', () => {
+    const managed = agentControl({
+      name: uniqueName(),
+      codex: { config: { model_instructions_file: 'no/such/base.md' } },
+      thread: { workingDirectory: '/tmp' },
+      publishBaseline: false,
+    })
+    expect(warnings.messages.join('\n')).toContain('/tmp/no/such/base.md')
+    expect(JSON.stringify(managed.baseline())).not.toContain('base_instructions')
+  })
+
+  it('leaves out a reasoning effort the contract cannot express', () => {
+    // Codex has `max`, `ultra`, and `persistent`; the contract's `thinking` does not, and a baseline
+    // carrying one would not validate against the schema the variable is created with.
+    const managed = agentControl({
+      name: uniqueName(),
+      thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'ultra' },
+      publishBaseline: false,
+    })
+    expect(managed.baseline().settings).toBeUndefined()
+    expect(managed.baseline().model).toBe('gpt-5.6-sol')
+  })
+
+  it('reports the provider the code pinned, not the default one', () => {
+    const managed = agentControl({
+      name: uniqueName(),
+      codex: { config: { model_provider: 'ollama' } },
+      thread: { model: 'qwen3' },
+      publishBaseline: false,
+    })
+    expect(managed.baseline().model).toBe('ollama:qwen3')
+  })
+
+  it('reads the model and the effort from `codex.config` when the thread names neither', () => {
+    const managed = agentControl({
+      name: uniqueName(),
+      // Where an agent that pins one model for every thread it starts writes it. Both keys lower to
+      // `-c` flags, so a baseline that only read `ThreadOptions` described this agent as having no
+      // model and no effort at all -- and publishing either one back would have looked like a change
+      // when it was the code all along.
+      codex: { config: { model: 'qwen3', model_provider: 'ollama', model_reasoning_effort: 'high' } },
+      publishBaseline: false,
+    })
+    expect(managed.baseline().model).toBe('ollama:qwen3')
+    expect(managed.baseline().settings).toEqual({ thinking: 'high' })
+  })
+
+  it('prefers the thread over `codex.config`, which is the order Codex applies them in', () => {
+    // `thread.model` becomes `--model`, which beats `-c model=`; `thread.modelReasoningEffort`
+    // becomes the last `-c model_reasoning_effort=` flag, and the last `-c` wins. Both verified
+    // against codex-cli 0.153.4.
+    const managed = agentControl({
+      name: uniqueName(),
+      codex: { config: { model: 'qwen3', model_reasoning_effort: 'high' } },
+      thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'low' },
+      publishBaseline: false,
+    })
+    expect(managed.baseline().model).toBe('gpt-5.6-sol')
+    expect(managed.baseline().settings).toEqual({ thinking: 'low' })
+  })
+
+  it('leaves out a `codex.config` effort the contract cannot express, and a model that is not a slug', () => {
+    const managed = agentControl({
+      name: uniqueName(),
+      codex: { config: { model: 42, model_reasoning_effort: 'persistent' } },
+      publishBaseline: false,
+    })
+    expect(managed.baseline().model).toBeUndefined()
+    expect(managed.baseline().settings).toBeUndefined()
+  })
+
+  it('publishes nothing at all for an agent whose options say nothing', () => {
+    const managed = agentControl({ name: uniqueName(), publishBaseline: false })
+    // Every block Codex owns is still a seam, so the editor can show what it cannot change.
+    expect(managed.baseline()).toEqual({
+      instructions: [
+        { id: 'host_skills', dynamic: true },
+        { id: 'permissions', dynamic: true },
+        { id: 'agents_md', dynamic: true },
+        { id: 'environment_context', dynamic: true },
+      ],
+    })
+  })
+
+  it('does not publish when asked not to', async () => {
+    const name = uniqueName()
+    useLocalVariables()
+    agentControl({ name, publishBaseline: false, thread: { model: 'gpt-5.6-sol' } })
+    await settle()
+    expect(storedConfig(`agent__${name}`)).toBeUndefined()
+  })
+})
+
+describe('the agent name', () => {
+  it('is required, because Codex has none of its own to derive one from', () => {
+    expect(() => agentControl({ name: '  ' })).toThrow(/needs an explicit `name`/u)
+    expect(() => agentControl({} as unknown as { name: string })).toThrow(/needs an explicit `name`/u)
+  })
+
+  it('picks out the agent variable, and carries the label and policy through', () => {
+    const managed = agentControl({
+      name: 'ci_fixer',
+      label: 'staging',
+      onUnmatched: 'ignore',
+      publishBaseline: false,
+    })
+    expect(managed.control.variableName).toBe('agent__ci_fixer')
+    expect(managed.control.label).toBe('staging')
+    expect(managed.control.onUnmatched).toBe('ignore')
+  })
+})

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/baseline.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/baseline.test.ts
@@ -6,6 +6,8 @@
  * published is text that anyone who can read the project can read.
  */
 
+import { dirname } from 'node:path'
+
 import { describe, expect, it } from 'vite-plus/test'
 
 import { agentControl } from '../index'
@@ -62,6 +64,30 @@ describe('the published baseline', () => {
     // Nothing replaced it, so the built-in prompt is not offered as an empty box to overwrite.
     const builtIn = agentControl({ name: uniqueName(), publishBaseline: false })
     expect(JSON.stringify(builtIn.baseline())).not.toContain('base_instructions')
+  })
+
+  it("expands a leading `~` the way Codex does, so a home-relative prompt is not 'unreadable'", () => {
+    // Codex reads `~/base.md`; `resolve` would have joined the `~` onto the working directory and
+    // this package would have warned about a file that is perfectly readable, and published a
+    // baseline missing the one block the agent replaced.
+    const file = tempFile('base.md', 'You are a release bot.')
+    const home = process.env['HOME']
+    process.env['HOME'] = dirname(file)
+    try {
+      const managed = agentControl({
+        name: uniqueName(),
+        codex: { config: { model_instructions_file: '~/base.md' } },
+        publishBaseline: false,
+      })
+      expect(managed.baseline().instructions).toContainEqual({
+        id: 'base_instructions',
+        instructions: 'You are a release bot.',
+        dynamic: false,
+      })
+      expect(warnings.messages).toEqual([])
+    } finally {
+      process.env['HOME'] = home
+    }
   })
 
   it('says so when the base prompt cannot be read, and publishes the rest', () => {

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/codex.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/codex.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The end of the pipe: a published config, through the real Codex SDK, to the flags a `codex`
+ * process is actually started with.
+ *
+ * Every other test here asserts on the options object this package returns. This one asserts on the
+ * argv of a child process, because the options object is only a claim about what the SDK will do
+ * with it -- `config` becomes dotted `--config` flags, `model` becomes `--model`, and
+ * `modelReasoningEffort` becomes a `--config` flag rather than a flag of its own. The stand-in
+ * binary never talks to a model; it records what it was given and prints a finished turn.
+ */
+
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import { argvCapture, captureWarnings, configOverrides, FAKE_CODEX, flag, publishedValue, uniqueName, useLocalVariables } from './helpers'
+
+captureWarnings()
+
+/** Run one turn against the fake binary and hand back the argv it saw. */
+async function runFake(managed: { startThread: () => Promise<{ run: (input: string) => Promise<{ finalResponse: string }> }> }) {
+  const capture = argvCapture()
+  process.env['FAKE_CODEX_ARGV'] = capture.path
+  const thread = await managed.startThread()
+  const turn = await thread.run('hello')
+  expect(turn.finalResponse).toBe('ok')
+  return capture.read()
+}
+
+describe('a managed Codex run', () => {
+  it('starts the binary with the published instructions, model, and reasoning effort', async () => {
+    const name = uniqueName()
+    useLocalVariables(
+      publishedValue(`agent__${name}`, {
+        instructions: [{ id: 'developer_instructions', instructions: 'Escalate anything over $500 to a human.' }, 'Never force-push.'],
+        model: 'openai:gpt-5.6-sol',
+        settings: { thinking: 'high' },
+      })
+    )
+    const managed = agentControl({
+      name,
+      codex: {
+        codexPathOverride: FAKE_CODEX,
+        config: { developer_instructions: 'Be terse.', sandbox_mode: 'read-only' },
+      },
+      thread: { model: 'gpt-5.5', modelReasoningEffort: 'low', skipGitRepoCheck: true },
+    })
+
+    const argv = await runFake(managed)
+
+    expect(argv[0]).toBe('exec')
+    expect(configOverrides(argv)).toEqual({
+      // The added block is joined onto the developer message, after the block it follows.
+      developer_instructions: '"Escalate anything over $500 to a human.\\n\\nNever force-push."',
+      // Untouched keys survive: this adapter patches a copy of the caller's config.
+      sandbox_mode: '"read-only"',
+      model_provider: '"openai"',
+      model_reasoning_effort: '"high"',
+    })
+    expect(flag(argv, '--model')).toBe('gpt-5.6-sol')
+  })
+
+  it('leaves the binary running on code when nothing is published', async () => {
+    const managed = agentControl({
+      name: uniqueName(),
+      codex: { codexPathOverride: FAKE_CODEX, config: { developer_instructions: 'Be terse.' } },
+      thread: { model: 'gpt-5.5', skipGitRepoCheck: true },
+    })
+
+    const argv = await runFake(managed)
+
+    expect(configOverrides(argv)).toEqual({ developer_instructions: '"Be terse."' })
+    expect(flag(argv, '--model')).toBe('gpt-5.5')
+  })
+
+  it('runs a whole thread inside the resolution the config came from', async () => {
+    const name = uniqueName()
+    useLocalVariables(publishedValue(`agent__${name}`, { instructions: 'Only touch the changelog.' }))
+    const managed = agentControl({
+      name,
+      codex: { codexPathOverride: FAKE_CODEX },
+      thread: { skipGitRepoCheck: true },
+    })
+    const capture = argvCapture()
+    process.env['FAKE_CODEX_ARGV'] = capture.path
+
+    const answer = await managed.run(async (thread) => (await thread.run('go')).finalResponse)
+
+    expect(answer).toBe('ok')
+    expect(configOverrides(capture.read())).toEqual({ developer_instructions: '"Only touch the changelog."' })
+  })
+
+  it('resumes a thread with the published config re-sent as flags', async () => {
+    const name = uniqueName()
+    useLocalVariables(publishedValue(`agent__${name}`, { settings: { thinking: 'minimal' } }))
+    const managed = agentControl({
+      name,
+      codex: { codexPathOverride: FAKE_CODEX },
+      thread: { skipGitRepoCheck: true },
+    })
+    const capture = argvCapture()
+    process.env['FAKE_CODEX_ARGV'] = capture.path
+
+    const thread = await managed.resumeThread('t_earlier')
+    await thread.run('and now the changelog')
+
+    const argv = capture.read()
+    expect(argv[0]).toBe('exec')
+    expect(flag(argv, 'resume')).toBe('t_earlier')
+    expect(configOverrides(argv)['model_reasoning_effort']).toBe('"minimal"')
+  })
+
+  it('clears a removed developer block on the command line rather than dropping the flag', async () => {
+    const name = uniqueName()
+    useLocalVariables(publishedValue(`agent__${name}`, { instructions: [{ id: 'developer_instructions', instructions: null }] }))
+    const managed = agentControl({
+      name,
+      codex: { codexPathOverride: FAKE_CODEX, config: { developer_instructions: 'Be terse.' } },
+      thread: { skipGitRepoCheck: true },
+    })
+
+    const argv = await runFake(managed)
+
+    // `developer_instructions=""` is on the command line, because a missing flag is not a removal:
+    // it is Codex falling back to the `developer_instructions` in the user's own `config.toml`.
+    expect(configOverrides(argv)).toEqual({ developer_instructions: '""' })
+  })
+
+  it('points the binary at a file holding a published base prompt', async () => {
+    const name = uniqueName()
+    useLocalVariables(
+      publishedValue(`agent__${name}`, {
+        instructions: [{ id: 'base_instructions', instructions: 'You are a release bot. Only edit CHANGELOG.md.' }],
+      })
+    )
+    const managed = agentControl({
+      name,
+      codex: { codexPathOverride: FAKE_CODEX },
+      thread: { skipGitRepoCheck: true },
+    })
+
+    const argv = await runFake(managed)
+
+    const file = configOverrides(argv)['model_instructions_file']
+    expect(file).toMatch(/^".*\.md"$/u)
+    const { readFileSync } = await import('node:fs')
+    expect(readFileSync(JSON.parse(file as string) as string, 'utf8')).toBe('You are a release bot. Only edit CHANGELOG.md.')
+  })
+})

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/helpers.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/helpers.ts
@@ -1,0 +1,137 @@
+/**
+ * Test scaffolding: a local variables provider, captured warnings, and the fake `codex` binary.
+ *
+ * Everything is offline. Variables come from the Logfire SDK's `LocalVariableProvider`, which
+ * implements the same interface the remote one does, and the `codex` process is a Node script that
+ * records its argv -- so the two things this package does, reading a published value and turning it
+ * into CLI flags, are both exercised end to end with no network and no API key.
+ */
+
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { resetAgentControl } from '@pydantic/logfire-node/agent-control/testing'
+import { configureVariables, getVariableProvider } from '@pydantic/logfire-node/vars'
+import type { VariableConfig, VariablesConfig } from '@pydantic/logfire-node/vars'
+import { afterEach, beforeEach, vi } from 'vite-plus/test'
+
+/** The stand-in `codex` binary, made executable here so a fresh clone does not depend on file modes. */
+export const FAKE_CODEX: string = join(dirname(fileURLToPath(import.meta.url)), '../../test-fixtures/fake-codex.ts')
+chmodSync(FAKE_CODEX, 0o755)
+
+/**
+ * A distinct agent name per call.
+ *
+ * `resetAgentControl` clears the core's once-per-process guards between tests, but two agents that
+ * share a name also share a variable, and several tests here run two at once on purpose.
+ */
+let counter = 0
+export function uniqueName(prefix = 'agent'): string {
+  counter += 1
+  return `${prefix}_${String(counter)}`
+}
+
+/** A variables config in which `name` holds `value` under one label at full rollout. */
+export function publishedValue(name: string, value: unknown, label = 'production'): VariablesConfig {
+  return {
+    variables: {
+      [name]: {
+        name,
+        labels: { [label]: { version: 1, serialized_value: JSON.stringify(value) } },
+        rollout: { labels: { [label]: 1 } },
+        overrides: [],
+      },
+    },
+  }
+}
+
+/** Point the SDK at a local provider holding `config`. */
+export function useLocalVariables(config: VariablesConfig = { variables: {} }): void {
+  configureVariables({ config, instrument: false })
+}
+
+/** Switch variables off entirely, which installs the no-op provider. */
+export function useNoVariables(): void {
+  configureVariables(false)
+}
+
+/** Read a variable's stored definition back out of the local provider. */
+export function storedConfig(name: string): VariableConfig | undefined {
+  return getVariableProvider().getVariableConfig?.(name) as VariableConfig | undefined
+}
+
+/**
+ * Capture `console.warn` for the duration of each test, starting from no variables at all.
+ *
+ * The core's warning memory and baseline-publish guard are per process by design, so each test
+ * starts from a process that has done neither -- through the same `@pydantic/logfire-node/agent-control/testing`
+ * entry point this package tells adapter authors to use.
+ */
+export function captureWarnings(): { messages: string[] } {
+  const captured: { messages: string[] } = { messages: [] }
+  beforeEach(() => {
+    captured.messages.length = 0
+    resetAgentControl()
+    useNoVariables()
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+      captured.messages.push(String(message))
+    })
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    useNoVariables()
+  })
+  return captured
+}
+
+/** Wait for the background baseline publish to settle. */
+export async function settle(): Promise<void> {
+  await Promise.all(Array.from({ length: 5 }, async () => Promise.resolve()))
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+/** A temporary file holding `contents`, for the tests that need a real path on disk. */
+export function tempFile(name: string, contents: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'agent-control-test-')), name)
+  writeFileSync(path, contents, 'utf8')
+  return path
+}
+
+/** Where the fake binary writes what it was given, and the reader for it. */
+export function argvCapture(): { path: string; read: () => string[] } {
+  const path = join(mkdtempSync(join(tmpdir(), 'agent-control-argv-')), 'argv.json')
+  return { path, read: () => JSON.parse(readFileSync(path, 'utf8')) as string[] }
+}
+
+/**
+ * The `--config key=value` overrides in an argv, in order, as a mapping.
+ *
+ * Values are left exactly as the SDK serialized them -- TOML literals, so strings keep their quotes
+ * -- because that is what the assertion is about: `developer_instructions="Be terse."` is the flag
+ * the binary parses, and a test that compared unquoted text would not notice the SDK changing how it
+ * serializes one.
+ */
+export function configOverrides(argv: readonly string[]): Record<string, string> {
+  const overrides: Record<string, string> = {}
+  for (const [index, argument] of argv.entries()) {
+    if (argument !== '--config') {
+      continue
+    }
+    const pair = argv[index + 1] ?? ''
+    const equals = pair.indexOf('=')
+    if (equals !== -1) {
+      overrides[pair.slice(0, equals)] = pair.slice(equals + 1)
+    }
+  }
+  return overrides
+}
+
+/** The value of a flag such as `--model`, or `undefined` when the argv does not carry it. */
+export function flag(argv: readonly string[], name: string): string | undefined {
+  const index = argv.indexOf(name)
+  return index === -1 ? undefined : argv[index + 1]
+}

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/instructions.test.ts
@@ -39,7 +39,10 @@ describe('a managed base prompt on disk', () => {
     expect(existsSync(first)).toBe(false)
   })
 
-  it('fails loudly when the prompt cannot be written at all', () => {
+  // Root ignores the directory mode this test relies on, so a suite run as root -- which a
+  // container often is -- would see the write succeed and the assertion fail. The behaviour under
+  // test is unprivileged behaviour; skipping is honest, and CI runs unprivileged.
+  it.skipIf(process.getuid?.() === 0)('fails loudly when the prompt cannot be written at all', () => {
     const path = writeBaseInstructions('You are a release bot.')
     const directory = dirname(path)
     // Not an already-written file this time but a directory nothing may write to, which is the

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/instructions.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The pieces with a life of their own: the temp file a managed base prompt lives in, and the model
+ * string the contract and Codex disagree about the shape of.
+ */
+
+import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+import { describe, expect, it } from 'vite-plus/test'
+
+import { removeBaseInstructions, writeBaseInstructions } from '../instructions'
+import { agentControl } from '../index'
+import { joinModel, splitModel } from '../model'
+import { captureWarnings, publishedValue, uniqueName, useLocalVariables } from './helpers'
+
+captureWarnings()
+
+describe('a managed base prompt on disk', () => {
+  it('is written once per distinct text and cleaned up at exit', () => {
+    // Nothing written yet, so there is nothing to clean up and saying so is not an error: this is
+    // what the `exit` handler does in a process that never published a base prompt.
+    removeBaseInstructions()
+
+    const first = writeBaseInstructions('You are a release bot.')
+    const other = writeBaseInstructions('You are a changelog bot.')
+    expect(other).not.toBe(first)
+    expect(dirname(other)).toBe(dirname(first))
+
+    // Written *once*, not rewritten with the same bytes: the path is content-addressed, so a second
+    // application of the same prompt must not truncate a file a `codex` process spawned by another
+    // thread may be reading right now. A marker written over the file survives, which nothing but
+    // leaving the file alone can do -- comparing the two paths would pass either way.
+    writeFileSync(first, 'MARKER', 'utf8')
+    const again = writeBaseInstructions('You are a release bot.')
+    expect(again).toBe(first)
+    expect(readFileSync(first, 'utf8')).toBe('MARKER')
+
+    removeBaseInstructions()
+    expect(existsSync(first)).toBe(false)
+  })
+
+  it('fails loudly when the prompt cannot be written at all', () => {
+    const path = writeBaseInstructions('You are a release bot.')
+    const directory = dirname(path)
+    // Not an already-written file this time but a directory nothing may write to, which is the
+    // difference between "Codex already has this prompt" and "Codex will not be given this prompt".
+    chmodSync(directory, 0o500)
+    try {
+      expect(() => writeBaseInstructions('You are a changelog bot.')).toThrow(/EACCES/u)
+    } finally {
+      chmodSync(directory, 0o700)
+      removeBaseInstructions()
+    }
+  })
+})
+
+describe('the model string', () => {
+  it('comes apart at the first colon and goes back together the same way', () => {
+    expect(splitModel('openai:gpt-5.6-sol')).toEqual({ provider: 'openai', model: 'gpt-5.6-sol' })
+    expect(splitModel('openrouter:openai/gpt-5:beta')).toEqual({
+      provider: 'openrouter',
+      model: 'openai/gpt-5:beta',
+    })
+    expect(joinModel({ model: 'gpt-5.6-sol', provider: undefined })).toBe('gpt-5.6-sol')
+    expect(joinModel({ model: 'qwen3', provider: 'ollama' })).toBe('ollama:qwen3')
+  })
+
+  it('is a bare slug when a colon has nothing on one side of it', () => {
+    // Neither is a provider-qualified model, whatever it was meant to be, and resolving a provider
+    // id of `''` would silently point the run at nothing.
+    expect(splitModel('gpt-5.6-sol')).toEqual({ provider: undefined, model: 'gpt-5.6-sol' })
+    expect(splitModel('openai:')).toEqual({ provider: undefined, model: 'openai:' })
+    expect(splitModel(':gpt-5.6-sol')).toEqual({ provider: undefined, model: ':gpt-5.6-sol' })
+  })
+
+  it('names no provider the code does not pin', () => {
+    const name = uniqueName()
+    useLocalVariables(publishedValue(`agent__${name}`, {}))
+    const agent = agentControl({
+      name,
+      // A `-c model_provider=...` that is not a string is not a provider id, so the code pins none.
+      // Codex resolves the slug against a `config.toml` this package cannot read, and inventing
+      // `openai` would both describe an identity the run need not have and, echoed back by an
+      // editor, change the provider it was only meant to describe.
+      codex: { config: { model_provider: 42 } },
+      thread: { model: 'gpt-5.5' },
+      publishBaseline: false,
+    })
+    expect(agent.baseline().model).toBe('gpt-5.5')
+  })
+})

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/resolve.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/resolve.test.ts
@@ -308,8 +308,14 @@ describe('when the agent is running on code', () => {
 
     expect(codex).toEqual(code.codex)
     expect(thread).toEqual({ model: 'gpt-5.5', skipGitRepoCheck: true, sandboxMode: 'read-only' })
-    // A copy, so a caller that edits what it got back does not edit the agent.
+    // A copy all the way down, so a caller that edits what it got back does not edit the agent.
+    // The `config` object is the one that matters: it is where every key this contract touches
+    // lives, and a shallow copy of the options around it would have shared it.
     expect(codex).not.toBe(code.codex)
+    expect(codex.config).not.toBe(code.codex?.config)
+    codex.config = { ...codex.config, developer_instructions: 'Edited by the caller.' }
+    const again = await agent.resolveOptions()
+    expect(again.codex.config).toEqual({ developer_instructions: 'Be terse.' })
     expect(warnings.messages).toEqual([])
   })
 

--- a/packages/logfire-agent-control-codex-sdk/src/__test__/resolve.test.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/__test__/resolve.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Applying a published config to the caller's options: what lands, what is refused, and what is
+ * reported because Codex has nowhere to put it.
+ */
+
+import { readFileSync } from 'node:fs'
+
+import { UnmatchedConfigError } from '@pydantic/logfire-node/agent-control'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import type { CodexAgentControlOptions } from '../index'
+import { captureWarnings, publishedValue, tempFile, uniqueName, useLocalVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+/** A managed agent whose variable holds `config`. */
+function managed(config: unknown, options: Omit<CodexAgentControlOptions, 'name'> = {}) {
+  const name = uniqueName()
+  useLocalVariables(publishedValue(`agent__${name}`, config))
+  return agentControl({ name, publishBaseline: false, ...options })
+}
+
+describe('instructions', () => {
+  it('replaces the developer block and joins added blocks onto it', async () => {
+    const agent = managed(
+      {
+        instructions: [{ id: 'developer_instructions', instructions: 'Escalate anything over $500.' }, 'Never force-push.'],
+      },
+      { codex: { config: { developer_instructions: 'Be terse.' } } }
+    )
+
+    const { codex } = await agent.resolveOptions()
+
+    expect(codex.config).toEqual({ developer_instructions: 'Escalate anything over $500.\n\nNever force-push.' })
+  })
+
+  it('adds a developer block to an agent whose code passes none', async () => {
+    const agent = managed({ instructions: 'Always run the tests before you push.' })
+    const { codex } = await agent.resolveOptions()
+    expect(codex.config).toEqual({ developer_instructions: 'Always run the tests before you push.' })
+  })
+
+  it('clears the developer block explicitly when the published config removes it', async () => {
+    const agent = managed(
+      { instructions: [{ id: 'developer_instructions', instructions: null }] },
+      { codex: { config: { developer_instructions: 'Be terse.', sandbox_mode: 'read-only' } } }
+    )
+
+    const { codex } = await agent.resolveOptions()
+
+    // An empty override rather than a dropped key. Dropping the `-c` flag would not remove the
+    // developer message, it would hand the decision back to the machine's `config.toml`, whose own
+    // `developer_instructions` would then reach the model instead. `developer_instructions=""` is
+    // what Codex reads as "none" (verified against codex-cli 0.153.4). Everything else the caller
+    // configured is untouched either way.
+    expect(codex.config).toEqual({ developer_instructions: '', sandbox_mode: 'read-only' })
+  })
+
+  it('leaves the key alone for an agent that never set developer instructions', async () => {
+    // Nothing was removed here -- the block is empty because the code says nothing -- so nothing is
+    // sent, and a `developer_instructions` in the user's own `config.toml` still applies.
+    const agent = managed({ settings: { thinking: 'high' } })
+    const { codex } = await agent.resolveOptions()
+    expect(codex.config).toEqual({})
+  })
+
+  it('keeps an added block when the developer block itself is removed', async () => {
+    const agent = managed(
+      { instructions: [{ id: 'developer_instructions', instructions: null }, 'Never force-push.'] },
+      { codex: { config: { developer_instructions: 'Be terse.' } } }
+    )
+    const { codex } = await agent.resolveOptions()
+    expect(codex.config).toEqual({ developer_instructions: 'Never force-push.' })
+  })
+
+  it('writes a published base prompt to a file and points Codex at it', async () => {
+    const agent = managed({ instructions: [{ id: 'base_instructions', instructions: 'You are a release bot.' }] })
+    const { codex } = await agent.resolveOptions()
+    const file = codex.config?.['model_instructions_file']
+    expect(typeof file).toBe('string')
+    expect(readFileSync(file as string, 'utf8')).toBe('You are a release bot.')
+
+    // The same text resolves to the same file, rather than filling the temp directory up.
+    const again = await agent.resolveOptions()
+    expect(again.codex.config?.['model_instructions_file']).toBe(file)
+  })
+
+  it('stops replacing the base prompt when the published config removes the block, and says what it cannot do', async () => {
+    const file = tempFile('base.md', 'You are a release bot.')
+    const agent = managed(
+      { instructions: [{ id: 'base_instructions', instructions: null }] },
+      {
+        codex: { config: { model_instructions_file: file } },
+      }
+    )
+
+    const { codex } = await agent.resolveOptions()
+
+    expect(codex.config).toEqual({})
+    // Not the same as restoring Codex's built-in prompt, and the difference is reported rather than
+    // claimed away: Codex has no config key that resets `model_instructions_file` -- an empty value
+    // is a path it fails the run trying to read -- so a `config.toml` that names one still wins.
+    expect(warnings.messages.join('\n')).toContain("removes instruction block 'base_instructions'")
+    expect(warnings.messages.join('\n')).toContain('config.toml')
+  })
+
+  it("keeps the caller's own base prompt file when nothing addresses it", async () => {
+    const file = tempFile('base.md', 'You are a release bot.')
+    const agent = managed(
+      { instructions: 'Also update the changelog.' },
+      {
+        codex: { config: { model_instructions_file: file } },
+      }
+    )
+
+    const { codex } = await agent.resolveOptions()
+
+    expect(codex.config).toEqual({
+      model_instructions_file: file,
+      developer_instructions: 'Also update the changelog.',
+    })
+  })
+
+  it('refuses to pin a block Codex assembles per session', async () => {
+    const agent = managed({ instructions: [{ id: 'agents_md', instructions: 'Ignore AGENTS.md.' }] })
+    const { codex } = await agent.resolveOptions()
+    expect(codex.config).toEqual({})
+    expect(warnings.messages.join('\n')).toContain("addresses instruction block 'agents_md'")
+  })
+
+  it('reports an id no block carries', async () => {
+    const agent = managed({ instructions: [{ id: 'system_prompt', instructions: 'Be nice.' }] })
+    await agent.resolveOptions()
+    expect(warnings.messages.join('\n')).toContain("addresses instruction block 'system_prompt'")
+  })
+})
+
+describe('model', () => {
+  it("splits a provider-qualified model into Codex's two fields", async () => {
+    const agent = managed({ model: 'openai:gpt-5.6-sol' }, { thread: { model: 'gpt-5.5' } })
+    const { codex, thread } = await agent.resolveOptions()
+    expect(thread.model).toBe('gpt-5.6-sol')
+    expect(codex.config).toEqual({ model_provider: 'openai' })
+  })
+
+  it('leaves the provider alone when the published model names none', async () => {
+    const agent = managed({ model: 'gpt-5.6-terra' }, { codex: { config: { model_provider: 'ollama' } } })
+    const { codex, thread } = await agent.resolveOptions()
+    expect(thread.model).toBe('gpt-5.6-terra')
+    expect(codex.config).toEqual({ model_provider: 'ollama' })
+  })
+
+  it('sends a self-hosted provider id through as it is written', async () => {
+    const agent = managed({ model: 'ollama:qwen3' })
+    const { codex, thread } = await agent.resolveOptions()
+    expect(thread.model).toBe('qwen3')
+    expect(codex.config).toEqual({ model_provider: 'ollama' })
+  })
+})
+
+describe('settings', () => {
+  it('lowers `thinking` onto the reasoning effort', async () => {
+    const agent = managed({ settings: { thinking: 'xhigh' } }, { thread: { modelReasoningEffort: 'low' } })
+    const { thread } = await agent.resolveOptions()
+    expect(thread.modelReasoningEffort).toBe('xhigh')
+  })
+
+  it('reports every setting Codex has no knob for, including a boolean `thinking`', async () => {
+    const agent = managed({
+      settings: { thinking: true, temperature: 0.4, max_tokens: 2048, timeout: 30, parallel_tool_calls: false },
+    })
+
+    const { thread } = await agent.resolveOptions()
+
+    expect(thread.modelReasoningEffort).toBeUndefined()
+    const reported = warnings.messages.join('\n')
+    for (const key of ['thinking', 'temperature', 'max_tokens', 'timeout', 'parallel_tool_calls']) {
+      expect(reported).toContain(`Managed agent config sets '${key}'`)
+    }
+  })
+})
+
+describe('tool definitions', () => {
+  it('reports every override, because Codex defines its tools in the binary', async () => {
+    const agent = managed({
+      tool_definitions: [{ name: 'shell', new_name: 'run_command', description: 'Run a command.' }],
+    })
+
+    const { codex, thread } = await agent.resolveOptions()
+
+    expect(codex.config).toEqual({})
+    expect(thread).toEqual({})
+    expect(warnings.messages.join('\n')).toContain("patches tool 'shell'")
+  })
+})
+
+describe('the `onUnmatched` policy', () => {
+  it('fails the run under `error`', async () => {
+    const agent = managed({ settings: { temperature: 0.4 } }, { onUnmatched: 'error' })
+    await expect(agent.resolveOptions()).rejects.toThrow(UnmatchedConfigError)
+  })
+
+  it('says nothing under `ignore`', async () => {
+    const agent = managed({ settings: { temperature: 0.4 }, tool_definitions: [{ name: 'nothing_at_all' }] }, { onUnmatched: 'ignore' })
+    await agent.resolveOptions()
+    expect(warnings.messages).toEqual([])
+  })
+})
+
+describe('precedence', () => {
+  it('lets a per-thread override win over the published config', async () => {
+    const agent = managed(
+      { model: 'openai:gpt-5.6-sol', settings: { thinking: 'high' } },
+      { thread: { model: 'gpt-5.5', sandboxMode: 'read-only' } }
+    )
+
+    const { thread } = await agent.resolveOptions({ model: 'gpt-6-astra', modelReasoningEffort: 'minimal' })
+
+    expect(thread).toEqual({
+      model: 'gpt-6-astra',
+      modelReasoningEffort: 'minimal',
+      sandboxMode: 'read-only',
+    })
+  })
+
+  it('lets the published config win over the options the agent was built with', async () => {
+    const agent = managed(
+      { model: 'ollama:qwen3', settings: { thinking: 'high' } },
+      { codex: { config: { model_provider: 'openai' } }, thread: { model: 'gpt-5.5', modelReasoningEffort: 'low' } }
+    )
+
+    const { codex, thread } = await agent.resolveOptions()
+
+    expect(thread).toEqual({ model: 'qwen3', modelReasoningEffort: 'high' })
+    expect(codex.config).toEqual({ model_provider: 'ollama' })
+  })
+
+  it('keeps the published provider out when the model it qualified lost to a per-thread one', async () => {
+    const agent = managed({ model: 'ollama:qwen3' }, { codex: { config: { model_provider: 'openai' } }, thread: { model: 'gpt-5.5' } })
+
+    const { codex, thread } = await agent.resolveOptions({ model: 'gpt-6-astra' })
+
+    // The provider travels with the model it qualifies. Applying `ollama` to a thread that asked for
+    // an OpenAI model would send this call to somebody else's endpoint under a model slug that
+    // provider has never heard of -- a worse outcome than either value on its own.
+    expect(thread.model).toBe('gpt-6-astra')
+    expect(codex.config).toEqual({ model_provider: 'openai' })
+  })
+
+  it('applies the published provider when the code, not the call, named the model', async () => {
+    const agent = managed({ model: 'ollama:qwen3' }, { thread: { model: 'gpt-5.5' } })
+    const { codex, thread } = await agent.resolveOptions({ sandboxMode: 'read-only' })
+    expect(thread.model).toBe('qwen3')
+    expect(codex.config).toEqual({ model_provider: 'ollama' })
+  })
+})
+
+describe('two agents running at once', () => {
+  it('keep their own options and their own published config', async () => {
+    // Nothing about applying a config is held on the instance between calls, so interleaving two
+    // agents -- or two calls on one -- cannot leak one's model, prompt, or provider into the other.
+    const first = uniqueName()
+    const second = uniqueName()
+    useLocalVariables({
+      variables: {
+        ...publishedValue(`agent__${first}`, {
+          model: 'ollama:qwen3',
+          instructions: [{ id: 'developer_instructions', instructions: 'Only Rust.' }],
+        }).variables,
+        ...publishedValue(`agent__${second}`, { settings: { thinking: 'minimal' } }).variables,
+      },
+    })
+    const one = agentControl({
+      name: first,
+      publishBaseline: false,
+      codex: { config: { developer_instructions: 'Be terse.' } },
+      thread: { model: 'gpt-5.5' },
+    })
+    const two = agentControl({
+      name: second,
+      publishBaseline: false,
+      codex: { config: { developer_instructions: 'Ship it.' } },
+      thread: { model: 'gpt-6-astra' },
+    })
+
+    const [a, b] = await Promise.all([one.resolveOptions(), two.resolveOptions({ modelReasoningEffort: 'xhigh' })])
+
+    expect(a.thread).toEqual({ model: 'qwen3' })
+    expect(a.codex.config).toEqual({ developer_instructions: 'Only Rust.', model_provider: 'ollama' })
+    expect(b.thread).toEqual({ model: 'gpt-6-astra', modelReasoningEffort: 'xhigh' })
+    expect(b.codex.config).toEqual({ developer_instructions: 'Ship it.' })
+  })
+})
+
+describe('when the agent is running on code', () => {
+  it('hands back the options it was given, plus the overrides', async () => {
+    const code: CodexAgentControlOptions = {
+      name: uniqueName(),
+      codex: { config: { developer_instructions: 'Be terse.' } },
+      thread: { model: 'gpt-5.5', skipGitRepoCheck: true },
+      publishBaseline: false,
+    }
+    useLocalVariables()
+    const agent = agentControl(code)
+
+    const { codex, thread } = await agent.resolveOptions({ sandboxMode: 'read-only' })
+
+    expect(codex).toEqual(code.codex)
+    expect(thread).toEqual({ model: 'gpt-5.5', skipGitRepoCheck: true, sandboxMode: 'read-only' })
+    // A copy, so a caller that edits what it got back does not edit the agent.
+    expect(codex).not.toBe(code.codex)
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('says so once when Logfire holds a value it cannot make sense of', async () => {
+    const name = uniqueName()
+    useLocalVariables({
+      variables: {
+        [`agent__${name}`]: {
+          name: `agent__${name}`,
+          labels: { production: { version: 1, serialized_value: '{"model": 12}' } },
+          rollout: { labels: { production: 1 } },
+          overrides: [],
+        },
+      },
+    })
+    const agent = agentControl({ name, publishBaseline: false, thread: { model: 'gpt-5.5' } })
+
+    const { thread } = await agent.resolveOptions()
+
+    expect(thread.model).toBe('gpt-5.5')
+    expect(warnings.messages.join('\n')).toContain('model')
+  })
+})

--- a/packages/logfire-agent-control-codex-sdk/src/index.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Logfire Agent Control for the OpenAI Codex SDK.
+ *
+ * Wrap the options you already pass to `new Codex(...)` and `startThread(...)`, give the agent a
+ * name, and its developer instructions, its base prompt, its model, and its reasoning effort become
+ * editable in Logfire without a deploy:
+ *
+ * ```ts
+ * const managed = agentControl({ name: 'ci_fixer', thread: { model: 'gpt-5.6-sol' } });
+ * const answer = await managed.run(async (thread) => (await thread.run('Fix the failing job.')).finalResponse);
+ * ```
+ *
+ * What is *not* here is as much of the point. Codex assembles its prompt and defines its tools
+ * inside the `codex` binary, so nothing published can rename a tool, reword one, or set a
+ * temperature; every such value is reported through the core's `onUnmatched` policy instead of being
+ * dropped where nobody would see it. See the README for the full table.
+ */
+
+export { BASE_INSTRUCTIONS_ID, CODEX_OWNED_BLOCK_IDS, DEVELOPER_INSTRUCTIONS_ID } from './instructions'
+
+export { agentControl, ManagedCodex } from './managed'
+export type { CodexAgentControlOptions, ManagedCodexConfiguration } from './managed'

--- a/packages/logfire-agent-control-codex-sdk/src/instructions.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/instructions.ts
@@ -19,7 +19,7 @@
 
 import { createHash } from 'node:crypto'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 import type { InstructionBlock } from '@pydantic/logfire-node/agent-control'
@@ -86,7 +86,7 @@ export function codeInstructions(codex: CodexOptions | undefined, thread: Thread
 }
 
 function readBaseInstructions(file: string, workingDirectory: string | undefined): string {
-  const path = resolve(workingDirectory ?? process.cwd(), file)
+  const path = resolve(workingDirectory ?? process.cwd(), expandTilde(file))
   try {
     return readFileSync(path, 'utf8')
   } catch (error) {
@@ -98,6 +98,25 @@ function readBaseInstructions(file: string, workingDirectory: string | undefined
     )
     return ''
   }
+}
+
+/**
+ * Expand a leading `~` the way Codex does before it reads the file.
+ *
+ * The binary expands `~` and `~/` in `model_instructions_file` to the home directory: verified
+ * against codex-cli 0.153.4, which reads a `~/prompt.md` that exists and fails with `failed to read
+ * model instructions file` on one that does not. `resolve` would instead join `~` onto the working
+ * directory, so without this a path Codex reads perfectly well would be reported here as unreadable
+ * and its text left out of the baseline. `~user` is not expanded, which is also what Codex does.
+ */
+function expandTilde(file: string): string {
+  if (file === '~') {
+    return homedir()
+  }
+  if (file.startsWith('~/')) {
+    return join(homedir(), file.slice(2))
+  }
+  return file
 }
 
 /**

--- a/packages/logfire-agent-control-codex-sdk/src/instructions.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/instructions.ts
@@ -1,0 +1,267 @@
+/**
+ * Codex's prompt as instruction blocks, and the two config keys those blocks come back down to.
+ *
+ * Codex assembles the prompt inside the Rust binary and labels every piece of it with a kind
+ * (`developer_instructions`, `agents_md`, `permissions`, ...). Those labels are the block ids here,
+ * because they are the names Codex itself uses and the only ones a reader of `codex debug
+ * prompt-input` would recognize. Exactly two of them are text a caller can set:
+ *
+ * - `base_instructions` -- Codex's built-in system prompt, replaced wholesale by pointing
+ *   `model_instructions_file` at a file.
+ * - `developer_instructions` -- an extra developer message injected into the session.
+ *
+ * Everything else Codex assembles is `dynamic: true`: skills, the permissions preamble, the
+ * `AGENTS.md` chain, and the environment context are read off the machine and the repository at
+ * session start, so a managed value could only pin one machine's rendering. The core refuses to
+ * address a dynamic block, which is why they are listed at all -- an entry naming one gets a warning
+ * that says the block is Codex's to compute, rather than "no such block".
+ */
+
+import { createHash } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import type { InstructionBlock } from '@pydantic/logfire-node/agent-control'
+import type { CodexOptions, ThreadOptions } from '@openai/codex-sdk'
+
+/**
+ * The `config` object Codex lowers to `--config key=value` overrides.
+ *
+ * Named off `CodexOptions` rather than imported: the SDK declares the type but does not export it,
+ * and deriving it is how this package stays right about it across SDK versions.
+ */
+export type CodexConfig = NonNullable<CodexOptions['config']>
+
+/** The id of the block that stands for Codex's whole system prompt. */
+export const BASE_INSTRUCTIONS_ID = 'base_instructions'
+/** The id of the one developer block a caller can set. */
+export const DEVELOPER_INSTRUCTIONS_ID = 'developer_instructions'
+
+/**
+ * The Codex config key each writable block lowers to.
+ *
+ * `model_instructions_file` takes a path rather than text, which is why a managed base prompt is
+ * written to a file; `experimental_instructions_file` is its deprecated spelling and is deliberately
+ * not read here.
+ */
+export const BASE_INSTRUCTIONS_KEY = 'model_instructions_file'
+/** The Codex config key `developer_instructions` blocks lower to. */
+export const DEVELOPER_INSTRUCTIONS_KEY = 'developer_instructions'
+
+/**
+ * The blocks Codex assembles that nothing here can set, in the order the model sees them.
+ *
+ * `host_skills` and `permissions` share the developer message with `developer_instructions`;
+ * `agents_md` and `environment_context` come later, in a user message. Order matters because the
+ * core lands an added block before the first dynamic one -- which puts it at the end of the
+ * developer message, next to the block it is a sibling of, and never in front of a cached prefix.
+ */
+export const CODEX_OWNED_BLOCK_IDS = ['host_skills', 'permissions', 'agents_md', 'environment_context'] as const
+
+/** The text of the two writable blocks, as the caller's own options define them. */
+export interface CodeInstructions {
+  /** The base prompt the caller replaced Codex's built-in one with, or `''` for the built-in one. */
+  base: string
+  /** The caller's developer instructions, or `''` when they set none. */
+  developer: string
+}
+
+/**
+ * Read the two writable blocks out of the options the caller would have passed to `new Codex(...)`.
+ *
+ * The base prompt is a *path* in the caller's options, so its text has to be read off disk to be
+ * shown in a baseline. It is resolved against the thread's `workingDirectory`, since that is the cwd
+ * the Codex process will resolve it against. A file that cannot be read is not an error: the run is
+ * Codex's to fail or not, and all that is lost here is the baseline showing the text.
+ */
+export function codeInstructions(codex: CodexOptions | undefined, thread: ThreadOptions | undefined): CodeInstructions {
+  const config = codex?.config
+  const developer = config?.[DEVELOPER_INSTRUCTIONS_KEY]
+  const file = config?.[BASE_INSTRUCTIONS_KEY]
+  return {
+    base: typeof file === 'string' ? readBaseInstructions(file, thread?.workingDirectory) : '',
+    developer: typeof developer === 'string' ? developer : '',
+  }
+}
+
+function readBaseInstructions(file: string, workingDirectory: string | undefined): string {
+  const path = resolve(workingDirectory ?? process.cwd(), file)
+  try {
+    return readFileSync(path, 'utf8')
+  } catch (error) {
+    console.warn(
+      // `String(error)` rather than an `instanceof Error` dance: `readFileSync` throws an Error and
+      // nothing else, and its `Error: ENOENT: ...` rendering is exactly what says which file it was.
+      `Could not read the base instructions at '${path}' (${String(error)}); Codex will still be pointed at ` +
+        'it, but the baseline published to Logfire will not show its text.'
+    )
+    return ''
+  }
+}
+
+/**
+ * The blocks a managed config is applied to, in the order Codex sends them.
+ *
+ * A writable block with no text is still listed, so a published entry that names it lands instead of
+ * being reported as an id nothing carries. The core drops a blank static block from the baseline on
+ * its own, so listing it here costs nothing there -- which is deliberate for `base_instructions`: an
+ * agent that has not replaced Codex's built-in prompt should not be shown an empty box inviting
+ * someone to replace it, but should still honor the id when an expert publishes one.
+ *
+ * Codex's own blocks are listed with empty text, which is the truth about them: they are assembled
+ * inside the binary and the seam is all this adapter can see. The core publishes a dynamic block's
+ * id and never its text, and keeps such a block on its id alone, so empty text costs it nothing --
+ * the editor still learns that the block exists and that it is not anyone's to change.
+ */
+export function instructionBlocks(code: CodeInstructions): InstructionBlock[] {
+  return [
+    { id: BASE_INSTRUCTIONS_ID, text: code.base, dynamic: false },
+    { id: DEVELOPER_INSTRUCTIONS_ID, text: code.developer, dynamic: false },
+    ...CODEX_OWNED_BLOCK_IDS.map((id) => ({ id, text: '', dynamic: true })),
+  ]
+}
+
+/** The two writable blocks after a managed config was applied. */
+export interface AppliedCodexInstructions {
+  /**
+   * The developer message text; `''` when there is none to send, `null` when the published config
+   * *removed* the block.
+   *
+   * The two empties are different instructions to give Codex, which is why they are different
+   * values. `''` is an agent whose code sets no developer instructions and whose managed config says
+   * nothing about them, and it leaves the key alone. `null` is someone deleting the block in
+   * Logfire, which has to be sent as an explicit empty override -- see `withInstructions`.
+   */
+  developer: string | null
+  /** The base prompt, or `null` when the published config removed it. */
+  base: string | null
+}
+
+/**
+ * Fold applied blocks back into the two texts Codex takes.
+ *
+ * Blocks the managed config *added* carry no id, and there is exactly one place in Codex's prompt
+ * for text that is not the system prompt, so they are joined onto the developer message in the order
+ * the core placed them. Joining rather than dropping is the whole reason an id-less entry is worth
+ * supporting here: it is how someone adds a rule to an agent whose code passes no developer
+ * instructions at all.
+ *
+ * A block the core dropped is gone from `blocks` entirely, which is how removal is told apart from a
+ * block that is simply empty.
+ */
+export function foldInstructions(blocks: readonly InstructionBlock[]): AppliedCodexInstructions {
+  const developer = blocks
+    .filter((block) => block.id === DEVELOPER_INSTRUCTIONS_ID || block.id === null)
+    .map((block) => block.text)
+    .filter((text) => text.trim() !== '')
+    .join('\n\n')
+  const removed = !blocks.some((block) => block.id === DEVELOPER_INSTRUCTIONS_ID)
+  const base = blocks.find((block) => block.id === BASE_INSTRUCTIONS_ID)
+  return {
+    developer: developer === '' && removed ? null : developer,
+    base: base === undefined ? null : base.text,
+  }
+}
+
+/**
+ * The directory managed base prompts are written to, created on first use.
+ *
+ * Codex takes the base prompt as a path, and the file has to outlive every `codex exec` the thread
+ * spawns, so it lives for the process rather than for the call. One directory per process, mode 0700
+ * from `mkdtemp`, one file per distinct text so a config that resolves to the same prompt on every
+ * run does not fill it up.
+ */
+let instructionsDirectory: string | undefined
+
+/**
+ * Write a managed base prompt where Codex can read it, and return the path.
+ *
+ * Written **once** per distinct text, and never rewritten: the path is content-addressed, so a file
+ * that exists already holds exactly this text, and a `codex` process started for another thread may
+ * be reading that path right now. `writeFileSync` truncates before it writes, and nothing about a
+ * synchronous call in this process stops an independent child process from reading the empty file in
+ * between -- so the write is exclusive (`wx`), and an already-existing file is the success case
+ * rather than a reason to write again.
+ */
+export function writeBaseInstructions(text: string): string {
+  if (instructionsDirectory === undefined) {
+    instructionsDirectory = mkdtempSync(join(tmpdir(), 'logfire-agent-control-'))
+    process.once('exit', removeBaseInstructions)
+  }
+  const path = join(instructionsDirectory, `${createHash('sha256').update(text).digest('hex').slice(0, 16)}.md`)
+  try {
+    // Mode 0600 on a file in a shared temp directory: the prompt is the agent's, not the machine's.
+    writeFileSync(path, text, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+  } catch (error) {
+    // Anything else -- a directory that has been removed, a full or read-only filesystem -- is a
+    // prompt Codex will not be given, and pointing it at a path that does not hold this text would
+    // be worse than saying so.
+    if (!exists(error)) {
+      throw error
+    }
+  }
+  return path
+}
+
+/** Whether a failed exclusive write failed because the file was already there. */
+function exists(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'EEXIST'
+}
+
+/**
+ * Remove the directory written base prompts live in.
+ *
+ * Registered on `exit` rather than after each run, because the file has to still be there when Codex
+ * reads it and nothing here knows when the last thread is done with it.
+ */
+export function removeBaseInstructions(): void {
+  if (instructionsDirectory === undefined) {
+    return
+  }
+  rmSync(instructionsDirectory, { recursive: true, force: true })
+  instructionsDirectory = undefined
+}
+
+/**
+ * Lower applied instructions onto a copy of the caller's Codex config.
+ *
+ * The caller's own config is the base, so every key they set that this contract says nothing about
+ * -- `sandbox_mode`, `mcp_servers`, `model_verbosity` -- survives untouched.
+ *
+ * The two keys are lowered differently, because Codex offers a reset for one of them and not the
+ * other. Dropping a `-c` override does not restore a default: it exposes whatever the user's
+ * `config.toml` says, which this package cannot read. So a *removed* developer block is sent as
+ * `developer_instructions=""`, which Codex reads as "no developer instructions" and which beats the
+ * config file (verified against `codex debug prompt-input` on codex-cli 0.153.4: the block leaves the
+ * developer message entirely). `model_instructions_file` has no such spelling -- an empty value is a
+ * path, and Codex fails the run trying to read it -- so removing the base block can only stop *this*
+ * package from overriding the prompt. `ManagedCodex` reports that gap under `onUnmatched`.
+ */
+export function withInstructions(config: CodexConfig | undefined, applied: AppliedCodexInstructions, code: CodeInstructions): CodexConfig {
+  let lowered: CodexConfig = { ...config }
+  if (applied.developer === null) {
+    lowered[DEVELOPER_INSTRUCTIONS_KEY] = ''
+  } else if (applied.developer === '') {
+    lowered = withoutKey(lowered, DEVELOPER_INSTRUCTIONS_KEY)
+  } else {
+    lowered[DEVELOPER_INSTRUCTIONS_KEY] = applied.developer
+  }
+
+  if (applied.base === null) {
+    lowered = withoutKey(lowered, BASE_INSTRUCTIONS_KEY)
+  } else if (applied.base !== code.base) {
+    lowered[BASE_INSTRUCTIONS_KEY] = writeBaseInstructions(applied.base)
+  }
+  return lowered
+}
+
+/**
+ * A copy of a Codex config with one key gone.
+ *
+ * Rebuilt rather than `delete`d: a Codex config is an index signature, so removing a key from it is
+ * a dynamic delete, and building the copy says the same thing without one.
+ */
+function withoutKey(config: CodexConfig, key: string): CodexConfig {
+  return Object.fromEntries(Object.entries(config).filter(([name]) => name !== key))
+}

--- a/packages/logfire-agent-control-codex-sdk/src/managed.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/managed.ts
@@ -1,0 +1,363 @@
+/**
+ * The adapter itself: the caller's Codex options in, the same options with the managed config
+ * applied out.
+ *
+ * The Codex SDK is a wrapper around the `codex` binary, not an agent framework. There is no agent
+ * object to patch, no tool registry, and no per-model-request hook to install: everything the model
+ * sees is assembled inside the binary from `config.toml`, the `-c key=value` overrides the SDK
+ * forwards, and files on disk. The only seam is therefore the options themselves, and the moment the
+ * managed config can be applied is the moment a thread is started -- which is why this is a factory
+ * over options rather than a middleware.
+ *
+ * That also fixes what is manageable. Instructions (the two writable blocks), the model, and the
+ * reasoning effort lower onto real Codex knobs. Sampling settings and tool definitions have no
+ * Codex-side equivalent at all, so a published value for them is reported rather than applied.
+ */
+
+import {
+  AgentControl,
+  applyInstructions,
+  applySettings,
+  buildBaseline,
+  CANONICAL_SETTINGS_KEYS,
+  mergeSettings,
+  reportUnapplied,
+  useResolution,
+} from '@pydantic/logfire-node/agent-control'
+import type { AgentConfig, AgentConfigSettings, OnUnmatched } from '@pydantic/logfire-node/agent-control'
+import { Codex } from '@openai/codex-sdk'
+import type { CodexOptions, ModelReasoningEffort, Thread, ThreadOptions } from '@openai/codex-sdk'
+
+import { BASE_INSTRUCTIONS_ID, codeInstructions, foldInstructions, instructionBlocks, withInstructions } from './instructions'
+import type { CodeInstructions } from './instructions'
+import { joinModel, splitModel } from './model'
+
+/**
+ * The contract's `thinking` values, minus the `true`/`false` Codex has no meaning for.
+ *
+ * Every one of them is also a `ModelReasoningEffort`, which is why applying `thinking` needs no
+ * translation table -- and if a later release of the contract adds a value Codex does not have, this
+ * type stops assigning and the mismatch is a compile error rather than a bad `-c` flag.
+ */
+type ReasoningThinking = Exclude<NonNullable<AgentConfigSettings['thinking']>, boolean>
+
+/**
+ * The Codex reasoning efforts the contract has a `thinking` value for.
+ *
+ * The other direction, and partial in the other direction too: Codex's `max`, `ultra`, and
+ * `persistent` have no `thinking` value, so an agent whose code asks for one of them keeps it and
+ * simply does not publish it as a baseline -- publishing a value the stored schema rejects would put
+ * an uneditable `settings` section in front of whoever opens the editor.
+ */
+const CONTRACT_THINKING: Partial<Record<ModelReasoningEffort, ReasoningThinking>> = {
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+}
+
+/** The Codex config key that names the provider a model slug is looked up under. */
+const MODEL_PROVIDER_KEY = 'model_provider'
+/** The Codex config key that names the model, for an agent that sets it there rather than per thread. */
+const MODEL_KEY = 'model'
+/** The Codex config key that names the reasoning effort, likewise. */
+const MODEL_REASONING_EFFORT_KEY = 'model_reasoning_effort'
+
+/** How a Codex agent's Agent Control is set up. */
+export interface CodexAgentControlOptions {
+  /**
+   * The agent's name, which picks out the `agent__<name>` Logfire variable holding its config.
+   *
+   * Required and never inferred: Codex has no agent identity of its own to derive one from, and a
+   * name that is guessed at is a name two agents can collide on. It is normalized to the variable
+   * key by the core's one rule, so `ci_fixer` and `CI Fixer` are the same config.
+   */
+  name: string
+  /** The options the code would have passed to `new Codex(...)`. */
+  codex?: CodexOptions
+  /** The options the code would have passed to `startThread(...)` / `resumeThread(...)`. */
+  thread?: ThreadOptions
+  /** Read this label instead of letting the variable's rollout choose one. */
+  label?: string
+  /** What to do about a published entry Codex has nowhere to put: `'warn'` (default), `'ignore'`, `'error'`. */
+  onUnmatched?: OnUnmatched
+  /** Whether to publish the code-side baseline to the variable's `example`. On by default. */
+  publishBaseline?: boolean
+}
+
+/** Codex options with the managed config applied, ready to be handed to the SDK. */
+export interface ManagedCodexConfiguration {
+  /** What to pass to `new Codex(...)`. */
+  codex: CodexOptions
+  /** What to pass to `startThread(...)` or `resumeThread(...)`. */
+  thread: ThreadOptions
+}
+
+/**
+ * One Codex agent's options, managed from Logfire.
+ *
+ * ```ts
+ * const managed = agentControl({
+ *   name: 'ci_fixer',
+ *   thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'medium', sandboxMode: 'workspace-write' },
+ *   codex: { config: { developer_instructions: 'Fix CI without changing public APIs.' } },
+ * });
+ * const answer = await managed.run(async (thread) => (await thread.run('Fix the failing job.')).finalResponse);
+ * ```
+ *
+ * The published config is read once per thread, when the thread is started, because that is the last
+ * moment Codex accepts any of it. A turn on an already-started thread runs with what its thread was
+ * started with; start a new thread to pick up a change.
+ *
+ * `run(fn)` is the form to reach for: it starts the thread and holds the resolution's telemetry
+ * context open for the whole callback, so the spans your code opens around the turn say which
+ * published label drove it. `startThread` and `resumeThread` are the same application of the config
+ * without that scope -- they return an object, so the context is closed by the time you use it --
+ * and `resolveOptions` is the way out for code that builds its own `Codex`.
+ */
+export class ManagedCodex {
+  /** The Logfire variable behind this agent, exposed for its `name`, `label`, and `onUnmatched`. */
+  readonly control: AgentControl
+
+  readonly #codex: CodexOptions
+  readonly #thread: ThreadOptions
+  readonly #code: CodeInstructions
+
+  constructor(options: CodexAgentControlOptions) {
+    const { name } = options
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new Error(
+        '`agentControl` needs an explicit `name`: it is what picks out the `agent__<name>` Logfire variable ' +
+          "holding this agent's managed config, and Codex has no agent name of its own to derive one from."
+      )
+    }
+    this.control = new AgentControl(name, {
+      ...(options.label === undefined ? {} : { label: options.label }),
+      ...(options.onUnmatched === undefined ? {} : { onUnmatched: options.onUnmatched }),
+      ...(options.publishBaseline === undefined ? {} : { publishBaseline: options.publishBaseline }),
+    })
+    this.#codex = options.codex ?? {}
+    this.#thread = options.thread ?? {}
+    this.#code = codeInstructions(options.codex, options.thread)
+    // Everything a Codex agent is, it is at construction: there is no request to wait for and no
+    // tool list to discover, so the baseline is complete now and the Logfire editor can have it
+    // before the first run rather than after it. `'code'` and not `'observed'` for the same reason
+    // -- it is read off the options the code passes, not off a request that happened first.
+    this.control.publishBaseline(this.baseline(), { source: 'code' })
+  }
+
+  /**
+   * The `AgentConfig` describing this agent as its code defines it.
+   *
+   * Published to the variable's `example`, which is what the Logfire editor shows a managed value
+   * being layered onto. Only the blocks whose text this adapter actually knows carry any: Codex's
+   * built-in prompt, its skills, its permissions preamble, the `AGENTS.md` chain, and the
+   * environment context are assembled inside the binary, so they are published as seams -- and the
+   * built-in prompt is not published at all, since an empty box labelled `base_instructions` is an
+   * invitation to replace the instructions that tell Codex how to use its own tools.
+   *
+   * The model and the reasoning effort are read wherever the code sets them: `ThreadOptions` first,
+   * because the SDK sends `thread.model` as `--model` and its effort as the last `-c` flag, both of
+   * which beat the `config` keys; and `codex.config` otherwise, which is how an agent that pins its
+   * model once for every thread writes it. What is *not* read is the machine's `config.toml`, so an
+   * agent whose code names no model publishes none rather than a guess.
+   *
+   * There is no `tool_definitions` section, because Codex's tools are defined in the binary and this
+   * adapter cannot see or change them.
+   */
+  baseline(): AgentConfig {
+    const model = this.#codeModel()
+    const thinking = contractThinking(this.#codeReasoningEffort())
+    return buildBaseline({
+      instructions: instructionBlocks(this.#code),
+      ...(model === undefined ? {} : { model: joinModel({ model, provider: this.#codeProvider() }) }),
+      settings: thinking === undefined ? {} : { thinking },
+    })
+  }
+
+  /**
+   * The caller's options with the published config applied.
+   *
+   * `overrides` are `ThreadOptions` for this thread only, and they win over the published config,
+   * which wins over the options this `ManagedCodex` was built with. Per-call values beating a
+   * managed value is the contract's precedence rule, and it is what keeps a `workingDirectory` or a
+   * `signal` computed per call from being second-guessed by something published a week ago.
+   *
+   * The resolution's telemetry context covers the application of the config and closes when this
+   * returns, because what comes back is an object rather than a scope; `run` is the form whose
+   * context covers the turn itself.
+   *
+   * When the agent is running on code -- nothing published, Logfire unreachable, variables switched
+   * off -- the caller's own options come back merged with `overrides` and nothing else, so a Logfire
+   * outage is indistinguishable from this package not being installed.
+   */
+  async resolveOptions(overrides: ThreadOptions = {}): Promise<ManagedCodexConfiguration> {
+    const resolution = await this.control.resolution()
+    // Resolved once and installed for the work that reads it, rather than resolved again inside it:
+    // the config applied and the label its warnings and spans carry are then the same one.
+    return useResolution(resolution, () => this.#apply(resolution.config, overrides))
+  }
+
+  /**
+   * Start a thread with the published config applied and run `fn` with it, inside the resolution's
+   * telemetry context.
+   *
+   * The form to reach for when the whole thread is a unit you can wrap, because every span opened
+   * inside `fn` carries the label the config was resolved under. A `codex` child process is not
+   * something this package can instrument, but the spans your own code opens around a turn are, and
+   * they are what tell "this agent regressed" apart from "this agent regressed on the value someone
+   * published at 14:02".
+   *
+   * ```ts
+   * const answer = await managed.run(async (thread) => (await thread.run('Fix the failing job.')).finalResponse);
+   * ```
+   *
+   * The `thread` is the SDK's own, so a second `thread.run(...)` inside `fn` is a second turn on the
+   * options this one resolved; call `run` again for a thread that reads the config again.
+   */
+  async run<T>(fn: (thread: Thread) => Promise<T>, overrides: ThreadOptions = {}): Promise<T> {
+    return this.control.run(async ({ config }) => {
+      const { codex, thread } = this.#apply(config, overrides)
+      return fn(new Codex(codex).startThread(thread))
+    })
+  }
+
+  /**
+   * The pure half of `resolveOptions`: one resolved config, applied to the caller's options.
+   *
+   * Separate so `run` can apply the config it was handed *inside* the resolution's context instead of
+   * resolving a second time and possibly getting a different label.
+   */
+  #apply(config: AgentConfig | null, overrides: ThreadOptions): ManagedCodexConfiguration {
+    if (config === null) {
+      return { codex: { ...this.#codex }, thread: { ...this.#thread, ...overrides } }
+    }
+    const onUnmatched = this.control.onUnmatched
+
+    const applied = foldInstructions(applyInstructions(instructionBlocks(this.#code), config, { onUnmatched }).blocks)
+    if (applied.base === null) {
+      // Removing this block stops *this* package from replacing Codex's system prompt, which is as
+      // far as the CLI lets it go: there is no `-c` value that resets `model_instructions_file`, and
+      // an empty one is a path Codex fails the run trying to read.
+      this.control.reportUnmatched(
+        `Managed agent config removes instruction block '${BASE_INSTRUCTIONS_ID}'. This agent stops replacing ` +
+          "Codex's built-in system prompt, but Codex has no config key that resets one, so a " +
+          "'model_instructions_file' in the machine's own config.toml would still replace it."
+      )
+    }
+    const codex: CodexOptions = { ...this.#codex, config: withInstructions(this.#codex.config, applied, this.#code) }
+
+    const settings = applySettings(config, { onUnmatched })
+    const published: ThreadOptions = {}
+    if (config.model !== undefined) {
+      published.model = splitModel(config.model).model
+    }
+    if (typeof settings.thinking === 'string') {
+      published.modelReasoningEffort = settings.thinking
+    }
+    // The contract's precedence, from the core rather than from a spread, because the answer to
+    // "who set this" is what the model provider below turns on: `overrides` are the keys this call
+    // set explicitly, so a run that picks its own model is telling this adapter something a run that
+    // inherited one is not.
+    const merged = mergeSettings(this.#thread, published, overrides)
+    // A cast because `mergeSettings` is framework-neutral and hands back a flat record; every key in
+    // it came from a `ThreadOptions` this method was given or wrote.
+    const thread = merged.settings as ThreadOptions
+
+    // The provider travels with the model it qualifies, and only with it. A published
+    // `openai:gpt-5.6-sol` that lost the model to an explicit per-thread one must not leave its
+    // `model_provider` behind, or this call sends the caller's model to somebody else's endpoint.
+    if (config.model !== undefined && merged.sources.get('model') === 'published') {
+      // Left alone when the published model names no provider, so an agent pointed at a self-hosted
+      // provider in `config.toml` keeps it when someone publishes only a model slug.
+      const { provider } = splitModel(config.model)
+      if (provider !== undefined) {
+        codex.config = { ...codex.config, [MODEL_PROVIDER_KEY]: provider }
+      }
+    }
+
+    // Everything else the contract can carry -- the sampling settings, `max_tokens`, `timeout`,
+    // `parallel_tool_calls`, and a `thinking` of `true`/`false` -- has no Codex config key at all,
+    // so it is reported rather than quietly dropped. Codex is a coding-agent runtime: what it
+    // exposes is reasoning effort, not a sampler.
+    reportUnapplied(unapplicableSettings(settings), { onUnmatched })
+    // Codex's tools are defined inside the binary and are never sent by a client, so there is no
+    // list to patch and no rename to route back -- and saying that outright is better than letting a
+    // match against an empty tool list report it as a tool this deployment happens not to advertise.
+    for (const override of config.tool_definitions ?? []) {
+      this.control.reportUnmatched(
+        `Managed agent config patches tool '${override.name}', which Codex defines inside its own binary; ` +
+          "a Codex tool's name, description, and parameters cannot be managed from Logfire."
+      )
+    }
+
+    return { codex, thread }
+  }
+
+  /** Start a Codex thread with the published config applied; see `resolveOptions`. */
+  async startThread(overrides: ThreadOptions = {}): Promise<Thread> {
+    const { codex, thread } = await this.resolveOptions(overrides)
+    return new Codex(codex).startThread(thread)
+  }
+
+  /**
+   * Resume a Codex thread with the published config applied; see `resolveOptions`.
+   *
+   * The overrides are re-sent as `-c` flags on the `codex exec resume` process, and Codex takes some
+   * of them and not others. A published model and reasoning effort apply to the resumed turn; a
+   * changed developer block does **not** -- the binary replays the developer message it persisted
+   * with the session, and the flag is ignored. Both observed against codex-cli 0.153.4 and pinned by
+   * `live-tests/codex.live.ts`. So a published instruction change is something new threads pick up.
+   */
+  async resumeThread(id: string, overrides: ThreadOptions = {}): Promise<Thread> {
+    const { codex, thread } = await this.resolveOptions(overrides)
+    return new Codex(codex).resumeThread(id, thread)
+  }
+
+  /** The model slug the code runs on, from whichever of the two places it set one. */
+  #codeModel(): string | undefined {
+    return this.#thread.model ?? stringOf(this.#codex.config?.[MODEL_KEY])
+  }
+
+  /** The reasoning effort the code runs on, likewise. */
+  #codeReasoningEffort(): string | undefined {
+    return this.#thread.modelReasoningEffort ?? stringOf(this.#codex.config?.[MODEL_REASONING_EFFORT_KEY])
+  }
+
+  /** The provider id the code pins, if it pins one. */
+  #codeProvider(): string | undefined {
+    return stringOf(this.#codex.config?.[MODEL_PROVIDER_KEY])
+  }
+}
+
+/**
+ * Manage a Codex agent's instructions, model, and reasoning effort from Logfire.
+ *
+ * A function rather than a bare `new` so the one line a user adds reads like the SDK's own idiom;
+ * see `ManagedCodex`.
+ */
+export function agentControl(options: CodexAgentControlOptions): ManagedCodex {
+  return new ManagedCodex(options)
+}
+
+/** The contract's `thinking` value for a Codex reasoning effort, when it has one. */
+function contractThinking(effort: string | undefined): ReasoningThinking | undefined {
+  // Looked up by iteration rather than by index so a value read out of a `config.toml`-shaped object
+  // -- an arbitrary string -- can be matched against the table without being asserted into its key
+  // type first, and so the table itself keeps the exhaustiveness check that makes a new contract
+  // value a compile error.
+  return Object.entries(CONTRACT_THINKING).find(([codex]) => codex === effort)?.[1]
+}
+
+/** A Codex config value when it is a string, which is all a model or provider id can be. */
+function stringOf(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+/** The canonical settings a published value set that Codex has no knob for. */
+function unapplicableSettings(settings: AgentConfigSettings): string[] {
+  return CANONICAL_SETTINGS_KEYS.filter(
+    (key) => settings[key] !== undefined && !(key === 'thinking' && typeof settings.thinking === 'string')
+  )
+}

--- a/packages/logfire-agent-control-codex-sdk/src/managed.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/managed.ts
@@ -231,7 +231,14 @@ export class ManagedCodex {
    */
   #apply(config: AgentConfig | null, overrides: ThreadOptions): ManagedCodexConfiguration {
     if (config === null) {
-      return { codex: { ...this.#codex }, thread: { ...this.#thread, ...overrides } }
+      // `config` is copied too, not just the options object around it. The managed path below builds
+      // a fresh one, and a caller that edits what it got back must not be editing this agent's own
+      // options on the run where nothing was published either.
+      const codex: CodexOptions = { ...this.#codex }
+      if (codex.config !== undefined) {
+        codex.config = { ...codex.config }
+      }
+      return { codex, thread: { ...this.#thread, ...overrides } }
     }
     const onUnmatched = this.control.onUnmatched
 

--- a/packages/logfire-agent-control-codex-sdk/src/model.ts
+++ b/packages/logfire-agent-control-codex-sdk/src/model.ts
@@ -1,0 +1,52 @@
+/**
+ * Translating between the contract's `provider:model` string and Codex's two separate fields.
+ *
+ * Codex takes a bare model slug (`gpt-5.6-sol`) plus a `model_provider` id that indexes into the
+ * user's `model_providers` table in `config.toml`. The contract's `model` is one string, so an
+ * adapter is where the two halves come apart and go back together.
+ */
+
+/** A model as Codex takes it: the slug, and the provider id it is looked up under. */
+export interface CodexModel {
+  /** The bare model slug, e.g. `gpt-5.6-sol`. */
+  model: string
+  /** The `model_provider` id, or `undefined` to leave whatever the user's config says in place. */
+  provider: string | undefined
+}
+
+/**
+ * Split a contract `model` string into Codex's model slug and provider id.
+ *
+ * Split at the *first* colon, because a provider id never contains one while a model slug can
+ * (`openrouter:openai/gpt-5` is one provider and one slug, and some gateways use colons in slugs).
+ *
+ * A string with nothing on one side of the colon is not a provider-qualified model, whatever it was
+ * meant to be, so it is passed through as a bare slug: Codex then fails on an unknown model, which
+ * says what happened, rather than this silently resolving a provider id of `''`.
+ */
+export function splitModel(model: string): CodexModel {
+  const colon = model.indexOf(':')
+  if (colon === -1) {
+    return { model, provider: undefined }
+  }
+  const provider = model.slice(0, colon)
+  const slug = model.slice(colon + 1)
+  if (provider === '' || slug === '') {
+    return { model, provider: undefined }
+  }
+  return { model: slug, provider }
+}
+
+/**
+ * Join Codex's two fields back into the contract's `model` string for a baseline.
+ *
+ * A model whose provider the code does not pin comes back as a bare slug, because that is all this
+ * package knows. Codex resolves an unqualified model against the `model_provider` in a `config.toml`
+ * on the machine the agent runs on, which is not a file the SDK reads -- so naming `openai` here
+ * would put an identity in front of the editor that the run need not have, and a published value
+ * echoing it back would then *change* the provider it was only meant to describe. A bare slug
+ * round-trips instead: publishing it leaves whatever the machine resolves alone.
+ */
+export function joinModel({ model, provider }: CodexModel): string {
+  return provider === undefined ? model : `${provider}:${model}`
+}

--- a/packages/logfire-agent-control-codex-sdk/test-fixtures/fake-codex.ts
+++ b/packages/logfire-agent-control-codex-sdk/test-fixtures/fake-codex.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// A stand-in for the `codex` binary: records the argv and the prompt it was given, then emits the
+// minimal JSONL turn the SDK needs to consider the run finished.
+//
+// This is the whole reason the option mapping can be proven offline. Everything this adapter does
+// ends up as `--config key=value` and `--model` flags on a child process, so a binary that writes
+// its argv to a file is a complete, honest assertion target -- with no API key, no network, and no
+// model involved.
+//
+// TypeScript rather than JavaScript, and run through the shebang above: Node strips the types on its
+// own, and being a `.ts` file inside the package's `tsconfig.json` is what puts this file under the
+// same typecheck and type-aware lint as everything else here.
+import { writeFileSync } from 'node:fs'
+
+writeFileSync(process.env['FAKE_CODEX_ARGV'] ?? '', JSON.stringify(process.argv.slice(2)), 'utf8')
+
+let prompt = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => {
+  prompt += String(chunk)
+})
+process.stdin.on('end', () => {
+  const promptFile = process.env['FAKE_CODEX_PROMPT']
+  if (promptFile !== undefined) {
+    writeFileSync(promptFile, prompt, 'utf8')
+  }
+  for (const event of [
+    { type: 'thread.started', thread_id: 't_fake' },
+    { type: 'turn.started' },
+    { type: 'item.completed', item: { id: 'm1', type: 'agent_message', text: 'ok' } },
+    {
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 1,
+        cached_input_tokens: 0,
+        cache_write_input_tokens: 0,
+        output_tokens: 1,
+        reasoning_output_tokens: 0,
+      },
+    },
+  ]) {
+    process.stdout.write(`${JSON.stringify(event)}\n`)
+  }
+})

--- a/packages/logfire-agent-control-codex-sdk/tsconfig.json
+++ b/packages/logfire-agent-control-codex-sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "test-fixtures", "vite.config.ts", "vite.live.config.ts"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/logfire-agent-control-codex-sdk/vite.config.ts
+++ b/packages/logfire-agent-control-codex-sdk/vite.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vite-plus'
+
+import { packageDefines } from '../../vite.shared'
+
+const defines = packageDefines(import.meta.url)
+
+const config: ReturnType<typeof defineConfig> = defineConfig({
+  define: defines,
+  pack: {
+    define: defines,
+    dts: {
+      resolver: 'tsc',
+    },
+    deps: {
+      neverBundle: [/^node:/u, '@openai/codex-sdk', '@pydantic/logfire-node', '@pydantic/logfire-node/agent-control'],
+    },
+    entry: 'src/index.ts',
+    // ESM only, unlike every other package here: `@openai/codex-sdk` publishes no `require`
+    // condition, so a CommonJS build of this adapter would be a build that cannot load its own peer.
+    format: ['esm'],
+    minify: true,
+    // `.js` and `.d.ts` rather than the `.mjs` default an ESM-only build would otherwise take, so
+    // the file names match every other package here; `"type": "module"` already makes `.js` ESM.
+    outExtensions: () => ({ dts: '.d.ts', js: '.js' }),
+    outputOptions: {
+      exports: 'named',
+    },
+  },
+  test: {
+    // Starting a `codex` process -- the stand-in binary in the offline suite, the real one in
+    // `live-tests` -- is slower than an in-process assertion, and slower again on a loaded CI runner.
+    testTimeout: 20_000,
+  },
+})
+
+export default config

--- a/packages/logfire-agent-control-codex-sdk/vite.live.config.ts
+++ b/packages/logfire-agent-control-codex-sdk/vite.live.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite-plus'
+
+/**
+ * The live suite: real `codex` processes against a real model, run by hand.
+ *
+ * Kept out of `vp test` by its own config and its own `.live.ts` suffix -- the same way
+ * `@pydantic/logfire-session-replay` keeps its Playwright specs out with `.pw.ts` -- so CI stays
+ * offline by construction rather than by a skip nobody notices went permanent. Run it with
+ * `vp run @pydantic/logfire-agent-control-codex-sdk#test:live` on a machine where `codex` is
+ * installed and logged in; see `live-tests/README.md`.
+ */
+const config: ReturnType<typeof defineConfig> = defineConfig({
+  test: {
+    include: ['live-tests/**/*.live.ts'],
+    // A real turn on a real model, and three of them in one file.
+    testTimeout: 300_000,
+    hookTimeout: 300_000,
+    fileParallelism: false,
+  },
+})
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@openai/codex-sdk':
+      specifier: ^0.153.4
+      version: 0.153.4
     '@opentelemetry/api':
       specifier: ^1.9.1
       version: 1.9.1
@@ -427,6 +430,21 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+
+  packages/logfire-agent-control-codex-sdk:
+    devDependencies:
+      '@openai/codex-sdk':
+        specifier: 'catalog:'
+        version: 0.153.4
+      '@pydantic/logfire-node':
+        specifier: workspace:*
+        version: link:../logfire-node
+      '@types/node':
+        specifier: ^22.5.1
+        version: 22.19.5
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(@vitest/browser-preview@4.1.9)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
 
   packages/logfire-api:
     dependencies:
@@ -1418,6 +1436,51 @@ packages:
   '@next/swc-win32-x64-msvc@16.3.0':
     resolution: {integrity: sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==}
     engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@openai/codex-sdk@0.153.4':
+    resolution: {integrity: sha512-z0rN8WMQxwEHYHpDJyKHZwNNUtM/1pdnxmKopIJ3qMCZyyDestaIhSGDZ0v0RSjm+REujcFyNd95oWs78zWgRg==}
+    engines: {node: '>=18'}
+
+  '@openai/codex@0.153.4':
+    resolution: {integrity: sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.153.4-darwin-arm64':
+    resolution: {integrity: sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.153.4-darwin-x64':
+    resolution: {integrity: sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.153.4-linux-arm64':
+    resolution: {integrity: sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.153.4-linux-x64':
+    resolution: {integrity: sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.153.4-win32-arm64':
+    resolution: {integrity: sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.153.4-win32-x64':
+    resolution: {integrity: sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ==}
+    engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
@@ -3689,10 +3752,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -4498,6 +4557,37 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@16.3.0':
+    optional: true
+
+  '@openai/codex-sdk@0.153.4':
+    dependencies:
+      '@openai/codex': 0.153.4
+
+  '@openai/codex@0.153.4':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.153.4-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.153.4-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.153.4-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.153.4-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.153.4-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.153.4-win32-x64'
+
+  '@openai/codex@0.153.4-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.153.4-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.153.4-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.153.4-linux-x64':
+    optional: true
+
+  '@openai/codex@0.153.4-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.153.4-win32-x64':
     optional: true
 
   '@opentelemetry/api-logs@0.219.0':
@@ -7085,8 +7175,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.1.2: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.16:
@@ -7226,7 +7314,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
+      tinyexec: 1.3.0
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@22.19.5)(esbuild@0.28.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ overrides:
   'vitest': '4.1.9'
 
 catalog:
+  '@openai/codex-sdk': ^0.153.4
   '@opentelemetry/api': ^1.9.1
   '@opentelemetry/api-logs': '>=0.219.0 <0.300.0'
   '@opentelemetry/auto-instrumentations-node': '>=0.77.0 <0.100.0'


### PR DESCRIPTION
Stacked on #321. Base is `agent-control-core`; it will retarget to `main` when the core merges.

## What this is

The Agent Control adapter for the [Codex SDK](https://developers.openai.com/codex/sdk). Wrap the options you already pass to `new Codex(...)` and `startThread(...)`, give the agent a name, and its developer instructions, its base prompt, its model, and its reasoning effort become editable from the Logfire UI without a deploy.

```bash
npm install @pydantic/logfire-agent-control-codex-sdk @openai/codex-sdk @pydantic/logfire-node
```

```ts
const managed = agentControl({
  name: 'ci_fixer',
  codex: { config: { developer_instructions: 'Fix CI without changing public APIs.' } },
  thread: { model: 'gpt-5.6-sol', modelReasoningEffort: 'medium', sandboxMode: 'workspace-write' },
})

const answer = await managed.run(async (thread) => (await thread.run('Fix the failing job.')).finalResponse)
```

`run` is the form to reach for: it holds the resolution's telemetry context open for the callback, so the spans your own code opens around the turn say which published label drove it. `startThread`, `resumeThread` and `resolveOptions` apply the same config without that scope, and `baseline()` returns the document describing your code without publishing it.

What is *not* here is as much of the point. Codex is a process wrapper, not an in-process agent framework: everything the model sees is assembled inside the `codex` binary from `config.toml`, the `-c key=value` overrides the SDK forwards, and files on disk. So there is no agent object to patch, no tool registry, and no per-model-request hook — the only seam is the options themselves. This is the case the core PR named as the reason a dynamic block has to be publishable with an id and no text.

## What becomes editable

| Published | Applies as | Support |
| --- | --- | --- |
| `developer_instructions` block | `-c developer_instructions=` | **Yes.** Removing it sends `developer_instructions=""`, because a *dropped* flag is not a removal — it hands the decision back to the machine's `config.toml`. |
| an entry with no `id` | joined onto the developer message | **Yes**, after your own text and before the first dynamic block, so nothing moves ahead of a cached prefix. Works for an agent whose code sets no developer instructions at all. |
| `base_instructions` block | `-c model_instructions_file=` pointing at a private temp file | **Conditional.** Replaces Codex's *entire* built-in system prompt. In the baseline only when your code already sets `model_instructions_file`. |
| `model` | the `--model` slug plus `-c model_provider=` | **Yes.** `openai:gpt-5.6-sol` splits in two; a bare slug leaves your provider alone. |
| `settings.thinking` | `-c model_reasoning_effort=` | **Conditional.** `minimal`/`low`/`medium`/`high`/`xhigh`; `true`/`false` is reported. Codex's own `max`, `ultra`, `persistent` are outside the contract, so an agent that uses one keeps it and does not publish it. |
| `agents_md`, `host_skills`, `permissions`, `environment_context` | — | **No.** Assembled inside the binary per session. Published as seams so the editor can show they exist. |
| every other `settings` key | — | **No.** Codex exposes a reasoning effort, not a sampler. |
| `tool_definitions` | — | **No.** Codex defines its tools inside its own binary. |

Every "No" row is reported through the control's `onUnmatched` policy rather than dropped in silence, so Logfire never shows a value the agent is quietly ignoring.

**What your code sees on a rename: nothing, because renames do not exist here.** A `tool_definitions` entry is reported and no tool is renamed — `shell`, `apply_patch`, `update_plan`, web search and MCP tools are defined in the binary and never sent by a client — so the question of whether your code, your hooks, or a resumed session sees the old name or the new one never arises. Saying that outright is better than matching against an empty tool list, which would report it as a tool this deployment happens not to advertise.

## When the config applies

**Per thread, at thread start**, because that is the last moment Codex accepts any of it. A second turn on a `Thread` you kept runs on what that thread was started with.

Precedence is the contract's: code < published < the options you pass to *this* call. The model is the one value that is more than a per-key merge, because Codex splits it in two — if a call passes its own `model`, the published provider is dropped along with the model it qualified, rather than left behind to send that model to somebody else's endpoint.

## Placement: its own package, not a subpath and not an optional peer

The core PR's rule is that every `packages/*` entry is a runtime and every feature area is a subpath. An adapter is neither, so the tiebreaker has to come from somewhere else — and this repository already has one. `@pydantic/logfire-session-replay` is a `packages/*` entry that is not a runtime either; its README says why, and it is the same reason: *"It is standalone on purpose: `@rrweb/record` and `fflate` are not dependencies of the core `logfire` API package or `@pydantic/logfire-browser`."* A package is how this repository keeps a third-party coupling out of a runtime's dependency tree.

I considered the optional-peer arrangement that pairs with it — `agent-control/codex-sdk` as another subpath of `logfire-node`, with `@openai/codex-sdk` as an optional peer, loaded the way `logfire-browser` loads session replay. It does not fit:

- **`logfire-browser` dynamically imports its optional peer and never exposes its types.** `sessionReplay.ts` imports one type and `import()`s the module inside a `try`. This adapter is the opposite: `CodexOptions` and `ThreadOptions` are in its public signatures, so a subpath would put `@openai/codex-sdk` types in `@pydantic/logfire-node`'s published `.d.ts` and every `logfire-node` user's typechecker would have to resolve a package they do not have.
- **`logfire-node` is dual-format.** `@openai/codex-sdk` publishes no `require` condition, so the CJS half of that subpath could not load its own peer. As its own package it is honestly ESM-only, which is also what its README already told users.
- **Semver.** The adapter tracks a fast-moving third-party SDK. Its own package means a breaking change there is a major here and not on the Node runtime everyone installs.

So: `packages/logfire-agent-control-codex-sdk`, ESM-only, with `@openai/codex-sdk` and `@pydantic/logfire-node` both as peer dependencies — the second because Logfire's variable provider is a module-level singleton and a second copy of it would read a different one, which a peer turns into a resolution error rather than a silent one. Its range is `workspace:^` and not `workspace:^0.18.24`: `0.18.24` is what `@pydantic/logfire-node` is *today*, and it has no `/agent-control` subpath, since that arrives in the minor #321 releases. `workspace:^` stamps whatever version the two are published together at.

Version `0.0.0` plus a `minor` changeset, so the first published version is `0.1.0`. Per the release workflow's own comment, a brand-new package cannot use OIDC for its first publish ([npm/cli#8544](https://github.com/npm/cli/issues/8544)): it needs one manual publish, then its trusted publisher configured on npmjs.com, and CI takes over.

Mastra and the Vercel AI SDK are landing in parallel and justify their own placement.

## Tests

**49 offline tests**, which is what CI runs. They drive the *real* `@openai/codex-sdk` against a stand-in binary (`test-fixtures/fake-codex.ts`) that records the argv it was started with, so the whole mapping from a published value to real CLI flags — `config` to dotted `--config` flags, `model` to `--model`, `modelReasoningEffort` to a `--config` flag rather than a flag of its own — is asserted end to end with no API key, no network and no model. Variables come from the SDK's own `LocalVariableProvider`, and the once-per-process guards are cleared through `@pydantic/logfire-node/agent-control/testing`, the entry point the core PR added for exactly this. The suite was held at 100% statements, branches, functions and lines in the workspace it came from; this PR does not add a coverage gate, matching the standard as it stands.

**A live suite that CI does not run.** Codex's HTTP traffic leaves from a binary the adapter spawns, so there is no fetch for a JS recorder to intercept and a cassette here would record nothing. `live-tests/codex.live.ts` is therefore a real run, kept out of the default `vp test` include by its own config and a `.live.ts` suffix — the same mechanism `@pydantic/logfire-session-replay` uses for `.pw.ts` — and skipped entirely unless the machine has a logged-in Codex account. `vp run @pydantic/logfire-agent-control-codex-sdk#test:live`. Three claims it settles, all three run and passing here:

1. **A published `developer_instructions` block changes what the model is told**, beating the one in the code, and a published `settings.thinking` is accepted by the provider on the same request rather than rejected.
2. **`codex exec resume` does not re-inject a changed developer block.** This was an open question in the README, which told users to treat a change as new-thread-only without having checked. It is now observed: a session started under one published instruction, resumed with another published, answers with the first. The `-c developer_instructions=` on the resume is ignored in favour of the developer message the session persisted. A published *model* and *reasoning effort* do apply on a resumed turn — checked separately by resuming a `low` session with `minimal` and getting the provider's `minimal` rejection.
3. **A published `model` whose provider id is not `openai` reaches that provider.** The test writes a `CODEX_HOME` holding one extra `model_providers` entry and no `auth.json`, so nothing but that entry can serve the turn.

Two findings from running them, both now in the README:

- **`thinking` is forwarded verbatim and the provider has the last word, per model.** `gpt-5.6-sol` answers `minimal` with `400 unsupported_value: 'minimal' is not supported with the 'gpt-5.6-sol' model. Supported values are: 'none', 'low', 'medium', 'high', 'xhigh', and 'max'`. Nothing for the adapter to fix — Codex passes the effort through and the contract's value set is not per-model — but the README no longer implies all five always apply.
- **The resume behaviour above**, which turns a hedge in the docs into a stated fact with a test behind it.
- **Codex expands a leading `~` in `model_instructions_file`** (checked with `codex debug prompt-input`, which reads a `~/prompt.md` that exists and errors on a path that does not). This package was joining the `~` onto the working directory, so a home-relative base prompt was warned about as unreadable and left out of the published baseline while the run itself worked. Fixed, with a test.

There was no provider translation table to correct: this adapter splits `provider:model` at the first colon and passes both halves through, precisely because the provider ids Codex accepts are whatever is in the user's `config.toml`, not a fixed list. So the `google-gla` / `google-vertex` correction does not apply here.

Review also caught two things the tests had not: `resolveOptions` on a run with nothing published handed back a shallow copy whose `config` still aliased the agent's own — contradicting the assertion right next to it — and the README named `LOGFIRE_TOKEN` as a credential that resolves variables, which it does not. Both fixed, both with a test that fails without the fix.

## One thing to flag

`@openai/codex-sdk` depends on `@openai/codex`, whose per-platform optional dependency vendors the ~320 MB Codex CLI binary. Nothing in CI runs that binary — the offline suite always passes `codexPathOverride` — but a plain `vp install` downloads it. I tried excluding it with `ignoredOptionalDependencies` in `pnpm-workspace.yaml` and pnpm 11.5.2 did not honour the key, so I left it out rather than ship a repo-wide install setting I could not verify. Happy to swap the devDependency for a hand-written stub if the download is not worth it, at the cost of the offline suite no longer proving that the real SDK turns `config` into `--config` flags.

## Docs

`docs/frameworks/codex-sdk.md` under **Frameworks & Runtimes**, plus a `nav.json` entry, and the Agent Control guide's "Framework Adapters" section now links to it instead of saying the adapters are in progress.

## Gates

From the repository root, everything CI runs, green: `pnpm install --frozen-lockfile`, `vp run --filter "./packages/*" build`, `vp check` (529 files formatted, 332 lint- and type-clean), `vp run --filter "./packages/*" typecheck`, `vp run --filter "./packages/*" test` (226 tests across 17 files), and `node scripts/create-npm-token.test.mjs`. `vp run @pydantic/logfire-agent-control-codex-sdk#test:live` passes 3/3 against a real model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTCke3iTd1KUvgqwpXxE9f


