### PR TITLE
Add `@pydantic/logfire-agent-control-mastra`, the Mastra adapter for Agent Control

### DIFF
--- a/.changeset/agent-control-mastra.md
+++ b/.changeset/agent-control-mastra.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-agent-control-mastra': minor
+---
+
+Add `@pydantic/logfire-agent-control-mastra`, the Mastra adapter for Logfire Agent Control. One processor on an agent's `inputProcessors` makes its instructions, model, model settings, and tool definitions editable from the Logfire UI without a deploy, and the agent keeps running on its code whenever nothing is published, Logfire is unreachable, or a published value cannot be understood. A managed tool rename lives on the wire and nowhere else: the tool record Mastra dispatches, traces, and stores from keeps its code-side keys, so `execute`, hooks, spans, and stored threads all still read the name your code gave the tool.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository is the Pydantic Logfire JavaScript SDK monorepo. It provides Ope
 - `packages/otel-cf-workers` publishes `@pydantic/otel-cf-workers`, the lower-level Cloudflare Workers OpenTelemetry implementation used by the Logfire wrapper.
 - `packages/logfire-browser` publishes `@pydantic/logfire-browser`, which adapts Logfire to browser tracing.
 - `packages/logfire-session-replay` publishes `@pydantic/logfire-session-replay`, the optional standalone rrweb recorder used by the browser package's session replay integration.
+- `packages/logfire-agent-control-mastra` publishes `@pydantic/logfire-agent-control-mastra`, the Mastra adapter for Agent Control. It is the first package here that is neither a runtime nor a feature subpath: it depends on a third-party framework, so `@mastra/core` is a peer dependency and the package exists to keep that dependency off every other package.
 - `vite.shared.ts` holds the build helpers every package config imports: `packageDefines()` stamps `PACKAGE_VERSION` and `PACKAGE_TIMESTAMP` from the package's own `package.json`, and `copyCjsDeclarations()` emits the `.d.cts` files.
 - `vite.config.ts` and `tsconfig.base.json` at the repository root hold the shared format, lint, task, and TypeScript configuration.
 - `examples/` contains runnable examples for Express, Next.js, Deno, Cloudflare Workers, browser usage, and related integrations.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -140,7 +140,7 @@ The stored JSON schema is pinned by `SCHEMA_SHA256`, and the cross-language rule
 
 The core is framework-neutral on purpose: it knows about instruction blocks, tool definitions, and settings, and about no framework's spelling of them. An adapter is what maps one framework onto those three: it enumerates a baseline, installs the framework's hook, and calls the pure helpers.
 
-TypeScript adapters for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Codex SDK** are in progress, each as its own package, because a project that uses one has no reason to install the other two. Until they land, the paragraph below is how to drive Agent Control from any framework directly.
+[**Mastra**](frameworks/mastra.md) has one: `@pydantic/logfire-agent-control-mastra`, a processor you add to an agent's `inputProcessors`. Adapters for the **Vercel AI SDK** and the **OpenAI Codex SDK** are in progress, each as its own package, because a project that uses one has no reason to install the other two. Until they land, the paragraph below is how to drive Agent Control from any framework directly.
 
 Python users get the same contract from [`logfire`](https://logfire.pydantic.dev/docs/) and [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness). A config published from the Logfire UI drives every one of them, because the variable name, the baseline, and the parse are the same three rules in both languages.
 

--- a/docs/frameworks/mastra.md
+++ b/docs/frameworks/mastra.md
@@ -1,0 +1,67 @@
+---
+title: Mastra
+description: Use @pydantic/logfire-agent-control-mastra to change a Mastra agent's instructions, model, settings, and tool definitions from Logfire.
+---
+
+# Mastra
+
+[Agent Control](../agent-control.md) lets someone change what a running agent does — its instructions, its model, its model settings, the names and descriptions its tools are advertised under — from the Logfire UI, without a deploy. `@pydantic/logfire-agent-control-mastra` is the [Mastra](https://mastra.ai) half of it: one processor on an agent, and its configuration becomes a document you can edit in Logfire.
+
+Until someone edits it, and any time Logfire cannot be reached, the agent runs exactly as your code defines it.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-agent-control-mastra @pydantic/logfire-node
+```
+
+`@mastra/core` 1.65 or newer is a peer dependency, and so is `@pydantic/logfire-node`, which is what the adapter resolves the variable through. There is nothing of its own to configure: the Logfire SDK's own configuration decides where the variable is read from.
+
+## Usage
+
+Add the processor to the agent's `inputProcessors`, last, so it applies the published config to the prompt every other processor has finished with:
+
+```ts
+import { Agent } from '@mastra/core/agent'
+import { createTool } from '@mastra/core/tools'
+import { agentControl } from '@pydantic/logfire-agent-control-mastra'
+import * as logfire from '@pydantic/logfire-node'
+import { z } from 'zod'
+
+logfire.configure()
+
+const getWeather = createTool({
+  id: 'get_weather',
+  description: 'Get the weather for a city.',
+  inputSchema: z.object({ city: z.string().describe('City name') }),
+  execute: ({ city }) => Promise.resolve({ city, temperatureC: 21 }),
+})
+
+export const checkout = new Agent({
+  id: 'checkout_assistant',
+  name: 'Checkout Assistant',
+  instructions: ['You are a concise checkout assistant.', 'Always confirm the order total.'],
+  model: 'anthropic/claude-fable-5-1',
+  tools: { getWeather },
+  inputProcessors: [agentControl({ label: 'production' })],
+})
+```
+
+The agent's config lives in a Logfire variable named `agent__checkout_assistant` — the agent's Mastra `id`, normalized by the contract's rule — or a `name` you pass to `agentControl` instead. The first request publishes a description of the agent as the variable's `example`, so the Logfire editor shows what it is you are changing.
+
+`agentControl` also takes `label` (read one label rather than letting the variable's rollout choose), `onUnmatched` (`'warn'`, `'ignore'` or `'error'` for a published entry that reaches nothing), and `publishBaseline: false` (for a read-only token).
+
+## What becomes editable
+
+- **Instructions.** An agent whose `instructions` are a list gets one addressable block per entry, under `agent:0`, `agent:1`, and so on — or under an id the entry declares for itself as `providerOptions: { logfire: { id: 'persona' } }`, which is worth doing for anything you intend to manage, because a positional id re-points when you reorder the list. A published entry with no `id` adds a block, and it lands after your text and before anything Mastra assembles per request, so a provider's prompt cache keeps its prefix. Instructions written as a function are computed per request and are described but not editable, as are Mastra's own prompt sections — recalled memory, MCP guidance, a per-call `system` option.
+- **Model.** A published `provider:model` becomes Mastra's `provider/model`. The provider has to be one Mastra's built-in model router knows; anything else is reported and the agent keeps its code-defined model rather than failing every request.
+- **Model settings.** The contract's eleven canonical keys map onto Mastra's model settings, with `timeout` becoming its per-step budget and `parallel_tool_calls` becoming the provider option each provider spells differently. Whether a provider then acts on a setting is the provider's decision; one that will not reports an `unsupported` warning on the run.
+- **Tool definitions.** A tool's description and its parameters' descriptions are patched onto what the model is told. A rename changes the name the model is offered and nothing else: the tool record Mastra dispatches, traces and stores from keeps its code-side keys, so your `execute` runs, your spans read, and your threads are written under the name your code gave the tool.
+
+The package README carries the full table, including what happens for each row when it does not apply.
+
+## Related Guides
+
+- [Agent Control](../agent-control.md)
+- [Managed Variables](../managed-variables.md)
+- [Node.js](../packages/node.md)

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -47,6 +47,10 @@
             "slug": "frameworks/deno"
           },
           {
+            "label": "Mastra",
+            "slug": "frameworks/mastra"
+          },
+          {
             "label": "Vercel AI SDK",
             "slug": "frameworks/vercel-ai"
           }

--- a/packages/logfire-agent-control-mastra/.gitignore
+++ b/packages/logfire-agent-control-mastra/.gitignore
@@ -1,0 +1,25 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+*.tgz

--- a/packages/logfire-agent-control-mastra/README.md
+++ b/packages/logfire-agent-control-mastra/README.md
@@ -1,0 +1,227 @@
+# `@pydantic/logfire-agent-control-mastra`
+
+Agent Control lets someone change what a running [Mastra](https://mastra.ai) agent does — its
+instructions, its model, its model settings, the names and descriptions its tools are advertised
+under — from the Logfire UI, without a deploy. Add one processor to an agent and its configuration
+becomes a document you can edit in Logfire; until someone edits it, and any time Logfire cannot be
+reached, the agent runs exactly as your code defines it.
+
+You need Mastra (`@mastra/core` 1.65 or newer), the Logfire Node SDK, and a Logfire project. Nothing
+here reads an environment variable of its own: the Logfire SDK's own configuration decides where the
+variable is read from — `logfire.configure({ apiKey })` or `LOGFIRE_TOKEN`, with `LOGFIRE_BASE_URL`
+naming the region.
+
+```bash
+npm install @pydantic/logfire-agent-control-mastra @pydantic/logfire-node
+```
+
+## Quick start
+
+Add the processor to your agent's `inputProcessors`, last:
+
+```ts
+import { Agent } from '@mastra/core/agent'
+import { createTool } from '@mastra/core/tools'
+import * as logfire from '@pydantic/logfire-node'
+import { agentControl } from '@pydantic/logfire-agent-control-mastra'
+import { z } from 'zod'
+
+logfire.configure()
+
+const getWeather = createTool({
+  id: 'get_weather',
+  description: 'Get the weather for a city.',
+  inputSchema: z.object({ city: z.string().describe('City name') }),
+  execute: ({ city }) => Promise.resolve({ city, temperatureC: 21 }),
+})
+
+export const checkout = new Agent({
+  id: 'checkout_assistant',
+  name: 'Checkout Assistant',
+  instructions: ['You are a concise checkout assistant.', 'Always confirm the order total.'],
+  model: 'anthropic/claude-fable-5-1',
+  tools: { getWeather },
+  inputProcessors: [agentControl({ label: 'production' })],
+})
+
+const { text } = await checkout.generate('What is the weather in Paris?')
+```
+
+That is the whole installation. The agent's config lives in a Logfire variable named
+`agent__checkout_assistant` — the agent's Mastra `id`, normalized by the core's rule (trimmed,
+lowercased, everything outside `[a-z0-9_]` replaced with `_`), or a `name` you pass to `agentControl`
+instead. The first request publishes a description of the agent, so the Logfire editor shows what it
+is you are changing.
+
+## The factory
+
+```ts
+agentControl(options?: MastraAgentControlOptions): InputProcessor
+```
+
+It returns a Mastra `InputProcessor` and nothing else: your agent, your tools and your model object
+are not touched or mutated by this call. Register it **last** in `inputProcessors`, so it applies the
+published config to the prompt every other processor has finished with.
+
+- `name` — the variable name to use, instead of the agent's `id`. Pass it to keep the config attached
+  across a rename of the agent, or to point two deployments at one config. An agent with neither an
+  `id` nor a `name` fails the request with an error naming both ways to fix it.
+- `label` — read this label instead of letting the variable's rollout choose one.
+- `onUnmatched` — what to do about a published entry that reaches nothing: `'warn'` (default, once
+  per process), `'ignore'`, or `'error'`, which fails the run. Mastra reports a processor that throws
+  as a `PROCESSOR_WORKFLOW_FAILED` error carrying the message.
+- `publishBaseline` — set `false` when the Logfire token is read-only, or when code must not write
+  variable metadata.
+
+One processor instance can be registered on several agents: each reads its own agent's variable, and
+two requests that overlap never see each other's config.
+
+For a step it applies a config to, the processor hands Mastra back new `systemMessages`,
+`modelSettings`, `providerOptions`, `tools` and `model` **only** for the sections the published value
+carries, and only where they differ from what the step already had. Everything else about the step is
+the one Mastra assembled.
+
+## What becomes editable
+
+| Source, or canonical field                                                               | Block id, or runtime mapping                                                                             | Support                      | Conditions, and what happens when it does not apply                                                                                                                                                                                                                                                                                                                            |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `instructions` written as a list                                                         | `agent:0`, `agent:1`, … by position                                                                      | Yes                          | Ids are positional; see the next row for a stable one                                                                                                                                                                                                                                                                                                                          |
+| `instructions` written as one string, or one message                                     | `agent`                                                                                                  | Yes                          |                                                                                                                                                                                                                                                                                                                                                                                |
+| An instruction entry that declares its own id                                            | the declared id                                                                                          | Yes                          | Write the entry as a system message carrying `providerOptions: { logfire: { id: 'persona' } }` — the AI SDK v4 spelling, `experimental_providerMetadata`, is read too. Mastra's `instructions` takes a list of strings or a list of messages rather than a mix, so the other entries become messages with it. Worth doing: a positional id re-points when you reorder the list |
+| `instructions` written as a function                                                     | `agent` for the first block, nothing after it                                                            | No                           | The text is built per request from the request context, so replacing it would freeze one rendering. An override naming it is reported as the dynamic block it is. To manage the fixed part, keep it in a list entry and add the computed part from a processor of your own — see below                                                                                         |
+| Adding an instruction block                                                              | an entry with no `id`                                                                                    | Yes                          | Lands after your agent's own text and before anything Mastra adds per request, so a provider's prompt cache keeps its prefix                                                                                                                                                                                                                                                   |
+| Mastra's own prompt sections — recalled memory, MCP guidance, a per-call `system` option | `tag:memory`, `tag:mcp-guidance`, `tag:user-provided`                                                    | No                           | They belong to the subsystems that write them. They are described in the baseline so the editor can show the prompt has more in it than your text; an override naming one is reported                                                                                                                                                                                          |
+| `model`                                                                                  | `provider:model` → Mastra's `provider/model`                                                             | Conditional                  | The provider has to be one Mastra's built-in model router knows. Anything else — an unknown provider, one Mastra has no entry for (`bedrock`, `azure`, `cohere`, `google-cloud`), or one reachable only through a custom gateway — is reported, and the agent keeps its code-defined model                                                                                     |
+| `max_tokens`                                                                             | `maxOutputTokens`                                                                                        | Yes                          |                                                                                                                                                                                                                                                                                                                                                                                |
+| `temperature`                                                                            | `temperature`                                                                                            | Yes                          | Sent; a provider may still refuse it. OpenAI rejects it for its reasoning models, which every current GPT-5 is                                                                                                                                                                                                                                                                 |
+| `top_p`                                                                                  | `topP`                                                                                                   | Yes                          | Sent; same caveat as `temperature` on OpenAI, and Anthropic's provider drops it when `temperature` is published with it                                                                                                                                                                                                                                                        |
+| `top_k`                                                                                  | `topK`                                                                                                   | Yes                          | Sent; OpenAI has no field for it                                                                                                                                                                                                                                                                                                                                               |
+| `seed`                                                                                   | `seed`                                                                                                   | Yes                          | Sent; neither OpenAI's Responses API nor Anthropic has a field for it                                                                                                                                                                                                                                                                                                          |
+| `presence_penalty`                                                                       | `presencePenalty`                                                                                        | Yes                          | Sent; same                                                                                                                                                                                                                                                                                                                                                                     |
+| `frequency_penalty`                                                                      | `frequencyPenalty`                                                                                       | Yes                          | Sent; same                                                                                                                                                                                                                                                                                                                                                                     |
+| `stop_sequences`                                                                         | `stopSequences`                                                                                          | Yes                          | Sent; Anthropic takes it, OpenAI's Responses API has no field for it                                                                                                                                                                                                                                                                                                           |
+| `timeout` (seconds)                                                                      | `timeout.stepMs`                                                                                         | Yes                          | Mastra's per-model-call budget, not a request field. A run-wide `totalMs` set in code is merged through rather than replaced. A value the contract cannot represent is dropped and reported by the core before it reaches Mastra                                                                                                                                               |
+| `thinking`                                                                               | `reasoning` (`true` → `'provider-default'`, `false` → `'none'`)                                          | No, through the model router | Mastra passes `reasoning` only to AI SDK v7 (`LanguageModelV4`) providers, and `ModelRouterLanguageModel` — what every `provider/model` string resolves to — declares `specificationVersion = 'v2'`. So a published `thinking` on a router model is **always** reported rather than applied. Pass a v7 model object as the agent's `model` and it applies                      |
+| `parallel_tool_calls`                                                                    | `providerOptions.openai.parallelToolCalls`; `providerOptions.anthropic.disableParallelToolUse`, inverted | Conditional                  | Those are the two providers that expose it, and both accept it. On any other provider it is reported, not applied                                                                                                                                                                                                                                                              |
+| A tool's advertised name                                                                 | the model's declarations only; see "How a renamed tool behaves"                                          | Yes                          | A rename onto a name another tool already advertises is refused and reported, and that tool keeps its own name                                                                                                                                                                                                                                                                 |
+| A tool's description, and its parameters' descriptions                                   | patched onto the tool Mastra advertises                                                                  | Yes                          | A patch naming a parameter the tool does not have, or one whose schema has nothing to describe, is reported                                                                                                                                                                                                                                                                    |
+| A tool's parameters, types, or implementation                                            | —                                                                                                        | No                           | An override changes only what the model is told. Arguments are still validated against the schema your code declared                                                                                                                                                                                                                                                           |
+| A provider-defined tool — `google.tools.googleSearch()` and its kind                     | —                                                                                                        | No                           | Its name is a contract with the provider, and Mastra advertises it under the tool's own `name` rather than the record key. It is neither described nor renamed, its advertised name is held against a managed rename of another tool, and an override naming it is reported                                                                                                    |
+| Narrowing an override to one `toolset`                                                   | —                                                                                                        | No                           | By the time a processor sees them, Mastra has assembled every source (your tools, memory, workspace, skills, sub-agents, workflows, MCP) into one flat record with no source label, so overrides match by name alone                                                                                                                                                           |
+
+"Sent" above means the value reaches the AI SDK call settings, which is as far as this adapter can
+take it: whether a provider acts on one is the provider's decision, and a provider that will not
+reports an `unsupported` warning on the run rather than failing it. The rows say what was **observed**
+against `openai/gpt-5.4-nano` and `anthropic/claude-haiku-4-5`, not what was read off source.
+
+Model ids are the contract's, which is Pydantic AI's vocabulary: `google` is the Gemini API and
+`google-cloud` is Vertex AI. The v1 spellings `google-gla` and `google-vertex` are still accepted, so
+a config published against an older agent keeps working, but they are never what a baseline publishes.
+
+To keep a computed tail on your instructions while still managing the fixed part, leave the fixed
+text in the agent's `instructions` and add the computed part from a processor registered **before**
+this one:
+
+```ts
+import type { ProcessInputArgs, ProcessInputResult, Processor } from '@mastra/core/processors'
+
+const today: Processor = {
+  id: 'today',
+  processInput({ messageList }: ProcessInputArgs): ProcessInputResult {
+    return messageList.addSystem(`Today is ${new Date().toDateString()}.`, 'user-provided')
+  },
+}
+
+// inputProcessors: [today, agentControl({ label: 'production' })]
+```
+
+## When it applies, and what beats what
+
+**Resolution is once per request.** The variable is read in the processor's `processInput` hook,
+which Mastra runs once, and the value is applied before **every** model call of that request. One
+resolve per request is deliberate: it means the prompt prefix cannot change between the steps of one
+run, which is what keeps a provider's prompt cache warm, and a value published mid-run takes effect
+on the next request. Everything this adapter does for a request — applying the config, publishing the
+baseline, reporting what did not apply — runs inside that resolution's telemetry context, and so does
+the provider call itself wherever this adapter wraps the model (see below), so a span carries the
+label and version that produced it.
+
+**The baseline is published once per process, from the first request, as an observation.** The
+agent's own text, model and default settings are read off the agent, but the tools the model is
+offered are only assembled per request — a request carrying a memory, workspace or MCP toolset
+assembles a different list — so the snapshot is published as the observation it is rather than as a
+description of the code, and the variable says so. Publishing is a read-modify-write of the
+variable's definition, so an edit saved in the Logfire UI inside that one round trip can be lost; set
+`publishBaseline: false` and create the variable in the UI where that matters.
+
+**Precedence is code < published < the values a run passed explicitly**, with one gap this
+integration cannot close:
+
+- **Instructions.** A per-run `instructions:` option replaces your agent's blocks outright, so the
+  published ids no longer name the blocks they were written against: the section stands down, the
+  caller's text is used, and the run reports that it did — a published section that reaches nothing
+  should not do so silently. The same happens where two of your instruction blocks are identical,
+  since Mastra drops the duplicate and every later position shifts; that report names the blocks to
+  make distinct.
+- **Model settings and provider options.** Mastra deep-merges a call's `modelSettings` and
+  `providerOptions` into the agent's `defaultOptions` before any processor runs, and gives a
+  processor nothing that records which keys the call carried. So "the caller set this" is recovered
+  by comparing the step's value against the agent's default: a key that differs is the run's, and is
+  left alone — in provider options as much as in model settings, so a run that sets
+  `openai.parallelToolCalls` for itself keeps it. **The gap:** a call passing a value _equal_ to the
+  agent's default is indistinguishable from a call that passed nothing, and the published value wins
+  there. Where the three disagree, the run gets what it asked for; where the call and the code agree,
+  the published value applies.
+- **Model.** Mastra has no per-run model option, so a published model always applies. If your agent
+  has a fallback list, a published model replaces the model for the step rather than reordering the
+  list.
+
+## How a renamed tool behaves
+
+**Your code keeps seeing the name your code gave the tool.** Rename `getWeather` to
+`lookup_current_weather` in Logfire and the model is offered `lookup_current_weather` — but the tool
+record Mastra dispatches from keeps its `getWeather` key, so your `execute` runs, your tool hooks
+fire, your spans are recorded and the thread's messages are stored all under `getWeather`. The rename
+lives on the wire and nowhere else: for a request that renames something, this adapter hands Mastra a
+wrapped model that advertises the managed names, translates the model's calls back before Mastra
+dispatches them, and translates the replayed history forward on the way out.
+
+Three consequences worth knowing:
+
+- **A `toolChoice` naming a tool by its code name keeps working**, because it is translated with the
+  declarations, and so does an `activeTools` list, which Mastra filters against the record's keys.
+- **A thread survives the rename changing, or being withdrawn.** What was stored is code-side, so a
+  resumed conversation is replayed under whatever the tool is advertised as now — or under its own
+  name once the override is gone.
+- **A thread stored by a build of this adapter older than this one is not repaired.** Those messages
+  hold the managed name; nothing here rewrites them, and no versioned mapping is kept.
+
+## Known limits
+
+- The processor has to be registered on an `Agent` (`inputProcessors`). Mastra hands the agent to
+  `processInput` only, so a processor-only workflow context has nothing to read the agent's
+  configuration from; the adapter says so once and changes nothing.
+- Instruction ids are positional unless an entry declares one. Reordering the entries in your code
+  re-points every id after the one you moved, so a published override then addresses a different
+  block, and a block whose source is deleted takes its id with it. Declare
+  `providerOptions: { logfire: { id: … } }` on the entries you intend to manage.
+- `thinking` cannot be applied to a model named as a `provider/model` router string; see the table.
+- A per-run setting equal to the agent's own default cannot be told from an inherited one, and loses
+  to a published value; see the precedence section.
+- The baseline describes one request, and publishing it can lose a concurrent edit made in the UI.
+- Overrides cannot be narrowed to a toolset, and provider-defined tools are not editable.
+
+## Development
+
+Run this package's checks from the repository root:
+
+```bash
+vp run @pydantic/logfire-agent-control-mastra#test
+vp run @pydantic/logfire-agent-control-mastra#typecheck
+vp lint packages/logfire-agent-control-mastra
+```
+
+Most of the suite is offline: a local variables provider and the AI SDK's mock models, so a test
+asserts on the exact call Mastra would have made. The `live.test.ts` tests drive real providers and
+replay from recorded cassettes in `src/__test__/cassettes/`; see `src/__test__/cassette.ts` for what
+a cassette holds and how to re-record one.

--- a/packages/logfire-agent-control-mastra/README.md
+++ b/packages/logfire-agent-control-mastra/README.md
@@ -50,8 +50,8 @@ const { text } = await checkout.generate('What is the weather in Paris?')
 
 That is the whole installation. The agent's config lives in a Logfire variable named
 `agent__checkout_assistant` — the agent's Mastra `id`, normalized by the core's rule (trimmed,
-lowercased, everything outside `[a-z0-9_]` replaced with `_`), or a `name` you pass to `agentControl`
-instead. The first request publishes a description of the agent, so the Logfire editor shows what it
+lowercased, everything outside `[a-z0-9_]` replaced with `_`, runs of `_` collapsed, and `_` stripped
+from both ends), or a `name` you pass to `agentControl` instead. The first request publishes a description of the agent, so the Logfire editor shows what it
 is you are changing.
 
 ## The factory

--- a/packages/logfire-agent-control-mastra/README.md
+++ b/packages/logfire-agent-control-mastra/README.md
@@ -8,8 +8,9 @@ reached, the agent runs exactly as your code defines it.
 
 You need Mastra (`@mastra/core` 1.65 or newer), the Logfire Node SDK, and a Logfire project. Nothing
 here reads an environment variable of its own: the Logfire SDK's own configuration decides where the
-variable is read from — `logfire.configure({ apiKey })` or `LOGFIRE_TOKEN`, with `LOGFIRE_BASE_URL`
-naming the region.
+variable is read from — `logfire.configure({ apiKey })` or `LOGFIRE_API_KEY`, with `LOGFIRE_BASE_URL`
+naming the region. That is the platform API key, which is what a managed variable is read through;
+`LOGFIRE_TOKEN` is the write token for telemetry and does not resolve one.
 
 ```bash
 npm install @pydantic/logfire-agent-control-mastra @pydantic/logfire-node
@@ -204,7 +205,15 @@ Three consequences worth knowing:
 - Instruction ids are positional unless an entry declares one. Reordering the entries in your code
   re-points every id after the one you moved, so a published override then addresses a different
   block, and a block whose source is deleted takes its id with it. Declare
-  `providerOptions: { logfire: { id: … } }` on the entries you intend to manage.
+  `providerOptions: { logfire: { id: … } }` on the entries you intend to manage. An id two entries
+  both declare addresses neither of them: both fall back to their positional ids and the override is
+  reported, rather than one winning by declaration order. `tag:` is reserved for Mastra's own prompt
+  sections, so an entry that declares an id in it keeps its positional id too.
+- A per-run `instructions:` option that _starts_ with your agent's own text — a call passing
+  `['A', 'something for this call']` to an agent whose code says `['A']` — cannot be told from that
+  agent plus a block a subsystem added, because Mastra puts both in the same untagged bucket and
+  offers a processor nothing that says which is which. A published override on the block whose text
+  the two agree on applies there; the rest of what the call passed is untouched.
 - `thinking` cannot be applied to a model named as a `provider/model` router string; see the table.
 - A per-run setting equal to the agent's own default cannot be told from an inherited one, and loses
   to a published value; see the precedence section.

--- a/packages/logfire-agent-control-mastra/package.json
+++ b/packages/logfire-agent-control-mastra/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@pydantic/logfire-agent-control-mastra",
+  "description": "Logfire Agent Control for Mastra: edit a Mastra agent's instructions, model, model settings, and tool definitions from the Logfire UI - https://pydantic.dev/logfire",
+  "author": {
+    "name": "The Pydantic Team",
+    "email": "engineering@pydantic.dev",
+    "url": "https://pydantic.dev"
+  },
+  "repository": {
+    "url": "git+https://github.com/pydantic/logfire-js.git",
+    "directory": "packages/logfire-agent-control-mastra"
+  },
+  "sideEffects": false,
+  "homepage": "https://pydantic.dev/logfire",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "agent",
+    "llm",
+    "logfire",
+    "mastra",
+    "observability",
+    "prompt-management"
+  ],
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "dev": "vp pack --watch",
+    "build": "vp pack",
+    "lint": "vp lint",
+    "preview": "vp preview",
+    "typecheck": "tsc",
+    "prepack": "cp ../../LICENSE .",
+    "postpublish": "rm LICENSE",
+    "test": "vp test"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.65.0 <2",
+    "@pydantic/logfire-node": "workspace:^0.18.24"
+  },
+  "devDependencies": {
+    "@ai-sdk/provider": "^3.0.16",
+    "@mastra/core": "^1.65.0",
+    "@pydantic/logfire-node": "workspace:*",
+    "@types/node": "^22.5.1",
+    "ai": "^7.0.95",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
+}

--- a/packages/logfire-agent-control-mastra/src/__test__/baseline.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/baseline.test.ts
@@ -1,0 +1,197 @@
+import { Agent } from '@mastra/core/agent'
+import { createTool } from '@mastra/core/tools'
+import { getVariableProvider } from '@pydantic/logfire-node/vars'
+import type { VariableConfig } from '@pydantic/logfire-node/vars'
+import { describe, expect, it } from 'vite-plus/test'
+import { z } from 'zod'
+
+import { agentControl } from '../index'
+import { captureWarnings, mockModel, nextAgentId, run, settle, useLocalVariables } from './helpers'
+
+captureWarnings()
+
+/** The variable definition the adapter published for `agentId`. */
+function publishedVariable(agentId: string): VariableConfig | undefined {
+  const provider = getVariableProvider()
+  return provider.getVariableConfig?.(`agent__${agentId}`) as VariableConfig | undefined
+}
+
+/** The baseline the adapter published for `agentId`, as the JSON that reached the variable. */
+function publishedBaseline(agentId: string): string {
+  return publishedVariable(agentId)?.example ?? ''
+}
+
+const getWeather = createTool({
+  id: 'get_weather',
+  description: 'Get the weather for a city.',
+  inputSchema: z.object({
+    city: z.string().describe('City name'),
+    unit: z.enum(['c', 'f']).optional().describe('Temperature unit'),
+  }),
+  execute: async () => Promise.resolve({ temp: 21 }),
+})
+
+describe('the published baseline', () => {
+  it('describes the agent as written, in the contract order', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const agent = new Agent({
+      id,
+      name: 'Checkout Assistant',
+      instructions: ['You are a concise checkout assistant.', 'Always confirm the order total.'],
+      model: mockModel('anthropic.messages', 'claude-fable-5-1'),
+      tools: { getWeather },
+      defaultOptions: {
+        modelSettings: { temperature: 0.2, maxOutputTokens: 100, timeout: { stepMs: 30_000 } },
+        providerOptions: { openai: { parallelToolCalls: false } },
+      },
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+    await settle()
+
+    // Compared as the exact string, not as a parsed object: this is what someone reads in the Logfire
+    // editor, so the order of the keys and the shape of each entry are part of what is being tested.
+    expect(publishedBaseline(id)).toBe(
+      JSON.stringify(
+        {
+          instructions: [
+            { id: 'agent:0', instructions: 'You are a concise checkout assistant.', dynamic: false },
+            { id: 'agent:1', instructions: 'Always confirm the order total.', dynamic: false },
+          ],
+          model: 'anthropic:claude-fable-5-1',
+          settings: { max_tokens: 100, temperature: 0.2, parallel_tool_calls: false, timeout: 30 },
+          tool_definitions: [
+            {
+              name: 'getWeather',
+              description: 'Get the weather for a city.',
+              parameters: { city: { description: 'City name' }, unit: { description: 'Temperature unit' } },
+            },
+          ],
+        },
+        null,
+        2
+      )
+    )
+  })
+
+  it('says it was snapshotted from one request, because the tool list was', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model: mockModel(),
+      tools: { getWeather },
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+    await settle()
+
+    // The agent's own text, model and settings are read off the agent, but the tools the model is
+    // offered are only assembled per request -- a request carrying a memory, workspace or MCP toolset
+    // assembles a different list -- so the whole baseline is published as the observation it is.
+    expect(publishedVariable(id)?.description).toContain('snapshotted from one request')
+  })
+
+  it('gives a lone instruction string the reserved `agent` id', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'You are helpful.',
+      model: mockModel('openai.responses', 'gpt-5.6-sol'),
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+    await settle()
+
+    expect(JSON.parse(publishedBaseline(id))).toEqual({
+      instructions: [{ id: 'agent', instructions: 'You are helpful.', dynamic: false }],
+      model: 'openai:gpt-5.6-sol',
+    })
+  })
+
+  it('publishes the seam of instructions that are computed per request, never their text', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      // The tenant's name is exactly the kind of thing a baseline every project member can read must
+      // not carry, and exactly what a computed block is usually built from.
+      instructions: ({ requestContext }) => `You serve ${String(requestContext.get('tenant') ?? 'nobody')}.`,
+      model: mockModel(),
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+    await settle()
+
+    expect(JSON.parse(publishedBaseline(id))).toEqual({
+      instructions: [{ id: 'agent', dynamic: true }],
+      model: 'mock:mock-model',
+    })
+  })
+
+  it('leaves out a model it cannot name once, rather than pinning one sample of it', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model: () => model,
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+    await settle()
+
+    const baseline = JSON.parse(publishedBaseline(id)) as Record<string, unknown>
+    expect(baseline['model']).toBeUndefined()
+    expect(baseline['instructions']).toEqual([{ id: 'agent', instructions: 'x', dynamic: false }])
+  })
+
+  it('describes what the code says even when a per-run option replaced it', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'Code instructions.',
+      model: mockModel(),
+      inputProcessors: [agentControl()],
+    })
+
+    await agent.generate('hi', { instructions: 'Per-run instructions.' })
+    await settle()
+
+    expect(JSON.parse(publishedBaseline(id))).toMatchObject({
+      instructions: [{ id: 'agent', instructions: 'Code instructions.', dynamic: false }],
+    })
+  })
+
+  it('can be switched off for a read-only token', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model: mockModel(),
+      inputProcessors: [agentControl({ publishBaseline: false })],
+    })
+
+    await run(agent)
+    await settle()
+
+    expect(publishedBaseline(id)).toBe('')
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/baseline.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/baseline.test.ts
@@ -43,7 +43,7 @@ describe('the published baseline', () => {
       tools: { getWeather },
       defaultOptions: {
         modelSettings: { temperature: 0.2, maxOutputTokens: 100, timeout: { stepMs: 30_000 } },
-        providerOptions: { openai: { parallelToolCalls: false } },
+        providerOptions: { anthropic: { disableParallelToolUse: true } },
       },
       inputProcessors: [agentControl()],
     })

--- a/packages/logfire-agent-control-mastra/src/__test__/cassette.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/cassette.ts
@@ -1,0 +1,207 @@
+/**
+ * Record-and-replay for the provider requests the live tests make.
+ *
+ * The rest of this suite drives Mastra against mock models, which proves what this adapter hands the
+ * framework. It cannot prove what a provider does with it: whether a rewritten instruction changes
+ * the answer, whether a renamed tool is the name a real model calls back with, whether a setting the
+ * table claims is editable is one the provider accepts. Those are questions only a real request
+ * answers, and a recording is how the answer stays answered in CI.
+ *
+ * ## Why this rather than a recording library
+ *
+ * `nock` records the response as the bytes that came off the socket, which for every provider here
+ * means a gzip stream stored as hex. A cassette nobody can read is a cassette nobody can check for a
+ * leaked key, and the request body is the assertion material in half of these tests. So the seam is
+ * `globalThis.fetch` -- which is what every AI SDK provider calls, whatever transport it wraps -- and
+ * a cassette is decoded JSON, greppable and diffable.
+ *
+ * ## What is stored, and what is not
+ *
+ * Request headers are never written: that is where `authorization`, `x-api-key` and `api-key` live,
+ * and the way to keep them out of a file is not to have a list of them. The URL keeps its path and
+ * loses any credential-bearing query parameter, because Google's client puts the key there. Response
+ * headers are narrowed to `content-type`, which is the only one replay needs and which leaves
+ * `set-cookie` and the per-organization headers out.
+ *
+ * ## Recording
+ *
+ * ```bash
+ * RECORD_CASSETTES=1 node --env-file=.env node_modules/.bin/vp test -- -t "against a real provider"
+ * ```
+ *
+ * A cassette is replayed in order: request `n` of the test gets response `n` of the file, and a
+ * request whose method or URL is not the recorded one fails the test rather than reaching the
+ * network, so a change that alters the calls an agent makes shows up as drift instead of a bill.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { getProviderConfig } from '@mastra/core/llm'
+import { onTestFinished } from 'vite-plus/test'
+
+/** Where the cassettes live, resolved from this file so the cwd a runner picks cannot matter. */
+const CASSETTE_DIR = join(dirname(fileURLToPath(import.meta.url)), 'cassettes')
+
+/** Query parameters that carry a credential, which are dropped from a recorded URL. */
+const CREDENTIAL_PARAMS = ['key', 'api_key', 'access_token']
+
+/** One request as it is recorded, which is also what a test reads to assert what went out. */
+export interface RecordedRequest {
+  method: string
+  url: string
+  /** The parsed JSON body, or `null` for a request that sent none. */
+  body: unknown
+}
+
+/** One response as it is recorded. `body` is parsed JSON for a JSON response and text otherwise. */
+interface RecordedResponse {
+  status: number
+  contentType: string
+  body: unknown
+}
+
+interface Interaction {
+  request: RecordedRequest
+  response: RecordedResponse
+}
+
+/** What a live test holds on to: the requests it actually made, in order. */
+export interface Wire {
+  /** Every request the run sent, whether it was recorded now or replayed from the file. */
+  readonly requests: readonly RecordedRequest[]
+  /** The body of request `index`, as the object the provider was sent. */
+  request: (index: number) => Record<string, unknown>
+}
+
+/** Whether this run is recording against the real providers rather than replaying. */
+function recording(): boolean {
+  return process.env['RECORD_CASSETTES'] !== undefined && process.env['RECORD_CASSETTES'] !== ''
+}
+
+/**
+ * Install a cassette for the current test, and take it out again when the test finishes.
+ *
+ * Replaying is the default and needs no credentials; `RECORD_CASSETTES=1` passes the requests
+ * through to the real provider and writes what came back.
+ *
+ * `provider` is the Mastra registry name of the provider the test drives, and it is needed because
+ * the router resolves its credential *before* it builds a request: with no key in the environment it
+ * throws rather than calling `fetch`, and there would be nothing for a cassette to answer. So in
+ * replay a placeholder is put in the environment for the duration of the test -- only where the
+ * variable is unset, and never in record mode, where the real one is what a recording needs.
+ */
+export function useCassette(name: string, provider: string): Wire {
+  const path = join(CASSETTE_DIR, `${name}.json`)
+  if (!recording()) {
+    stubCredentials(provider)
+  }
+  const requests: RecordedRequest[] = []
+  const recorded: Interaction[] = []
+  const stored = recording() ? [] : (JSON.parse(readFileSync(path, 'utf8')) as Interaction[])
+  const original = globalThis.fetch
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = new Request(input as RequestInfo, init)
+    const body = await readJson(request.clone())
+    const index = requests.length
+    requests.push({ method: request.method, url: scrubUrl(request.url), body })
+    if (!recording()) {
+      return replay(name, stored, index, requests[index] as RecordedRequest)
+    }
+    const response = await original(request)
+    const text = await response.clone().text()
+    const contentType = response.headers.get('content-type') ?? 'application/json'
+    recorded.push({
+      request: requests[index] as RecordedRequest,
+      response: { status: response.status, contentType, body: parse(text, contentType) },
+    })
+    return response
+  }
+
+  onTestFinished(() => {
+    globalThis.fetch = original
+    if (recording()) {
+      mkdirSync(CASSETTE_DIR, { recursive: true })
+      writeFileSync(path, `${JSON.stringify(recorded, null, 2)}\n`)
+    } else if (requests.length !== stored.length) {
+      throw new Error(
+        `Cassette '${name}' holds ${String(stored.length)} interactions but the test made ` +
+          `${String(requests.length)} requests; re-record it with RECORD_CASSETTES=1.`
+      )
+    }
+  })
+
+  return {
+    requests,
+    request: (index: number): Record<string, unknown> => requests[index]?.body as Record<string, unknown>,
+  }
+}
+
+/** The stored response for request `index`, or an explanation of how the request drifted. */
+function replay(name: string, stored: readonly Interaction[], index: number, request: RecordedRequest): Response {
+  const interaction = stored[index]
+  if (interaction === undefined) {
+    throw new Error(
+      `Cassette '${name}' has no interaction ${String(index)}; the test made more requests than were ` +
+        'recorded. Re-record it with RECORD_CASSETTES=1.'
+    )
+  }
+  if (interaction.request.method !== request.method || interaction.request.url !== request.url) {
+    throw new Error(
+      `Cassette '${name}' interaction ${String(index)} recorded ${interaction.request.method} ` +
+        `${interaction.request.url}, but the test sent ${request.method} ${request.url}.`
+    )
+  }
+  const { status, contentType, body } = interaction.response
+  const text = typeof body === 'string' ? body : JSON.stringify(body)
+  return new Response(text, { status, headers: { 'content-type': contentType } })
+}
+
+/** A request's body as JSON, or `null` where it sent none. Every provider here posts JSON. */
+async function readJson(request: Request): Promise<unknown> {
+  const text = await request.text()
+  return text === '' ? null : (JSON.parse(text) as unknown)
+}
+
+/** A response body as the value to store: parsed for JSON, the text itself for anything else. */
+function parse(text: string, contentType: string): unknown {
+  return contentType.includes('json') ? (JSON.parse(text) as unknown) : text
+}
+
+/** A URL with any credential-bearing query parameter removed. */
+function scrubUrl(url: string): string {
+  const parsed = new URL(url)
+  for (const param of CREDENTIAL_PARAMS) {
+    parsed.searchParams.delete(param)
+  }
+  return parsed.toString()
+}
+
+/**
+ * Put a placeholder in the environment for a provider's key, for the duration of the test.
+ *
+ * A variable that already holds something is left alone: replay never reaches the network, so a
+ * developer's real key is neither needed nor used, and overwriting it would only make the two runs
+ * differ for no reason.
+ */
+function stubCredentials(provider: string): void {
+  const configured = getProviderConfig(provider)?.apiKeyEnvVar
+  const names = typeof configured === 'string' ? [configured] : (configured ?? [])
+  const restore: (() => void)[] = []
+  for (const name of names) {
+    if (process.env[name] !== undefined) {
+      continue
+    }
+    process.env[name] = 'cassette-replay-placeholder'
+    restore.push(() => {
+      Reflect.deleteProperty(process.env, name)
+    })
+  }
+  onTestFinished(() => {
+    for (const undo of restore) {
+      undo()
+    }
+  })
+}

--- a/packages/logfire-agent-control-mastra/src/__test__/cassettes/instructions-openai.json
+++ b/packages/logfire-agent-control-mastra/src/__test__/cassettes/instructions-openai.json
@@ -1,0 +1,124 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "url": "https://api.openai.com/v1/responses",
+      "body": {
+        "model": "gpt-5.4-nano",
+        "input": [
+          {
+            "role": "developer",
+            "content": "Reply with exactly the word BANANA, nothing else."
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "What is the capital of France?"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "response": {
+      "status": 200,
+      "contentType": "application/json",
+      "body": {
+        "id": "resp_05f2f9521742d463006aa1e9e587cc87d1a5cbeef053e377e2",
+        "object": "response",
+        "created_at": 1788996069,
+        "status": "completed",
+        "background": false,
+        "billing": {
+          "payer": "developer"
+        },
+        "completed_at": 1788996070,
+        "error": null,
+        "frequency_penalty": 0,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": null,
+        "max_tool_calls": null,
+        "model": "gpt-5.4-nano-2026-03-17",
+        "moderation": null,
+        "output": [
+          {
+            "id": "msg_05f2f9521742d463006aa1e9e6144c87d1a99bd306f932cd2c",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "output_text",
+                "annotations": [],
+                "logprobs": [],
+                "text": "BANANA"
+              }
+            ],
+            "phase": "final_answer",
+            "role": "assistant"
+          }
+        ],
+        "parallel_tool_calls": true,
+        "presence_penalty": 0,
+        "previous_response_id": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": "24h",
+        "reasoning": {
+          "context": "current_turn",
+          "effort": "none",
+          "mode": "standard",
+          "summary": null
+        },
+        "safety_identifier": null,
+        "service_tier": "default",
+        "store": true,
+        "temperature": 1,
+        "text": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
+        "tools": [],
+        "top_logprobs": 0,
+        "top_p": 0.98,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 28,
+          "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 0
+          },
+          "output_tokens": 6,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 34
+        },
+        "user": null,
+        "metadata": {}
+      }
+    }
+  }
+]

--- a/packages/logfire-agent-control-mastra/src/__test__/cassettes/settings-anthropic.json
+++ b/packages/logfire-agent-control-mastra/src/__test__/cassettes/settings-anthropic.json
@@ -1,0 +1,86 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "url": "https://api.anthropic.com/v1/messages",
+      "body": {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 512,
+        "temperature": 0.2,
+        "top_k": 20,
+        "stop_sequences": ["###NEVER###"],
+        "system": [
+          {
+            "type": "text",
+            "text": "Answer in one word."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "Capital of France?"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "getWeather",
+            "description": "Get the weather for a city.",
+            "input_schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name"
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          }
+        ],
+        "tool_choice": {
+          "type": "auto",
+          "disable_parallel_tool_use": true
+        }
+      }
+    },
+    "response": {
+      "status": 200,
+      "contentType": "application/json",
+      "body": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_011CetiwV3bL7UeMcfPSLTMC",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "Paris."
+          }
+        ],
+        "container": null,
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "stop_details": null,
+        "usage": {
+          "input_tokens": 393,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 0
+          },
+          "output_tokens": 5,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        }
+      }
+    }
+  }
+]

--- a/packages/logfire-agent-control-mastra/src/__test__/cassettes/settings-openai.json
+++ b/packages/logfire-agent-control-mastra/src/__test__/cassettes/settings-openai.json
@@ -1,0 +1,166 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "url": "https://api.openai.com/v1/responses",
+      "body": {
+        "model": "gpt-5.4-nano",
+        "input": [
+          {
+            "role": "developer",
+            "content": "Answer in one word."
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "Capital of France?"
+              }
+            ]
+          }
+        ],
+        "max_output_tokens": 512,
+        "parallel_tool_calls": false,
+        "tools": [
+          {
+            "type": "function",
+            "name": "getWeather",
+            "description": "Get the weather for a city.",
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name"
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          }
+        ],
+        "tool_choice": "auto"
+      }
+    },
+    "response": {
+      "status": 200,
+      "contentType": "application/json",
+      "body": {
+        "id": "resp_09e7e16e308bb917006aa1e9e9a38487d1bc517e574eb2a1a9",
+        "object": "response",
+        "created_at": 1788996073,
+        "status": "completed",
+        "background": false,
+        "billing": {
+          "payer": "developer"
+        },
+        "completed_at": 1788996074,
+        "error": null,
+        "frequency_penalty": 0,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": 512,
+        "max_tool_calls": null,
+        "model": "gpt-5.4-nano-2026-03-17",
+        "moderation": null,
+        "output": [
+          {
+            "id": "msg_09e7e16e308bb917006aa1e9ea2ba087d196908e7ba8307c32",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "output_text",
+                "annotations": [],
+                "logprobs": [],
+                "text": "Paris"
+              }
+            ],
+            "phase": "final_answer",
+            "role": "assistant"
+          }
+        ],
+        "parallel_tool_calls": false,
+        "presence_penalty": 0,
+        "previous_response_id": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": "24h",
+        "reasoning": {
+          "context": "current_turn",
+          "effort": "none",
+          "mode": "standard",
+          "summary": null
+        },
+        "safety_identifier": null,
+        "service_tier": "default",
+        "store": true,
+        "temperature": 1,
+        "text": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
+        "tools": [
+          {
+            "type": "function",
+            "description": "Get the weather for a city.",
+            "name": "getWeather",
+            "output_schema": null,
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name"
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            },
+            "strict": true
+          }
+        ],
+        "top_logprobs": 0,
+        "top_p": 0.98,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 138,
+          "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 0
+          },
+          "output_tokens": 5,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 143
+        },
+        "user": null,
+        "metadata": {}
+      }
+    }
+  }
+]

--- a/packages/logfire-agent-control-mastra/src/__test__/cassettes/tool-rename-openai.json
+++ b/packages/logfire-agent-control-mastra/src/__test__/cassettes/tool-rename-openai.json
@@ -1,0 +1,330 @@
+[
+  {
+    "request": {
+      "method": "POST",
+      "url": "https://api.openai.com/v1/responses",
+      "body": {
+        "model": "gpt-5.4-nano",
+        "input": [
+          {
+            "role": "developer",
+            "content": "Use your tools to answer."
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "What is the weather in Paris?"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "type": "function",
+            "name": "lookup_current_weather",
+            "description": "Look up the current weather for a city.",
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "The city to look up, for example 'Paris'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          }
+        ],
+        "tool_choice": "auto"
+      }
+    },
+    "response": {
+      "status": 200,
+      "contentType": "application/json",
+      "body": {
+        "id": "resp_0a0c6d25c5e72d57006aa1e9e6d43087d1abf7dd570ee4a918",
+        "object": "response",
+        "created_at": 1788996070,
+        "status": "completed",
+        "background": false,
+        "billing": {
+          "payer": "developer"
+        },
+        "completed_at": 1788996071,
+        "error": null,
+        "frequency_penalty": 0,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": null,
+        "max_tool_calls": null,
+        "model": "gpt-5.4-nano-2026-03-17",
+        "moderation": null,
+        "output": [
+          {
+            "id": "fc_0a0c6d25c5e72d57006aa1e9e733f487d1ad8246e53a04b9c4",
+            "type": "function_call",
+            "status": "completed",
+            "arguments": "{\"city\":\"Paris\"}",
+            "call_id": "call_53mWrv5D2k4ldBJe3FuZHNta",
+            "name": "lookup_current_weather"
+          }
+        ],
+        "parallel_tool_calls": true,
+        "presence_penalty": 0,
+        "previous_response_id": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": "24h",
+        "reasoning": {
+          "context": "current_turn",
+          "effort": "none",
+          "mode": "standard",
+          "summary": null
+        },
+        "safety_identifier": null,
+        "service_tier": "default",
+        "store": true,
+        "temperature": 1,
+        "text": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
+        "tools": [
+          {
+            "type": "function",
+            "description": "Look up the current weather for a city.",
+            "name": "lookup_current_weather",
+            "output_schema": null,
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "The city to look up, for example 'Paris'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            },
+            "strict": true
+          }
+        ],
+        "top_logprobs": 0,
+        "top_p": 0.98,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 75,
+          "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 0
+          },
+          "output_tokens": 19,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 94
+        },
+        "user": null,
+        "metadata": {}
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "url": "https://api.openai.com/v1/responses",
+      "body": {
+        "model": "gpt-5.4-nano",
+        "input": [
+          {
+            "role": "developer",
+            "content": "Use your tools to answer."
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "What is the weather in Paris?"
+              }
+            ]
+          },
+          {
+            "type": "function_call",
+            "call_id": "call_53mWrv5D2k4ldBJe3FuZHNta",
+            "name": "lookup_current_weather",
+            "arguments": "{\"city\":\"Paris\"}"
+          },
+          {
+            "type": "function_call_output",
+            "call_id": "call_53mWrv5D2k4ldBJe3FuZHNta",
+            "output": "{\"city\":\"Paris\",\"temperatureC\":21}"
+          }
+        ],
+        "tools": [
+          {
+            "type": "function",
+            "name": "lookup_current_weather",
+            "description": "Look up the current weather for a city.",
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "The city to look up, for example 'Paris'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          }
+        ],
+        "tool_choice": "auto"
+      }
+    },
+    "response": {
+      "status": 200,
+      "contentType": "application/json",
+      "body": {
+        "id": "resp_08db06938d20dc71006aa1e9e7a78c87d1a92a76eb388ce546",
+        "object": "response",
+        "created_at": 1788996071,
+        "status": "completed",
+        "background": false,
+        "billing": {
+          "payer": "developer"
+        },
+        "completed_at": 1788996072,
+        "error": null,
+        "frequency_penalty": 0,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": null,
+        "max_tool_calls": null,
+        "model": "gpt-5.4-nano-2026-03-17",
+        "moderation": null,
+        "output": [
+          {
+            "id": "msg_08db06938d20dc71006aa1e9e800f087d1a1946fb6f74beb25",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "output_text",
+                "annotations": [],
+                "logprobs": [],
+                "text": "The current weather in **Paris** is **21°C**."
+              }
+            ],
+            "phase": "final_answer",
+            "role": "assistant"
+          }
+        ],
+        "parallel_tool_calls": true,
+        "presence_penalty": 0,
+        "previous_response_id": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": "24h",
+        "reasoning": {
+          "context": "current_turn",
+          "effort": "none",
+          "mode": "standard",
+          "summary": null
+        },
+        "safety_identifier": null,
+        "service_tier": "default",
+        "store": true,
+        "temperature": 1,
+        "text": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
+        "tools": [
+          {
+            "type": "function",
+            "description": "Look up the current weather for a city.",
+            "name": "lookup_current_weather",
+            "output_schema": null,
+            "parameters": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "The city to look up, for example 'Paris'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            },
+            "strict": true
+          }
+        ],
+        "top_logprobs": 0,
+        "top_p": 0.98,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 116,
+          "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 0
+          },
+          "output_tokens": 17,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 133
+        },
+        "user": null,
+        "metadata": {}
+      }
+    }
+  }
+]

--- a/packages/logfire-agent-control-mastra/src/__test__/degradation.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/degradation.test.ts
@@ -1,0 +1,217 @@
+import { Agent } from '@mastra/core/agent'
+import type { InputProcessor, ProcessInputArgs, ProcessInputStepArgs } from '@mastra/core/processors'
+import { configureVariables, getVariableProvider } from '@pydantic/logfire-node/vars'
+import type { SerializedResolvedVariable } from '@pydantic/logfire-node/vars'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import {
+  callAt,
+  captureWarnings,
+  mockModel,
+  nextAgentId,
+  publishedValue,
+  run,
+  systemPrompt,
+  useLocalVariables,
+  useManagedAgent,
+  useNoVariables,
+} from './helpers'
+
+const warnings = captureWarnings()
+
+/** A provider that fails every read, the way an unreachable Logfire API does. */
+function useBrokenProvider(): void {
+  configureVariables(false)
+  const provider = getVariableProvider() as { getSerializedValue: () => Promise<SerializedResolvedVariable> }
+  provider.getSerializedValue = async () => Promise.reject(new Error('connection refused'))
+}
+
+/** A promise and the call that settles it, for holding one request open while another runs. */
+function deferred(): { settled: Promise<void>; settle: () => void } {
+  let settle!: () => void
+  const settled = new Promise<void>((resolve) => {
+    settle = resolve
+  })
+  return { settled, settle }
+}
+
+function agentWith(id: string, model = mockModel(), options = {}): Agent {
+  return new Agent({ id, name: 'A', instructions: 'Code text.', model, inputProcessors: [agentControl(options)] })
+}
+
+describe('when Logfire has nothing to say', () => {
+  it('runs the agent as written when variables are switched off', async () => {
+    const id = nextAgentId()
+    useNoVariables()
+    const model = mockModel()
+
+    expect(await run(agentWith(id, model))).toBe('ok')
+    expect(systemPrompt(model)).toEqual(['Code text.'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('runs the agent as written when nothing is published for it', async () => {
+    const id = nextAgentId()
+    useLocalVariables()
+    const model = mockModel()
+
+    expect(await run(agentWith(id, model))).toBe('ok')
+    expect(systemPrompt(model)).toEqual(['Code text.'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('runs the agent as written, saying so once, when Logfire cannot be reached', async () => {
+    const id = nextAgentId()
+    useBrokenProvider()
+    const model = mockModel()
+
+    expect(await run(agentWith(id, model))).toBe('ok')
+    expect(systemPrompt(model)).toEqual(['Code text.'])
+    expect(warnings.messages).toEqual([expect.stringContaining(`Logfire managed variable 'agent__${id}' could not be resolved`)])
+  })
+
+  it('applies the sections of a published value it can read, and warns about the one it cannot', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: 42, settings: { temperature: 0.4 } })
+    const model = mockModel()
+
+    await run(agentWith(id, model))
+
+    expect(systemPrompt(model)).toEqual(['Code text.'])
+    expect(warnings.messages).toEqual([expect.stringContaining('Managed instructions section has invalid container')])
+  })
+})
+
+/** The hook arguments a processor-only context supplies, which is everything but the agent. */
+function inputArgs(state: Record<string, unknown>): ProcessInputArgs {
+  return { state, messageList: { get: {} }, systemMessages: [] } as unknown as ProcessInputArgs
+}
+
+function stepArgs(state: Record<string, unknown>): ProcessInputStepArgs {
+  return {
+    state,
+    systemMessages: [],
+    messageList: { getSystemMessages: () => [] },
+    modelSettings: {},
+  } as unknown as ProcessInputStepArgs
+}
+
+/**
+ * A stand-in for the `Agent` a processor-only context has no real one of.
+ *
+ * Mastra's types require an `id` and its runtime falls over without one long before a processor is
+ * reached, so an agent with no name is only reachable by hand. The guard is still worth having: a
+ * JavaScript caller can leave both `id` and `name` out, and an unnamed agent would otherwise share
+ * one variable with every other unnamed agent.
+ */
+function unnamedAgentArgs(id: unknown): ProcessInputArgs {
+  return {
+    state: {},
+    agent: { id, __getOverridableFields: () => ({ instructions: 'x' }), getDefaultOptions: () => ({}) },
+  } as unknown as ProcessInputArgs
+}
+
+describe('when the processor is not on an agent', () => {
+  it('changes nothing, and says why, when there is no agent to read', async () => {
+    const processor: InputProcessor = agentControl()
+    const state: Record<string, unknown> = {}
+
+    await processor.processInput?.(inputArgs(state))
+    const result = await processor.processInputStep?.(stepArgs(state))
+
+    expect(result).toBeUndefined()
+    expect(warnings.messages).toEqual([expect.stringContaining('ran without an agent')])
+  })
+
+  it('changes nothing, and says why, when the per-request hook never ran', async () => {
+    const processor: InputProcessor = agentControl()
+
+    const result = await processor.processInputStep?.(stepArgs({}))
+
+    expect(result).toBeUndefined()
+    expect(warnings.messages).toEqual([expect.stringContaining('ran without the per-request state')])
+  })
+})
+
+describe('two runs that overlap', () => {
+  it("keeps each one on its own agent's config", async () => {
+    const first = nextAgentId()
+    const second = nextAgentId()
+    useLocalVariables({
+      variables: {
+        ...publishedValue(`agent__${first}`, { settings: { temperature: 0.9 } }).variables,
+        ...publishedValue(`agent__${second}`, { settings: { temperature: 0.1 } }).variables,
+      },
+    })
+
+    // One processor instance on both agents, and the first request held open at the model call until
+    // the second has been through the whole of its own. Anything this adapter kept per instance
+    // rather than per request would have been overwritten by the time the first call is let go.
+    const held = deferred()
+    const processor = agentControl()
+    const firstModel = mockModel()
+    const inner = firstModel.doGenerate.bind(firstModel)
+    firstModel.doGenerate = async (options) => {
+      await held.settled
+      return inner(options)
+    }
+    const secondModel = mockModel()
+    const agentOf = (id: string, model: ReturnType<typeof mockModel>): Agent =>
+      new Agent({ id, name: 'A', instructions: 'Code text.', model, inputProcessors: [processor] })
+
+    const running = run(agentOf(first, firstModel))
+    await run(agentOf(second, secondModel))
+    held.settle()
+    await running
+
+    expect(callAt(firstModel, 0)).toMatchObject({ temperature: 0.9 })
+    expect(callAt(secondModel, 0)).toMatchObject({ temperature: 0.1 })
+  })
+})
+
+describe('naming the agent', () => {
+  it('reads the variable the agent id names', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent', instructions: 'Managed.' }] })
+    const model = mockModel()
+
+    await run(agentWith(id, model))
+
+    expect(systemPrompt(model)).toEqual(['Managed.'])
+  })
+
+  it('reads the same variable on every request the agent serves', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent', instructions: 'Managed.' }] })
+    const model = mockModel()
+    const agent = agentWith(id, model)
+
+    await run(agent)
+    await run(agent)
+
+    // The control is built once per agent and reused, so a long-lived agent does not re-register its
+    // variable, re-warm the SDK's cache, or re-attempt the baseline publish on every request.
+    expect(systemPrompt(model, 0)).toEqual(['Managed.'])
+    expect(systemPrompt(model, 1)).toEqual(['Managed.'])
+  })
+
+  it('takes a name of its own, for an agent whose id is not the one to key on', async () => {
+    const id = nextAgentId()
+    const managedName = nextAgentId()
+    useLocalVariables(publishedValue(`agent__${managedName}`, { instructions: [{ id: 'agent', instructions: 'Managed.' }] }))
+    const model = mockModel()
+
+    await run(agentWith(id, model, { name: managedName }))
+
+    expect(systemPrompt(model)).toEqual(['Managed.'])
+  })
+
+  it('refuses to run an agent it cannot name', async () => {
+    useLocalVariables()
+    const processor = agentControl()
+
+    await expect(processor.processInput?.(unnamedAgentArgs(undefined))).rejects.toThrow(/needs a name for this agent/u)
+    await expect(processor.processInput?.(unnamedAgentArgs('  '))).rejects.toThrow(/needs a name for this agent/u)
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/helpers.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/helpers.ts
@@ -1,0 +1,204 @@
+/**
+ * Shared test scaffolding: a local variables provider, mock models, and unique agent names.
+ *
+ * Everything is offline. The Logfire SDK's `LocalVariableProvider` serves a published value from
+ * memory through the same interface the remote one implements, and every model is a `MockLanguageModel`
+ * from the AI SDK's own test kit, so a test asserts on the exact call Mastra would have made.
+ */
+
+import type { LanguageModelV3CallOptions, LanguageModelV3GenerateResult } from '@ai-sdk/provider'
+import type { Agent } from '@mastra/core/agent'
+import { configureVariables } from '@pydantic/logfire-node/vars'
+import type { VariablesConfig } from '@pydantic/logfire-node/vars'
+import { MockLanguageModelV3, MockLanguageModelV4 } from 'ai/test'
+import { afterEach, beforeEach, vi } from 'vite-plus/test'
+
+import { resetAgentControl } from '@pydantic/logfire-node/agent-control/testing'
+
+/**
+ * A fresh agent name for each test.
+ *
+ * The core deduplicates its warnings, and publishes a baseline, once per process per variable.
+ * `resetAgentControl` clears both between tests, but a name no other test uses is the belt to that
+ * pair of braces: it keeps a test that forgets the reset -- or one that runs a second control inside
+ * a single test -- from silently observing nothing and passing for the wrong reason.
+ */
+let counter = 0
+export function nextAgentId(): string {
+  counter += 1
+  return `test_agent_${String(counter)}`
+}
+
+/** A variables config in which `name` holds `value` under one label at full rollout. */
+export function publishedValue(name: string, value: unknown, label = 'production'): VariablesConfig {
+  return {
+    variables: {
+      [name]: {
+        name,
+        labels: { [label]: { version: 1, serialized_value: JSON.stringify(value) } },
+        rollout: { labels: { [label]: 1 } },
+        overrides: [],
+      },
+    },
+  }
+}
+
+/** Point the SDK at a local provider holding `config`. */
+export function useLocalVariables(config: VariablesConfig = { variables: {} }): void {
+  configureVariables({ config, instrument: false })
+}
+
+/** Publish `value` for `agentId` and point the SDK at it, which is what most tests want. */
+export function useManagedAgent(agentId: string, value: unknown): void {
+  useLocalVariables(publishedValue(`agent__${agentId}`, value))
+}
+
+/** Switch variables off entirely, which installs the no-op provider. */
+export function useNoVariables(): void {
+  configureVariables(false)
+}
+
+/** Capture `console.warn` for the duration of a test. */
+export function captureWarnings(): { messages: string[] } {
+  const captured: { messages: string[] } = { messages: [] }
+  beforeEach(() => {
+    captured.messages.length = 0
+    resetAgentControl()
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+      captured.messages.push(String(message))
+    })
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    useNoVariables()
+  })
+  return captured
+}
+
+/** Wait for the background baseline publish to settle. */
+export async function settle(): Promise<void> {
+  await Promise.all(Array.from({ length: 5 }, async () => Promise.resolve()))
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+const USAGE = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+} as unknown as LanguageModelV3GenerateResult['usage']
+
+/** One `doGenerate` result: a plain text answer. */
+export function text(value = 'ok'): LanguageModelV3GenerateResult {
+  return {
+    content: [{ type: 'text', text: value }],
+    finishReason: { unified: 'stop', raw: 'stop' },
+    usage: USAGE,
+    warnings: [],
+  }
+}
+
+/** One `doGenerate` result: a call to `toolName` with `input`. */
+export function toolCall(toolName: string, input: Record<string, unknown>): LanguageModelV3GenerateResult {
+  return {
+    content: [{ type: 'tool-call', toolCallId: 'call_1', toolName, input: JSON.stringify(input) }],
+    finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+    usage: USAGE,
+    warnings: [],
+  }
+}
+
+/**
+ * A v3 mock model that answers with `results` in order, repeating the last one.
+ *
+ * Both call methods answer, because Mastra uses one for `generate` and the other for `stream` and an
+ * adapter that sits at the model boundary has to sit at both of them. The streamed form is the
+ * generated one taken apart into the parts a provider would have sent.
+ */
+export function mockModel(
+  provider = 'mock',
+  modelId = 'mock-model',
+  results: LanguageModelV3GenerateResult[] = [text()]
+): MockLanguageModelV3 {
+  let index = 0
+  const next = (): LanguageModelV3GenerateResult => results[Math.min(index++, results.length - 1)] as never
+  return new MockLanguageModelV3({
+    provider,
+    modelId,
+    doGenerate: async () => Promise.resolve(next()),
+    doStream: () => Promise.resolve({ stream: streamOf(next()) }) as never,
+  })
+}
+
+/** One generated answer as the stream of parts a provider would have sent for it. */
+function streamOf(result: LanguageModelV3GenerateResult): ReadableStream<unknown> {
+  const parts: unknown[] = [{ type: 'stream-start', warnings: [] }]
+  for (const [n, part] of result.content.entries()) {
+    if (part.type === 'tool-call') {
+      parts.push(
+        { type: 'tool-input-start', id: part.toolCallId, toolName: part.toolName },
+        { type: 'tool-input-delta', id: part.toolCallId, delta: part.input },
+        { type: 'tool-input-end', id: part.toolCallId },
+        part
+      )
+    } else if (part.type === 'text') {
+      parts.push(
+        { type: 'text-start', id: `msg_${String(n)}` },
+        { type: 'text-delta', id: `msg_${String(n)}`, delta: part.text },
+        { type: 'text-end', id: `msg_${String(n)}` }
+      )
+    }
+  }
+  parts.push({ type: 'finish', finishReason: result.finishReason, usage: result.usage })
+  return new ReadableStream({
+    start(controller) {
+      for (const part of parts) {
+        controller.enqueue(part)
+      }
+      controller.close()
+    },
+  })
+}
+
+/**
+ * A v4 mock model, for the settings only an AI SDK v7 provider acts on.
+ *
+ * Mastra passes `reasoning` to v4 models and drops it for older ones, so which specification version
+ * a test uses is the difference between a setting applied and a setting reported.
+ */
+export function mockModelV4(provider = 'openai', modelId = 'mock-v4'): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    provider,
+    modelId,
+    doGenerate: async () =>
+      Promise.resolve({
+        content: [{ type: 'text', text: 'ok' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: USAGE,
+        warnings: [],
+      } as never),
+  })
+}
+
+/** The options of the model's `index`-th call. */
+export function callAt(model: MockLanguageModelV3, index: number): LanguageModelV3CallOptions {
+  return model.doGenerateCalls[index] as LanguageModelV3CallOptions
+}
+
+/** The system messages of the model's `index`-th call, in order. */
+export function systemPrompt(model: MockLanguageModelV3, index = 0): string[] {
+  return callAt(model, index)
+    .prompt.filter((message) => message.role === 'system')
+    .map((message) => message.content)
+}
+
+/** The tool declarations of the model's `index`-th call. */
+export function toolsOf(model: MockLanguageModelV3, index = 0): Record<string, unknown>[] {
+  return (callAt(model, index).tools ?? []) as unknown as Record<string, unknown>[]
+}
+
+/** Run an agent once and return its text, keeping the call site of every test to one line. */
+export async function run(agent: Agent, prompt = 'hi'): Promise<string> {
+  const result = await agent.generate(prompt)
+  return result.text
+}

--- a/packages/logfire-agent-control-mastra/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/instructions.test.ts
@@ -65,6 +65,54 @@ describe('the instructions section', () => {
     expect(systemPrompt(model)).toEqual(['Always confirm the order total.', 'You are a refund specialist.'])
   })
 
+  it('keeps an entry that declares an id in the reserved `tag:` namespace, under its position', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: ['Added.'] })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: [
+        // `tag:` names Mastra's own buckets, and a block carrying one is dropped from the prompt
+        // rather than sent -- so an entry claiming one keeps its positional id instead.
+        { role: 'system' as const, content: 'Persona.', providerOptions: { logfire: { id: 'tag:persona' } } },
+        { role: 'system' as const, content: 'Second.' },
+      ],
+      model,
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    expect(systemPrompt(model)).toEqual(['Persona.', 'Second.', 'Added.'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('refuses an id two entries both declare, rather than letting one override rewrite both', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'persona', instructions: 'Rewritten.' }] })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: [
+        { role: 'system' as const, content: 'First.', providerOptions: { logfire: { id: 'persona' } } },
+        { role: 'system' as const, content: 'Second.', providerOptions: { logfire: { id: 'persona' } } },
+      ],
+      model,
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    // Both fall back to their positional ids, so the ambiguous id addresses nothing and is reported;
+    // the alternative is one of the two winning by declaration order, silently.
+    expect(systemPrompt(model)).toEqual(['First.', 'Second.'])
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("addresses instruction block 'persona', which this request does not assemble"),
+    ])
+  })
+
   it("adds a block after the agent's own text and before what Mastra adds per request", async () => {
     const id = nextAgentId()
     useManagedAgent(id, { instructions: 'Escalate anything over $500 to a human.' })
@@ -251,5 +299,9 @@ describe('the instructions section', () => {
     // appended to what the previous step returned, would move the provider's cache boundary.
     expect(systemPrompt(model, 0)).toEqual(['Managed.', 'Second.'])
     expect(systemPrompt(model, 1)).toEqual(['Managed.', 'Second.'])
+    // And nothing is reported on the second step. Mastra rebuilds a step's system messages from the
+    // agent rather than from what the previous step returned, so the already-managed text is never
+    // compared against the code's and read as a per-run option that replaced it.
+    expect(warnings.messages).toEqual([])
   })
 })

--- a/packages/logfire-agent-control-mastra/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/instructions.test.ts
@@ -1,0 +1,255 @@
+import { Agent } from '@mastra/core/agent'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import { captureWarnings, mockModel, nextAgentId, run, systemPrompt, useManagedAgent } from './helpers'
+
+const warnings = captureWarnings()
+
+/** An agent whose two instruction blocks are the ones a published value addresses by index. */
+function twoBlockAgent(id: string, model = mockModel()): Agent {
+  return new Agent({
+    id,
+    name: 'A',
+    instructions: ['You are a concise checkout assistant.', 'Always confirm the order total.'],
+    model,
+    inputProcessors: [agentControl()],
+  })
+}
+
+describe('the instructions section', () => {
+  it('rewrites the block an id names and leaves its neighbours alone', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:0', instructions: 'You are a refund specialist.' }] })
+    const model = mockModel()
+
+    await run(twoBlockAgent(id, model))
+
+    expect(systemPrompt(model)).toEqual(['You are a refund specialist.', 'Always confirm the order total.'])
+  })
+
+  it('addresses a lone instruction string as `agent`', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent', instructions: 'Rewritten.' }] })
+    const model = mockModel()
+    const agent = new Agent({ id, name: 'A', instructions: 'Original.', model, inputProcessors: [agentControl()] })
+
+    await run(agent)
+
+    expect(systemPrompt(model)).toEqual(['Rewritten.'])
+  })
+
+  it('addresses a block by the id its entry declares, wherever the entry sits', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'persona', instructions: 'You are a refund specialist.' }] })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      // Declared second, and addressed as `persona` rather than as `agent:1` -- which is the point:
+      // moving it back to the front does not re-point the override at the other block.
+      instructions: [
+        { role: 'system' as const, content: 'Always confirm the order total.' },
+        {
+          role: 'system' as const,
+          content: 'You are a concise checkout assistant.',
+          providerOptions: { logfire: { id: 'persona' } },
+        },
+      ],
+      model,
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    expect(systemPrompt(model)).toEqual(['Always confirm the order total.', 'You are a refund specialist.'])
+  })
+
+  it("adds a block after the agent's own text and before what Mastra adds per request", async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: 'Escalate anything over $500 to a human.' })
+    const model = mockModel()
+
+    // The caller's `system` option lands in a tagged bucket, which the model sees after the untagged
+    // one: an added block must go before it, or every request would push the cached prefix along.
+    await twoBlockAgent(id, model).generate('hi', { system: 'Today is Tuesday.' })
+
+    expect(systemPrompt(model)).toEqual([
+      'You are a concise checkout assistant.',
+      'Always confirm the order total.',
+      'Escalate anything over $500 to a human.',
+      'Today is Tuesday.',
+    ])
+  })
+
+  it('drops a block whose entry publishes no text', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:1', instructions: null }] })
+    const model = mockModel()
+
+    await run(twoBlockAgent(id, model))
+
+    expect(systemPrompt(model)).toEqual(['You are a concise checkout assistant.'])
+  })
+
+  it('stands down where a per-run `instructions` option replaced the code it addresses', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:0', instructions: 'Managed.' }] })
+    const model = mockModel()
+
+    await twoBlockAgent(id, model).generate('hi', { instructions: 'Per-run instructions.' })
+
+    // Per-run beats published: the ids no longer name the blocks they were written against, so the
+    // section applies to nothing rather than to whatever happens to be at index 0 -- and says so,
+    // rather than leaving someone to wonder why what they published did nothing.
+    expect(systemPrompt(model)).toEqual(['Per-run instructions.'])
+    expect(warnings.messages).toEqual([expect.stringContaining('this request passed its own `instructions:` option')])
+  })
+
+  it('stands down, and says what to fix, where two of the code blocks are identical', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:1', instructions: 'Managed.' }] })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      // Mastra's `MessageList` drops the duplicate, so `agent:1` would land on whatever followed it.
+      instructions: ['Say it once.', 'Say it once.', 'And then stop.'],
+      model,
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    expect(systemPrompt(model)).toEqual(['Say it once.', 'And then stop.'])
+    expect(warnings.messages).toEqual([expect.stringContaining("two of this agent's own instruction blocks are identical")])
+  })
+
+  it('refuses to rewrite instructions the agent computes per request', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      instructions: [{ id: 'agent', instructions: 'Pinned.' }, 'Escalate anything over $500 to a human.'],
+    })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: ({ requestContext }) => `You serve ${String(requestContext.get('tenant') ?? 'nobody')}.`,
+      model,
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    // The computed block keeps what the code produces; the added block still applies, before it,
+    // because an added block never moves an existing one.
+    expect(systemPrompt(model)).toEqual(['Escalate anything over $500 to a human.', 'You serve nobody.'])
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("addresses instruction block 'agent', which the agent recomputes per request"),
+    ])
+  })
+
+  it("describes Mastra's own tagged prompt sections without touching them", async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'tag:user-provided', instructions: 'Rewritten.' }] })
+    const model = mockModel()
+
+    await twoBlockAgent(id, model).generate('hi', { system: 'Today is Tuesday.' })
+
+    expect(systemPrompt(model)).toEqual(['You are a concise checkout assistant.', 'Always confirm the order total.', 'Today is Tuesday.'])
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("addresses instruction block 'tag:user-provided', which the agent recomputes per request"),
+    ])
+  })
+
+  it('reports an id that names no block in this request', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:7', instructions: 'Nowhere.' }] })
+    const model = mockModel()
+
+    await run(twoBlockAgent(id, model))
+
+    expect(systemPrompt(model)).toEqual(['You are a concise checkout assistant.', 'Always confirm the order total.'])
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("addresses instruction block 'agent:7', which this request does not assemble"),
+    ])
+  })
+
+  it("fails the run instead, under `onUnmatched: 'error'`", async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:7', instructions: 'Nowhere.' }] })
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: ['One.'],
+      model: mockModel(),
+      inputProcessors: [agentControl({ onUnmatched: 'error' })],
+    })
+
+    // The run fails, but not with `UnmatchedConfigError` itself: Mastra runs input processors as a
+    // workflow and wraps whatever a step throws in a `PROCESSOR_WORKFLOW_FAILED` error, keeping the
+    // message. So the policy stops the run, and what it says survives; the class does not.
+    await expect(run(agent)).rejects.toThrow(
+      /Managed agent config addresses instruction block 'agent:7', which this request does not assemble/u
+    )
+  })
+
+  it("says nothing under `onUnmatched: 'ignore'`", async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:7', instructions: 'Nowhere.' }] })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: ['One.'],
+      model,
+      inputProcessors: [agentControl({ onUnmatched: 'ignore' })],
+    })
+
+    await run(agent)
+
+    expect(systemPrompt(model)).toEqual(['One.'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('applies the same value to every step of a run', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { instructions: [{ id: 'agent:0', instructions: 'Managed.' }] })
+    const model = mockModel('mock', 'm', [
+      {
+        content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 'noop', input: '{}' }],
+        finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+        usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } },
+        warnings: [],
+      } as never,
+      {
+        content: [{ type: 'text', text: 'done' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } },
+        warnings: [],
+      } as never,
+    ])
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: ['Original.', 'Second.'],
+      model,
+      tools: {
+        noop: {
+          id: 'noop',
+          description: 'Does nothing.',
+          inputSchema: { type: 'object', properties: {} },
+          execute: async () => Promise.resolve('done'),
+        },
+      },
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    // The prompt prefix is identical on both calls: an adapter that resolved per step, or that
+    // appended to what the previous step returned, would move the provider's cache boundary.
+    expect(systemPrompt(model, 0)).toEqual(['Managed.', 'Second.'])
+    expect(systemPrompt(model, 1)).toEqual(['Managed.', 'Second.'])
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/live.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/live.test.ts
@@ -1,0 +1,230 @@
+/**
+ * What a real provider does with a published config, recorded once and replayed offline.
+ *
+ * The rest of this suite proves what the adapter hands Mastra. These tests are the other half: that
+ * what Mastra then puts on the wire is what the provider is willing to act on. Every assertion is on
+ * a request this run actually built -- the cassette supplies the response, never the request -- so a
+ * change that stops a published value from reaching the provider fails here rather than in a bill.
+ *
+ * See `./cassette.ts` for the recorder and how to re-record.
+ */
+
+import { Agent } from '@mastra/core/agent'
+import { createTool } from '@mastra/core/tools'
+import { describe, expect, it } from 'vite-plus/test'
+import { z } from 'zod'
+
+import { agentControl } from '../index'
+import { useCassette } from './cassette'
+import { captureWarnings, nextAgentId, useManagedAgent } from './helpers'
+
+const warnings = captureWarnings()
+
+/**
+ * The cheapest current model of each provider, named as Mastra's router names it.
+ *
+ * Both are in `PROVIDER_REGISTRY`, which is what `isRoutableModelId` checks, so these ids are the
+ * ones a published `openai:gpt-5.4-nano` or `anthropic:claude-haiku-4-5` translates to.
+ */
+const OPENAI = 'openai/gpt-5.4-nano'
+const ANTHROPIC = 'anthropic/claude-haiku-4-5'
+
+/** The tool the rename and settings tests offer, whose record key is what the code calls it. */
+function weatherTool(): ReturnType<typeof createTool> {
+  return createTool({
+    id: 'get_weather',
+    description: 'Get the weather for a city.',
+    inputSchema: z.object({ city: z.string().describe('City name') }),
+    execute: async ({ city }: { city: string }) => Promise.resolve({ city, temperatureC: 21 }),
+  })
+}
+
+/** Every canonical setting at once, so one request says which of them a provider takes. */
+const ALL_SETTINGS = {
+  max_tokens: 512,
+  temperature: 0.2,
+  top_p: 0.5,
+  top_k: 20,
+  seed: 42,
+  presence_penalty: 0.3,
+  frequency_penalty: 0.3,
+  stop_sequences: ['###NEVER###'],
+  timeout: 60,
+  thinking: 'low',
+  parallel_tool_calls: false,
+} as const
+
+/** The features an AI SDK provider said it could not honor, which is how a dropped setting is visible. */
+function unsupported(result: { warnings?: unknown }): string[] {
+  const list = (result.warnings ?? []) as { type?: string; feature?: string }[]
+  return list
+    .filter((warning) => warning.type === 'unsupported')
+    .map((warning) => warning.feature ?? '')
+    .sort((left, right) => left.localeCompare(right))
+}
+
+describe('against a real provider', () => {
+  it('sends a published instruction block, and the model answers to it', async () => {
+    const wire = useCassette('instructions-openai', 'openai')
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      instructions: [{ id: 'agent', instructions: 'Reply with exactly the word BANANA, nothing else.' }],
+    })
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'You are a helpful assistant.',
+      model: OPENAI,
+      inputProcessors: [agentControl()],
+    })
+
+    const result = await agent.generate('What is the capital of France?')
+
+    // The published text is the system prompt the provider received, and the code's own text is gone
+    // from the request rather than sitting alongside it.
+    expect(wire.request(0)['input']).toEqual([
+      { role: 'developer', content: 'Reply with exactly the word BANANA, nothing else.' },
+      { role: 'user', content: [{ type: 'input_text', text: 'What is the capital of France?' }] },
+    ])
+    // And it is what the model did, which no offline test can show.
+    expect(result.text).toBe('BANANA')
+  })
+
+  it('advertises a renamed tool, and dispatches the call under the code name', async () => {
+    const wire = useCassette('tool-rename-openai', 'openai')
+    const seen: { city: string }[] = []
+    const getWeather = createTool({
+      id: 'get_weather',
+      description: 'Get the weather for a city.',
+      inputSchema: z.object({ city: z.string().describe('City name') }),
+      execute: async (input: { city: string }) => {
+        seen.push(input)
+        return Promise.resolve({ city: input.city, temperatureC: 21 })
+      },
+    })
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      tool_definitions: [
+        {
+          name: 'getWeather',
+          new_name: 'lookup_current_weather',
+          description: 'Look up the current weather for a city.',
+          parameters: { city: { description: "The city to look up, for example 'Paris'." } },
+        },
+      ],
+    })
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'Use your tools to answer.',
+      model: OPENAI,
+      tools: { getWeather },
+      inputProcessors: [agentControl()],
+    })
+
+    const result = await agent.generate('What is the weather in Paris?')
+
+    // On the wire: the managed name, the managed description, and the reworded parameter description
+    // inside the schema the code declared.
+    expect(wire.request(0)['tools']).toEqual([
+      {
+        type: 'function',
+        name: 'lookup_current_weather',
+        description: 'Look up the current weather for a city.',
+        parameters: {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: { city: { type: 'string', description: "The city to look up, for example 'Paris'." } },
+          required: ['city'],
+          additionalProperties: false,
+        },
+      },
+    ])
+    // The model called it under that name, and the second request replays the history forward under
+    // the managed name too -- which is what keeps a stored thread readable to the provider.
+    const input = wire.request(1)['input'] as Record<string, unknown>[]
+    const replayed = input.filter((item) => item['type'] === 'function_call')
+    expect(replayed).toHaveLength(1)
+    expect(replayed[0]?.['name']).toBe('lookup_current_weather')
+    expect(replayed[0]?.['arguments']).toBe('{"city":"Paris"}')
+
+    // On this side of the boundary nothing knows about the rename: the code's `execute` ran with the
+    // arguments the model sent, and everything Mastra records reads `getWeather`.
+    expect(seen).toEqual([{ city: 'Paris' }])
+    expect(result.toolCalls.map((call) => call.payload.toolName)).toEqual(['getWeather'])
+    expect(toolNamesIn(result.response.messages ?? [])).toEqual(['getWeather', 'getWeather'])
+  })
+
+  it("takes the settings OpenAI's Responses API accepts, and reports what it drops", async () => {
+    const wire = useCassette('settings-openai', 'openai')
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: ALL_SETTINGS })
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'Answer in one word.',
+      model: OPENAI,
+      tools: { getWeather: weatherTool() },
+      inputProcessors: [agentControl()],
+    })
+
+    const result = await agent.generate('Capital of France?')
+
+    // Two of the eleven reach the request. `parallel_tool_calls` is the one that only exists as a
+    // provider option, which is the mapping this proves.
+    expect(wire.request(0)['max_output_tokens']).toBe(512)
+    expect(wire.request(0)['parallel_tool_calls']).toBe(false)
+    // Six the provider itself refuses. `temperature` and `top_p` it refuses only for its reasoning
+    // models, which every current GPT-5 is; the other four the Responses API has no field for at all.
+    expect(unsupported(result)).toEqual(['frequencyPenalty', 'presencePenalty', 'seed', 'stopSequences', 'temperature', 'topK', 'topP'])
+    // `timeout` is Mastra's own budget and is not a request field; `thinking` cannot be applied at
+    // all through the model router, and the adapter says so rather than dropping it in silence.
+    expect(wire.request(0)['timeout']).toBeUndefined()
+    expect(warnings.messages).toEqual([expect.stringContaining("Managed agent config sets 'thinking'")])
+  })
+
+  it('takes the settings Anthropic accepts, and reports what it drops', async () => {
+    const wire = useCassette('settings-anthropic', 'anthropic')
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: ALL_SETTINGS })
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'Answer in one word.',
+      model: ANTHROPIC,
+      tools: { getWeather: weatherTool() },
+      inputProcessors: [agentControl()],
+    })
+
+    const result = await agent.generate('Capital of France?')
+
+    expect(wire.request(0)['max_tokens']).toBe(512)
+    expect(wire.request(0)['temperature']).toBe(0.2)
+    expect(wire.request(0)['top_k']).toBe(20)
+    expect(wire.request(0)['stop_sequences']).toEqual(['###NEVER###'])
+    // The inverted polarity of the `parallel_tool_calls` mapping, as Anthropic spells it.
+    expect(wire.request(0)['tool_choice']).toEqual({ type: 'auto', disable_parallel_tool_use: true })
+    // `top_p` is the one that depends on its company: Anthropic asks callers not to send it together
+    // with `temperature`, and the AI SDK provider drops it when both are published. Alone it applies.
+    expect(wire.request(0)['top_p']).toBeUndefined()
+    expect(unsupported(result)).toEqual(['frequencyPenalty', 'presencePenalty', 'seed', 'topP'])
+    expect(warnings.messages).toEqual([expect.stringContaining("Managed agent config sets 'thinking'")])
+  })
+})
+
+/** Every tool name in a run's response messages, which is the set a thread is stored from. */
+function toolNamesIn(messages: readonly unknown[]): string[] {
+  const names: string[] = []
+  for (const message of messages) {
+    const content = (message as { content?: unknown }).content
+    if (!Array.isArray(content)) {
+      continue
+    }
+    for (const part of content as { toolName?: unknown }[]) {
+      if (typeof part.toolName === 'string') {
+        names.push(part.toolName)
+      }
+    }
+  }
+  return names
+}

--- a/packages/logfire-agent-control-mastra/src/__test__/model.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/model.test.ts
@@ -1,0 +1,117 @@
+import { Agent } from '@mastra/core/agent'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import { isRoutableModelId, toCanonicalModelId, toRouterModelId } from '../model'
+import { captureWarnings, mockModel, nextAgentId, run, useManagedAgent } from './helpers'
+
+const warnings = captureWarnings()
+
+function agentWith(id: string, model = mockModel('mock', 'code-model')): Agent {
+  return new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+}
+
+describe('the model section', () => {
+  it('sends the request to the published model instead of the code-defined one', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { model: 'openai:gpt-5.6-sol' })
+    const code = mockModel('mock', 'code-model')
+
+    // Offline, and that is the assertion: the run reaches OpenAI's router entry and stops for want of
+    // a key, which is only possible if the published model replaced the code-defined one.
+    await expect(run(agentWith(id, code))).rejects.toThrow(/OPENAI_API_KEY.*openai\/gpt-5\.6-sol/u)
+    expect(code.doGenerateCalls).toHaveLength(0)
+  })
+
+  it("translates the contract's provider names into Mastra's", async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { model: 'together:moonshotai/Kimi-K2-Thinking' })
+
+    // The contract calls it `together` and Mastra's registry calls it `togetherai`; the error names
+    // the router id the translation produced.
+    await expect(run(agentWith(id))).rejects.toThrow(/togetherai\/moonshotai\/Kimi-K2-Thinking/u)
+  })
+
+  it('accepts the provider ids Pydantic AI v1 used', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { model: 'google-gla:gemini-2.5-flash-lite' })
+
+    // `google-gla` was v1's name for the Gemini API and is `google` now, but a config published
+    // against a v1-era agent can still carry it, so it is normalized rather than refused.
+    await expect(run(agentWith(id))).rejects.toThrow(/google\/gemini-2\.5-flash-lite/u)
+  })
+
+  it('keeps the code-defined model when the published provider is not one Mastra can route', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { model: 'bedrock:claude-fable-5-1' })
+    const code = mockModel('mock', 'code-model')
+
+    // Mastra would build a model object for an unknown provider and fail at every request, so a
+    // provider its router does not know is refused here and reported, and the agent keeps running.
+    expect(await run(agentWith(id, code))).toBe('ok')
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("selects model 'bedrock:claude-fable-5-1', whose provider is not one Mastra's model router knows"),
+    ])
+  })
+
+  it('keeps the code-defined model for Vertex AI, which Mastra has no provider for', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { model: 'google-cloud:gemini-2.5-flash-lite' })
+    const code = mockModel('mock', 'code-model')
+
+    // Mastra's registry has one `google`, and it is the Gemini API. Mapping Vertex onto it would send
+    // the request to a different service than the one the published value named.
+    expect(await run(agentWith(id, code))).toBe('ok')
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("selects model 'google-cloud:gemini-2.5-flash-lite', whose provider is not one Mastra's model router knows"),
+    ])
+  })
+})
+
+describe('model id translation', () => {
+  it('swaps the separator and maps the provider names that differ', () => {
+    expect(toRouterModelId('anthropic:claude-fable-5-1')).toBe('anthropic/claude-fable-5-1')
+    // The three providers both sides have under different names.
+    expect(toRouterModelId('together:zai-org/GLM-4.6')).toBe('togetherai/zai-org/GLM-4.6')
+    expect(toRouterModelId('fireworks:kimi-k2-instruct')).toBe('fireworks-ai/kimi-k2-instruct')
+    expect(toRouterModelId('snowflake:claude-sonnet-4-5')).toBe('snowflake-cortex/claude-sonnet-4-5')
+    // Only the first colon separates: the rest belongs to the model id.
+    expect(toRouterModelId('bedrock:us.anthropic.claude:0')).toBe('bedrock/us.anthropic.claude:0')
+    // A string with no provider separator is one this cannot classify, and is left as it stands --
+    // most likely someone wrote Mastra's own notation into the config.
+    expect(toRouterModelId('openai/gpt-5.6-sol')).toBe('openai/gpt-5.6-sol')
+  })
+
+  it("normalizes Pydantic AI v1's provider ids to the current ones", () => {
+    expect(toRouterModelId('google-gla:gemini-2.5-flash')).toBe('google/gemini-2.5-flash')
+    expect(toRouterModelId('google:gemini-2.5-flash')).toBe('google/gemini-2.5-flash')
+    // Both spellings of Vertex land on the same unroutable id, so both are refused the same way
+    // rather than one of them reaching Mastra's Gemini API entry.
+    expect(toRouterModelId('google-vertex:gemini-2.5-flash')).toBe('google-cloud/gemini-2.5-flash')
+    expect(toRouterModelId('google-cloud:gemini-2.5-flash')).toBe('google-cloud/gemini-2.5-flash')
+  })
+
+  it('knows which providers Mastra can route', () => {
+    expect(isRoutableModelId('openai/gpt-5.6-sol')).toBe(true)
+    expect(isRoutableModelId('google/gemini-2.5-flash')).toBe(true)
+    expect(isRoutableModelId('google-cloud/gemini-2.5-flash')).toBe(false)
+    expect(isRoutableModelId('bedrock/claude')).toBe(false)
+    expect(isRoutableModelId('gpt-5.6-sol')).toBe(false)
+  })
+
+  it('names a configured model the way the contract does, or not at all', () => {
+    expect(toCanonicalModelId('anthropic/claude-fable-5-1')).toBe('anthropic:claude-fable-5-1')
+    // The baseline emits the current ids only, never the v1 aliases the input side still accepts.
+    expect(toCanonicalModelId('google/gemini-2.5-flash')).toBe('google:gemini-2.5-flash')
+    expect(toCanonicalModelId('togetherai/zai-org/GLM-4.6')).toBe('together:zai-org/GLM-4.6')
+    // An AI SDK provider names its API surface; only the part before the dot is the provider.
+    expect(toCanonicalModelId({ provider: 'openai.responses', modelId: 'gpt-5.6-sol' })).toBe('openai:gpt-5.6-sol')
+    expect(toCanonicalModelId({ provider: 'openai', modelId: 'gpt-5.6-sol' })).toBe('openai:gpt-5.6-sol')
+    // Nothing here names a provider: a bare model id, an OpenAI-compatible endpoint config, a
+    // callable, a fallback list. The baseline leaves `model` out rather than inventing one.
+    expect(toCanonicalModelId('gpt-5.6-sol')).toBeUndefined()
+    expect(toCanonicalModelId({ id: 'gpt-5.6-sol', url: 'https://example.test' })).toBeUndefined()
+    expect(toCanonicalModelId(() => 'openai/gpt-5.6-sol')).toBeUndefined()
+    expect(toCanonicalModelId(undefined)).toBeUndefined()
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/renaming.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/renaming.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The model boundary, at the level of one call in and one call out.
+ *
+ * A rename is exercised end to end against a real Mastra agent in `tools.test.ts`; what is here is
+ * the handful of calls a run cannot produce -- a request with no tools on it, a tool the core routed
+ * nowhere -- and the pass-through that has to keep working for every part a rename does not touch.
+ */
+
+import type { AppliedTools, Resolution, ToolDef } from '@pydantic/logfire-node/agent-control'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { renamingModel, toolRenames } from '../renaming'
+import type { ResolvedModel, ToolRenames } from '../renaming'
+
+/** Nothing published: the shape a resolution has when the agent is running on its code. */
+const CODE_ONLY: Resolution = {
+  config: null,
+  variableName: 'agent__renaming',
+  label: null,
+  version: null,
+  reason: 'code_default',
+}
+
+const RENAMES: ToolRenames = {
+  toModel: new Map([['getWeather', 'lookup_weather']]),
+  toCode: new Map([['lookup_weather', 'getWeather']]),
+}
+
+/** One call, in the shape both of a model's methods take and answer with. */
+interface Call {
+  tools?: { name: string }[]
+  toolChoice?: { type: string; toolName?: string }
+  prompt: { role: string; content: string | { type: string; toolName?: string }[] }[]
+}
+
+/** A stub in the shape Mastra's own model classes have: both call methods answer with a stream. */
+function stubModel(chunks: { type: string; toolName?: string }[]): {
+  model: ResolvedModel
+  calls: Call[]
+} {
+  const calls: Call[] = []
+  const answer = async (options: Call): Promise<unknown> => {
+    calls.push(options)
+    return Promise.resolve({
+      warnings: [],
+      stream: new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(chunk)
+          }
+          controller.close()
+        },
+      }),
+    })
+  }
+  const model = { specificationVersion: 'v3', provider: 'mock', modelId: 'm', doGenerate: answer, doStream: answer }
+  return { model: model as unknown as ResolvedModel, calls }
+}
+
+/** Call one method of a wrapped model, and read back both the call it made and the chunks it gave. */
+async function call(
+  model: ResolvedModel,
+  method: 'doGenerate' | 'doStream',
+  options: Call
+): Promise<{ type: string; toolName?: string }[]> {
+  const invoke = (model as unknown as Record<typeof method, (options: Call) => Promise<{ stream: ReadableStream }>>)[method]
+  const { stream } = await invoke(options)
+  const chunks: { type: string; toolName?: string }[] = []
+  for await (const chunk of stream as ReadableStream<{ type: string; toolName?: string }>) {
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
+describe('the renames a request amounts to', () => {
+  const definitions: ToolDef[] = [{ name: 'getWeather', parametersJsonSchema: {} }]
+
+  it('leaves a tool the core routed nowhere under its own name', () => {
+    // Not a table the core hands back -- `forward` covers every tool it was given -- and the point of
+    // the fallback is that a missing route is never read as a rename.
+    const applied = { forward: new Map(), reverse: new Map() } as unknown as AppliedTools
+
+    expect(toolRenames(definitions, applied)).toEqual({ toModel: new Map(), toCode: new Map() })
+  })
+})
+
+describe('a model that speaks the managed names', () => {
+  it('passes through a call that names no tool at all', async () => {
+    const { model, calls } = stubModel([{ type: 'text-delta' }])
+    const prompt = [{ role: 'user', content: 'hi' }]
+
+    // Mastra sends neither declarations nor a named choice when the step offers no tools, and a text
+    // part names nothing on the way back.
+    const chunks = await call(renamingModel(model, RENAMES, CODE_ONLY), 'doGenerate', { prompt })
+
+    expect(calls[0]).toEqual({ prompt })
+    expect(chunks).toEqual([{ type: 'text-delta' }])
+  })
+
+  it('renames only the tools an override renamed', async () => {
+    const { model, calls } = stubModel([])
+
+    await call(renamingModel(model, RENAMES, CODE_ONLY), 'doStream', {
+      tools: [{ name: 'getWeather' }, { name: 'sendEmail' }],
+      prompt: [],
+    })
+
+    expect(calls[0]?.tools).toEqual([{ name: 'lookup_weather' }, { name: 'sendEmail' }])
+  })
+
+  it('is the model it wraps in every other respect', () => {
+    const { model } = stubModel([])
+    const wrapped = renamingModel(model, RENAMES, CODE_ONLY)
+
+    // Mastra reads the version to decide whether it can run the step at all, and the provider and id
+    // to label the span; a wrapper that answered differently would be a different model.
+    expect(wrapped.specificationVersion).toBe('v3')
+    expect(wrapped.provider).toBe('mock')
+    expect(wrapped.modelId).toBe('m')
+  })
+
+  it('lets the wrapped model reach its own private state', async () => {
+    // The one thing a `Proxy` gets wrong by default. Mastra's `ModelRouterLanguageModel` keeps its
+    // transport in a `#private` field and reads it from a method the loop calls between steps; a trap
+    // that forwards the proxy as the receiver makes that read throw `Cannot read private member ...
+    // from an object whose class did not declare it`, which took down every renaming run against the
+    // model router. So every read is made with the target as the receiver and every method comes back
+    // bound to it.
+    class PrivateModel {
+      readonly specificationVersion = 'v3'
+      readonly provider = 'mock'
+      readonly modelId = 'm'
+      readonly #transport = 'sse'
+      getTransport(): string {
+        return this.#transport
+      }
+      get transport(): string {
+        return this.#transport
+      }
+      async doGenerate(): Promise<{ stream: ReadableStream }> {
+        return Promise.resolve({
+          stream: new ReadableStream({
+            start: (controller) => {
+              controller.close()
+            },
+          }),
+        })
+      }
+    }
+    const wrapped = renamingModel(new PrivateModel() as unknown as ResolvedModel, RENAMES, CODE_ONLY)
+    const model = wrapped as unknown as { getTransport: () => string; transport: string }
+
+    expect(model.getTransport()).toBe('sse')
+    expect(model.transport).toBe('sse')
+    // And reading a method twice gives the same function, as it does on the model itself.
+    expect(model.getTransport).toBe(model.getTransport)
+    // The call methods are still the wrapping ones, and still work.
+    await expect(call(wrapped, 'doGenerate', { prompt: [] })).resolves.toEqual([])
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/settings.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/settings.test.ts
@@ -1,0 +1,287 @@
+import { Agent } from '@mastra/core/agent'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import { lowerSettings, raiseSettings } from '../settings'
+import { callAt, captureWarnings, mockModel, mockModelV4, nextAgentId, run, useManagedAgent } from './helpers'
+
+const warnings = captureWarnings()
+
+/** Lower one published patch against one step's settings, with everything else held still. */
+function lower(
+  settings: Parameters<typeof lowerSettings>[0],
+  effective: Record<string, unknown> | undefined,
+  defaults: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  return lowerSettings(settings, {
+    provider: 'openai',
+    supportsReasoning: true,
+    modelSettings: { effective, defaults },
+    providerOptions: { effective: undefined, defaults: undefined },
+  }).modelSettings
+}
+
+describe('the settings section', () => {
+  it('lowers every canonical setting onto the call Mastra makes', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      settings: {
+        max_tokens: 2048,
+        temperature: 0.4,
+        top_p: 0.9,
+        top_k: 40,
+        seed: 7,
+        presence_penalty: 0.1,
+        frequency_penalty: 0.2,
+        stop_sequences: ['END'],
+      },
+    })
+    const model = mockModel()
+    const agent = new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+
+    await run(agent)
+
+    expect(callAt(model, 0)).toMatchObject({
+      maxOutputTokens: 2048,
+      temperature: 0.4,
+      topP: 0.9,
+      topK: 40,
+      seed: 7,
+      presencePenalty: 0.1,
+      frequencyPenalty: 0.2,
+      stopSequences: ['END'],
+    })
+  })
+
+  it('keeps the settings the agent already had that the published value says nothing about', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { temperature: 0.9 } })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model,
+      // Mastra replaces the step's whole settings object with whatever a processor returns, so the
+      // agent's own `maxOutputTokens` has to survive a published `temperature`.
+      defaultOptions: { modelSettings: { temperature: 0.2, maxOutputTokens: 100 } },
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    expect(callAt(model, 0)).toMatchObject({ temperature: 0.9, maxOutputTokens: 100 })
+  })
+
+  it('lets a value the caller passed for this run beat the published one', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { temperature: 0.9 } })
+    const model = mockModel()
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model,
+      defaultOptions: { modelSettings: { temperature: 0.2 } },
+      inputProcessors: [agentControl()],
+    })
+
+    await agent.generate('hi', { modelSettings: { temperature: 0.5 } })
+
+    // Per-run beats published beats code. Mastra merges the call's settings into the agent's defaults
+    // before any processor runs, so "the caller set this" is recovered by diffing against them.
+    expect(callAt(model, 0)).toMatchObject({ temperature: 0.5 })
+  })
+
+  it('enforces a published timeout as the per-step budget it is', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { timeout: 0.01 } })
+    const model = mockModel()
+    model.doGenerate = async () =>
+      new Promise<never>(() => {
+        // Never settles, so the step budget is the only thing that can end this call.
+      })
+    const agent = new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+
+    // The contract's `timeout` is seconds and is per model request, which is Mastra's `stepMs`. It
+    // never reaches the provider call, so the only honest proof is that it stops one.
+    await expect(run(agent)).rejects.toThrow(/timed out|timeout/iu)
+  })
+
+  it('lowers `thinking` onto the reasoning level of a model that acts on it', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { thinking: 'high' } })
+    const model = mockModelV4()
+    const agent = new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+
+    await run(agent)
+
+    expect(model.doGenerateCalls[0]).toMatchObject({ reasoning: 'high' })
+  })
+
+  it('reports `thinking` where Mastra would drop it, rather than letting it look applied', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { thinking: true } })
+    const model = mockModel()
+    const agent = new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+
+    await run(agent)
+
+    // Mastra forwards `reasoning` only to AI SDK v7 providers and silently drops it for older ones.
+    expect(callAt(model, 0)).not.toHaveProperty('reasoning')
+    expect(warnings.messages).toEqual([expect.stringContaining("sets 'thinking', which this agent framework has no model setting for")])
+  })
+
+  it('lowers `parallel_tool_calls` onto the provider option each provider gives it', async () => {
+    const openaiId = nextAgentId()
+    useManagedAgent(openaiId, { settings: { parallel_tool_calls: false } })
+    const openai = mockModel('openai.responses', 'gpt-5.6-sol')
+    await run(new Agent({ id: openaiId, name: 'A', instructions: 'x', model: openai, inputProcessors: [agentControl()] }))
+    expect(callAt(openai, 0).providerOptions).toEqual({ openai: { parallelToolCalls: false } })
+
+    const anthropicId = nextAgentId()
+    useManagedAgent(anthropicId, { settings: { parallel_tool_calls: false } })
+    const anthropic = mockModel('anthropic.messages', 'claude-fable-5-1')
+    await run(new Agent({ id: anthropicId, name: 'A', instructions: 'x', model: anthropic, inputProcessors: [agentControl()] }))
+    // Anthropic asks the opposite question, so the value is inverted rather than copied.
+    expect(callAt(anthropic, 0).providerOptions).toEqual({ anthropic: { disableParallelToolUse: true } })
+  })
+
+  it('leaves a provider option this run set for itself alone', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { parallel_tool_calls: false } })
+    const model = mockModel('openai.responses', 'gpt-5.6-sol')
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model,
+      defaultOptions: { providerOptions: { openai: { parallelToolCalls: false } } },
+      inputProcessors: [agentControl()],
+    })
+
+    await agent.generate('hi', { providerOptions: { openai: { parallelToolCalls: true } } })
+
+    // The published value and the agent's default agree, and the run disagrees with both: per-run
+    // beats published, in provider options as much as in model settings.
+    expect(callAt(model, 0).providerOptions).toEqual({ openai: { parallelToolCalls: true } })
+  })
+
+  it('keeps a provider option the agent set alongside the one it publishes', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { parallel_tool_calls: true } })
+    const model = mockModel('openai.responses', 'gpt-5.6-sol')
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model,
+      defaultOptions: { providerOptions: { openai: { serviceTier: 'flex' } } },
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    expect(callAt(model, 0).providerOptions).toEqual({ openai: { serviceTier: 'flex', parallelToolCalls: true } })
+  })
+
+  it('reports `parallel_tool_calls` for a provider that has nowhere to put it', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { parallel_tool_calls: true } })
+    const model = mockModel('cerebras', 'llama')
+    const agent = new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+
+    await run(agent)
+
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("sets 'parallel_tool_calls', which this agent framework has no model setting for"),
+    ])
+  })
+
+  it('reports a settings key this SDK has no field for', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { settings: { temperature: 0.4, reasoning_budget: 1024 } })
+    const model = mockModel()
+    const agent = new Agent({ id, name: 'A', instructions: 'x', model, inputProcessors: [agentControl()] })
+
+    await run(agent)
+
+    expect(callAt(model, 0)).toMatchObject({ temperature: 0.4 })
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("sets 'reasoning_budget', which this version of the SDK has no model setting for"),
+    ])
+  })
+})
+
+describe('raising Mastra settings back to the contract', () => {
+  it('reverses every lowering, units included', () => {
+    expect(
+      raiseSettings(
+        {
+          maxOutputTokens: 100,
+          temperature: 0.2,
+          topP: 0.9,
+          topK: 40,
+          seed: 7,
+          presencePenalty: 0.1,
+          frequencyPenalty: 0.2,
+          stopSequences: ['END'],
+          timeout: { stepMs: 30_000, totalMs: 120_000 },
+          reasoning: 'high',
+        },
+        { anthropic: { disableParallelToolUse: true } }
+      )
+    ).toEqual({
+      max_tokens: 100,
+      temperature: 0.2,
+      top_p: 0.9,
+      top_k: 40,
+      seed: 7,
+      presence_penalty: 0.1,
+      frequency_penalty: 0.2,
+      stop_sequences: ['END'],
+      timeout: 30,
+      thinking: 'high',
+      parallel_tool_calls: false,
+    })
+  })
+
+  it('reads the two reasoning levels that stand for a boolean, and describes nothing it cannot', () => {
+    expect(raiseSettings({ reasoning: 'provider-default' }, undefined)).toEqual({ thinking: true })
+    expect(raiseSettings({ reasoning: 'none' }, undefined)).toEqual({ thinking: false })
+    // A run-wide budget is not the contract's per-request `timeout`, and a level this SDK does not
+    // know is not one it can name.
+    expect(raiseSettings({ timeout: { totalMs: 1000 }, reasoning: 'exhaustive' }, undefined)).toEqual({})
+    expect(raiseSettings(undefined, undefined)).toEqual({})
+  })
+})
+
+describe('telling a value this run chose from a code default', () => {
+  it('leaves a value that differs from the agent default standing, and overwrites one that does not', () => {
+    // Nothing to return: the step already carries the value this run chose, so the published one is
+    // simply not applied.
+    expect(lower({ temperature: 0.9 }, { temperature: 0.5 }, { temperature: 0.2 })).toBeUndefined()
+    // A key the agent has no default for and the step does carry is one this run set, too.
+    expect(lower({ seed: 1 }, { seed: 7 }, undefined)).toBeUndefined()
+    expect(lower({ temperature: 0.9 }, { temperature: 0.2 }, { temperature: 0.2 })).toMatchObject({
+      temperature: 0.9,
+    })
+  })
+
+  it('compares structural values by value, not by reference', () => {
+    // A fresh but identical `stopSequences` array is the agent's own default, not something this call
+    // asked for, so the published value wins it.
+    expect(lower({ stop_sequences: ['DONE'] }, { stopSequences: ['END'] }, { stopSequences: ['END'] })).toMatchObject({
+      stopSequences: ['DONE'],
+    })
+  })
+
+  it('merges a published step budget into a run-wide one rather than replacing it', () => {
+    // `totalMs` is a deadline for the whole run and the contract has no way to say it, so a published
+    // per-request budget has to leave the one in code standing.
+    const budget = { timeout: { totalMs: 120_000 } }
+    expect(lower({ timeout: 30 }, budget, budget)).toMatchObject({
+      timeout: { stepMs: 30_000, totalMs: 120_000 },
+    })
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/settings.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/settings.test.ts
@@ -229,7 +229,8 @@ describe('raising Mastra settings back to the contract', () => {
           timeout: { stepMs: 30_000, totalMs: 120_000 },
           reasoning: 'high',
         },
-        { anthropic: { disableParallelToolUse: true } }
+        { anthropic: { disableParallelToolUse: true } },
+        'anthropic'
       )
     ).toEqual({
       max_tokens: 100,
@@ -247,12 +248,22 @@ describe('raising Mastra settings back to the contract', () => {
   })
 
   it('reads the two reasoning levels that stand for a boolean, and describes nothing it cannot', () => {
-    expect(raiseSettings({ reasoning: 'provider-default' }, undefined)).toEqual({ thinking: true })
-    expect(raiseSettings({ reasoning: 'none' }, undefined)).toEqual({ thinking: false })
+    expect(raiseSettings({ reasoning: 'provider-default' }, undefined, undefined)).toEqual({ thinking: true })
+    expect(raiseSettings({ reasoning: 'none' }, undefined, undefined)).toEqual({ thinking: false })
     // A run-wide budget is not the contract's per-request `timeout`, and a level this SDK does not
     // know is not one it can name.
-    expect(raiseSettings({ timeout: { totalMs: 1000 }, reasoning: 'exhaustive' }, undefined)).toEqual({})
-    expect(raiseSettings(undefined, undefined)).toEqual({})
+    expect(raiseSettings({ timeout: { totalMs: 1000 }, reasoning: 'exhaustive' }, undefined, undefined)).toEqual({})
+    expect(raiseSettings(undefined, undefined, undefined)).toEqual({})
+  })
+
+  it('reads `parallel_tool_calls` from the provider serving the agent, and no other', () => {
+    const options = { openai: { parallelToolCalls: false } }
+
+    expect(raiseSettings(undefined, options, 'openai')).toEqual({ parallel_tool_calls: false })
+    // An agent may carry options for a provider it is not running on. Describing one as this agent's
+    // setting would make a publish of the baseline apply it -- inverted -- to the provider it is.
+    expect(raiseSettings(undefined, options, 'anthropic')).toEqual({})
+    expect(raiseSettings(undefined, options, 'groq')).toEqual({})
   })
 })
 

--- a/packages/logfire-agent-control-mastra/src/__test__/tools.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/tools.test.ts
@@ -1,0 +1,272 @@
+import { Agent } from '@mastra/core/agent'
+import { createTool } from '@mastra/core/tools'
+import { describe, expect, it } from 'vite-plus/test'
+import { z } from 'zod'
+
+import { agentControl } from '../index'
+import { captureWarnings, callAt, mockModel, nextAgentId, run, text, toolCall, toolsOf, useManagedAgent } from './helpers'
+
+/** The tool names in a prompt or a run's messages, in order, wherever a part names one. */
+function historyNames(messages: readonly { content: unknown }[] | undefined): string[] {
+  return (messages ?? []).flatMap((message) =>
+    Array.isArray(message.content)
+      ? (message.content as { toolName?: string }[]).flatMap((part) => (part.toolName === undefined ? [] : [part.toolName]))
+      : []
+  )
+}
+
+const warnings = captureWarnings()
+
+/** An agent with one tool, and a record of every argument its implementation was actually called with. */
+function weatherAgent(id: string, model = mockModel(), extraTools: Record<string, unknown> = {}): { agent: Agent; executed: unknown[] } {
+  const executed: unknown[] = []
+  const getWeather = createTool({
+    id: 'get_weather',
+    description: 'Get the weather for a city.',
+    inputSchema: z.object({ city: z.string().describe('City name') }),
+    execute: async (input) => {
+      executed.push(input)
+      return Promise.resolve({ temp: 21 })
+    },
+  })
+  const agent = new Agent({
+    id,
+    name: 'A',
+    instructions: 'x',
+    model,
+    tools: { getWeather, ...extraTools } as never,
+    inputProcessors: [agentControl()],
+  })
+  return { agent, executed }
+}
+
+describe('the tool definitions section', () => {
+  it('renames a tool for the model and for nothing else', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      tool_definitions: [{ name: 'getWeather', new_name: 'lookup_weather' }],
+    })
+    const model = mockModel('mock', 'm', [toolCall('lookup_weather', { city: 'Paris' }), text('done')])
+    const { agent, executed } = weatherAgent(id, model)
+
+    const result = await agent.generate('hi')
+
+    expect(result.text).toBe('done')
+    // The model is offered the published name and calls it by that name.
+    expect(toolsOf(model).map((tool) => tool['name'])).toEqual(['lookup_weather'])
+    // Everything on this side of the model boundary keeps the name the code gave it: the tool that
+    // ran, the call and result Mastra reports, and the messages it stores for the thread.
+    expect(executed).toEqual([expect.objectContaining({ city: 'Paris' })])
+    expect(result.toolCalls[0]?.payload.toolName).toBe('getWeather')
+    expect(result.steps[0]?.toolResults[0]?.payload.toolName).toBe('getWeather')
+    expect(historyNames(result.response.messages)).toEqual(['getWeather', 'getWeather'])
+    // And the history those code-side names are replayed from goes out under the published name, so
+    // the model is never shown a call to a tool it was not offered.
+    expect(historyNames(callAt(model, 1).prompt)).toEqual(['lookup_weather', 'lookup_weather'])
+  })
+
+  it('renames the same way through a streamed run', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'lookup_weather' }] })
+    const model = mockModel('mock', 'm', [toolCall('lookup_weather', { city: 'Paris' }), text('done')])
+    const { agent, executed } = weatherAgent(id, model)
+
+    // Mastra calls the model's other method for a streamed run, and both of them are the boundary.
+    const stream = await agent.stream('hi')
+    expect(await stream.text).toBe('done')
+
+    const advertised = model.doStreamCalls[0]?.tools ?? []
+    expect(advertised.map((tool) => tool.name)).toEqual(['lookup_weather'])
+    expect(executed).toEqual([expect.objectContaining({ city: 'Paris' })])
+  })
+
+  it('replays a thread through whatever the tool is called now', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'lookup_weather' }] })
+    const first = mockModel('mock', 'm1', [toolCall('lookup_weather', { city: 'Paris' }), text('done')])
+    const conversation = await weatherAgent(id, first).agent.generate('hi')
+
+    // The rename changes under a thread that was written while the old one was published. Because
+    // what Mastra stored is code-side, a resumed thread is translated to the name in force now
+    // rather than replaying a name this request does not advertise.
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'fetch_weather' }] })
+    const resumed = mockModel('mock', 'm2', [text('resumed')])
+    const { agent } = weatherAgent(id, resumed)
+
+    const result = await agent.generate([
+      { role: 'user', content: 'hi' },
+      ...(conversation.response.messages ?? []),
+      { role: 'user', content: 'and now?' },
+    ])
+
+    expect(result.text).toBe('resumed')
+    expect(toolsOf(resumed).map((tool) => tool['name'])).toEqual(['fetch_weather'])
+    expect(historyNames(callAt(resumed, 0).prompt)).toEqual(['fetch_weather', 'fetch_weather'])
+  })
+
+  it('replays a thread under the code name once the rename is withdrawn', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'lookup_weather' }] })
+    const first = mockModel('mock', 'm1', [toolCall('lookup_weather', { city: 'Paris' }), text('done')])
+    const conversation = await weatherAgent(id, first).agent.generate('hi')
+
+    useManagedAgent(id, {})
+    const resumed = mockModel('mock', 'm2', [text('resumed')])
+    const { agent } = weatherAgent(id, resumed)
+
+    const result = await agent.generate([
+      { role: 'user', content: 'hi' },
+      ...(conversation.response.messages ?? []),
+      { role: 'user', content: 'and now?' },
+    ])
+
+    expect(result.text).toBe('resumed')
+    expect(toolsOf(resumed).map((tool) => tool['name'])).toEqual(['getWeather'])
+    expect(historyNames(callAt(resumed, 0).prompt)).toEqual(['getWeather', 'getWeather'])
+  })
+
+  it('carries a forced tool choice across a rename, and leaves an active-tools list alone', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'lookup_weather' }] })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model)
+
+    // Both are code-defined choices, written against the name the code gave the tool, and both have
+    // to go on meaning what they meant. `activeTools` is filtered against the record, which still
+    // carries that name; `toolChoice` reaches the model, so it is translated with the declarations.
+    await agent.generate('hi', { toolChoice: { type: 'tool', toolName: 'getWeather' }, activeTools: ['getWeather'] })
+
+    expect(toolsOf(model).map((tool) => tool['name'])).toEqual(['lookup_weather'])
+    expect(callAt(model, 0).toolChoice).toEqual({ type: 'tool', toolName: 'lookup_weather' })
+  })
+
+  it('advertises no tool at all under a tool choice that forbids one', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'lookup_weather' }] })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model)
+
+    // Mastra sends no declarations and no named choice for `'none'`, which the wrapped model has to
+    // pass through as the empty call it is rather than reading a rename into it.
+    await agent.generate('hi', { toolChoice: 'none' })
+
+    expect(callAt(model, 0).tools).toBeUndefined()
+    expect(callAt(model, 0).toolChoice).toEqual({ type: 'none' })
+  })
+
+  it('rewrites what the model is told about a tool, and nothing about how it runs', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      tool_definitions: [
+        {
+          name: 'getWeather',
+          description: 'Look up the current weather for a city.',
+          parameters: { city: { description: "City name, e.g. 'London'" } },
+        },
+      ],
+    })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model)
+
+    await run(agent)
+
+    const [tool] = toolsOf(model)
+    expect(tool?.['description']).toBe('Look up the current weather for a city.')
+    expect(tool?.['inputSchema']).toMatchObject({
+      properties: { city: { type: 'string', description: "City name, e.g. 'London'" } },
+      required: ['city'],
+    })
+  })
+
+  it('leaves a schema alone where an override names a parameter the tool does not have', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      tool_definitions: [{ name: 'getWeather', parameters: { country: { description: 'No.' } } }],
+    })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model)
+
+    await run(agent)
+
+    expect(toolsOf(model)[0]?.['inputSchema']).toMatchObject({ properties: { city: { description: 'City name' } } })
+  })
+
+  it('reports an override that patches a tool this request does not advertise', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'sendEmail', description: 'Nowhere.' }] })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model)
+
+    await run(agent)
+
+    expect(warnings.messages).toEqual([expect.stringContaining("patches tool 'sendEmail', which no toolset advertises for this request")])
+  })
+
+  it('keeps every tool callable when a rename collides with another tool', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', new_name: 'getForecast' }] })
+    const model = mockModel()
+    const getForecast = createTool({
+      id: 'get_forecast',
+      description: 'Forecast.',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async () => Promise.resolve({ temp: 21 }),
+    })
+    const getWeather = createTool({
+      id: 'get_weather',
+      description: 'Weather.',
+      inputSchema: z.object({ city: z.string() }),
+      execute: async () => Promise.resolve({ temp: 21 }),
+    })
+    const agent = new Agent({
+      id,
+      name: 'A',
+      instructions: 'x',
+      model,
+      tools: { getWeather, getForecast },
+      inputProcessors: [agentControl()],
+    })
+
+    await run(agent)
+
+    expect(toolsOf(model).map((tool) => tool['name'])).toEqual(['getWeather', 'getForecast'])
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("renames 'getWeather' to 'getForecast', which is already advertised by another tool"),
+    ])
+  })
+
+  it('holds a provider-defined tool out of the overlay, and holds its name against a rename', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, {
+      tool_definitions: [
+        { name: 'getWeather', new_name: 'web_search' },
+        { name: 'web_search', description: "Not this adapter's to describe." },
+      ],
+    })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model, {
+      // A provider-executed tool: its name is a contract with the provider rather than a description
+      // the model reads, so it is neither described nor renamed, and nothing may take its name.
+      search: { type: 'provider-defined', id: 'openai.web_search', name: 'web_search', args: {} },
+    })
+
+    await run(agent)
+
+    expect(toolsOf(model).map((tool) => tool['name'])).toEqual(['getWeather', 'web_search'])
+    expect(warnings.messages).toEqual([
+      expect.stringContaining("renames 'getWeather' to 'web_search', which is already advertised by another tool"),
+      expect.stringContaining("patches tool 'web_search', which no toolset advertises for this request"),
+    ])
+  })
+
+  it('advertises the code-defined tools untouched when nothing matches', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [] })
+    const model = mockModel()
+    const { agent } = weatherAgent(id, model)
+
+    await run(agent)
+
+    expect(toolsOf(model)).toMatchObject([{ name: 'getWeather', description: 'Get the weather for a city.' }])
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/__test__/tools.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/tools.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vite-plus/test'
 import { z } from 'zod'
 
 import { agentControl } from '../index'
+import { applyToTools, readTools } from '../tools'
 import { captureWarnings, callAt, mockModel, nextAgentId, run, text, toolCall, toolsOf, useManagedAgent } from './helpers'
 
 /** The tool names in a prompt or a run's messages, in order, wherever a part names one. */
@@ -268,5 +269,24 @@ describe('the tool definitions section', () => {
     await run(agent)
 
     expect(toolsOf(model)).toMatchObject([{ name: 'getWeather', description: 'Get the weather for a city.' }])
+  })
+})
+
+describe('rebuilding the tool record', () => {
+  it('keeps a tool whose key is `__proto__`', () => {
+    // A record built with a computed key can carry one, and `__proto__` is a legal function name to
+    // every provider -- so a rebuild that assigned into a plain object would run the prototype setter
+    // and lose the tool from every request a config was applied to.
+    const tools = {
+      ['__proto__']: { description: 'Reflect on yourself.', parameters: { jsonSchema: {} } },
+      getWeather: { description: 'Get the weather.', parameters: { jsonSchema: {} } },
+    }
+    const { definitions } = readTools(tools)
+    const applied = definitions.map((def) => ({ ...def, description: 'Patched.' }))
+
+    const rebuilt = applyToTools(tools, definitions, applied)
+
+    expect(Object.keys(rebuilt)).toEqual(['__proto__', 'getWeather'])
+    expect(rebuilt).toMatchObject({ ['__proto__']: { description: 'Patched.' }, getWeather: { description: 'Patched.' } })
   })
 })

--- a/packages/logfire-agent-control-mastra/src/__test__/units.test.ts
+++ b/packages/logfire-agent-control-mastra/src/__test__/units.test.ts
@@ -1,0 +1,325 @@
+/**
+ * The mappings, at the level of one value in and one value out.
+ *
+ * Everything here is also exercised through a real Mastra run in the other files; these are the
+ * shapes a run cannot easily produce -- a tool that reached the step unbuilt, a system message
+ * carrying something other than text, a provider with nowhere to put a setting.
+ */
+
+import type { InputProcessor, ProcessInputArgs, ProcessInputStepArgs } from '@mastra/core/processors'
+import { describe, expect, it } from 'vite-plus/test'
+
+import { agentControl } from '../index'
+import { baselineBlocks, readCodeInstructions, requestBlocks, toSystemMessages } from '../instructions'
+import { honorsReasoning, providerOf } from '../model'
+import { lowerSettings } from '../settings'
+import { applyToTools, readTools } from '../tools'
+import { captureWarnings, nextAgentId, useManagedAgent } from './helpers'
+
+const warnings = captureWarnings()
+
+const NO_TAGS = { getSystemMessages: () => [] }
+
+describe("reading the agent's instructions", () => {
+  it('reads every shape Mastra accepts, and refuses the ones it cannot address', () => {
+    expect(readCodeInstructions('One.')).toEqual({ blocks: [{ id: 'agent', text: 'One.' }] })
+    expect(readCodeInstructions(['One.', 'Two.'])).toEqual({
+      blocks: [
+        { id: 'agent:0', text: 'One.' },
+        { id: 'agent:1', text: 'Two.' },
+      ],
+    })
+    // A single system message object is one block, like the string it wraps.
+    expect(readCodeInstructions({ role: 'system', content: 'One.' })).toEqual({
+      blocks: [{ id: 'agent', text: 'One.' }],
+    })
+    expect(readCodeInstructions([{ role: 'system', content: 'One.' }])).toEqual({
+      blocks: [{ id: 'agent:0', text: 'One.' }],
+    })
+    // Computed per request, so there is no code-side text to point an id at.
+    expect(readCodeInstructions(() => 'One.')).toBeNull()
+    // Neither is anything this cannot read as text -- and one unreadable entry disqualifies the whole
+    // list, because ids after it would name blocks that are not the ones they say.
+    expect(readCodeInstructions(['One.', { role: 'system', content: [{ type: 'text', text: 'Two.' }] }])).toBeNull()
+    expect(readCodeInstructions(42)).toBeNull()
+    expect(readCodeInstructions(undefined)).toBeNull()
+  })
+
+  it('takes the id an entry declares for itself, in either dialect, over its position', () => {
+    expect(
+      readCodeInstructions([
+        { role: 'system', content: 'One.', providerOptions: { logfire: { id: 'persona' } } },
+        // Mastra's `SystemMessage` is the union of the AI SDK's v4 and v5 message shapes, and this is
+        // what v4 calls the same field.
+        { role: 'system', content: 'Two.', experimental_providerMetadata: { logfire: { id: 'policy' } } },
+        // Everything a declaration could be but is not: another provider's namespace, a namespace
+        // without an id, an id that is not a string, and one that is empty.
+        { role: 'system', content: 'Three.', providerOptions: { openai: { id: 'theirs' } } },
+        { role: 'system', content: 'Four.', providerOptions: { logfire: 'no' } },
+        { role: 'system', content: 'Five.', providerOptions: { logfire: { id: 5 } } },
+        { role: 'system', content: 'Six.', providerOptions: { logfire: { id: '' } } },
+      ])
+    ).toEqual({
+      blocks: [
+        { id: 'persona', text: 'One.' },
+        { id: 'policy', text: 'Two.' },
+        { id: 'agent:2', text: 'Three.' },
+        { id: 'agent:3', text: 'Four.' },
+        { id: 'agent:4', text: 'Five.' },
+        { id: 'agent:5', text: 'Six.' },
+      ],
+    })
+  })
+})
+
+describe('the blocks a request assembles', () => {
+  const systemMessages = [
+    { role: 'system' as const, content: 'Agent.' },
+    { role: 'system' as const, content: 'Added by a skill.' },
+  ]
+
+  it("names the agent's own blocks and marks everything else as the framework's", () => {
+    const blocks = requestBlocks(
+      systemMessages,
+      { blocks: [{ id: 'agent', text: 'Agent.' }] },
+      {
+        getSystemMessages: (tag?: string) => (tag === 'memory' ? [{ role: 'system' as const, content: 'Recalled.' }] : []),
+      }
+    )
+
+    expect(blocks).toEqual([
+      { id: 'agent', text: 'Agent.', dynamic: false, message: systemMessages[0] },
+      { id: null, text: 'Added by a skill.', dynamic: true, message: systemMessages[1] },
+      { id: 'tag:memory', text: 'Recalled.', dynamic: true },
+    ])
+  })
+
+  it('gives computed instructions one seam and no addressable text', () => {
+    expect(requestBlocks(systemMessages, null, NO_TAGS)).toEqual([
+      { id: 'agent', text: 'Agent.', dynamic: true, message: systemMessages[0] },
+      { id: null, text: 'Added by a skill.', dynamic: true, message: systemMessages[1] },
+    ])
+  })
+
+  it('returns an untouched block as the very message it was read from', () => {
+    const message = { role: 'system' as const, content: 'Agent.', providerOptions: { logfire: { keep: true } } }
+    const blocks = requestBlocks([message], { blocks: [{ id: 'agent', text: 'Agent.' }] }, NO_TAGS)
+
+    // Identity, not equality: everything else riding on the message survives a request this adapter
+    // did not change.
+    expect(toSystemMessages(blocks)[0]).toBe(message)
+    expect(toSystemMessages([{ id: 'agent', text: 'Rewritten.', dynamic: false }])).toEqual([{ role: 'system', content: 'Rewritten.' }])
+  })
+
+  it("describes the code, and carries the framework's seams through, in the baseline", () => {
+    const blocks = requestBlocks(systemMessages, { blocks: [{ id: 'agent:0', text: 'Agent.' }] }, NO_TAGS)
+
+    expect(baselineBlocks(blocks, { blocks: [{ id: 'agent:0', text: 'Agent.' }] })).toEqual([
+      { id: 'agent:0', text: 'Agent.', dynamic: false },
+      { id: null, text: 'Added by a skill.', dynamic: true, message: systemMessages[1] },
+    ])
+    // With nothing knowable in code, the baseline is exactly what the request showed.
+    expect(baselineBlocks(blocks, null)).toEqual(blocks)
+  })
+})
+
+describe('reading a model', () => {
+  it('names the provider serving a step, whatever form the model is in', () => {
+    expect(providerOf('openai/gpt-5.6-sol')).toBe('openai')
+    expect(providerOf({ provider: 'anthropic.messages' })).toBe('anthropic')
+    expect(providerOf('gpt-5.6-sol')).toBeUndefined()
+    expect(providerOf({ modelId: 'x' })).toBeUndefined()
+    expect(providerOf(undefined)).toBeUndefined()
+  })
+
+  it('knows which models act on a reasoning level', () => {
+    expect(honorsReasoning({ specificationVersion: 'v4' })).toBe(true)
+    expect(honorsReasoning({ specificationVersion: 'v3' })).toBe(false)
+    // A router id is resolved after the hook, so it cannot be asked and gets the benefit of the doubt.
+    expect(honorsReasoning('openai/gpt-5.6-sol')).toBe(true)
+    expect(honorsReasoning({})).toBe(true)
+  })
+})
+
+describe('lowering settings', () => {
+  const NO_SETTINGS = {
+    modelSettings: { effective: undefined, defaults: undefined },
+    providerOptions: { effective: undefined, defaults: undefined },
+  }
+
+  it('has nowhere to put `parallel_tool_calls` when the step names no provider', () => {
+    expect(lowerSettings({ parallel_tool_calls: true }, { provider: undefined, supportsReasoning: true, ...NO_SETTINGS })).toEqual({
+      modelSettings: undefined,
+      providerOptions: undefined,
+      unapplied: ['parallel_tool_calls'],
+    })
+  })
+
+  it('leaves the step alone when the published value is the one it already has', () => {
+    // Not the same as publishing nothing: the section is there and it was applied, it just asks for
+    // what the code already says, and returning an equal object would have Mastra rebuild the step
+    // for nothing.
+    expect(
+      lowerSettings(
+        { temperature: 0.2, parallel_tool_calls: true },
+        {
+          provider: 'openai',
+          supportsReasoning: true,
+          modelSettings: { effective: { temperature: 0.2 }, defaults: { temperature: 0.2 } },
+          providerOptions: {
+            effective: { openai: { parallelToolCalls: true } },
+            defaults: { openai: { parallelToolCalls: true } },
+          },
+        }
+      )
+    ).toEqual({ modelSettings: undefined, providerOptions: undefined, unapplied: [] })
+  })
+})
+
+describe('reading and patching tools', () => {
+  const jsonSchema = { type: 'object', properties: { city: { type: 'string', description: 'City name' } } }
+
+  it('reads a built tool, an unbuilt one, and one whose schema it cannot read', () => {
+    expect(
+      readTools({
+        built: { description: 'Built.', parameters: { jsonSchema, validate: () => true } },
+        unbuilt: { description: 'Unbuilt.', inputSchema: jsonSchema },
+        // A Standard Schema (a Zod schema, say) is not a JSON schema, and turning one into a JSON
+        // schema means knowing which library wrote it.
+        opaque: { inputSchema: { '~standard': { version: 1 } } },
+      })
+    ).toEqual({
+      definitions: [
+        { name: 'built', description: 'Built.', parametersJsonSchema: jsonSchema },
+        { name: 'unbuilt', description: 'Unbuilt.', parametersJsonSchema: jsonSchema },
+        { name: 'opaque', parametersJsonSchema: {} },
+      ],
+      reserved: [],
+    })
+  })
+
+  it('leaves a provider-defined tool out of the editable set and holds its name against a rename', () => {
+    expect(
+      readTools({
+        // Mastra sends `tool.name ?? recordKey`, so the wire name is the tool's own where it has one.
+        search: { type: 'provider-defined', id: 'openai.web_search', name: 'web_search', args: {} },
+        keyed: { type: 'provider-defined', id: 'openai.code_interpreter', args: {} },
+      })
+    ).toEqual({ definitions: [], reserved: ['web_search', 'keyed'] })
+  })
+
+  it("patches an unbuilt tool's schema where it keeps it", () => {
+    const tools = { unbuilt: { description: 'Unbuilt.', inputSchema: jsonSchema } }
+    const patched = { type: 'object', properties: { city: { type: 'string', description: 'Patched.' } } }
+
+    expect(
+      applyToTools(tools, readTools(tools).definitions, [{ name: 'unbuilt', description: 'Patched.', parametersJsonSchema: patched }])
+    ).toEqual({ unbuilt: { description: 'Patched.', inputSchema: patched } })
+  })
+
+  it('rewrites a parameter description without touching the tool description', () => {
+    const tools = { built: { description: 'Built.', parameters: { jsonSchema } } }
+    const patched = { type: 'object', properties: { city: { type: 'string', description: 'Patched.' } } }
+
+    expect(applyToTools(tools, readTools(tools).definitions, [{ name: 'built', parametersJsonSchema: patched }])).toEqual({
+      built: { description: 'Built.', parameters: { jsonSchema: patched } },
+    })
+  })
+
+  it('hands back the record it was given when no override changed anything', () => {
+    const tools = { built: { description: 'Built.', parameters: { jsonSchema } } }
+
+    // Identity: the caller uses it to leave the step's tools alone, so Mastra does not re-prepare a
+    // tool set that is the one it already had.
+    const { definitions } = readTools(tools)
+    expect(applyToTools(tools, definitions, definitions)).toBe(tools)
+  })
+
+  it('rewrites a tool description without touching its schema', () => {
+    const tools = { built: { description: 'Built.', parameters: { jsonSchema } } }
+
+    expect(
+      applyToTools(tools, readTools(tools).definitions, [{ name: 'built', description: 'Patched.', parametersJsonSchema: jsonSchema }])
+    ).toEqual({ built: { description: 'Patched.', parameters: { jsonSchema } } })
+  })
+
+  it('leaves a tool alone when the applied definitions run out before it', () => {
+    const tools = { built: { description: 'Built.', parameters: { jsonSchema } } }
+
+    // Not a result the core returns -- it hands back one definition per definition it was given --
+    // and the point of the guard is that a short list is never read as an offset one.
+    expect(applyToTools(tools, readTools(tools).definitions, [])).toBe(tools)
+  })
+})
+
+describe('a step with nothing on it', () => {
+  /** Drive the two hooks by hand, for the arguments a real agent run never produces. */
+  async function driveStep(agentId: string, step: Partial<ProcessInputStepArgs>): Promise<unknown> {
+    const processor: InputProcessor = agentControl({ label: 'production' })
+    const state: Record<string, unknown> = {}
+    await processor.processInput?.({
+      state,
+      agent: {
+        id: agentId,
+        __getOverridableFields: () => ({ instructions: 'Code text.', model: 'openai/gpt-5.6-sol' }),
+        getDefaultOptions: () => ({}),
+      },
+    } as unknown as ProcessInputArgs)
+    return processor.processInputStep?.({
+      state,
+      systemMessages: [{ role: 'system', content: 'Code text.' }],
+      messageList: NO_TAGS,
+      ...step,
+    } as unknown as ProcessInputStepArgs)
+  }
+
+  it('reports a tool override when the step advertises no tools at all', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { tool_definitions: [{ name: 'getWeather', description: 'Nowhere.' }] })
+
+    // No `tools` key at all, which is what Mastra passes an agent that has none, and a shape only a
+    // hand-built step can produce here.
+    expect(await driveStep(id, {})).toEqual({})
+    expect(warnings.messages).toEqual([expect.stringContaining("patches tool 'getWeather', which no toolset advertises for this request")])
+  })
+
+  it('notes which published value drove the request, on its own span', async () => {
+    const id = nextAgentId()
+    useManagedAgent(id, { model: 'openai:gpt-5.6-sol' })
+    const updates: unknown[] = []
+    const processor: InputProcessor = agentControl({ label: 'production' })
+
+    await processor.processInput?.({
+      state: {},
+      agent: { id, __getOverridableFields: () => ({ instructions: 'x' }), getDefaultOptions: () => ({}) },
+      tracingContext: { currentSpan: { update: (options: unknown) => updates.push(options) } },
+    } as unknown as ProcessInputArgs)
+
+    // The core's `run()` would put this on every span of the run as baggage, but a processor is a
+    // callback rather than a scope to wrap; the processor's own span is where this adapter can say it.
+    expect(updates).toEqual([
+      {
+        metadata: {
+          'logfire.agent_control': {
+            variable: `agent__${id}`,
+            label: 'production',
+            version: 1,
+            reason: 'resolved',
+          },
+        },
+      },
+    ])
+  })
+
+  it('says the same thing once, however many requests hit it', async () => {
+    const processor: InputProcessor = agentControl()
+    const args = { state: {} } as unknown as ProcessInputArgs
+
+    await processor.processInput?.(args)
+    await processor.processInput?.(args)
+
+    // The config is resolved on every request, so a report that repeated per request would bury
+    // itself. The core deduplicates its own warnings the same way.
+    expect(warnings.messages).toEqual([expect.stringContaining('ran without an agent')])
+  })
+})

--- a/packages/logfire-agent-control-mastra/src/index.ts
+++ b/packages/logfire-agent-control-mastra/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Logfire Agent Control for Mastra.
+ *
+ * One processor on a Mastra agent makes its instructions, model, model settings and tool definitions
+ * editable from the Logfire UI, without a deploy. Everything the contract itself owns -- the
+ * `AgentConfig` shape, the variable, the pure helpers that apply a published value -- lives in
+ * `@pydantic/logfire-node/agent-control`; this package is the Mastra half: where the hook is, which ids
+ * address which blocks, and how a canonical model string and settings become Mastra's own.
+ */
+
+export { AGENT_BLOCK_ID, PROVIDER_OPTIONS_NAMESPACE } from './instructions'
+
+export { agentControl, PROCESSOR_ID } from './processor'
+export type { MastraAgentControlOptions } from './processor'

--- a/packages/logfire-agent-control-mastra/src/instructions.ts
+++ b/packages/logfire-agent-control-mastra/src/instructions.ts
@@ -104,15 +104,29 @@ export function readCodeInstructions(value: unknown): CodeInstructions | null {
     return null
   }
   if (Array.isArray(value)) {
+    const entries = value as unknown[]
+    // Counted before any id is assigned, because an id two entries both declare names neither of
+    // them: an override written against it would rewrite both blocks, which is the thing declared
+    // ids exist to avoid. Both fall back to their positional ids, so the id addresses nothing and
+    // the core reports it, rather than one of the two winning by declaration order.
+    const declared = new Map<string, number>()
+    for (const entry of entries) {
+      const id = declaredId(entry)
+      if (id !== undefined) {
+        declared.set(id, (declared.get(id) ?? 0) + 1)
+      }
+    }
     const blocks: CodeBlock[] = []
-    for (const [index, entry] of (value as unknown[]).entries()) {
+    for (const [index, entry] of entries.entries()) {
       const text = entryText(entry)
       // One unreadable entry makes the whole value unaddressable rather than shifting every id after
       // it: an id that points at the wrong block is worse than no ids at all.
       if (text === null) {
         return null
       }
-      blocks.push({ id: declaredId(entry) ?? `${AGENT_BLOCK_ID}:${String(index)}`, text })
+      const id = declaredId(entry)
+      const unique = id !== undefined && declared.get(id) === 1
+      blocks.push({ id: unique ? id : `${AGENT_BLOCK_ID}:${String(index)}`, text })
     }
     return { blocks }
   }
@@ -141,7 +155,10 @@ function entryText(entry: unknown): string | null {
  * silently ignored because it was written in the other dialect is worse than no id at all.
  *
  * Anything that is not a non-empty string is no id: a half-filled value should fall back to the
- * positional id rather than make a block addressable under `''` or `123`.
+ * positional id rather than make a block addressable under `''` or `123`. Neither is anything in the
+ * reserved `tag:` namespace, which names Mastra's own buckets: `toSystemMessages` drops those blocks
+ * because they belong to the subsystems that write them, so an entry that claimed one would go
+ * missing from the prompt instead of being addressable under it.
  */
 function declaredId(entry: unknown): string | undefined {
   if (typeof entry !== 'object' || entry === null) {
@@ -157,7 +174,7 @@ function declaredId(entry: unknown): string | undefined {
     return undefined
   }
   const id = namespace['id']
-  return typeof id === 'string' && id !== '' ? id : undefined
+  return typeof id === 'string' && id !== '' && !id.startsWith(TAG_PREFIX) ? id : undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -182,6 +199,13 @@ export type Unaddressable =
  * duplicated block is an agent that cannot be addressed until its blocks say different things.
  *
  * `'duplicated'` wins when both are true, because it is the one with something to fix.
+ *
+ * The one case this cannot see is a per-run option that *starts* with the agent's own text -- a call
+ * passing `['A', 'something for this call']` to an agent whose code says `['A']` reads exactly like
+ * that agent plus a block a subsystem added, because Mastra puts both in the same untagged bucket
+ * and offers a processor nothing that says which is which. The published value then applies to the
+ * block whose text the two agree on. It is the same shape of gap as the one on settings, and it is
+ * documented in the README rather than guessed at.
  */
 export function unaddressable(systemMessages: readonly SystemMessage[], code: CodeInstructions): Unaddressable | null {
   if (code.blocks.every((block, index) => systemMessages[index]?.content === block.text)) {

--- a/packages/logfire-agent-control-mastra/src/instructions.ts
+++ b/packages/logfire-agent-control-mastra/src/instructions.ts
@@ -1,0 +1,274 @@
+/**
+ * Mapping Mastra's system messages onto addressable instruction blocks, and back.
+ *
+ * Mastra's instructions are a `SystemMessage`: one string, or a list of them, each becoming one
+ * system message in the order written. The list is the seam a managed config needs -- but an entry
+ * carries no name of its own, so an id is either one the entry declares under
+ * `providerOptions.logfire` or one synthesized from its position, and a position is only meaningful
+ * while the request's system messages still line up with the ones the code wrote. Most of this file
+ * is about establishing that they do.
+ */
+
+import type { CoreMessageV4, MessageList } from '@mastra/core/agent/message-list'
+import type { InstructionBlock } from '@pydantic/logfire-node/agent-control'
+
+/**
+ * A system message as Mastra's buckets hold one.
+ *
+ * `CoreMessageV4` is the union over every role, so narrowing to the system arm is what lets `content`
+ * be read as the string it is declared to be for that role.
+ */
+export type SystemMessage = Extract<CoreMessageV4, { role: 'system' }>
+
+/** The id of the agent's own instructions when they are a single block, per the contract's reserved name. */
+export const AGENT_BLOCK_ID = 'agent'
+
+/**
+ * The `providerOptions` namespace an instruction entry declares its own id under.
+ *
+ * `providerOptions` is `Record<provider, JSONObject>` and every provider reads only its own
+ * namespace, so a key under `logfire` reaches this adapter and reaches no provider's wire body --
+ * which is what makes it usable as block metadata rather than as a request field. It is the AI SDK's
+ * own idiom for attaching something to one system message, where Anthropic's `cacheControl` is
+ * declared the same way, and it is the same namespace the AI SDK adapter reads an id from.
+ *
+ * A declared id is the answer to the one thing a positional id cannot do: survive a reorder. Moving
+ * the second entry of a list to the front re-points `agent:0` and `agent:1` at each other's text, so
+ * an override published against one of them then rewrites the block it was not written for. An entry
+ * carrying `providerOptions: { logfire: { id: 'persona' } }` is addressed as `persona` wherever it
+ * sits.
+ */
+export const PROVIDER_OPTIONS_NAMESPACE = 'logfire'
+
+/**
+ * The prefix under which Mastra's own tagged system messages are described.
+ *
+ * They are named so the Logfire editor can show that the prompt has more in it than the agent's own
+ * text -- an MCP server's guidance, a caller's `system` option, recalled memory -- and named apart
+ * from `agent:<i>` because they are not the agent's to rewrite: the step hook replaces the *untagged*
+ * bucket and leaves every tagged one to the subsystem that owns it.
+ */
+const TAG_PREFIX = 'tag:'
+
+/**
+ * The tagged buckets this adapter describes.
+ *
+ * A fixed list because `MessageList` can be asked for a tag's messages but not for the tags it holds,
+ * so these are the ones Mastra itself writes. A tag another processor invents is invisible here,
+ * which costs nothing: it would be unaddressable either way.
+ */
+const MASTRA_SYSTEM_TAGS = ['mcp-guidance', 'user-provided', 'memory'] as const
+
+/**
+ * The agent's instructions as written, when they are addressable at all.
+ *
+ * `null` is the other outcome, and covers both a callable -- Mastra resolves instructions per request
+ * from the request context, so there is no code-side text to address, only a seam -- and a value this
+ * adapter cannot read as text, which is treated the same way rather than guessed at.
+ */
+export interface CodeInstructions {
+  /** One entry per block the agent's instructions contribute, in order. */
+  blocks: readonly CodeBlock[]
+}
+
+/** One block of the agent's own instructions, with the id that addresses it. */
+export interface CodeBlock {
+  /**
+   * What a published override names this block by.
+   *
+   * A `providerOptions.logfire.id` the entry declares, else the reserved `agent` when the agent wrote
+   * a single block and `agent:<i>` when it wrote a list.
+   */
+  id: string
+  /** The text the agent's code gives this block. */
+  text: string
+}
+
+/** An instruction block that remembers the message it came from, so an untouched one is returned as it was. */
+interface SourcedBlock extends InstructionBlock {
+  /** The message this block was read from, absent for a block the managed config added. */
+  readonly message?: SystemMessage
+}
+
+/**
+ * Read the agent's configured instructions without resolving them.
+ *
+ * Deliberately not `agent.getInstructions()`: that *invokes* a callable, which would run the agent's
+ * own per-request logic to build a document and could pin whatever one request happened to produce.
+ * The raw field says everything needed -- what the blocks are, or that they are computed.
+ */
+export function readCodeInstructions(value: unknown): CodeInstructions | null {
+  // A callable is resolved per request from the request context, so there is no code-side text to
+  // address: the request's blocks are seams, and a managed value may add to them but not rewrite them.
+  if (typeof value === 'function') {
+    return null
+  }
+  if (Array.isArray(value)) {
+    const blocks: CodeBlock[] = []
+    for (const [index, entry] of (value as unknown[]).entries()) {
+      const text = entryText(entry)
+      // One unreadable entry makes the whole value unaddressable rather than shifting every id after
+      // it: an id that points at the wrong block is worse than no ids at all.
+      if (text === null) {
+        return null
+      }
+      blocks.push({ id: declaredId(entry) ?? `${AGENT_BLOCK_ID}:${String(index)}`, text })
+    }
+    return { blocks }
+  }
+  const text = entryText(value)
+  return text === null ? null : { blocks: [{ id: declaredId(value) ?? AGENT_BLOCK_ID, text }] }
+}
+
+/** The text of one entry of a Mastra `SystemMessage`, or `null` when it is not one this adapter can read. */
+function entryText(entry: unknown): string | null {
+  if (typeof entry === 'string') {
+    return entry
+  }
+  if (typeof entry !== 'object' || entry === null) {
+    return null
+  }
+  const content = (entry as { content?: unknown }).content
+  return typeof content === 'string' ? content : null
+}
+
+/**
+ * The id an entry declares for itself, or `undefined` when it declares none.
+ *
+ * Read from both spellings of the same field, because Mastra's `SystemMessage` is the union of the AI
+ * SDK's v4 and v5 message shapes and they disagree on the name: v5 calls it `providerOptions` and v4
+ * calls it `experimental_providerMetadata`. Both are legal in an agent's `instructions`, and an id
+ * silently ignored because it was written in the other dialect is worse than no id at all.
+ *
+ * Anything that is not a non-empty string is no id: a half-filled value should fall back to the
+ * positional id rather than make a block addressable under `''` or `123`.
+ */
+function declaredId(entry: unknown): string | undefined {
+  if (typeof entry !== 'object' || entry === null) {
+    return undefined
+  }
+  const message = entry as { providerOptions?: unknown; experimental_providerMetadata?: unknown }
+  const options = message.providerOptions ?? message.experimental_providerMetadata
+  if (!isRecord(options)) {
+    return undefined
+  }
+  const namespace = options[PROVIDER_OPTIONS_NAMESPACE]
+  if (!isRecord(namespace)) {
+    return undefined
+  }
+  const id = namespace['id']
+  return typeof id === 'string' && id !== '' ? id : undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Why a request's blocks cannot be addressed by the ids the code's blocks carry. */
+export type Unaddressable =
+  /** The caller passed a per-run `instructions:` option, which replaced the agent's blocks outright. */
+  | 'replaced'
+  /** Two of the agent's own blocks are identical, so `MessageList` kept one and the rest shifted. */
+  | 'duplicated'
+
+/**
+ * Why this request's system messages do not start with the instructions the code wrote, if they do
+ * not.
+ *
+ * There are two reasons, they are told apart by whether the agent's own text repeats itself, and
+ * both are a reason to stand down rather than a mismatch to repair -- an id that addressed a block
+ * other than the one it names would rewrite text nobody pointed at. They are distinguished because
+ * what to do about them differs: a per-run option is precedence working as it should, and a
+ * duplicated block is an agent that cannot be addressed until its blocks say different things.
+ *
+ * `'duplicated'` wins when both are true, because it is the one with something to fix.
+ */
+export function unaddressable(systemMessages: readonly SystemMessage[], code: CodeInstructions): Unaddressable | null {
+  if (code.blocks.every((block, index) => systemMessages[index]?.content === block.text)) {
+    return null
+  }
+  const texts = new Set(code.blocks.map((block) => block.text))
+  return texts.size === code.blocks.length ? 'replaced' : 'duplicated'
+}
+
+/**
+ * The instruction blocks this request assembles, addressable where the code can be pointed at.
+ *
+ * Three groups, in the order the model sees them:
+ *
+ * - the agent's own blocks, under the id each one declares or the position it sits at, static, and
+ *   the only ones a managed value can rewrite;
+ * - the untagged blocks *after* them, which Mastra's skill and workspace subsystems add per request:
+ *   nothing names them, and they are marked dynamic so an added block lands before them rather than
+ *   after, keeping the provider's cached prefix where it was;
+ * - Mastra's tagged buckets, one block each, marked dynamic for the same reason and because they are
+ *   rebuilt per request by whatever owns them.
+ *
+ * When the agent's instructions are computed per request, every block falls into the second group,
+ * except that the first keeps the id `agent` -- so an override that names it is refused as the
+ * computed block it is, rather than reported as a block this request does not assemble.
+ */
+export function requestBlocks(
+  systemMessages: readonly SystemMessage[],
+  code: CodeInstructions | null,
+  messageList: Pick<MessageList, 'getSystemMessages'>
+): InstructionBlock[] {
+  const blocks: SourcedBlock[] = systemMessages.map((message, index) => {
+    const own = code === null ? undefined : code.blocks[index]
+    const id = own?.id ?? (index === 0 && code === null ? AGENT_BLOCK_ID : null)
+    return { id, text: message.content, dynamic: own === undefined, message }
+  })
+  for (const tag of MASTRA_SYSTEM_TAGS) {
+    const messages = messageList.getSystemMessages(tag) as SystemMessage[]
+    // One block per tag, not one per message: the text is never rewritten and never published, so the
+    // block exists to say the bucket is there, and one entry says that as well as five do.
+    if (messages.length > 0) {
+      blocks.push({
+        id: `${TAG_PREFIX}${tag}`,
+        text: messages.map((message) => message.content).join('\n\n'),
+        dynamic: true,
+      })
+    }
+  }
+  return blocks
+}
+
+/**
+ * The blocks that describe the agent as written, for the baseline.
+ *
+ * Built from the code value rather than from the request, so a run that carried a per-run
+ * `instructions:` option -- or that this adapter stood down on for any other reason -- still publishes
+ * what the agent says in code. Everything dynamic is carried through from the request, because a seam
+ * is only observable there.
+ */
+export function baselineBlocks(request: readonly InstructionBlock[], code: CodeInstructions | null): InstructionBlock[] {
+  if (code === null) {
+    return [...request]
+  }
+  const own = code.blocks.map((block) => ({ id: block.id, text: block.text, dynamic: false }))
+  return [...own, ...request.filter((block) => block.dynamic)]
+}
+
+/**
+ * Turn applied blocks back into the untagged system messages the step hook replaces.
+ *
+ * Tagged blocks are dropped: they describe buckets this hook does not own, and returning them would
+ * copy Mastra's own text into the untagged bucket where it would then be sent twice. A block whose
+ * text is unchanged comes back as the very message it was read from, so provider options and anything
+ * else riding on it survive a request this adapter did not actually change.
+ */
+export function toSystemMessages(blocks: readonly InstructionBlock[]): SystemMessage[] {
+  const messages: SystemMessage[] = []
+  for (const block of blocks) {
+    if (block.id?.startsWith(TAG_PREFIX) ?? false) {
+      continue
+    }
+    const source = (block as SourcedBlock).message
+    if (source === undefined) {
+      messages.push({ role: 'system', content: block.text })
+    } else {
+      messages.push(source.content === block.text ? source : { ...source, content: block.text })
+    }
+  }
+  return messages
+}

--- a/packages/logfire-agent-control-mastra/src/model.ts
+++ b/packages/logfire-agent-control-mastra/src/model.ts
@@ -1,0 +1,164 @@
+/**
+ * Translating model ids between the contract's `provider:model` and Mastra's `provider/model`.
+ *
+ * The two conventions differ in one character and a handful of provider names, which is exactly the
+ * kind of difference that is invisible until a published value silently names nothing. So the
+ * translation is explicit in both directions, and a router id whose provider Mastra has never heard
+ * of is refused before it reaches a request rather than after.
+ */
+
+import { getProviderConfig, parseModelString } from '@mastra/core/llm'
+
+/**
+ * Provider ids Pydantic AI v1 used, and what they are called now.
+ *
+ * Accepted as input and never emitted: a config published against a v1-era agent can still carry
+ * them, so they are normalized to the current id before anything else looks at them, and the
+ * baseline this adapter publishes only ever names the current one.
+ */
+const LEGACY_ALIASES: Readonly<Record<string, string>> = {
+  'google-gla': 'google',
+  'google-vertex': 'google-cloud',
+}
+
+/**
+ * Provider names that differ between the contract and Mastra's model router.
+ *
+ * Deliberately short, and checked rather than assumed: the contract's vocabulary is Pydantic AI's,
+ * Mastra's is its gateway registry's, and of the ~200 entries in that registry every provider both
+ * sides have agrees on the spelling except these three. `openai`, `anthropic`, `google`, `xai`,
+ * `groq`, `mistral`, `deepseek`, `cerebras`, `moonshotai`, `huggingface`, `nebius`, `openrouter`,
+ * `vercel`, `perplexity`, `crusoe`, `alibaba`, `ovhcloud` and `zai` are the same word on both sides,
+ * and a name in neither table passes through untouched so a provider added to Mastra's registry
+ * works here on the day it lands.
+ *
+ * `google-cloud` (Vertex AI) is deliberately absent: Mastra's registry has one `google`, which is the
+ * Gemini API, and nothing that serves Vertex. A published `google-cloud:` model is therefore refused
+ * and reported rather than quietly sent to the wrong endpoint.
+ */
+const CANONICAL_TO_MASTRA: Readonly<Record<string, string>> = {
+  fireworks: 'fireworks-ai',
+  snowflake: 'snowflake-cortex',
+  together: 'togetherai',
+}
+
+/** The reverse, for the baseline. Every value here is a current id; the legacy aliases are input-only. */
+const MASTRA_TO_CANONICAL: Readonly<Record<string, string>> = {
+  'fireworks-ai': 'fireworks',
+  'snowflake-cortex': 'snowflake',
+  togetherai: 'together',
+}
+
+/**
+ * A published `provider:model` as the router id Mastra resolves, or the string unchanged.
+ *
+ * Only the first `:` is the separator: a model id may contain more of them (`bedrock:us.anthropic
+ * .claude:0`), and everything after the provider belongs to the model. A string with no `:` at all is
+ * one this translation cannot classify -- most likely a router id someone wrote in Mastra's own
+ * notation -- and is handed to Mastra as it stands rather than rewritten into something else.
+ */
+export function toRouterModelId(model: string): string {
+  const separator = model.indexOf(':')
+  if (separator === -1) {
+    return model
+  }
+  const published = model.slice(0, separator)
+  const modelId = model.slice(separator + 1)
+  const provider = LEGACY_ALIASES[published] ?? published
+  return `${CANONICAL_TO_MASTRA[provider] ?? provider}/${modelId}`
+}
+
+/**
+ * Whether Mastra's model router knows the provider this router id names.
+ *
+ * Checked before a published model is applied, because Mastra resolves a router id lazily: an
+ * unknown provider builds a model object without complaint and fails at the first request instead,
+ * which would let one published value take down every run the agent makes. Refusing it here costs a
+ * report and keeps the agent on its code-defined model, which is the behavior a remote configuration
+ * has to degrade to.
+ *
+ * The check is against the built-in registry, so a provider reachable only through a custom gateway
+ * reads as unknown. That direction is the safe one: a refused model is a warning and a working agent.
+ */
+export function isRoutableModelId(routerModelId: string): boolean {
+  const { provider } = parseModelString(routerModelId)
+  // `null` is what Mastra's parser reports for a string that is not `provider/model` at all, which
+  // names no provider and so cannot name a registered one.
+  return provider !== null && getProviderConfig(provider) !== undefined
+}
+
+/**
+ * The `provider:model` form of a model the agent is configured with, or `undefined`.
+ *
+ * Reads the agent's *configured* model rather than resolving it, so the baseline describes what the
+ * code says and no dynamic model function is invoked to build a document. Three shapes carry a name:
+ * a router id, an AI SDK model instance (`provider`/`modelId`), and neither of those. A function or a
+ * fallback list resolves per request into something this cannot name once, and an OpenAI-compatible
+ * config names a URL rather than a provider; both come back `undefined`, which leaves `model` out of
+ * the baseline entirely rather than pinning one sample of it.
+ */
+export function toCanonicalModelId(config: unknown): string | undefined {
+  if (typeof config === 'string') {
+    const { provider, modelId } = parseModelString(config)
+    // A string Mastra's parser finds no provider in names a model and nothing else, and the contract
+    // has no way to say that, so the baseline leaves `model` out rather than inventing a provider.
+    if (provider === null) {
+      return undefined
+    }
+    return `${MASTRA_TO_CANONICAL[provider] ?? provider}:${modelId}`
+  }
+  if (typeof config !== 'object' || config === null) {
+    return undefined
+  }
+  const model = config as { provider?: unknown; modelId?: unknown }
+  if (typeof model.provider !== 'string' || typeof model.modelId !== 'string') {
+    return undefined
+  }
+  const provider = baseProvider(model.provider)
+  return `${MASTRA_TO_CANONICAL[provider] ?? provider}:${model.modelId}`
+}
+
+/**
+ * The provider serving a model, for the settings that only exist as provider options.
+ *
+ * Takes a router id or a resolved model object, because the model a step runs on is whichever of the
+ * two the hook was handed or this adapter is about to hand back.
+ */
+export function providerOf(config: unknown): string | undefined {
+  if (typeof config === 'string') {
+    return parseModelString(config).provider ?? undefined
+  }
+  if (typeof config !== 'object' || config === null) {
+    return undefined
+  }
+  const provider = (config as { provider?: unknown }).provider
+  return typeof provider === 'string' ? baseProvider(provider) : undefined
+}
+
+/**
+ * The provider name an AI SDK model instance really carries.
+ *
+ * A provider names itself by its API surface -- `anthropic.messages`, `openai.responses`,
+ * `google.generative-ai` -- and only the part before the dot is the provider the contract means.
+ * Mastra makes the same split when it labels a span with the model that served it.
+ */
+function baseProvider(provider: string): string {
+  const dot = provider.indexOf('.')
+  return dot === -1 ? provider : provider.slice(0, dot)
+}
+
+/**
+ * Whether a model would act on Mastra's `reasoning` setting.
+ *
+ * Mastra forwards it only to AI SDK v7 (`LanguageModelV4`) providers and drops it for older ones
+ * without a word, so a published `thinking` on a v2 or v3 model has to be reported rather than
+ * applied. A router id is not resolved here and so cannot be asked, and is given the benefit of the
+ * doubt: over-reporting a setting that did apply is its own kind of wrong answer.
+ */
+export function honorsReasoning(config: unknown): boolean {
+  if (typeof config !== 'object' || config === null) {
+    return true
+  }
+  const version = (config as { specificationVersion?: unknown }).specificationVersion
+  return version === undefined || version === 'v4'
+}

--- a/packages/logfire-agent-control-mastra/src/processor.ts
+++ b/packages/logfire-agent-control-mastra/src/processor.ts
@@ -216,7 +216,7 @@ class AgentControlProcessor implements Processor {
       buildBaseline({
         instructions: baselineBlocks(blocks, session.code),
         model: toCanonicalModelId(session.modelConfig) ?? null,
-        settings: raiseSettings(session.defaultModelSettings, session.defaultProviderOptions),
+        settings: raiseSettings(session.defaultModelSettings, session.defaultProviderOptions, providerOf(session.modelConfig)),
         tools: definitions,
       }),
       { source: 'observed' }

--- a/packages/logfire-agent-control-mastra/src/processor.ts
+++ b/packages/logfire-agent-control-mastra/src/processor.ts
@@ -1,0 +1,420 @@
+/**
+ * The Mastra processor that applies an agent's managed config.
+ *
+ * Mastra gives a processor two hooks that matter here, and the split between them is not a style
+ * choice. `processInput` runs once per request and is the only one Mastra hands the `Agent` to, so it
+ * is where the agent is read and where the variable is resolved -- once, so every step of a run sees
+ * the same published value and the prompt prefix cannot change underneath a provider's cache.
+ * `processInputStep` runs before every model call and is the only hook whose return value can replace
+ * the system messages, the model, the tools and the settings, so it is where all four sections are
+ * applied. The two share the per-request `state` bag Mastra threads between them.
+ */
+
+import { resolveModelConfig } from '@mastra/core/llm'
+import type {
+  InputProcessor,
+  Processor,
+  ProcessInputArgs,
+  ProcessInputResult,
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+} from '@mastra/core/processors'
+import {
+  AgentControl,
+  applyInstructions,
+  applySettings,
+  applyToolDefinitions,
+  buildBaseline,
+  reportUnapplied,
+  useResolution,
+  warnOnce,
+} from '@pydantic/logfire-node/agent-control'
+import type { AgentConfig, OnUnmatched, Resolution } from '@pydantic/logfire-node/agent-control'
+
+import { baselineBlocks, readCodeInstructions, requestBlocks, toSystemMessages, unaddressable } from './instructions'
+import type { CodeInstructions, SystemMessage, Unaddressable } from './instructions'
+import { honorsReasoning, isRoutableModelId, providerOf, toCanonicalModelId, toRouterModelId } from './model'
+import { renamingModel, toolRenames } from './renaming'
+import type { ResolvedModel } from './renaming'
+import { lowerSettings, raiseSettings } from './settings'
+import { applyToTools, readTools } from './tools'
+import type { ToolRecord } from './tools'
+
+/**
+ * The agent as `processInput` hands one over.
+ *
+ * Read off the hook's own argument rather than written as `Agent<string>`, because Mastra's `Agent`
+ * takes five type parameters and the hook is declared with the widest instantiation of them; naming
+ * a narrower one here would only mean asserting the argument back into it at the call site.
+ */
+type MastraAgent = NonNullable<ProcessInputArgs['agent']>
+
+/** The processor's id, which is also the key Mastra keeps its per-request state under. */
+export const PROCESSOR_ID = 'logfire-agent-control'
+
+/** Where the resolved session is kept in Mastra's per-processor, per-request `state` bag. */
+const SESSION_KEY = 'session'
+
+/** What is said about a published `instructions` section this request cannot address; see `unaddressable`. */
+const UNADDRESSABLE: Record<Unaddressable, string> = {
+  replaced:
+    'Managed agent config publishes instructions, but this request passed its own `instructions:` ' +
+    "option, which replaces the agent's blocks outright -- so the published ids no longer name the " +
+    'blocks they were written against; that section is not applied.',
+  duplicated:
+    "Managed agent config publishes instructions, but two of this agent's own instruction blocks are " +
+    'identical, and Mastra keeps only the first -- so every id after it would address a different ' +
+    'block; that section is not applied. Give those blocks different text to make them addressable.',
+}
+
+/** Options for `agentControl`. */
+export interface MastraAgentControlOptions {
+  /**
+   * The agent name that picks out the `agent__<name>` Logfire variable; defaults to the agent's `id`.
+   *
+   * Mastra's `id` is the agent's identity -- what its registry, its stored versions and its spans are
+   * keyed by -- so it is the right default, and `name` is only a display name. Pass this to hold the
+   * variable name steady across a rename of the agent, or to point two deployments at one config.
+   */
+  name?: string
+  /** The label to read, or absent to let the variable's rollout choose one. */
+  label?: string
+  /** What to do with a published entry that reaches nothing: `'warn'` (default), `'ignore'`, `'error'`. */
+  onUnmatched?: OnUnmatched
+  /** Whether to publish the code-side baseline the Logfire editor shows; on by default. */
+  publishBaseline?: boolean
+}
+
+/**
+ * What one request resolved to, shared between the two hooks.
+ *
+ * `null` where the request has no agent to read, which is the one state in which this adapter cannot
+ * say anything about the agent and therefore changes nothing about it.
+ */
+interface Session {
+  control: AgentControl
+  /** What the variable resolved to for this request: the config, and the label and version it came from. */
+  resolution: Resolution
+  /** The agent's instructions as written, or `null` when they are computed per request. */
+  code: CodeInstructions | null
+  /** The agent's configured model, for the baseline; not resolved, so a dynamic one is left unnamed. */
+  modelConfig: unknown
+  /** The published model as a router id, once it is known Mastra can resolve it. */
+  routerModelId: string | undefined
+  /** The agent's default model settings, which is what a value this run chose is recognised by differing from. */
+  defaultModelSettings: Record<string, unknown> | undefined
+  /** The agent's default provider options, read the same way and for the same two uses. */
+  defaultProviderOptions: Record<string, Record<string, unknown>> | undefined
+}
+
+/**
+ * Manage a Mastra agent's instructions, model, model settings and tool definitions from Logfire.
+ *
+ * ```ts
+ * export const checkout = new Agent({
+ *   id: 'checkout-assistant',
+ *   name: 'Checkout Assistant',
+ *   instructions: ['You are a concise checkout assistant.', 'Always confirm the order total.'],
+ *   model: 'anthropic/claude-fable-5-1',
+ *   tools: { getWeather },
+ *   inputProcessors: [agentControl({ label: 'production' })],
+ * });
+ * ```
+ *
+ * The agent runs on its code until something is published for it, and goes on running on its code if
+ * Logfire is unreachable, if the value does not validate, or if variables are switched off.
+ */
+export function agentControl(options: MastraAgentControlOptions = {}): InputProcessor {
+  return new AgentControlProcessor(options)
+}
+
+/**
+ * The processor `agentControl` returns; a class so both hooks share one options bag and one voice.
+ *
+ * Returned as Mastra's `InputProcessor` rather than as the wider `Processor`, because that is the
+ * type `inputProcessors` accepts: it requires that at least one input hook actually be implemented.
+ */
+class AgentControlProcessor implements Processor {
+  readonly id = PROCESSOR_ID
+  readonly name = 'Logfire Agent Control'
+  readonly description = "Applies the agent's Logfire-managed instructions, model, settings and tool definitions."
+
+  readonly #options: MastraAgentControlOptions
+
+  /**
+   * One `AgentControl` per agent name, built on first use.
+   *
+   * A map rather than a field because one processor instance can be registered on more than one
+   * agent, and each agent's config is its own variable. Reusing the control across requests is what
+   * keeps the SDK's variable registration, its cache, and the once-per-process baseline publish
+   * attached to the agent rather than to the request.
+   */
+  readonly #controls = new Map<string, AgentControl>()
+
+  constructor(options: MastraAgentControlOptions) {
+    this.#options = options
+  }
+
+  /**
+   * Resolve the agent's config once for this request, and read the agent it belongs to.
+   *
+   * Everything that needs the `Agent` happens here, because this is the only hook Mastra passes it
+   * to: the step hook is run by a processor runner built without one. Resolving here rather than per
+   * step is also what keeps a run coherent -- a rollout that re-rolled between two steps of one run
+   * would otherwise change the prompt mid-conversation.
+   */
+  async processInput(args: ProcessInputArgs): Promise<ProcessInputResult> {
+    args.state[SESSION_KEY] = await this.#open(args)
+    return args.messageList
+  }
+
+  /**
+   * Apply the resolved config to this step, and publish the baseline on the first one.
+   *
+   * Only the sections the published value actually carries are returned, and only when they change
+   * something: a returned `modelSettings` replaces the step's whole settings object and a returned
+   * tool record is re-prepared from scratch, so handing back an untouched copy would be work and
+   * noise in the trace for nothing.
+   */
+  async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult | undefined> {
+    const session = args.state[SESSION_KEY] as Session | null | undefined
+    if (session === undefined) {
+      // The step hook alone cannot do this: without the `Agent` there is no variable name to read,
+      // no code-side instructions to address by id, and no defaults to tell a per-run setting from a
+      // managed one. Mastra runs `processInput` before the first step of every agent request, so this
+      // is a processor being run somewhere else -- a processor-only workflow -- rather than a fault.
+      warnOnce(
+        `Logfire Agent Control ran without the per-request state its \`processInput\` hook sets up, so this ` +
+          'request runs on the code-defined agent. Register the processor on a Mastra `Agent` ' +
+          '(`inputProcessors`), not on a processor-only workflow.'
+      )
+      return undefined
+    }
+    if (session === null) {
+      return undefined
+    }
+    // One resolution for the whole request, and this is the work it drives: everything below --
+    // including the baseline publish and every warning -- runs inside its telemetry context, so a
+    // span opened here says which published version it was opened under.
+    return await useResolution(session.resolution, async () => this.#apply(args, session))
+  }
+
+  /** Apply one request's resolved config to one step. */
+  async #apply(args: ProcessInputStepArgs, session: Session): Promise<ProcessInputStepResult | undefined> {
+    const systemMessages = args.systemMessages as SystemMessage[]
+    const tools: ToolRecord = args.tools ?? {}
+    const blocks = requestBlocks(systemMessages, session.code, args.messageList)
+    const { definitions, reserved } = readTools(tools)
+
+    // Published from the first step of the process, because that is the first moment the whole
+    // picture exists: the agent's own text and model come from its configuration, but the tools the
+    // model is actually offered are only assembled here. That is also why it is published as an
+    // observation rather than as a description of the code -- the tool list is one request's, and a
+    // request that carried a memory, workspace or MCP toolset assembles a different one. The core
+    // publishes at most once per process.
+    session.control.publishBaseline(
+      buildBaseline({
+        instructions: baselineBlocks(blocks, session.code),
+        model: toCanonicalModelId(session.modelConfig) ?? null,
+        settings: raiseSettings(session.defaultModelSettings, session.defaultProviderOptions),
+        tools: definitions,
+      }),
+      { source: 'observed' }
+    )
+
+    const config = session.resolution.config
+    if (config === null) {
+      return undefined
+    }
+    const onUnmatched = session.control.onUnmatched
+    const result: ProcessInputStepResult = {}
+
+    if (config.instructions !== undefined) {
+      // Where the request no longer starts with the code's own text, the published ids would address
+      // blocks that are not the ones they name, so the whole section stands down -- and says so,
+      // because a section that reaches nothing is exactly what `onUnmatched` is for.
+      const skipped = session.code === null ? null : unaddressable(systemMessages, session.code)
+      if (skipped === null) {
+        const messages = toSystemMessages(applyInstructions(blocks, config, { onUnmatched }).blocks)
+        if (differs(messages, systemMessages)) {
+          result.systemMessages = messages
+        }
+      } else {
+        session.control.reportUnmatched(UNADDRESSABLE[skipped])
+      }
+    }
+
+    if (session.routerModelId !== undefined) {
+      result.model = session.routerModelId
+    }
+
+    if (config.settings !== undefined) {
+      // The model this step will actually use, which is the published one where there is one: the
+      // settings that only exist as provider options have to be lowered for the provider being sent
+      // to, not the one the code named.
+      const model = session.routerModelId ?? args.model
+      const lowered = lowerSettings(applySettings(config, { onUnmatched }), {
+        provider: providerOf(model),
+        supportsReasoning: honorsReasoning(model),
+        modelSettings: {
+          effective: args.modelSettings as Record<string, unknown> | undefined,
+          defaults: session.defaultModelSettings,
+        },
+        providerOptions: {
+          effective: args.providerOptions as Record<string, Record<string, unknown>> | undefined,
+          defaults: session.defaultProviderOptions,
+        },
+      })
+      reportUnapplied(lowered.unapplied, { onUnmatched })
+      // Both come back as the whole object to send -- Mastra replaces rather than merges what a
+      // processor returns -- or as `undefined` where the published value changed nothing. The casts
+      // are the settings finding their way back into Mastra's own types: every key under them is one
+      // of Mastra's, carrying either the value it already had or one the contract's schema validated.
+      if (lowered.modelSettings !== undefined) {
+        result.modelSettings = lowered.modelSettings as NonNullable<ProcessInputStepResult['modelSettings']>
+      }
+      if (lowered.providerOptions !== undefined) {
+        result.providerOptions = lowered.providerOptions as NonNullable<ProcessInputStepResult['providerOptions']>
+      }
+    }
+
+    if (config.tool_definitions !== undefined) {
+      const applied = applyToolDefinitions(definitions, config, { onUnmatched, reserved, collisionScope: 'global' })
+      const rebuilt = applyToTools(tools, definitions, applied.tools)
+      if (rebuilt !== tools) {
+        result.tools = rebuilt
+      }
+      const renames = toolRenames(definitions, applied)
+      // A rename is the one overlay Mastra is not shown: the record keeps its code-side keys and the
+      // model is wrapped instead, so the new name lives on the wire and nowhere else. Resolving the
+      // model here is what Mastra would do with whatever this hook returns anyway -- its runner puts
+      // every returned model through the same `resolveModelConfig` -- and a wrapped one has to be
+      // resolved to be wrapped.
+      if (renames.toModel.size > 0) {
+        // The cast drops `resolveModelConfig`'s legacy v1 arm, which is not a model a step can run on
+        // in the first place: Mastra's loop refuses one before it calls it.
+        const model = (await resolveModelConfig(session.routerModelId ?? args.model)) as ResolvedModel
+        result.model = renamingModel(model, renames, session.resolution)
+      }
+    }
+
+    return result
+  }
+
+  /** Build this request's session, or `null` when there is no agent to build it from. */
+  async #open(args: ProcessInputArgs): Promise<Session | null> {
+    const agent = args.agent
+    if (agent === undefined) {
+      warnOnce(
+        'Logfire Agent Control ran without an agent, so this request runs on the code-defined agent. ' +
+          'Register the processor on a Mastra `Agent` (`inputProcessors`), not on a processor-only workflow.'
+      )
+      return null
+    }
+
+    const control = this.#control(this.#name(agent))
+    const resolution = await control.resolution()
+    recordResolution(args, control.variableName, resolution)
+
+    // `__getOverridableFields` is Mastra's own accessor for the raw, unresolved values behind the
+    // fields its editor can override -- the same three this adapter manages. It is the only way to
+    // read them without invoking a dynamic one, and Mastra's stored-config editor reads them the same
+    // way.
+    const fields = agent.__getOverridableFields()
+    const defaults = await agent.getDefaultOptions(requestContextOf(args))
+
+    return {
+      control,
+      resolution,
+      code: readCodeInstructions(fields.instructions),
+      modelConfig: fields.model,
+      routerModelId: this.#routerModelId(control, resolution.config),
+      defaultModelSettings: defaults.modelSettings as Record<string, unknown> | undefined,
+      defaultProviderOptions: defaults.providerOptions as Record<string, Record<string, unknown>> | undefined,
+    }
+  }
+
+  /** The control backing one agent's variable, built once and reused for every request after. */
+  #control(name: string): AgentControl {
+    const existing = this.#controls.get(name)
+    if (existing !== undefined) {
+      return existing
+    }
+    const control = new AgentControl(name, {
+      ...(this.#options.label === undefined ? {} : { label: this.#options.label }),
+      ...(this.#options.onUnmatched === undefined ? {} : { onUnmatched: this.#options.onUnmatched }),
+      ...(this.#options.publishBaseline === undefined ? {} : { publishBaseline: this.#options.publishBaseline }),
+    })
+    this.#controls.set(name, control)
+    return control
+  }
+
+  /**
+   * The published model as a router id, once it is one Mastra can resolve.
+   *
+   * A router id whose provider is not registered does not fail here: Mastra builds a model object for
+   * it and fails at the request, which would take down every run the agent makes on the strength of
+   * one published string. Reporting it and keeping the code-defined model is the behavior a managed
+   * value has to degrade to.
+   */
+  #routerModelId(control: AgentControl, config: AgentConfig | null): string | undefined {
+    if (config?.model === undefined) {
+      return undefined
+    }
+    const routerModelId = toRouterModelId(config.model)
+    if (isRoutableModelId(routerModelId)) {
+      return routerModelId
+    }
+    control.reportUnmatched(
+      `Managed agent config selects model '${config.model}', whose provider is not one Mastra's model router ` +
+        'knows; that section is not applied and the agent keeps its code-defined model.'
+    )
+    return undefined
+  }
+
+  /** The name of the variable to read: the one given, else the agent's own id. */
+  #name(agent: MastraAgent): string {
+    // Typed as possibly absent on purpose: Mastra declares `id` as a string, but an agent built
+    // without one carries `undefined` there, and that is the case this message exists for.
+    const name: string | undefined = this.#options.name ?? (agent.id as string | undefined)
+    if (name === undefined || name.trim() === '') {
+      throw new Error(
+        'Logfire Agent Control needs a name for this agent, which is what picks out the `agent__<name>` ' +
+          'variable holding its managed config: give the Mastra agent an `id`, or pass ' +
+          "`agentControl({ name: 'checkout_assistant' })`."
+      )
+    }
+    return name
+  }
+}
+
+/**
+ * Note which published value drove this request, on the processor's own span.
+ *
+ * The core's `run()` would put the label on every span a run opens, as OpenTelemetry baggage -- but it
+ * needs a scope to wrap, and a processor is a callback Mastra invokes rather than a scope around the
+ * run. So the label and version are recorded where this adapter does have a span: its own. It is
+ * enough to answer the question the baggage answers, which is which published version a trace ran on.
+ */
+function recordResolution(args: ProcessInputArgs, variableName: string, resolution: Resolution): void {
+  args.tracingContext?.currentSpan?.update({
+    metadata: {
+      'logfire.agent_control': {
+        variable: variableName,
+        label: resolution.label,
+        version: resolution.version,
+        reason: resolution.reason,
+      },
+    },
+  })
+}
+
+/** Mastra's `getDefaultOptions` takes a request context, and only when there is one to give. */
+function requestContextOf(args: ProcessInputArgs): { requestContext: NonNullable<ProcessInputArgs['requestContext']> } | undefined {
+  return args.requestContext === undefined ? undefined : { requestContext: args.requestContext }
+}
+
+/** Whether the applied messages are anything other than the ones that came in, by identity and length. */
+function differs(applied: readonly SystemMessage[], original: readonly SystemMessage[]): boolean {
+  return applied.length !== original.length || applied.some((message, index) => message !== original[index])
+}

--- a/packages/logfire-agent-control-mastra/src/renaming.ts
+++ b/packages/logfire-agent-control-mastra/src/renaming.ts
@@ -1,0 +1,217 @@
+/**
+ * Keeping a managed tool rename inside the model boundary.
+ *
+ * A rename is the one overlay that has to be undone again. Everything else a managed config changes
+ * -- a description, a parameter description, a prompt, a setting -- is only ever *sent*, but a new
+ * name comes back: the model calls the tool by it, and whatever the framework is handed then decides
+ * which tool runs, what a hook context says, what a span records, and what is written into a thread's
+ * message history. If the framework is handed the new name, a rename published in Logfire silently
+ * rewrites your code's own vocabulary.
+ *
+ * So Mastra is never told. The tool record it dispatches, remembers and traces keeps its code-side
+ * keys, and this module wraps the model instead: the tools go out advertised under their managed
+ * names, a `toolChoice` written against a code name goes out translated with them, the calls the
+ * model makes come back translated, and the history Mastra replays -- written in code names, and
+ * still in code names after the rename changes or is withdrawn -- is translated forward on every
+ * request. What the model sees is the managed vocabulary; what everything on this side of the
+ * boundary sees is the code's. An `activeTools` list needs nothing done to it for the same reason:
+ * Mastra filters the record by its keys, and those are the names the code wrote.
+ *
+ * The wrapper is a `Proxy`, which is how Mastra writes its own model wrappers
+ * (`withAzureResponsesInputCompatibility`), and it matters here for a second reason: the runner
+ * accepts a model a processor returns only after `resolveModelConfig` hands it back unchanged, which
+ * it does for an instance of one of its own model classes. A proxy is still that instance.
+ */
+
+import type { resolveModelConfig } from '@mastra/core/llm'
+import { toolKey, useResolution } from '@pydantic/logfire-node/agent-control'
+import type { AppliedTools, Resolution, ToolDef } from '@pydantic/logfire-node/agent-control'
+
+/**
+ * A model as Mastra resolves one, which is the only shape its loop will call.
+ *
+ * `resolveModelConfig` also has a legacy v1 arm; that one is left out, because Mastra's loop refuses
+ * a step whose model is not v2, v3 or v4 before it ever calls it.
+ */
+export type ResolvedModel = Extract<Awaited<ReturnType<typeof resolveModelConfig>>, { specificationVersion: 'v2' | 'v3' | 'v4' }>
+
+/** Which tools this request advertises under a name other than the one the code gave them. */
+export interface ToolRenames {
+  /** Code-side name to advertised name: the direction everything on the way *out* is rewritten in. */
+  toModel: ReadonlyMap<string, string>
+  /** Advertised name to code-side name: the direction a call coming *back* is rewritten in. */
+  toCode: ReadonlyMap<string, string>
+}
+
+/**
+ * The renames a request's applied tool definitions amount to, in both directions.
+ *
+ * Read out of the core's `forward` table rather than by comparing names, so the one place that
+ * decides what a tool ends up advertised as -- including a rename it refused for colliding -- is also
+ * the place this reads. Mastra advertises every tool into one flat namespace and has no toolsets, so
+ * every lookup is under the `null` one.
+ *
+ * `toCode` is `toModel` inverted, which is exact: the core refuses a rename onto a name that is
+ * already advertised, so no two tools of one request share an advertised name.
+ */
+export function toolRenames(definitions: readonly ToolDef[], applied: AppliedTools): ToolRenames {
+  const toModel = new Map<string, string>()
+  const toCode = new Map<string, string>()
+  for (const def of definitions) {
+    const advertised = applied.forward.get(toolKey(null, def.name)) ?? def.name
+    if (advertised === def.name) {
+      continue
+    }
+    toModel.set(def.name, advertised)
+    toCode.set(advertised, def.name)
+  }
+  return { toModel, toCode }
+}
+
+/**
+ * The parts of a model call this adapter rewrites, in the fields every specification version shares.
+ *
+ * Mastra runs AI SDK v2, v3 and v4 models, and their call options differ -- but not in any of the
+ * three fields here, and not in how a tool is named in any of them. So the wrapper reads this shape
+ * rather than branching on a version whose differences it never touches.
+ */
+interface ModelCall {
+  /** The tool declarations, absent when the request offers the model none. */
+  tools?: readonly ModelTool[]
+  /** What the model may or must call; `{ type: 'tool', toolName }` is the one that names a tool. */
+  toolChoice?: NamesTool
+  /** The messages, whose assistant and tool parts name the tools earlier steps called. */
+  prompt: readonly ModelMessage[]
+}
+
+/** One advertised tool declaration. */
+interface ModelTool {
+  readonly name: string
+}
+
+/** One message of a prompt: `content` is a string for a system message and a part list otherwise. */
+interface ModelMessage {
+  readonly content: string | readonly NamesTool[]
+}
+
+/** Anything that may name a tool: a content part, a stream chunk, a tool choice. */
+interface NamesTool {
+  readonly toolName?: string
+}
+
+/** What a Mastra model returns from both of its call methods: the response, as a stream. */
+interface ModelResult {
+  readonly stream: ReadableStream<NamesTool>
+}
+
+/**
+ * One signature for both call methods.
+ *
+ * `ResolvedModel` is a union of the v2, v3 and v4 model shapes, so the union's own `doGenerate` takes
+ * the *intersection* of their call options -- a type nothing can be passed. Going through one
+ * structural signature is what lets the wrapper stay version-agnostic; it is the same reason
+ * `ModelCall` describes only the shared fields.
+ */
+type ModelCallFn = (options: ModelCall) => Promise<ModelResult>
+
+/** The two methods a model call arrives through. Mastra's own wrappers give both a stream. */
+const CALL_METHODS = new Set<string | symbol>(['doGenerate', 'doStream'])
+
+/**
+ * A model that speaks the managed tool names, wrapping one that is given the code's.
+ *
+ * Both call methods are wrapped, and both return a stream: Mastra's model classes exist to give
+ * `doGenerate` one, and `MastraModelInput` reads the response from `stream` alone -- so the call's
+ * `content`, which the v2 wrapper also carries, is not what any tool is dispatched from.
+ *
+ * The call is made inside the run's resolution, so the request the provider actually receives is
+ * attributed to the published version that shaped it.
+ *
+ * **Everything reaches the wrapped model as itself.** A `Proxy` whose `get` trap forwards the
+ * receiver hands the proxy to whatever it read, and a model that keeps anything in a `#private`
+ * field -- Mastra's own `ModelRouterLanguageModel` keeps its transport in one -- then throws
+ * `Cannot read private member ... from an object whose class did not declare it` the moment that
+ * field is touched, because the proxy is not an instance of the class that declared it. So every
+ * read is made *with the target as the receiver*, and every method comes back bound to the target,
+ * which is what keeps a rename from turning a working model into a broken one. Bound methods are
+ * cached per property so that reading the same method twice gives the same function, as it would on
+ * the model itself.
+ */
+export function renamingModel(model: ResolvedModel, renames: ToolRenames, resolution: Resolution): ResolvedModel {
+  const bound = new Map<string | symbol, unknown>()
+  return new Proxy(model, {
+    get(target, property) {
+      const cached = bound.get(property)
+      if (cached !== undefined) {
+        return cached
+      }
+      const value: unknown = Reflect.get(target, property, target)
+      if (!CALL_METHODS.has(property)) {
+        if (typeof value !== 'function') {
+          return value
+        }
+        const method: unknown = (value as (...args: never[]) => unknown).bind(target)
+        bound.set(property, method)
+        return method
+      }
+      const call = value as ModelCallFn
+      const wrapped = async (options: ModelCall): Promise<ModelResult> =>
+        useResolution(resolution, async () => {
+          const result = await call.call(target, withManagedNames(options, renames.toModel))
+          return { ...result, stream: withCodeNames(result.stream, renames.toCode) }
+        })
+      bound.set(property, wrapped)
+      return wrapped
+    },
+  })
+}
+
+/** One call, with every tool it names rewritten to the name the model is being shown. */
+function withManagedNames(call: ModelCall, names: ReadonlyMap<string, string>): ModelCall {
+  return {
+    ...call,
+    ...(call.tools === undefined ? {} : { tools: call.tools.map((tool) => renameTool(tool, names)) }),
+    ...(call.toolChoice === undefined ? {} : { toolChoice: rename(call.toolChoice, names) }),
+    prompt: call.prompt.map((message) => renameMessage(message, names)),
+  }
+}
+
+/** One response stream, with every tool the model named rewritten to the name the code gave it. */
+function withCodeNames(stream: ReadableStream<NamesTool>, names: ReadonlyMap<string, string>): ReadableStream<NamesTool> {
+  return stream.pipeThrough(
+    new TransformStream<NamesTool, NamesTool>({
+      transform(chunk, controller) {
+        controller.enqueue(rename(chunk, names))
+      },
+    })
+  )
+}
+
+/**
+ * Rewrite whatever names a tool, and hand back the original when nothing does.
+ *
+ * Keyed on carrying a `toolName` rather than on a list of part or chunk types, so a shape a later AI
+ * SDK release adds is renamed too rather than quietly going unmapped.
+ */
+function rename<T extends NamesTool>(value: T, names: ReadonlyMap<string, string>): T {
+  const renamed = value.toolName === undefined ? undefined : names.get(value.toolName)
+  return renamed === undefined ? value : { ...value, toolName: renamed }
+}
+
+/** A tool declaration names its tool in `name`, which is the one place the advertised name is set. */
+function renameTool<T extends ModelTool>(tool: T, names: ReadonlyMap<string, string>): T {
+  const renamed = names.get(tool.name)
+  return renamed === undefined ? tool : { ...tool, name: renamed }
+}
+
+/** One prompt message, with the tool names in its parts rewritten; unchanged when none were. */
+function renameMessage<T extends ModelMessage>(message: T, names: ReadonlyMap<string, string>): T {
+  const parts = message.content
+  if (typeof parts === 'string') {
+    return message
+  }
+  const content = parts.map((part) => rename(part, names))
+  // The original is handed back when nothing named a tool, so a message this adapter did not change
+  // is the very object Mastra passed in rather than a copy of it.
+  return content.some((part, index) => part !== parts[index]) ? { ...message, content } : message
+}

--- a/packages/logfire-agent-control-mastra/src/settings.ts
+++ b/packages/logfire-agent-control-mastra/src/settings.ts
@@ -276,10 +276,15 @@ function same(a: unknown, b: unknown): boolean {
  * contract names are described, so a value the Logfire editor offers is a value that can be published
  * back. `core.buildBaseline` filters to the canonical keys again, which makes this the place to get
  * the *units* right rather than the vocabulary.
+ *
+ * `provider` is the one the agent's code-defined model names, and it decides which namespace
+ * `parallel_tool_calls` is read from -- an agent may carry provider options for a provider it is not
+ * running on, and those are not settings this agent has.
  */
 export function raiseSettings(
   modelSettings: Readonly<Record<string, unknown>> | undefined,
-  providerOptions: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined
+  providerOptions: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined,
+  provider: string | undefined
 ): Record<string, unknown> {
   const settings: Record<string, unknown> = {}
   if (modelSettings !== undefined) {
@@ -299,11 +304,13 @@ export function raiseSettings(
       settings['thinking'] = thinking
     }
   }
-  for (const [provider, option] of Object.entries(PARALLEL_TOOL_CALLS)) {
-    const value = providerOptions?.[provider]?.[option.key]
-    if (typeof value === 'boolean') {
-      settings['parallel_tool_calls'] = option.negated ? !value : value
-    }
+  // Only the provider that will serve the agent. Options under another provider's namespace are
+  // inert for this agent, and raising one would describe the agent as having a setting it does not
+  // have -- which a publish would then turn into a setting it does.
+  const option = provider === undefined ? undefined : PARALLEL_TOOL_CALLS[provider]
+  const value = option === undefined || provider === undefined ? undefined : providerOptions?.[provider]?.[option.key]
+  if (option !== undefined && typeof value === 'boolean') {
+    settings['parallel_tool_calls'] = option.negated ? !value : value
   }
   return settings
 }

--- a/packages/logfire-agent-control-mastra/src/settings.ts
+++ b/packages/logfire-agent-control-mastra/src/settings.ts
@@ -1,0 +1,313 @@
+/**
+ * Lowering the contract's canonical settings onto Mastra's, and raising Mastra's back for a baseline.
+ *
+ * Mastra's own settings are the AI SDK's `CallSettings` plus two of its own (`reasoning`, `timeout`),
+ * so most of this is a `snake_case`-to-`camelCase` rename. The interesting keys are the three the AI
+ * SDK has no field for at all: `timeout`, which Mastra splits per step and per run; `thinking`, which
+ * only a v7 provider honours; and `parallel_tool_calls`, which lives in provider options under a
+ * different name -- and a different polarity -- for each provider.
+ */
+
+import { mergeSettings, toMilliseconds } from '@pydantic/logfire-node/agent-control'
+import type { AgentConfigSettings } from '@pydantic/logfire-node/agent-control'
+
+/** Canonical settings that are one rename away from a Mastra model setting. */
+const RENAMED = {
+  max_tokens: 'maxOutputTokens',
+  temperature: 'temperature',
+  top_p: 'topP',
+  top_k: 'topK',
+  seed: 'seed',
+  presence_penalty: 'presencePenalty',
+  frequency_penalty: 'frequencyPenalty',
+  stop_sequences: 'stopSequences',
+} as const satisfies Partial<Record<keyof AgentConfigSettings, string>>
+
+/**
+ * How a canonical `thinking` reaches Mastra's `reasoning`.
+ *
+ * The contract's levels are the AI SDK's levels, word for word, so only the two booleans need a
+ * decision: `true` asks for reasoning without saying how much, which is what `'provider-default'`
+ * means, and `false` asks for none, which the SDK spells `'none'`.
+ */
+const THINKING = {
+  true: 'provider-default',
+  false: 'none',
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+} as const
+
+/** The keys of `THINKING`, which are exactly the values the contract lets `thinking` take. */
+type ThinkingKey = keyof typeof THINKING
+
+/** The reverse, for a baseline. `'provider-default'` and `'none'` are the booleans they came from. */
+const REASONING: Readonly<Record<string, AgentConfigSettings['thinking']>> = {
+  'provider-default': true,
+  none: false,
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+}
+
+/**
+ * Where each provider keeps "may the model call several tools at once".
+ *
+ * The AI SDK has no call setting for it, so it is a provider option, and the two providers that
+ * expose one disagree about both its name and its sense: OpenAI asks whether parallel calls are
+ * allowed, Anthropic asks whether they are disabled. A provider not in this table has no knob to
+ * lower it onto, which is reported rather than guessed at.
+ */
+const PARALLEL_TOOL_CALLS: Readonly<Record<string, { key: string; negated: boolean }>> = {
+  openai: { key: 'parallelToolCalls', negated: false },
+  anthropic: { key: 'disableParallelToolUse', negated: true },
+}
+
+/** Every Mastra model setting this adapter writes, which is also every one a run can take back. */
+const MANAGED_MODEL_SETTINGS: readonly string[] = [...Object.values(RENAMED), 'reasoning', 'timeout']
+
+/**
+ * Provider options this adapter writes, which are booleans and only booleans.
+ *
+ * Narrower than the AI SDK's `Record<string, JSONValue>` on purpose: `parallel_tool_calls` is the one
+ * canonical setting with no home outside provider options, so anything wider would be room for a
+ * shape the contract has no way to express.
+ */
+type ProviderOptionsPatch = Record<string, Record<string, boolean>>
+
+/** One settings object as it reaches a step, and the agent's own defaults it was merged onto. */
+export interface SettingsLayers<T> {
+  /**
+   * What the step would run with: the agent's defaults with this run's own values merged in.
+   *
+   * Mastra deep-merges a call's `modelSettings` and `providerOptions` into the agent's
+   * `defaultOptions` before the loop starts, so by the time a processor sees them the two are one
+   * object and nothing records which value came from where.
+   */
+  effective: Readonly<Record<string, T>> | undefined
+  /** The agent's own defaults, which is what a value this run chose is recognised by differing from. */
+  defaults: Readonly<Record<string, T>> | undefined
+}
+
+/** What a published `settings` section becomes on Mastra's side. */
+export interface LoweredSettings {
+  /** The `modelSettings` to return for this step, or `undefined` when nothing about them changes. */
+  modelSettings: Record<string, unknown> | undefined
+  /** The `providerOptions` to return for this step, or `undefined` when nothing about them changes. */
+  providerOptions: Record<string, Record<string, unknown>> | undefined
+  /** Canonical keys that reached no Mastra knob, for `reportUnapplied`. */
+  unapplied: string[]
+}
+
+/** What the lowering needs to know about the request it is lowering for. */
+export interface LoweringContext {
+  /** The provider serving this step, for the settings that only exist as provider options. */
+  provider: string | undefined
+  /**
+   * Whether this step's model would honour `reasoning`.
+   *
+   * Mastra passes `reasoning` only to AI SDK v7 (`LanguageModelV4`) providers and silently drops it
+   * for older ones, and a setting dropped without a word is the one thing this contract exists to
+   * prevent -- so where it would be dropped, it is reported instead.
+   */
+  supportsReasoning: boolean
+  /** The step's model settings, and the agent defaults they were merged onto. */
+  modelSettings: SettingsLayers<unknown>
+  /** The step's provider options, and the agent defaults they were merged onto. */
+  providerOptions: SettingsLayers<Readonly<Record<string, unknown>>>
+}
+
+/**
+ * Lower a canonical settings patch onto Mastra's model settings and provider options.
+ *
+ * The contract's precedence is code < published < the values this run passed explicitly, and it is
+ * the core's `mergeSettings` that implements it here rather than anything local: each layer is handed
+ * over as it is, and what comes back is the object to send with a record of which layer won each key.
+ * That provenance is why a published `parallel_tool_calls` can no longer stamp over a run that set
+ * `openai.parallelToolCalls` for itself -- the two live in different places, and only the merge knows
+ * which of them the run asked for.
+ *
+ * The run layer is **recovered by diffing**, because Mastra merges a call's settings into the agent's
+ * defaults before any processor runs and offers a processor nothing that says which keys the call
+ * carried. A key whose value at the step differs from the agent's default is one this run chose. The
+ * cost is the case that cannot be recovered: a call passing a value *equal* to the agent's default is
+ * indistinguishable from a call that passed nothing, and the published value wins there. It is the
+ * weaker of the two contracts and it is documented as such; it is not fixable by diffing harder.
+ *
+ * Everything the framework cannot express comes back in `unapplied` rather than being dropped: the
+ * caller reports those under the same `onUnmatched` policy the rest of the config is applied with.
+ */
+export function lowerSettings(settings: AgentConfigSettings, context: LoweringContext): LoweredSettings {
+  const published: Record<string, unknown> = {}
+  const unapplied: string[] = []
+
+  for (const [canonicalKey, mastraKey] of Object.entries(RENAMED)) {
+    const value = settings[canonicalKey as keyof typeof RENAMED]
+    if (value !== undefined) {
+      published[mastraKey] = value
+    }
+  }
+
+  if (settings.timeout !== undefined) {
+    // Mastra's timeout is a budget object, in milliseconds, split between the whole run (`totalMs`)
+    // and one model call (`stepMs`). The contract's `timeout` is seconds and is per model request,
+    // which is `stepMs`; merging rather than replacing is what leaves a run-wide `totalMs` set in
+    // code exactly where it was. `applySettings` has already dropped and reported a timeout that is
+    // not a representable budget, so this conversion cannot be handed one.
+    const current = context.modelSettings.effective?.['timeout']
+    const budget = isRecord(current) ? current : {}
+    published['timeout'] = { ...budget, stepMs: toMilliseconds(settings.timeout) }
+  }
+
+  if (settings.thinking !== undefined) {
+    // The cast is exhaustive by construction: `THINKING` has a key for every value the contract's
+    // `thinking` can take, both booleans included, so stringifying one always lands on a key.
+    const reasoning = THINKING[String(settings.thinking) as ThinkingKey]
+    if (context.supportsReasoning) {
+      published['reasoning'] = reasoning
+    } else {
+      unapplied.push('thinking')
+    }
+  }
+
+  const provider = context.provider
+  const publishedOptions: ProviderOptionsPatch = {}
+  if (settings.parallel_tool_calls !== undefined) {
+    const option = provider === undefined ? undefined : PARALLEL_TOOL_CALLS[provider]
+    if (provider === undefined || option === undefined) {
+      unapplied.push('parallel_tool_calls')
+    } else {
+      publishedOptions[provider] = {
+        [option.key]: option.negated ? !settings.parallel_tool_calls : settings.parallel_tool_calls,
+      }
+    }
+  }
+
+  return {
+    modelSettings: merged(context.modelSettings, published, MANAGED_MODEL_SETTINGS),
+    providerOptions: mergedProviderOptions(context.providerOptions, publishedOptions),
+    unapplied,
+  }
+}
+
+/**
+ * The settings to send for this step, or `undefined` when the published ones change nothing.
+ *
+ * `undefined` rather than a copy because Mastra rebuilds the step from a returned `modelSettings`,
+ * and handing back an object equal to the one it already has is work and noise in the trace for
+ * nothing.
+ */
+function merged(
+  layers: SettingsLayers<unknown>,
+  published: Readonly<Record<string, unknown>>,
+  keys: readonly string[]
+): Record<string, unknown> | undefined {
+  if (Object.keys(published).length === 0) {
+    return undefined
+  }
+  const settings = mergeSettings(layers.effective, published, runValues(layers, keys)).settings
+  const changed = Object.keys(published).some((key) => !same(settings[key], layers.effective?.[key]))
+  return changed ? settings : undefined
+}
+
+/** The same, per provider, since each provider's options are their own namespace to merge in. */
+function mergedProviderOptions(
+  layers: SettingsLayers<Readonly<Record<string, unknown>>>,
+  published: ProviderOptionsPatch
+): Record<string, Record<string, unknown>> | undefined {
+  const merge: Record<string, Record<string, unknown>> = {}
+  let changed = false
+  for (const [provider, options] of Object.entries(published)) {
+    const inner: SettingsLayers<unknown> = {
+      effective: layers.effective?.[provider],
+      defaults: layers.defaults?.[provider],
+    }
+    const result = merged(inner, options, Object.keys(options))
+    if (result === undefined) {
+      continue
+    }
+    merge[provider] = result
+    changed = true
+  }
+  if (!changed) {
+    return undefined
+  }
+  // Every other provider's options are carried across: a returned `providerOptions` replaces the
+  // step's, so a managed `openai` key would otherwise take an `anthropic` block with it.
+  return { ...layers.effective, ...merge }
+}
+
+/**
+ * The values this run chose for itself, as the explicit layer `mergeSettings` takes.
+ *
+ * Only the keys a published value could otherwise overwrite are looked at: the rest of a step's
+ * settings are its own either way, and there is nothing to attribute.
+ */
+function runValues(layers: SettingsLayers<unknown>, keys: readonly string[]): Record<string, unknown> {
+  const explicit: Record<string, unknown> = {}
+  for (const key of keys) {
+    const value = layers.effective?.[key]
+    if (!same(value, layers.defaults?.[key])) {
+      explicit[key] = value
+    }
+  }
+  return explicit
+}
+
+/** Structural equality, for settings values that may be arrays (`stopSequences`) or objects (`timeout`). */
+function same(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a === undefined || b === undefined) {
+    return false
+  }
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+/**
+ * Raise Mastra's settings back to the canonical ones, for the baseline.
+ *
+ * The inverse of `lowerSettings`, minus the parts a baseline has no use for: only the keys the
+ * contract names are described, so a value the Logfire editor offers is a value that can be published
+ * back. `core.buildBaseline` filters to the canonical keys again, which makes this the place to get
+ * the *units* right rather than the vocabulary.
+ */
+export function raiseSettings(
+  modelSettings: Readonly<Record<string, unknown>> | undefined,
+  providerOptions: Readonly<Record<string, Readonly<Record<string, unknown>>>> | undefined
+): Record<string, unknown> {
+  const settings: Record<string, unknown> = {}
+  if (modelSettings !== undefined) {
+    for (const [canonicalKey, mastraKey] of Object.entries(RENAMED)) {
+      const value = modelSettings[mastraKey]
+      if (value !== undefined) {
+        settings[canonicalKey] = value
+      }
+    }
+    const timeout = modelSettings['timeout']
+    if (isRecord(timeout) && typeof timeout['stepMs'] === 'number') {
+      settings['timeout'] = timeout['stepMs'] / 1000
+    }
+    const reasoning = modelSettings['reasoning']
+    const thinking = typeof reasoning === 'string' ? REASONING[reasoning] : undefined
+    if (thinking !== undefined) {
+      settings['thinking'] = thinking
+    }
+  }
+  for (const [provider, option] of Object.entries(PARALLEL_TOOL_CALLS)) {
+    const value = providerOptions?.[provider]?.[option.key]
+    if (typeof value === 'boolean') {
+      settings['parallel_tool_calls'] = option.negated ? !value : value
+    }
+  }
+  return settings
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/logfire-agent-control-mastra/src/tools.ts
+++ b/packages/logfire-agent-control-mastra/src/tools.ts
@@ -93,17 +93,19 @@ export function applyToTools(tools: ToolRecord, definitions: readonly ToolDef[],
       patches.set(def.name, result)
     }
   }
-  const rebuilt: ToolRecord = {}
-  let changed = false
-  for (const [name, tool] of Object.entries(tools)) {
+  const original = Object.entries(tools)
+  const entries = original.map(([name, tool]): [string, unknown] => {
     const def = patches.get(name)
-    const patched = def === undefined ? tool : patch(tool, def)
-    if (patched !== tool) {
-      changed = true
-    }
-    rebuilt[name] = patched
+    return [name, def === undefined ? tool : patch(tool, def)]
+  })
+  if (entries.every(([, tool], index) => tool === original[index]?.[1])) {
+    return tools
   }
-  return changed ? rebuilt : tools
+  // `Object.fromEntries` rather than assignment in a loop, because `rebuilt[name] = tool` for a tool
+  // keyed `__proto__` -- which a record built with a computed key can carry, and which is a name
+  // every provider's function-name grammar allows -- runs the prototype setter instead of creating a
+  // property, and the tool would vanish from every request a config was applied to.
+  return Object.fromEntries(entries)
 }
 
 /** Overlay a definition's description and parameter schema onto one built tool, or return it unchanged. */

--- a/packages/logfire-agent-control-mastra/src/tools.ts
+++ b/packages/logfire-agent-control-mastra/src/tools.ts
@@ -1,0 +1,163 @@
+/**
+ * Mapping the tools Mastra hands the step hook onto tool definitions, and back.
+ *
+ * The one thing to know about Mastra's tools is that the **record key is the name the model sees**.
+ * `prepareToolsAndToolChoice` builds each function declaration from the key, filters `activeTools` by
+ * it, passes a `toolChoice` through under it, and routes the model's call back through it -- so the
+ * key is not only an advertisement, it is the name every hook context, span and stored thread message
+ * records a call under.
+ *
+ * That is why a managed rename is *not* done here. Re-keying the record would advertise the new name
+ * and route the call, but it would rewrite the name your own code sees along with it. The record
+ * keeps its code-side keys and only descriptions and parameter descriptions are overlaid onto it; the
+ * rename happens one layer down, at the model boundary, in `./renaming.ts`.
+ */
+
+import { isProviderDefinedTool } from '@mastra/core/tools'
+import type { JsonSchema, ToolDef } from '@pydantic/logfire-node/agent-control'
+
+/** The tool record `ProcessInputStepArgs` carries and `ProcessInputStepResult` accepts. */
+export type ToolRecord = Record<string, unknown>
+
+/** What a step advertises: the tools an override may patch, and the names it may not take. */
+export interface AdvertisedTools {
+  /** The definitions a managed config is applied to, in record order, named as the code names them. */
+  definitions: ToolDef[]
+  /**
+   * Advertised names that are not this adapter's to touch, which a rename must not collide with.
+   *
+   * Mastra's tool record may also hold *provider-defined* tools -- `google.tools.googleSearch()` and
+   * its kind -- whose name is a contract with the provider rather than a description the model reads,
+   * and which Mastra advertises under the tool's own `name` rather than the record key. So they are
+   * neither patched nor renamed, and their advertised names go to the core as reserved: a managed
+   * rename onto one of them would put two tools on the wire under one name and make both unreachable.
+   */
+  reserved: string[]
+}
+
+/**
+ * Read the LLM-facing definition of each tool the step advertises.
+ *
+ * By the time a processor sees them, Mastra has assembled every source into one flat record -- the
+ * agent's own tools, plus memory, workspace, skill, sub-agent, workflow and MCP tools -- and built
+ * each one into a `CoreTool` whose `parameters.jsonSchema` is what the provider is sent. There is no
+ * source label on the built tool, so no `toolset` is reported: an override matches by name alone.
+ */
+export function readTools(tools: ToolRecord): AdvertisedTools {
+  const definitions: ToolDef[] = []
+  const reserved: string[] = []
+  for (const [name, tool] of Object.entries(tools)) {
+    if (isProviderDefinedTool(tool)) {
+      reserved.push(advertisedName(tool, name))
+      continue
+    }
+    const description = (tool as { description?: unknown }).description
+    const def: ToolDef = { name, parametersJsonSchema: parametersOf(tool) }
+    if (typeof description === 'string') {
+      def.description = description
+    }
+    definitions.push(def)
+  }
+  return { definitions, reserved }
+}
+
+/**
+ * The name a provider-defined tool is advertised under.
+ *
+ * `prepareToolsAndToolChoice` sends `tool.name ?? recordKey`, so the record key is its wire name only
+ * when the tool carries none of its own.
+ */
+function advertisedName(tool: object, key: string): string {
+  const name = (tool as { name?: unknown }).name
+  return typeof name === 'string' ? name : key
+}
+
+/**
+ * Overlay the applied definitions onto the tool record, under the keys the code gave them.
+ *
+ * `applied` comes back from the core in the order it was handed `definitions`, so the two are zipped
+ * by position, and each patch is written under the *code-side* key -- never under a managed
+ * `new_name`. Every entry the core was not shown, a provider-defined tool included, is carried
+ * through untouched.
+ *
+ * Returns the record it was given when nothing changed, so a caller can tell an applied config from
+ * one that reached nothing and leave the step alone.
+ */
+export function applyToTools(tools: ToolRecord, definitions: readonly ToolDef[], applied: readonly ToolDef[]): ToolRecord {
+  const patches = new Map<string, ToolDef>()
+  for (const [index, def] of definitions.entries()) {
+    const result = applied[index]
+    // A shorter `applied` than `definitions` is not a shape the core returns; skipping is what keeps
+    // that from being read as "this tool's definition is the one at the wrong index".
+    if (result !== undefined) {
+      patches.set(def.name, result)
+    }
+  }
+  const rebuilt: ToolRecord = {}
+  let changed = false
+  for (const [name, tool] of Object.entries(tools)) {
+    const def = patches.get(name)
+    const patched = def === undefined ? tool : patch(tool, def)
+    if (patched !== tool) {
+      changed = true
+    }
+    rebuilt[name] = patched
+  }
+  return changed ? rebuilt : tools
+}
+
+/** Overlay a definition's description and parameter schema onto one built tool, or return it unchanged. */
+function patch(tool: unknown, def: ToolDef): unknown {
+  const original = tool as { description?: unknown; parameters?: { jsonSchema?: unknown }; inputSchema?: unknown }
+  const describes = def.description !== undefined && def.description !== original.description
+  const schema = def.parametersJsonSchema !== parametersOf(tool) ? def.parametersJsonSchema : undefined
+  if (!describes && schema === undefined) {
+    return tool
+  }
+  const patched: Record<string, unknown> = { ...(original as Record<string, unknown>) }
+  if (describes) {
+    patched['description'] = def.description
+  }
+  if (schema !== undefined) {
+    // A built `CoreTool` carries `parameters: { jsonSchema, validate }`, where only `jsonSchema` is
+    // sent to the provider and `validate` still checks the arguments against the code-defined shape --
+    // which is why an override may rewrite descriptions but never the schema's structure. A tool that
+    // reached the step unbuilt (a plain AI SDK tool) carries its JSON schema as `inputSchema` instead.
+    if (isRecord(original.parameters)) {
+      patched['parameters'] = { ...original.parameters, jsonSchema: schema }
+    } else {
+      patched['inputSchema'] = schema
+    }
+  }
+  return patched
+}
+
+/** The JSON Schema a tool advertises, or an empty schema when it is in a form this adapter cannot read. */
+function parametersOf(tool: unknown): JsonSchema {
+  const candidate = tool as { parameters?: { jsonSchema?: unknown }; inputSchema?: unknown }
+  const jsonSchema = candidate.parameters?.jsonSchema
+  if (isRecord(jsonSchema)) {
+    return jsonSchema
+  }
+  // An unbuilt tool's `inputSchema` is either a JSON schema already or a Standard Schema object (a
+  // Zod schema, say). Only the first is readable without knowing which validation library wrote it,
+  // and `~standard` is how the standard says to tell them apart.
+  const inputSchema = candidate.inputSchema
+  if (isRecord(inputSchema) && !('~standard' in inputSchema)) {
+    return inputSchema
+  }
+  return EMPTY_SCHEMA
+}
+
+/**
+ * The schema reported for a tool whose parameters cannot be read.
+ *
+ * One shared frozen object, so `parametersOf` returns the same reference every time it is asked about
+ * such a tool and `patch` can tell "the helper changed nothing" from "the helper rewrote it" by
+ * identity, exactly as it does for a schema that was readable.
+ */
+const EMPTY_SCHEMA: JsonSchema = Object.freeze({})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/logfire-agent-control-mastra/tsconfig.json
+++ b/packages/logfire-agent-control-mastra/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vite.config.ts"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/logfire-agent-control-mastra/vite.config.ts
+++ b/packages/logfire-agent-control-mastra/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite-plus'
+
+import { copyCjsDeclarations, packageDefines } from '../../vite.shared'
+
+const defines = packageDefines(import.meta.url)
+
+const config: ReturnType<typeof defineConfig> = defineConfig({
+  define: defines,
+  pack: {
+    define: defines,
+    dts: {
+      resolver: 'tsc',
+    },
+    deps: {
+      neverBundle: [/^@mastra\//u, /^node:/u, '@pydantic/logfire-node', '@pydantic/logfire-node/agent-control'],
+    },
+    entry: 'src/index.ts',
+    format: ['esm', 'cjs'],
+    hooks: {
+      'build:done': () => {
+        copyCjsDeclarations(['index'])
+      },
+    },
+    minify: true,
+    outExtensions: ({ format }) => ({
+      dts: format === 'cjs' ? '.d.cts' : '.d.ts',
+      js: format === 'cjs' ? '.cjs' : '.js',
+    }),
+    outputOptions: {
+      exports: 'named',
+    },
+  },
+})
+
+export default config

--- a/packages/logfire-node/README.md
+++ b/packages/logfire-node/README.md
@@ -376,7 +376,9 @@ const answer = await control.run(async ({ config }) => {
 })
 ```
 
-The core is framework-neutral; a framework adapter builds on it. See
+The core is framework-neutral; a framework adapter builds on it. For Mastra, that adapter is
+[`@pydantic/logfire-agent-control-mastra`](https://github.com/pydantic/logfire-js/blob/main/packages/logfire-agent-control-mastra/README.md),
+which is one processor on an agent. See
 [the Agent Control guide](https://github.com/pydantic/logfire-js/blob/main/docs/agent-control.md)
 and `examples/node/agent-control.ts`.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,30 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  packages/logfire-agent-control-mastra:
+    devDependencies:
+      '@ai-sdk/provider':
+        specifier: ^3.0.16
+        version: 3.0.16
+      '@mastra/core':
+        specifier: ^1.65.0
+        version: 1.65.0(@grpc/grpc-js@1.14.4)(ai@7.0.97(zod@4.4.3))(express@4.22.1)(zod@4.4.3)
+      '@pydantic/logfire-node':
+        specifier: workspace:*
+        version: link:../logfire-node
+      '@types/node':
+        specifier: ^22.5.1
+        version: 22.19.5
+      ai:
+        specifier: ^7.0.95
+        version: 7.0.97(zod@4.4.3)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(@vitest/browser-preview@4.1.9)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   packages/logfire-api:
     dependencies:
       handlebars:
@@ -660,6 +684,80 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(@vitest/browser-preview@4.1.9)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
 
 packages:
+
+  '@a2a-js/sdk@0.3.14':
+    resolution: {integrity: sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': 1.14.4
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
+
+  '@a2a-js/sdk@1.0.1':
+    resolution: {integrity: sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': 1.14.4
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
+
+  '@ai-sdk/gateway@4.0.78':
+    resolution: {integrity: sha512-fcamzmFlcy+c/tIc7QcATLe/kArgSVGQ1QxaddMjhOSX8zypc2hmD5sHB2bp1DSFcSxDD32d6usF9a7xLCTULg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.13':
+    resolution: {integrity: sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.39':
+    resolution: {integrity: sha512-VIFp4Qv3j+V941crFB1y2VG5yeGbeLOFRxiPaZJETkkpo1H5WviLx6H5yRkFkrXIGxnTGygKsPgCAJG0X61Auw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.16':
+    resolution: {integrity: sha512-9Av6kg0t/IN/dcYAAmEJ4B9OPhcEJqwSR+GfHEA8olRkindXpUHadc3p3cyvgFUQFTVm1G5thtsmgZ9yVb2w3A==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.13':
+    resolution: {integrity: sha512-sJvnbFIFLzmKFXIjfwS8XCOAj6puHCawItwvA9PBZgk2f/l/TiC4OSfK3ueDbUVXfRCOn5eJN97EIF10toIOmQ==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+    engines: {node: '>=22'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1341,6 +1439,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/ttlcache@2.1.5':
+    resolution: {integrity: sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==}
+    engines: {node: '>=12'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1354,6 +1456,14 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
+  '@lukeed/uuid@2.0.1':
+    resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
+    engines: {node: '>=8'}
+
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
     engines: {node: '>=20.0.0'}
@@ -1365,6 +1475,26 @@ packages:
   '@manypkg/tools@2.1.2':
     resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
     engines: {node: '>=20.0.0'}
+
+  '@mastra/core@1.65.0':
+    resolution: {integrity: sha512-FHis85lEo19XkpSfFcyVsTnm7HROzSEIr1zpwhs3ApaCpJNZJaBAyxZ5IEPUyZMd2QT1N+qFTC6yMGijHMLt0w==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@mastra/schema-compat@1.3.9':
+    resolution: {integrity: sha512-9qoxJzODLwUwGod2g5nv6yT7Nd2ImSAydz+699Gvxj8u8Jwg6icBMbS7cqk/DFQZlZvJED0N0w6kxkp+Ay/qcg==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@next/env@16.3.0':
     resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
@@ -2409,6 +2539,12 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/core@1.52.0':
+    resolution: {integrity: sha512-pvbdeRRpizktmo8MXZQxjAI4aFfNajwkzxbm72wKV9n2wWcnQWa4m+AqTI2zmmCSsYk7F666rRUdvYqZLjjhWg==}
+
+  '@posthog/types@1.410.0':
+    resolution: {integrity: sha512-741sltt/h+l0eYH+Nkow96qKfDmRxwKacfjF93Z+kMySjzL0a87ptmpklZxGkbjBp/DJH/CSowGrolYWK/1ToA==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -2451,9 +2587,24 @@ packages:
   '@rrweb/utils@2.1.1':
     resolution: {integrity: sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
+  '@sindresorhus/slugify@2.2.1':
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
+
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
 
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
@@ -2501,6 +2652,9 @@ packages:
   '@types/css-font-loading-module@0.0.7':
     resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2519,11 +2673,17 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
@@ -2571,6 +2731,13 @@ packages:
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vercel/otel@2.1.3':
     resolution: {integrity: sha512-Ofvzs9qhftRD1YMLuPnhbXjQZG6IKrJ9AmEKmRHRGfoWlV89ed2gAOkvddkFiZDFZJm2rrFNdeZKRVxoCdnWiw==}
@@ -2735,6 +2902,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
 
@@ -2756,6 +2929,15 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ai@7.0.97:
+    resolution: {integrity: sha512-tQGZ234p/bk5X/LNQdB43a5/z1Bve7wK0EOR1AwN6xrosZih4MIC/3pXhcnytcpBJHMbhLISW6J1dFTd/tnwPA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2767,6 +2949,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2780,6 +2965,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
@@ -2822,9 +3010,30 @@ packages:
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  chat@4.40.0:
+    resolution: {integrity: sha512-slu3VDxItlelEZ8A5vqzlmtT2WErqj2YCGuhhcNx+Ev0+wHeBUqUDUA7hXkca+BfFtW1ZX7ECcySCTG2q2gefg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ai: ^6.0.182 || ^7.0.0
+      workflow: ^5.0.0-beta.35
+      zod: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+      workflow:
+        optional: true
+      zod:
+        optional: true
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -2865,6 +3074,14 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  croner@10.0.1:
+    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
+    engines: {node: '>=18.0'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -2900,6 +3117,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2916,11 +3136,18 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -2971,12 +3198,29 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -2986,8 +3230,15 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -2995,8 +3246,14 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
+
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.3:
+    resolution: {integrity: sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3013,6 +3270,10 @@ packages:
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
@@ -3066,6 +3327,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   google-logging-utils@1.1.3:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
@@ -3073,6 +3338,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -3103,9 +3372,17 @@ packages:
     resolution: {integrity: sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw==}
     hasBin: true
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
+
+  ignore@7.0.9:
+    resolution: {integrity: sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==}
+    engines: {node: '>= 4'}
 
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
@@ -3121,6 +3398,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -3129,14 +3410,39 @@ packages:
     resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
     engines: {node: '>=16'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  jose@6.2.12:
+    resolution: {integrity: sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
+    hasBin: true
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
@@ -3154,8 +3460,22 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-schema-to-zod@2.8.1:
+    resolution: {integrity: sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -3244,6 +3564,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -3255,9 +3578,45 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -3272,6 +3631,90 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -3352,6 +3795,10 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3393,12 +3840,24 @@ packages:
       vite-plus:
         optional: true
 
+  p-map@7.0.7:
+    resolution: {integrity: sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==}
+    engines: {node: '>=18'}
+
   p-retry@6.2.1:
     resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
     engines: {node: '>=16.17'}
 
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -3406,6 +3865,14 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -3472,9 +3939,22 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-node@5.51.8:
+    resolution: {integrity: sha512-TCqgAYbACwb/D3VI2S861ugD+FavvowQfak8eMwS/wATS+g0Wj+YpsABrBEKi+ZP3Y5SJDcoc7bIH49rlGo1Ww==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-ms@9.3.1:
+    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
+    engines: {node: '>=18'}
 
   protobufjs@7.6.3:
     resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
@@ -3512,6 +3992,18 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remend@1.3.1:
+    resolution: {integrity: sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3527,6 +4019,10 @@ packages:
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rosie-skills-darwin-arm64@0.6.4:
     resolution: {integrity: sha512-rn1s5hqFKcxeiDEWWoFa1hdGPshR8TkwHLzy/cBavb9XJNAaUxbe3oQ78W9sQkRHAgRyzJYyk9tw68Qrdnizgg==}
@@ -3570,6 +4066,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -3604,6 +4104,14 @@ packages:
       '@types/node':
         optional: true
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shell-quote@1.10.0:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
@@ -3627,6 +4135,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -3641,6 +4153,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3659,6 +4174,14 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -3689,10 +4212,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -3720,6 +4239,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tokenx@1.6.0:
+    resolution: {integrity: sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw==}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -3731,6 +4253,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3764,6 +4289,25 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -3775,9 +4319,19 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plus@0.2.1:
     resolution: {integrity: sha512-q5q/Y38UkWFsNg1JO+RyRdPUqoewaSqIlMyK2p83GKNUvf4D38Ntb3PToRTDZbTRh7mWt+B+d0DQBv4nCDpMcQ==}
@@ -3855,6 +4409,11 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3894,6 +4453,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -3904,6 +4475,9 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3927,11 +4501,18 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+  zod-from-json-schema@0.5.6:
+    resolution: {integrity: sha512-U33AJ7ZWS6y9XNSzMWcdy8hRAvZmWhTtpYJu0SXPT5AArbc9nq2ur7Magzmn5RF9KBV4b3FP0nCpmqqlfXlR9w==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3939,7 +4520,76 @@ packages:
   zone.js@0.15.1:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
+
+  '@a2a-js/sdk@0.3.14(@grpc/grpc-js@1.14.4)(express@4.22.1)':
+    dependencies:
+      uuid: 11.1.1
+    optionalDependencies:
+      '@grpc/grpc-js': 1.14.4
+      express: 4.22.1
+
+  '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@4.22.1)':
+    dependencies:
+      jose: 6.2.12
+      uuid: 11.1.1
+    optionalDependencies:
+      '@grpc/grpc-js': 1.14.4
+      express: 4.22.1
+
+  '@ai-sdk/gateway@4.0.78(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.1
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.39(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.16':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.13':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
+    dependencies:
+      json-schema: 0.4.0
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -4448,6 +5098,8 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
+  '@isaacs/ttlcache@2.1.5': {}
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -4458,6 +5110,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@lukeed/csprng@1.1.0': {}
+
+  '@lukeed/uuid@2.0.1':
+    dependencies:
+      '@lukeed/csprng': 1.1.0
 
   '@manypkg/find-root@3.1.0':
     dependencies:
@@ -4473,6 +5131,66 @@ snapshots:
       jju: 1.4.0
       tinyglobby: 0.2.16
       yaml: 2.9.0
+
+  '@mastra/core@1.65.0(@grpc/grpc-js@1.14.4)(ai@7.0.97(zod@4.4.3))(express@4.22.1)(zod@4.4.3)':
+    dependencies:
+      '@a2a-js/sdk-v0_3': '@a2a-js/sdk@0.3.14(@grpc/grpc-js@1.14.4)(express@4.22.1)'
+      '@a2a-js/sdk-v1': '@a2a-js/sdk@1.0.1(@grpc/grpc-js@1.14.4)(express@4.22.1)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)'
+      '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
+      '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.14'
+      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.4'
+      '@isaacs/ttlcache': 2.1.5
+      '@lukeed/uuid': 2.0.1
+      '@mastra/schema-compat': 1.3.9(zod@4.4.3)
+      '@modelcontextprotocol/server': 2.0.0
+      '@sindresorhus/slugify': 2.2.1
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      chat: 4.40.0(ai@7.0.97(zod@4.4.3))(zod@4.4.3)
+      croner: 10.0.1
+      dotenv: 17.4.2
+      execa: 9.6.1
+      fastq: 1.20.3
+      gray-matter: 4.0.3
+      ignore: 7.0.9
+      jpeg-js: 0.4.4
+      json-schema: 0.4.0
+      lru-cache: 11.5.2
+      p-map: 7.0.7
+      p-retry: 7.1.1
+      picomatch: 4.0.4
+      posthog-node: 5.51.8
+      tokenx: 1.6.0
+      ws: 8.21.3
+      xxhash-wasm: 1.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@grpc/grpc-js'
+      - ai
+      - bufferutil
+      - express
+      - rxjs
+      - supports-color
+      - utf-8-validate
+      - workflow
+
+  '@mastra/schema-compat@1.3.9(zod@4.4.3)':
+    dependencies:
+      json-schema-to-zod: 2.8.1
+      zod: 4.4.3
+      zod-from-json-schema: 0.5.6
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@next/env@16.3.0': {}
 
@@ -5656,6 +6374,12 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/core@1.52.0':
+    dependencies:
+      '@posthog/types': 1.410.0
+
+  '@posthog/types@1.410.0': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -5693,7 +6417,20 @@ snapshots:
 
   '@rrweb/utils@2.1.1': {}
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@sindresorhus/is@7.2.0': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@sindresorhus/slugify@2.2.1':
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
+      escape-string-regexp: 5.0.0
 
   '@speed-highlight/core@1.2.14': {}
 
@@ -5746,6 +6483,10 @@ snapshots:
 
   '@types/css-font-loading-module@0.0.7': {}
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
@@ -5768,11 +6509,17 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/memcached@2.2.10':
     dependencies:
       '@types/node': 22.19.5
 
   '@types/mime@1.3.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.27':
     dependencies:
@@ -5832,6 +6579,10 @@ snapshots:
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 22.19.5
+
+  '@types/unist@3.0.3': {}
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vercel/otel@2.1.3(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -6016,6 +6767,10 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.1':
     optional: true
 
+  '@workflow/serde@4.1.0': {}
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
   '@xstate/fsm@1.6.5': {}
 
   accepts@1.3.8:
@@ -6031,6 +6786,20 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ai@7.0.97(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.78(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      zod: 4.4.3
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.7
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -6038,6 +6807,10 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -6048,6 +6821,8 @@ snapshots:
   array-flatten@1.1.1: {}
 
   assertion-error@2.0.1: {}
+
+  bail@2.0.2: {}
 
   base64-arraybuffer@1.0.2: {}
 
@@ -6094,7 +6869,26 @@ snapshots:
 
   caniuse-lite@1.0.30001780: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities@2.0.2: {}
+
+  chat@4.40.0(ai@7.0.97(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.1
+      unified: 11.0.5
+    optionalDependencies:
+      ai: 7.0.97(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   cjs-module-lexer@2.2.0: {}
 
@@ -6126,6 +6920,14 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  croner@10.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -6152,6 +6954,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -6160,9 +6966,15 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   dom-accessibility-api@0.5.16: {}
 
   dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -6223,11 +7035,32 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@5.0.0: {}
+
+  esprima@4.0.1: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
   etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.1
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.2.0
 
   expect-type@1.3.0: {}
 
@@ -6267,7 +7100,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
+
+  fast-deep-equal@3.1.3: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -6275,9 +7114,15 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
+  fast-uri@3.1.7: {}
+
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
+
+  fastq@1.20.3:
+    dependencies:
+      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6289,6 +7134,10 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   fflate@0.8.3: {}
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   finalhandler@1.3.2:
     dependencies:
@@ -6356,9 +7205,21 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.15.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   handlebars@4.7.9:
     dependencies:
@@ -6398,9 +7259,13 @@ snapshots:
 
   human-id@4.2.1: {}
 
+  human-signals@8.0.1: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
+
+  ignore@7.0.9: {}
 
   import-in-the-middle@3.0.1:
     dependencies:
@@ -6415,15 +7280,34 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-extendable@0.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-network-error@1.3.1: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
+
+  isexe@2.0.0: {}
 
   jju@1.4.0: {}
 
+  jose@6.2.12: {}
+
+  jpeg-js@0.4.4: {}
+
   js-tokens@4.0.0: {}
+
+  js-yaml@3.15.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.3.1:
     dependencies:
@@ -6459,7 +7343,15 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-schema-to-zod@2.8.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
+
   jsonc-parser@3.3.1: {}
+
+  kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -6521,6 +7413,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.5.2: {}
 
   lz-string@1.5.0: {}
@@ -6529,7 +7423,111 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -6538,6 +7536,197 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -6639,6 +7828,11 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
@@ -6705,19 +7899,31 @@ snapshots:
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
 
+  p-map@7.0.7: {}
+
   p-retry@6.2.1:
     dependencies:
       '@types/retry': 0.12.2
       is-network-error: 1.3.1
       retry: 0.13.1
 
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.1
+
   package-manager-detector@1.8.0: {}
+
+  parse-ms@4.0.0: {}
 
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
 
   parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-to-regexp@0.1.13: {}
 
@@ -6773,11 +7979,19 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  posthog-node@5.51.8:
+    dependencies:
+      '@posthog/core': 1.52.0
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  pretty-ms@9.3.1:
+    dependencies:
+      parse-ms: 4.0.0
 
   protobufjs@7.6.3:
     dependencies:
@@ -6823,6 +8037,34 @@ snapshots:
 
   react@19.2.3: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  remend@1.3.1: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -6835,6 +8077,8 @@ snapshots:
       - supports-color
 
   retry@0.13.1: {}
+
+  reusify@1.1.0: {}
 
   rosie-skills-darwin-arm64@0.6.4:
     optional: true
@@ -6879,6 +8123,11 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
 
   semver@7.7.4: {}
 
@@ -7012,6 +8261,12 @@ snapshots:
       '@types/node': 22.19.5
     optional: true
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   shell-quote@1.10.0: {}
 
   side-channel-list@1.0.0:
@@ -7044,6 +8299,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -7055,6 +8312,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
@@ -7072,6 +8331,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-bom-string@1.0.0: {}
+
+  strip-final-newline@4.0.0: {}
+
   styled-jsx@5.1.6(react@19.2.3):
     dependencies:
       client-only: 0.0.1
@@ -7084,8 +8347,6 @@ snapshots:
   systeminformation@5.31.7: {}
 
   tinybench@2.9.0: {}
-
-  tinyexec@1.1.2: {}
 
   tinyexec@1.3.0: {}
 
@@ -7106,6 +8367,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tokenx@1.6.0: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.2:
@@ -7115,6 +8378,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  trough@2.2.0: {}
 
   tslib@2.8.1: {}
 
@@ -7142,13 +8407,56 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  unicorn-magic@0.3.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unpipe@1.0.0: {}
 
   user-agent-data-types@0.4.2: {}
 
   utils-merge@1.0.1: {}
 
+  uuid@11.1.1: {}
+
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plus@0.2.1(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
@@ -7226,7 +8534,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
+      tinyexec: 1.3.0
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@22.19.5)(esbuild@0.28.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'
@@ -7277,6 +8585,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -7318,11 +8630,15 @@ snapshots:
 
   ws@8.20.1: {}
 
+  ws@8.21.3: {}
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
 
@@ -7342,6 +8658,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yoctocolors@2.2.0: {}
+
   youch-core@0.3.3:
     dependencies:
       '@poppinss/exception': 1.2.3
@@ -7355,6 +8673,12 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
+  zod-from-json-schema@0.5.6:
+    dependencies:
+      zod: 4.4.3
+
   zod@4.4.3: {}
 
   zone.js@0.15.1: {}
+
+  zwitch@2.0.4: {}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -221,7 +221,8 @@ export default defineConfig({
       'no-inline-comments': 'off',
       'no-negated-condition': 'off',
       'no-shadow': 'off',
-      'no-underscore-dangle': ['error', { allow: ['_resetRegistry', '_spanName'] }],
+      // `__getOverridableFields` is Mastra's own public accessor name, read by the agent-control adapter.
+      'no-underscore-dangle': ['error', { allow: ['__getOverridableFields', '_resetRegistry', '_spanName'] }],
       'no-unsafe-optional-chaining': 'off',
       'no-warning-comments': 'off',
       'require-await': 'off',


### PR DESCRIPTION
Stacked on #321, which adds the framework-neutral core as `@pydantic/logfire-node/agent-control`. Base is `agent-control-core`; it will retarget to `main` when the core merges.

**Parked as a draft on sequencing, not on anything in the PR:** the release was narrowed to the Pydantic AI path — the `pydantic-ai-harness` capability and the parts of the Logfire Python SDK it exercises — rather than carry maintenance for the framework adapters before the contract is settled. See the handover comment on this PR.

## What this is

The [Mastra](https://mastra.ai) adapter for Agent Control, as its own package at `packages/logfire-agent-control-mastra`. Add one processor to an agent's `inputProcessors` and its instructions, its model, its model settings, and the names and descriptions its tools are advertised under become editable from the Logfire UI, without a deploy. Until someone publishes a value — and any time Logfire is unreachable, or a published value cannot be understood — the agent runs exactly as the code defines it.

```bash
npm install @pydantic/logfire-agent-control-mastra @pydantic/logfire-node
```

```ts
import { Agent } from '@mastra/core/agent'
import { agentControl } from '@pydantic/logfire-agent-control-mastra'

export const checkout = new Agent({
  id: 'checkout_assistant',
  name: 'Checkout Assistant',
  instructions: ['You are a concise checkout assistant.', 'Always confirm the order total.'],
  model: 'anthropic/claude-fable-5-1',
  tools: { getWeather },
  inputProcessors: [agentControl({ label: 'production' })],
})
```

That is the whole installation. The config lives in a Logfire variable named `agent__checkout_assistant` — the agent's Mastra `id`, normalized by the core's rule, or a `name` you pass instead — and the first request publishes a description of the agent so the editor shows what it is you are changing. `agentControl` returns an `InputProcessor` and nothing else: your agent, your tools and your model object are never mutated. Register it **last**, so it applies the published config to the prompt every other processor has finished with.

`@mastra/core` (`>=1.65 <2`) and `@pydantic/logfire-node` are both peer dependencies, which is why this is a package and not another subpath of `logfire-node`: a subpath would have put a third-party agent framework in front of every user of the Node SDK. The Vercel AI SDK and Codex SDK adapters land in parallel and justify their own placement.

## Two hooks, because Mastra has two

`processInput` runs once per request and is the only hook Mastra hands the `Agent` to, so that is where the variable is read, the resolution is opened, and the baseline is published. `processInputStep` runs before every model call and is the only hook whose return value can replace what the step will send, so that is where the config is applied.

**Resolution is therefore once per request, applied to every step of it.** That is deliberate: the prompt prefix cannot change between the steps of one run, which is what keeps a provider's prompt cache warm, and a value published mid-run takes effect on the next request. Everything the adapter does for a request runs inside that resolution's telemetry context, and so does the provider call itself wherever the model is wrapped, so a span carries the label and version that produced it. A processor registered on a processor-only workflow, where `processInput` never ran, says so once and changes nothing.

**Precedence is code < published < the values a run passed explicitly**, with one gap this integration cannot close. Mastra deep-merges a call's `modelSettings` and `providerOptions` into the agent's `defaultOptions` before any processor runs, and gives a processor nothing that records which keys the call carried — so "the caller set this" is recovered by comparing the step's value against the agent's default. A call passing a value *equal* to the agent's default is indistinguishable from a call that passed nothing, and the published value wins there.

## What becomes editable

| Source, or canonical field | Block id, or runtime mapping | Support |
| --- | --- | --- |
| `instructions` as a list | `agent:0`, `agent:1`, … by position | Yes |
| `instructions` as one string or message | `agent` | Yes |
| An entry declaring its own id | the declared id | Yes. Written as `providerOptions: { logfire: { id: 'persona' } }` on a system message; the AI SDK v4 spelling `experimental_providerMetadata` is read too. Worth doing — a positional id re-points when you reorder the list |
| `instructions` as a function | `agent` for the first block | No. Built per request, so replacing it would freeze one rendering; reported as the dynamic block it is |
| Adding a block | an entry with no `id` | Yes. Lands after your own text and before anything Mastra adds per request, so a provider's prompt cache keeps its prefix |
| Mastra's own prompt sections | `tag:memory`, `tag:mcp-guidance`, `tag:user-provided` | No. They belong to the subsystems that write them; described in the baseline only so the editor can show the prompt has more in it than your text |
| `model` | `provider:model` → Mastra's `provider/model` | Conditional. The provider must be one Mastra's built-in router knows; `bedrock`, `azure`, `cohere`, `google-cloud` and custom gateways are reported, and the agent keeps its code-defined model |
| `max_tokens`, `temperature`, `top_p`, `top_k`, `seed`, the two penalties, `stop_sequences` | the AI SDK's own names | Yes, as far as the call settings — what a provider then does with one is the provider's decision; see the table below |
| `timeout` (seconds) | `timeout.stepMs` | Yes. Mastra's per-model-call budget, not a request field |
| `thinking` | `reasoning` | **No, through the model router** — see below |
| `parallel_tool_calls` | `providerOptions.openai.parallelToolCalls`; `providerOptions.anthropic.disableParallelToolUse`, inverted | Conditional. Those are the two providers that expose it; reported on any other |
| A tool's advertised name, description, and parameter descriptions | patched onto what Mastra advertises | Yes. Parameters, types and the implementation stay code-defined |
| A provider-defined tool (`google.tools.googleSearch()` and its kind) | — | No. Its name is a contract with the provider; its advertised name is still held against a managed rename of another tool |
| Narrowing an override to one toolset | — | No. By the time a processor sees them, Mastra has assembled every source — your tools, memory, workspace, skills, sub-agents, workflows, MCP — into one flat record with no source label |

Model ids are the contract's, which is Pydantic AI's vocabulary: `google` is the Gemini API and `google-cloud` is Vertex AI. The v1 spellings `google-gla` and `google-vertex` are still *accepted*, so a config published against an older agent keeps working, but neither is ever what a baseline publishes. Checking the rest of the contract's vocabulary against Mastra's registry turned up three more names the two sides spell differently: `together`, `fireworks` and `snowflake`.

**On a rename, your code keeps seeing the name your code gave the tool.** Rename `getWeather` to `lookup_current_weather` and the model is offered that name — but the record Mastra dispatches from keeps its `getWeather` key, so `execute` runs, tool hooks fire, spans are recorded and thread messages are stored all under `getWeather`. The rename lives on the wire and nowhere else: for a request that renames something, the adapter hands Mastra a wrapped model that advertises the managed names, translates the model's calls back before Mastra dispatches them, and translates the replayed history forward on the way out. A `toolChoice` or `activeTools` naming a tool by its code name keeps working, and a stored thread survives the rename changing or being withdrawn.

## What the live tests proved, and what they disproved

Most of the suite is offline — a local variables provider and the AI SDK's mock models, so a test asserts on the exact call Mastra would have made. `src/__test__/live.test.ts` is the other half: real providers, recorded through `globalThis.fetch` and replayed offline in CI, against `openai/gpt-5.4-nano` and `anthropic/claude-haiku-4-5`. Every assertion is on a request the run actually built — the cassette supplies the response, never the request — so a change that stops a published value from reaching the provider fails here rather than in a bill.

Proved:

- a published `agent` block is the system prompt the provider received, the code's own text is *gone* from the request rather than sitting alongside it, and the model answered to it;
- a renamed tool goes out as `lookup_current_weather` with the managed description and the reworded parameter description inside the code's own schema, a real model calls it, the second request replays the history forward under the managed name — and on this side of the boundary `execute` ran with the model's arguments, `result.toolCalls` and the stored response messages all read `getWeather`;
- which of the eleven canonical settings each provider actually accepts, published all at once on a single request. OpenAI's Responses API takes `max_output_tokens` and `parallel_tool_calls` and answers `unsupported` for seven others; Anthropic takes `max_tokens`, `temperature`, `top_k`, `stop_sequences` and the inverted `disable_parallel_tool_use`, and drops `top_p` when `temperature` is published with it.

So the README's support column says what was **observed**, not what was read off source.

**Disproved: `thinking` is not applicable through the model router at all.** Mastra passes `reasoning` only to AI SDK v7 (`LanguageModelV4`) providers, and `ModelRouterLanguageModel` — what *every* `provider/model` string resolves to — declares `specificationVersion = 'v2'`. A published `thinking` on a router model is therefore always reported rather than applied, which the live tests assert as a warning on both providers. Pass a v7 model object as the agent's `model` and it applies.

## Five holes review found, all closed

All five reproduce; each has a regression test that fails without its fix.

- A declared instruction id in the reserved `tag:` namespace was dropped from the prompt entirely, because that prefix names Mastra's own buckets and `toSystemMessages` skips them. Such an id is refused and the entry keeps its positional id.
- An id two entries both declared addressed both of them, so one published override rewrote two blocks. Both now fall back to their positional ids, so the ambiguous id addresses nothing and is reported, rather than one winning by declaration order.
- A tool keyed `__proto__` vanished from every request a config was applied to: assigning it into a plain object runs the prototype setter. The record is rebuilt with `Object.fromEntries`.
- `raiseSettings` raised `parallel_tool_calls` out of *any* provider's namespace, so an agent carrying an OpenAI option while running on Anthropic published a setting it did not have — which a publish of that baseline would then have applied, inverted, to Anthropic. It reads the serving provider's namespace only.
- The README named `LOGFIRE_TOKEN`, which is the telemetry write token. Resolving a managed variable needs `LOGFIRE_API_KEY`.

Two more reports did not hold up, and the tests now say so. Instructions do **not** stop applying across a tool loop: Mastra rebuilds a step's system messages from the agent rather than from what the previous step returned, so the already-managed text is never read back as a per-run option. And a per-run `instructions:` option that *starts* with the agent's own text genuinely cannot be told from that agent plus a block a subsystem added — Mastra puts both in the same untagged bucket — so that one is documented as a known limit rather than guessed at.

One defect from the port is worth knowing about independently of review: the renaming `Proxy` forwarded *itself* as the receiver, so every read of a wrapped model's own state ran with `this` set to the proxy. `ModelRouterLanguageModel` keeps its transport in a `#private` field and reads it from a method the loop calls between steps, which made every renaming run against the model router throw. Reads are now made with the target as the receiver and methods come back bound to it.

## Two open review findings

Both are unanswered P2s from @petyosi, and neither has a fix here:

1. [**Instruction id uniqueness is checked only among *declared* ids.**](https://github.com/pydantic/logfire-js/pull/324#discussion_r3976252954) With two system messages where the first declares `providerOptions.logfire.id: 'agent:1'` and the second declares none, both blocks end up as `agent:1`: publishing text for that id replaces both, publishing `null` removes both. The ask is to validate uniqueness across the *final* ids, or reserve the generated namespace.
2. [**The model timeout is merged as one object with the run timeout.**](https://github.com/pydantic/logfire-js/pull/324#discussion_r3976252965) Given defaults `{ stepMs: 60000, totalMs: 120000 }`, a caller changing only `totalMs` makes a published `timeout: 30` lose too — no patch, no warning, and the model keeps its 60 seconds. The ask is to recover and merge `stepMs` separately.

Both are the same shape as the duplicate-id defect already fixed above, which suggests the fix belongs alongside it.

## Known limits

- The processor has to be registered on an `Agent`. Mastra hands the agent to `processInput` only, so a processor-only workflow context has nothing to read the agent's configuration from.
- Instruction ids are positional unless an entry declares one, so reordering the entries in your code re-points every id after the one you moved. Declare ids on the blocks you intend to manage.
- A per-run `instructions:` option replaces your agent's blocks outright: the section stands down, the caller's text is used, and the run reports that it did.
- A per-run setting equal to the agent's own default cannot be told from an inherited one, and loses to a published value.
- The baseline describes one *observed* request — the tools a request is offered are only assembled per request — and publishing it is a read-modify-write, so an edit saved in the UI inside that round trip can be lost; `publishBaseline: false` opts out.
- Overrides cannot be narrowed to a toolset, and provider-defined tools are not editable.
- The settings table was observed against exactly two models; the three extra provider-id corrections were found by table lookup against Mastra's registry, not by a recorded request.

## Also in this PR

- A `minor` changeset, so the first published version is `0.1.0`.
- Docs at `docs/frameworks/mastra.md` with a `nav.json` entry, and the Agent Control guide's adapter paragraph now links it instead of saying all three adapters are in progress.
- The package README, which carries the full editable table, the precedence rules, and the variable-key rule in full — the last commit is there because the README stopped at replacing characters outside the class and left out collapsing runs of `_` and stripping them from the ends, so someone deriving the name for `checkout -- assistant` by hand would have looked for `agent__checkout____assistant` and found nothing.

## Gates

CI is green on `60e12ed3`: `build` passes, Macroscope and Veria are clean. CodeRabbit reports "review rate limited", not a failure, and `release` skips on a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
