### PR TITLE
Add `@pydantic/logfire-agent-control-ai-sdk`, the Vercel AI SDK adapter for Agent Control

### DIFF
--- a/.changeset/agent-control-ai-sdk.md
+++ b/.changeset/agent-control-ai-sdk.md
@@ -1,0 +1,5 @@
+---
+'@pydantic/logfire-agent-control-ai-sdk': minor
+---
+
+Add `@pydantic/logfire-agent-control-ai-sdk`, the Vercel AI SDK adapter for Logfire Agent Control: change an agent's instructions, model, model settings, and the names and descriptions its tools are advertised under from the Logfire UI, without a deploy. `agentControl({ settings })` wraps a `ToolLoopAgent`'s settings and `agentControl({ model })` wraps a bare model, both installing one `LanguageModelMiddleware` that applies the managed config to every model request — so a rollout can move between two steps of one tool loop. A renamed tool is advertised under its managed name and routed back to the code implementation, with the call, the result, and the replayed history all re-named so the model is never shown a tool the request does not offer, and application code always sees its own name. Precedence is code < published < what a run passed explicitly. If Logfire is unreachable, if nothing has been published, or if a published value cannot be understood, the agent runs on its code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository is the Pydantic Logfire JavaScript SDK monorepo. It provides Ope
 - `packages/otel-cf-workers` publishes `@pydantic/otel-cf-workers`, the lower-level Cloudflare Workers OpenTelemetry implementation used by the Logfire wrapper.
 - `packages/logfire-browser` publishes `@pydantic/logfire-browser`, which adapts Logfire to browser tracing.
 - `packages/logfire-session-replay` publishes `@pydantic/logfire-session-replay`, the optional standalone rrweb recorder used by the browser package's session replay integration.
+- `packages/logfire-agent-control-ai-sdk` publishes `@pydantic/logfire-agent-control-ai-sdk`, the Vercel AI SDK adapter for Agent Control. It peer-depends on `@pydantic/logfire-node` and on `ai`, which is why it is a package rather than another subpath of the Node SDK.
 - `vite.shared.ts` holds the build helpers every package config imports: `packageDefines()` stamps `PACKAGE_VERSION` and `PACKAGE_TIMESTAMP` from the package's own `package.json`, and `copyCjsDeclarations()` emits the `.d.cts` files.
 - `vite.config.ts` and `tsconfig.base.json` at the repository root hold the shared format, lint, task, and TypeScript configuration.
 - `examples/` contains runnable examples for Express, Next.js, Deno, Cloudflare Workers, browser usage, and related integrations.
@@ -120,6 +121,7 @@ vp run logfire#typecheck
 - Relevant environment variables include `LOGFIRE_TOKEN`, `LOGFIRE_SERVICE_NAME`, `LOGFIRE_SERVICE_VERSION`, `LOGFIRE_ENVIRONMENT`, `LOGFIRE_CONSOLE`, `LOGFIRE_SEND_TO_LOGFIRE`, and `LOGFIRE_DISTRIBUTED_TRACING`.
 - `packages/logfire-api` is the base API package and should not depend on runtime-specific packages.
 - `packages/logfire-node/src/agent-control/spec` is vendored from the Python repository, which owns those cross-language conformance vectors. It is excluded from `vp fmt` and pinned by a digest test; re-vendor by copying the files and updating the digests, never by editing them here.
+- `packages/logfire-agent-control-ai-sdk/src/__test__/cassettes` holds recorded provider responses so the live-provider tests replay offline with no credentials. Re-record with `node scripts/record-live-cassettes.mjs --env-file <path>`; the recorder stores no request headers, so no key can reach a cassette.
 - Cloudflare Workers code should stay compatible with Worker runtime constraints.
 - Browser code should avoid Node-only APIs.
 

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -140,7 +140,12 @@ The stored JSON schema is pinned by `SCHEMA_SHA256`, and the cross-language rule
 
 The core is framework-neutral on purpose: it knows about instruction blocks, tool definitions, and settings, and about no framework's spelling of them. An adapter is what maps one framework onto those three: it enumerates a baseline, installs the framework's hook, and calls the pure helpers.
 
-TypeScript adapters for **Mastra**, the **Vercel AI SDK**, and the **OpenAI Codex SDK** are in progress, each as its own package, because a project that uses one has no reason to install the other two. Until they land, the paragraph below is how to drive Agent Control from any framework directly.
+TypeScript adapters live in their own packages, because a project that uses one has no reason to install the other two and because each depends on a framework this package must not drag in:
+
+- **Vercel AI SDK** — [`@pydantic/logfire-agent-control-ai-sdk`](frameworks/vercel-ai.md#agent-control), a language model middleware, so it covers `ToolLoopAgent`, `generateText`, and `streamText` alike.
+- **Mastra** and the **OpenAI Codex SDK** are in progress.
+
+For a framework with no adapter yet, the paragraph below is how to drive Agent Control directly.
 
 Python users get the same contract from [`logfire`](https://logfire.pydantic.dev/docs/) and [`pydantic-ai-harness`](https://github.com/pydantic/pydantic-ai-harness). A config published from the Logfire UI drives every one of them, because the variable name, the baseline, and the parse are the same three rules in both languages.
 

--- a/docs/frameworks/vercel-ai.md
+++ b/docs/frameworks/vercel-ai.md
@@ -177,3 +177,50 @@ await generateText({
   },
 })
 ```
+
+## Agent Control
+
+[Agent Control](../agent-control.md) lets someone change what a running agent does — its instructions, its model, its model settings, the names and descriptions its tools are advertised under — from the Logfire UI, without a deploy. `@pydantic/logfire-agent-control-ai-sdk` is the adapter for the AI SDK: it installs as a [language model middleware](https://ai-sdk.dev/docs/ai-sdk-core/middleware), so it applies to every model request whether you use `ToolLoopAgent`, `generateText`, or `streamText`.
+
+```bash
+npm install @pydantic/logfire-agent-control-ai-sdk
+```
+
+Pass a `ToolLoopAgent`'s settings through `agentControl`:
+
+```ts
+import { anthropic } from '@ai-sdk/anthropic'
+import { agentControl } from '@pydantic/logfire-agent-control-ai-sdk'
+import * as logfire from '@pydantic/logfire-node'
+import { ToolLoopAgent } from 'ai'
+
+logfire.configure({ serviceName: 'checkout' })
+
+const agent = new ToolLoopAgent(
+  agentControl({
+    settings: {
+      id: 'checkout_assistant',
+      model: anthropic('claude-fable-5-1'),
+      instructions: 'You are a concise checkout assistant.',
+      tools: { get_weather },
+    },
+  })
+)
+```
+
+That is the whole installation. This agent's config lives in a Logfire variable named `agent__checkout_assistant`, and the first model request publishes a description of the agent as written, so the editor shows what it is you are changing. Until someone publishes a value — and any time Logfire cannot be reached — the agent runs exactly as the code defines it.
+
+For `generateText` and `streamText`, pass a `model` instead of `settings`, along with what your code declares:
+
+```ts
+const model = agentControl({
+  model: anthropic('claude-fable-5-1'),
+  name: 'checkout_assistant',
+  codeInstructions: 'You are a concise checkout assistant.',
+  codeSettings: { temperature: 0.2 },
+})
+```
+
+A renamed tool is a costume the tool wears in front of the model: the request advertises the managed name, and your `get_weather` implementation still runs, still under that name in `result.steps` and `response.messages`.
+
+See the [package README](https://github.com/pydantic/logfire-js/tree/main/packages/logfire-agent-control-ai-sdk) for the full table of what becomes editable, how a published setting interacts with a per-call one, and what each provider was observed to do with a published setting.

--- a/packages/logfire-agent-control-ai-sdk/.gitignore
+++ b/packages/logfire-agent-control-ai-sdk/.gitignore
@@ -1,0 +1,25 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+*.tgz

--- a/packages/logfire-agent-control-ai-sdk/README.md
+++ b/packages/logfire-agent-control-ai-sdk/README.md
@@ -1,0 +1,315 @@
+# `@pydantic/logfire-agent-control-ai-sdk`
+
+Agent Control lets someone change what a running [AI SDK](https://ai-sdk.dev) agent does — its
+instructions, its model, its model settings, the names and descriptions its tools are advertised
+under — from the Logfire UI, without a deploy. Pass your agent's settings through `agentControl` and
+its configuration becomes a document you can edit in Logfire; until someone edits it, and any time
+Logfire cannot be reached, the agent runs exactly as your code defines it.
+
+Nothing here reads an environment variable of its own: the Logfire SDK's own configuration decides
+where the variable is read from: `logfire.configure()`, with the read credential coming from
+`LOGFIRE_API_KEY` (or `variables` passed to `configure`) and `LOGFIRE_BASE_URL` naming the region.
+
+`@pydantic/logfire-node` is a peer dependency, so this adapter shares the copy your application
+already configured rather than resolving a second one: the Logfire SDK keeps its variable provider in
+a module-level singleton, and a nested copy would read a provider your `logfire.configure()` never
+touched. The AI SDK (`ai` v7), `@ai-sdk/provider`, and `@ai-sdk/provider-utils` are peers for the same
+reason a framework plugin's framework is. `@ai-sdk/gateway` is an optional one, needed only if someone
+publishes a model string and you have passed neither `providers` nor `resolveModel`.
+
+## Install
+
+```bash
+npm install @pydantic/logfire-agent-control-ai-sdk
+```
+
+## Quickstart
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+import { anthropic } from '@ai-sdk/anthropic'
+import { ToolLoopAgent, tool } from 'ai'
+import { z } from 'zod'
+
+import { agentControl } from '@pydantic/logfire-agent-control-ai-sdk'
+
+logfire.configure({ serviceName: 'checkout' })
+
+const get_weather = tool({
+  description: 'Get the current weather for a city.',
+  inputSchema: z.object({ city: z.string().describe('City name, e.g. `London`.') }),
+  execute: async ({ city }: { city: string }) => `sunny in ${city}`,
+})
+
+const agent = new ToolLoopAgent(
+  agentControl({
+    settings: {
+      id: 'checkout_assistant',
+      model: anthropic('claude-fable-5-1'),
+      instructions: [
+        { role: 'system', content: 'You are a concise checkout assistant.' },
+        {
+          role: 'system',
+          content: 'Always confirm the order total.',
+          providerOptions: { logfire: { id: 'refunds' } },
+        },
+      ],
+      tools: { get_weather },
+    },
+    label: 'production',
+  })
+)
+
+const { text } = await agent.generate({ prompt: 'What is the weather in London?' })
+console.log(text)
+```
+
+That is the whole installation. This agent's config lives in a Logfire variable named
+`agent__checkout_assistant`, and the first model request publishes a description of the agent as
+written, so the Logfire editor shows what it is you are changing.
+
+For `generateText`, `streamText`, or anywhere else a `LanguageModel` goes, pass a model instead:
+
+```ts
+import { generateText } from 'ai'
+import { anthropic } from '@ai-sdk/anthropic'
+
+import { agentControl } from '@pydantic/logfire-agent-control-ai-sdk'
+
+const model = agentControl({
+  model: anthropic('claude-fable-5-1'),
+  name: 'checkout_assistant',
+  // What your code declares, which is what a bare model cannot be asked; see "Precedence" and
+  // "The baseline" for what changes when you leave these out.
+  codeInstructions: 'You are a concise checkout assistant.',
+  codeSettings: { temperature: 0.2 },
+})
+
+const { text } = await generateText({
+  model,
+  instructions: 'You are a concise checkout assistant.',
+  prompt: 'Hello',
+  temperature: 0.2,
+})
+```
+
+## `agentControl`
+
+One function, one options bag, two forms — told apart by whether you pass a `model`.
+
+| Option                             | Applies to                                    | What it does                                                                                                                                                                                                                       |
+| ---------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `settings`                         | the agent form                                | The settings you would have passed to `new ToolLoopAgent(...)`. Required for this form.                                                                                                                                            |
+| `model`                            | the model form                                | The model to wrap. Required for this form, and it has to be a model object: a string is resolved by the AI SDK at call time, after this has run, so there would be nothing to wrap.                                                |
+| `name`                             | both                                          | The agent's name, which picks out the `agent__<name>` variable. In the agent form it defaults to the settings' `id`, then to `telemetry.functionId`; with none of the three, the call throws rather than publishing under a guess. |
+| `label`                            | both                                          | Read this label instead of letting the variable's rollout choose one.                                                                                                                                                              |
+| `onUnmatched`                      | both                                          | What to do about a published entry that reaches nothing: `'warn'` (default, one `console.warn` per distinct message per process), `'ignore'`, or `'error'`, which throws `UnmatchedConfigError` out of the model request.          |
+| `publishBaseline`                  | both                                          | Set `false` when the Logfire token is read-only, or when code must not write variable metadata.                                                                                                                                    |
+| `providers`, `resolveModel`        | both                                          | How a published `provider:model` string becomes a model; see "Which provider a managed model goes to".                                                                                                                             |
+| `codeInstructions`, `codeSettings` | the model form                                | What your code declares. The agent form reads both off `settings` and these are not accepted there.                                                                                                                                |
+| `modelSpecificationVersion`        | the model form (and `agentControlMiddleware`) | Only for a hand-rolled `wrapLanguageModel` install; the two `agentControl` forms fill it in. See "Known limits".                                                                                                                   |
+
+**What it returns.** The agent form returns a **new** settings object — your own is not mutated —
+with three changes: `model` is wrapped in the Agent Control middleware, and `id` and
+`telemetry.functionId` are filled in from the name **if they are not already set**. So an agent that
+carries `id: 'checkout'` while you pass `name: 'checkout_assistant'` reads the config at
+`agent__checkout_assistant` and still emits its traces under `checkout`: pass the same string to both,
+or set `telemetry.functionId` yourself, if you want the trace and the config to answer to one name.
+The model form returns a `LanguageModelV4`, which is the model your code passed with the middleware
+wrapped around it; the original object is untouched.
+
+`agentControlMiddleware({ name })` is the same thing as a plain `LanguageModelMiddleware`, for a
+`wrapLanguageModel` or `createProviderRegistry` call you already have. It is the low-level API and it
+knows least: everything the two `agentControl` forms fill in for you, it has to be told.
+
+## What becomes editable
+
+| Source / canonical field                                                                    | Block id or runtime mapping                                                                                                      | Support         | Conditions and unmatched behavior                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| A block of `instructions` your code declares                                                | `system:0`, `system:1`, … in the order they reach the model, or `providerOptions: { logfire: { id: 'refunds' } }` on the message | **Yes**         | Replaced by publishing text, removed by publishing none. The block keeps its position in the prompt, and its own `providerOptions` — an Anthropic cache breakpoint included. An `id` this request assembles no block for is reported.                                                                                                                                                                                                            |
+| Adding a block                                                                              | none — an entry with no `id`                                                                                                     | **Yes**         | Lands at the end of the static group, ahead of the first block the agent recomputes, so it never moves a provider's prompt-cache boundary. Text past the contract's per-request budget is refused, not truncated, and reported.                                                                                                                                                                                                                  |
+| A block a `prepareCall` / `prepareStep` hook computes, or one carried in a run's `messages` | `system:<n>`                                                                                                                     | **No**          | Replacing it would pin one run's rendering forever and dropping it would remove the computation. Recognized by its text differing from what your code declares, and reported. With no declared instructions there is nothing to differ from, so such a block is addressable until a second request shows it changing; see "Known limits".                                                                                                        |
+| A tool's advertised name                                                                    | `new_name`                                                                                                                       | **Yes**         | Your code keeps seeing the code-side name; see "What a renamed tool looks like from your code". A rename onto a name another tool already answers to — a provider-defined tool included — is dropped, the override's other patches still apply, and it is reported.                                                                                                                                                                              |
+| A tool's description                                                                        | `description`                                                                                                                    | **Yes**         |                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| A tool's parameter descriptions                                                             | `parameters.<name>.description`                                                                                                  | **Yes**         | Top-level parameters only. A name the tool's schema has no property for is reported. Parameter names, types, requiredness, and validation stay code-defined.                                                                                                                                                                                                                                                                                     |
+| Narrowing a tool override to one toolset                                                    | `toolset`                                                                                                                        | **No**          | The AI SDK's `tools` is one flat record with no grouping — `client.tools()` merges MCP tools into it too — so there is no toolset to match on and an override that sets one is reported.                                                                                                                                                                                                                                                         |
+| A provider-defined tool (web search, code execution)                                        | —                                                                                                                                | **No**          | Its name and arguments are a contract with the provider, not text the model reads. It passes through untouched, and its name is reserved so nothing can be renamed onto it.                                                                                                                                                                                                                                                                      |
+| Which tools exist at all                                                                    | —                                                                                                                                | **No**          | The config has no way to say it. `activeTools` is applied by the AI SDK before this middleware runs, so what reaches it is already the filtered set.                                                                                                                                                                                                                                                                                             |
+| `model`                                                                                     | `provider:model`, e.g. `anthropic:claude-fable-5-1`                                                                              | **Conditional** | Resolved through `resolveModel`, else `providers`, else the AI Gateway; see "Which provider a managed model goes to". Anything that resolves to nothing is reported and the agent keeps its own model.                                                                                                                                                                                                                                           |
+| `max_tokens`                                                                                | `maxOutputTokens`                                                                                                                | **Conditional** | Reaches every provider tested. Anthropic does not send it verbatim once `thinking` is on: the AI SDK raises the ceiling to fit the thinking budget, so a published 256 arrives as 6656. See "What a provider does with a published setting".                                                                                                                                                                                                     |
+| `temperature`                                                                               | `temperature`                                                                                                                    | **Conditional** | Honoured by Gemini. Dropped by OpenAI's Responses API on a reasoning model and by Anthropic once `thinking` is on, in both cases by the provider rather than by this adapter.                                                                                                                                                                                                                                                                    |
+| `top_p`                                                                                     | `topP`                                                                                                                           | **Conditional** | As `temperature`.                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `top_k`                                                                                     | `topK`                                                                                                                           | **Conditional** | Honoured by Gemini. Dropped by OpenAI's Responses API always, and by Anthropic once `thinking` is on.                                                                                                                                                                                                                                                                                                                                            |
+| `seed`                                                                                      | `seed`                                                                                                                           | **Conditional** | Honoured by Gemini. Not supported by OpenAI's Responses API or by Anthropic.                                                                                                                                                                                                                                                                                                                                                                     |
+| `presence_penalty`                                                                          | `presencePenalty`                                                                                                                | **Conditional** | Not supported by OpenAI's Responses API or by Anthropic, which drop it. Gemini **rejects the request** with a 400 on the models that do not enable penalties, which is the one published setting observed to fail a run rather than be ignored.                                                                                                                                                                                                  |
+| `frequency_penalty`                                                                         | `frequencyPenalty`                                                                                                               | **Conditional** | As `presence_penalty`.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `stop_sequences`                                                                            | `stopSequences`                                                                                                                  | **Conditional** | Honoured by Anthropic and Gemini. Not supported by OpenAI's Responses API.                                                                                                                                                                                                                                                                                                                                                                       |
+| `thinking`                                                                                  | `reasoning` (`true` → `'provider-default'`, `false` → `'none'`, else the effort level)                                           | **Conditional** | `reasoning` is the one call option AI SDK v4 models added. `wrapLanguageModel` accepts a v2 or v3 model and bridges it with a proxy that answers `'v4'` and forwards, so an older provider is handed the field and drops it — on one of those it is reported instead of applied. On a v4 provider it is applied and accepted: OpenAI takes it as `reasoning.effort`, Anthropic as a `thinking` budget, Gemini as `thinkingConfig.thinkingLevel`. |
+| `timeout` (seconds)                                                                         | an `AbortSignal` on each model request                                                                                           | **Yes**         | Composed with whatever signal the run carries, so either one still cancels; a value that is not a finite, non-negative number of seconds under 24.9 days is dropped and reported, and a positive one too small to round to a millisecond is armed at 1ms rather than throwing. A per-run timeout _longer_ than the published one cannot override it; see "Known limits".                                                                         |
+| `parallel_tool_calls`                                                                       | `providerOptions.openai.parallelToolCalls`, `providerOptions.anthropic.disableParallelToolUse` (inverted)                        | **Conditional** | The AI SDK has no provider-neutral field for it. On any other provider it is reported, not applied.                                                                                                                                                                                                                                                                                                                                              |
+
+Anything published that _this adapter_ cannot apply is reported through `onUnmatched`. What a
+provider then does with a setting this adapter did apply is a separate question, and one `onUnmatched`
+cannot answer; see below.
+
+### What a provider does with a published setting
+
+The eleven canonical settings are the contract's, not any one provider's, and a provider is free to
+ignore a field the AI SDK sent it. The rows above say what each of OpenAI, Anthropic, and Gemini was
+observed to do with a real request, rather than what their source suggested — three of those rows
+changed when the observation was made.
+
+Two things follow, and neither is fixable here:
+
+- **The provider's own report is the AI SDK's, not Agent Control's.** A dropped setting comes back on
+  `result.warnings` as `{ type: 'unsupported', feature: 'topK' }`, and the AI SDK also logs it. That
+  is the list to read; `onUnmatched` never sees it, because from this adapter's side the setting was
+  applied.
+- **A published setting can fail a request outright.** Gemini answers `400 Penalty is not enabled for
+this model` rather than ignoring `presence_penalty`, so publishing one takes that agent down until
+  the value is removed. This is the exception to "a published value can only ever be ignored", and
+  the reason to change one setting at a time on a production agent.
+
+## When it applies
+
+**Per model request** — every step of the tool loop, not once per conversation. A value saved in
+Logfire reaches the next model request, with no restart. The whole request runs inside the
+resolution's telemetry context, so its spans carry the label that drove it, and a rollout can move
+between two steps of one run.
+
+### The baseline
+
+The **baseline** is what the Logfire editor shows you as the thing you are changing. It is published
+in the background from the first model request, once per process per variable, so the variable
+appears in Logfire once the agent has run once. Pass `publishBaseline: false` to turn it off.
+
+A block's **text** is published only when this adapter can prove it is your code's: the agent form
+reads it off `settings.instructions`, and the model form off `codeInstructions`. Every other block —
+one a hook injected, or every block at all when nothing was declared — is published as a _seam_: its
+id, and that it is there, with no text. The baseline goes into a variable every member of your
+Logfire project can read, and a rendering this adapter merely observed is one tenant's, one user's,
+one retrieved document's.
+
+Model settings come from `codeSettings` where they were declared, and from the request otherwise. The
+variable's description says which: "the agent as written" when both instructions and settings were
+declared, and "snapshotted from one request" when they were not. The **tool list** is always the
+request's, in both forms — the AI SDK resolves tool schemas on the way to a model, and a
+`prepareStep` can change the set per step.
+
+### Precedence
+
+Code < published < what a run passed explicitly. By the time a request reaches a language model
+middleware, the agent's settings and this call's are one object with no record of which came from
+where, and there is no seam upstream that knows: `agent.generate()` takes no generation settings at
+all, and `prepareCall` — the one per-run hook that does — is a whole-object transform whose idiom is
+to spread through everything it did not change.
+
+So a run's own values are recognized by comparison: a request field that differs from what your code
+declares is one this run chose, and a published value does not overwrite it. That is exact except in
+one case, and the case is worth knowing: a run that sets a key to the value your code already
+declared is byte for byte a run that set nothing, and the published value wins. Without
+`codeSettings` — a bare model or middleware install that was told nothing — there is no comparison to
+make at all, and a published setting wins over a per-call one.
+
+## What a renamed tool looks like from your code
+
+Your code always sees the **code-side** name. A rename is a costume the tool wears in front of the
+model: the request advertises `lookup_weather`, the model calls `lookup_weather`, and your
+`get_weather` implementation runs with the arguments it sent. `result.steps[].toolResults`,
+`onToolExecutionStart`, and `response.messages` all say `get_weather`.
+
+Three things follow the rename outwards, so the model sees one consistent tool set:
+
+- the tool definition in the request;
+- a forced `toolChoice` that names the tool, which would otherwise name a tool this request no longer
+  advertises;
+- the `tool-call` and `tool-result` entries the SDK writes into the next step's prompt, which
+  otherwise alternate names between steps and bust the prompt cache.
+
+Parameter _names_ are never renamed, only their descriptions.
+
+## Which provider a managed model goes to
+
+`anthropic:claude-fable-5-1` has to become a model object. In order:
+
+1. `resolveModel: (id) => …` if you pass one. It is **authoritative**: what it returns is the answer,
+   and returning `undefined` means "not a model I will build", which keeps your model and reports the
+   published value. It is never a first guess that falls through to the steps below.
+2. `providers: { anthropic, openai }` if you pass them — the same record `createProviderRegistry`
+   takes, and `:` is already its separator. **Use this** to reach providers configured with your own
+   API key, base URL, or `fetch`. A key here is read exactly as written, before any name translation.
+3. Otherwise the [AI Gateway](https://ai-sdk.dev/docs/ai-sdk-core/provider-management) (or whatever
+   `globalThis.AI_SDK_DEFAULT_PROVIDER` names), with `:` rewritten to the `/` the gateway spells it
+   with — the same place a bare string model would have gone.
+
+The contract's provider vocabulary and the AI SDK's agree on every name but Vertex AI, and they even
+agree on `google` for the Gemini API. Vertex is `google-cloud` to the contract and `vertex` to the AI
+SDK — the name `@ai-sdk/google-vertex` exports its provider under — so a published `google-cloud:…`
+is resolved through your `vertex` provider, and a `@ai-sdk/google-vertex` model is published as
+`google-cloud:…`. That reverse direction reads more than the first segment of the provider id on
+purpose: `@ai-sdk/google` reports `google.generative-ai` and `@ai-sdk/google-vertex` reports
+`google.vertex.…`, so going by the namespace alone would name a Vertex model as a Gemini API one.
+
+`google-gla` and `google-vertex` are Pydantic AI v1's names for the same two providers. They were
+removed in v2, and they are still accepted here as input, because a config published against a v1-era
+agent is still sitting in a Logfire project; nothing ever publishes them.
+
+A name none of that covers is forwarded as it stands, so a provider package released tomorrow works
+here on the day it lands. If it reaches a registry or a gateway that has never heard of it, the
+failure is reported through `onUnmatched` and your code's model is kept.
+
+## Known limits
+
+- **A model swap is invisible to AI SDK telemetry.** The span still reports the code-defined
+  `modelId`, because `wrapLanguageModel` fixes that at wrap time and a published value is only known
+  once the variable resolves. The adapter warns once when it happens.
+- **A model passed as a string** (`model: 'anthropic/claude-fable-5-1'`) cannot be managed: the AI SDK
+  resolves it at call time, so there is nothing to wrap. `agentControl` refuses it with that message.
+- **A per-run `timeout` cannot override a published one.** By the time a request reaches a model, the
+  AI SDK has merged the run's `timeout` and its `abortSignal` into one signal with nothing to tell
+  them apart. The published budget is therefore composed with it and the shorter of the two wins.
+- **Positional block ids move.** If a hook injects a system message ahead of your own, `system:0` is
+  now that message; the adapter notices the text no longer matches and refuses to apply an override
+  rather than rewriting the wrong block. Declare `providerOptions.logfire.id` to be safe.
+- **A dynamic block is protected only once the adapter knows your code.** With `codeInstructions` or
+  an agent's own `instructions`, an injected block is refused from the very first request. Without
+  them, the first request has nothing to compare against and treats every block as addressable; from
+  the second request on, a block whose text changed is refused. Its text is never published into the
+  baseline in either case.
+- **A pre-v4 model has to say so** when you install `agentControlMiddleware` by hand:
+  `wrapLanguageModel` hides the real version behind a proxy, so pass
+  `modelSpecificationVersion: 'v3'` or a published `thinking` will be applied where it does nothing.
+  Both `agentControl` forms read it off the model you give them.
+- **A tool override invalidates the prompt cache.** Anthropic caches tools ahead of the system
+  prompt, so any tool rename or description edit rewrites the whole cached prefix — once, when you
+  publish.
+- **A provider has the last word on a setting**, and can reject the request over one. See "What a
+  provider does with a published setting".
+- **A baseline publish can lose a concurrent UI edit.** The platform API has no example-only write,
+  so publishing re-reads the variable and writes it back whole; a value saved in Logfire inside that
+  one round trip is overwritten. It runs at most once per process, off the request path, and is
+  skipped when the example is already current. Set `publishBaseline: false` if that window matters.
+
+## Development
+
+From the repository root:
+
+```bash
+vp install
+vp run --filter "./packages/*" build                       # the core this package imports
+vp run @pydantic/logfire-agent-control-ai-sdk#test
+vp run @pydantic/logfire-agent-control-ai-sdk#typecheck
+vp check                                                   # format and lint, repository-wide
+```
+
+Most of the suite runs offline against `MockLanguageModelV4` and the Logfire SDK's own
+`LocalVariableProvider`, so it drives the real AI SDK and the real variable plumbing with no network
+and no fixtures to drift.
+
+`src/__test__/live.test.ts` is the exception: it settles the claims only a real provider can, and
+replays from the cassettes in `src/__test__/cassettes/` — no credentials, no network. Re-record them
+with:
+
+```bash
+node scripts/record-live-cassettes.mjs --env-file <a .env with OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY>
+```

--- a/packages/logfire-agent-control-ai-sdk/package.json
+++ b/packages/logfire-agent-control-ai-sdk/package.json
@@ -1,0 +1,86 @@
+{
+  "name": "@pydantic/logfire-agent-control-ai-sdk",
+  "description": "Logfire Agent Control for the Vercel AI SDK - https://pydantic.dev/logfire",
+  "author": {
+    "name": "The Pydantic Team",
+    "email": "engineering@pydantic.dev",
+    "url": "https://pydantic.dev"
+  },
+  "repository": {
+    "url": "git+https://github.com/pydantic/logfire-js.git",
+    "directory": "packages/logfire-agent-control-ai-sdk"
+  },
+  "sideEffects": false,
+  "homepage": "https://pydantic.dev/logfire",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "agent",
+    "ai-sdk",
+    "llm",
+    "logfire",
+    "observability",
+    "prompt-management",
+    "vercel"
+  ],
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "dev": "vp pack --watch",
+    "build": "vp pack",
+    "lint": "vp lint",
+    "preview": "vp preview",
+    "typecheck": "tsc",
+    "prepack": "cp ../../LICENSE .",
+    "postpublish": "rm LICENSE",
+    "test": "vp test"
+  },
+  "devDependencies": {
+    "@ai-sdk/anthropic": "catalog:",
+    "@ai-sdk/gateway": "catalog:",
+    "@ai-sdk/google": "catalog:",
+    "@ai-sdk/openai": "catalog:",
+    "@ai-sdk/provider": "catalog:",
+    "@ai-sdk/provider-utils": "catalog:",
+    "@opentelemetry/api": "catalog:",
+    "@opentelemetry/context-async-hooks": "catalog:",
+    "@pydantic/logfire-node": "workspace:*",
+    "@types/json-schema": "catalog:",
+    "ai": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "@ai-sdk/gateway": "catalog:",
+    "@ai-sdk/provider": "catalog:",
+    "@ai-sdk/provider-utils": "catalog:",
+    "@pydantic/logfire-node": "workspace:^",
+    "ai": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "@ai-sdk/gateway": {
+      "optional": true
+    }
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/agent.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/agent.test.ts
@@ -1,0 +1,133 @@
+import { generateText, ToolLoopAgent } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { agentControl, agentControlMiddleware } from '../index'
+import { captureWarnings, publishedValue, stubModel, textResult, useLocalVariables } from './helpers'
+
+captureWarnings()
+
+describe('agentControl', () => {
+  it('fills in the agent id and the telemetry function id from the name', () => {
+    const settings = agentControl({
+      settings: { model: stubModel([]), temperature: 0.2 },
+      name: 'checkout_assistant',
+    })
+
+    expect(settings.id).toBe('checkout_assistant')
+    expect(settings.telemetry.functionId).toBe('checkout_assistant')
+    // Everything else is carried over untouched.
+    expect(settings.temperature).toBe(0.2)
+  })
+
+  it("takes the agent's own id as the name, and leaves an explicit function id alone", () => {
+    const settings = agentControl({
+      settings: {
+        id: 'from_id',
+        model: stubModel([]),
+        telemetry: { functionId: 'already_traced' },
+      },
+    })
+
+    expect(settings.id).toBe('from_id')
+    expect(settings.telemetry.functionId).toBe('already_traced')
+  })
+
+  it('falls back to the telemetry function id when there is no agent id', () => {
+    const settings = agentControl({ settings: { model: stubModel([]), telemetry: { functionId: 'from_telemetry' } } })
+
+    expect(settings.id).toBe('from_telemetry')
+  })
+
+  it('refuses an agent with no name at all', () => {
+    expect(() => agentControl({ settings: { model: stubModel([]) } })).toThrow(/needs an explicit agent name/u)
+    expect(() => agentControl({ settings: { id: '  ', model: stubModel([]) } })).toThrow(/needs an explicit agent name/u)
+  })
+
+  it('refuses a model it cannot wrap', () => {
+    expect(() => agentControl({ settings: { id: 'string_model', model: 'anthropic/claude-fable-5-1' } })).toThrow(
+      /cannot manage the string model/u
+    )
+  })
+
+  it('refuses a middleware with no name', () => {
+    expect(() => agentControlMiddleware({})).toThrow(/needs an explicit agent name/u)
+    expect(() => agentControl({ model: stubModel([]), name: '' })).toThrow(/needs an explicit agent name/u)
+  })
+
+  it('manages an agent built from the settings it returns', async () => {
+    useLocalVariables(
+      publishedValue('agent__end_to_end', {
+        instructions: [{ id: 'system:0', instructions: 'Be terse.' }],
+        settings: { temperature: 0.9 },
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: { id: 'end_to_end', model, instructions: 'Be brief.', temperature: 0.1 },
+        label: 'production',
+      })
+    )
+
+    const { text } = await agent.generate({ prompt: 'hi' })
+    expect(text).toBe('ok')
+    expect(model.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Be terse.' })
+    expect(model.doGenerateCalls[0]?.temperature).toBe(0.9)
+  })
+
+  it("accepts one system message as an agent's instructions", async () => {
+    useLocalVariables(publishedValue('agent__single_message', { instructions: [{ id: 'greeting', instructions: 'Managed.' }] }))
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'single_message',
+          model,
+          instructions: { role: 'system', content: 'Code.', providerOptions: { logfire: { id: 'greeting' } } },
+        },
+        label: 'production',
+      })
+    )
+
+    await agent.generate({ prompt: 'hi' })
+    expect(model.doGenerateCalls[0]?.prompt[0]).toMatchObject({ content: 'Managed.' })
+  })
+
+  it("leaves an agent's own `prepareCall` in place", async () => {
+    useLocalVariables(publishedValue('agent__own_prepare_call', { settings: { temperature: 0.4 } }))
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'own_prepare_call',
+          model,
+          instructions: 'Be brief.',
+          prepareCall: ({ options, ...rest }) => ({ ...rest, options, instructions: 'Prepared.' }),
+        },
+        label: 'production',
+      })
+    )
+
+    await agent.generate({ prompt: 'hi' })
+    // The hook ran and its instructions reached the model, and nothing was added to the request in
+    // passing: this helper wraps the model, not the agent's own hooks.
+    expect(model.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Prepared.' })
+    expect(model.doGenerateCalls[0]?.providerOptions).toBeUndefined()
+    // Nothing the hook changed was a generation setting, so the published one still applies.
+    expect(model.doGenerateCalls[0]?.temperature).toBe(0.4)
+  })
+
+  it('applies nothing when the published config says to change nothing', async () => {
+    useLocalVariables(publishedValue('agent__empty_config', {}))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'empty_config', label: 'production' }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+      temperature: 0.3,
+    })
+
+    expect(model.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Be brief.' })
+    expect(model.doGenerateCalls[0]?.temperature).toBe(0.3)
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/baseline.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/baseline.test.ts
@@ -1,0 +1,271 @@
+import { generateText, ToolLoopAgent, tool } from 'ai'
+import { z } from 'zod'
+import { describe, expect, it } from 'vitest'
+
+import { AGENT_CONFIG_JSON_SCHEMA } from '@pydantic/logfire-node/agent-control'
+
+import { agentControl } from '../index'
+import { captureWarnings, legacyModel, publishedValue, settle, storedConfig, stubModel, textResult, useLocalVariables } from './helpers'
+
+captureWarnings()
+
+const weather = tool({
+  description: 'Get the current weather for a city.',
+  inputSchema: z.object({ city: z.string().describe('City name, e.g. `London`.') }),
+  execute: async ({ city }: { city: string }) => Promise.resolve(`sunny in ${city}`),
+})
+
+/** The `example` a variable ended up with, parsed. */
+async function baselineOf(variableName: string): Promise<Record<string, unknown>> {
+  return JSON.parse((await storedConfig(variableName))?.example ?? 'null') as Record<string, unknown>
+}
+
+describe('baseline', () => {
+  it('publishes the agent as written, from the first request', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'checkout_assistant',
+          model,
+          instructions: [
+            { role: 'system', content: 'You are a concise checkout assistant.' },
+            {
+              role: 'system',
+              content: 'Always confirm the order total.',
+              providerOptions: { logfire: { id: 'refunds' } },
+            },
+          ],
+          temperature: 0.1,
+          maxOutputTokens: 1024,
+          tools: { get_weather: weather },
+        },
+      })
+    )
+
+    await agent.generate({ prompt: 'hi' })
+    await settle()
+
+    const stored = await storedConfig('agent__checkout_assistant')
+    expect(JSON.parse(stored?.example ?? 'null')).toMatchInlineSnapshot(`
+      {
+        "instructions": [
+          {
+            "dynamic": false,
+            "id": "system:0",
+            "instructions": "You are a concise checkout assistant.",
+          },
+          {
+            "dynamic": false,
+            "id": "refunds",
+            "instructions": "Always confirm the order total.",
+          },
+        ],
+        "model": "anthropic:claude-fable-5-1",
+        "settings": {
+          "max_tokens": 1024,
+          "temperature": 0.1,
+        },
+        "tool_definitions": [
+          {
+            "description": "Get the current weather for a city.",
+            "name": "get_weather",
+            "parameters": {
+              "city": {
+                "description": "City name, e.g. \`London\`.",
+              },
+            },
+          },
+        ],
+      }
+    `)
+    // The agent said what it is, so the baseline describes the code rather than one request.
+    expect(stored?.description).toContain('the agent as written')
+    // The stored schema is what makes the variable editable in the Logfire UI at all: the backend
+    // validates every value written against it.
+    expect(stored?.json_schema).toEqual(AGENT_CONFIG_JSON_SCHEMA)
+  })
+
+  it('publishes a block a hook injected as a seam, with neither its text nor a claim about it', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok'), textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'tenant_agent',
+          model,
+          instructions: 'You are a concise assistant.',
+          prepareStep: () => ({
+            instructions: [
+              { role: 'system' as const, content: 'You are a concise assistant.' },
+              { role: 'system' as const, content: `Tenant: acme-${String(Date.now())}` },
+            ],
+          }),
+        },
+      })
+    )
+
+    // The first request is what the baseline is sampled from, and the agent's declared instructions
+    // are known before it, so even that one classifies the injected block correctly.
+    await agent.generate({ prompt: 'hi' })
+    await settle()
+
+    expect((await baselineOf('agent__tenant_agent'))['instructions']).toEqual([
+      { id: 'system:0', instructions: 'You are a concise assistant.', dynamic: false },
+      { id: 'system:1', dynamic: true },
+    ])
+  })
+
+  it('publishes only seams, and says it is observing, when the agent declared nothing', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'bare_middleware' }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+      temperature: 0.5,
+    })
+    await settle()
+
+    const stored = await storedConfig('agent__bare_middleware')
+    // Nothing here is provably the agent's own: a bare model install cannot see a line of its code.
+    // So the block is a seam without its text, and the editor is told the example is one request's.
+    expect(JSON.parse(stored?.example ?? 'null')).toEqual({
+      instructions: [{ id: 'system:0', dynamic: true }],
+      model: 'anthropic:claude-fable-5-1',
+      settings: { temperature: 0.5 },
+    })
+    expect(stored?.description).toContain('snapshotted from one request')
+  })
+
+  it('publishes a block whose text the code declares, even installed on a bare model', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({
+        model,
+        name: 'declared_on_a_model',
+        codeInstructions: 'Be brief.',
+        codeSettings: { temperature: 0.1 },
+      }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+      temperature: 0.5,
+    })
+    await settle()
+
+    const stored = await storedConfig('agent__declared_on_a_model')
+    // The declared text matched, so it is publishable -- and `temperature` comes from what the code
+    // declared rather than from the value this one run happened to pass.
+    expect(JSON.parse(stored?.example ?? 'null')).toEqual({
+      instructions: [{ id: 'system:0', instructions: 'Be brief.', dynamic: false }],
+      model: 'anthropic:claude-fable-5-1',
+      settings: { temperature: 0.1 },
+    })
+    expect(stored?.description).toContain('the agent as written')
+  })
+
+  it("publishes the agent's declared settings rather than the first run's", async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'declared_settings',
+          model,
+          instructions: 'Be brief.',
+          temperature: 0.1,
+          // One run asking for something else must not become the published code default.
+          prepareCall: ({ options, ...rest }) => ({ ...rest, options, temperature: 0.9 }),
+        },
+      })
+    )
+
+    await agent.generate({ prompt: 'hi' })
+    await settle()
+
+    expect((await baselineOf('agent__declared_settings'))['settings']).toEqual({ temperature: 0.1 })
+    expect(model.doGenerateCalls[0]?.temperature).toBe(0.9)
+  })
+
+  it('leaves `thinking` out for a model whose provider has no reasoning contract', async () => {
+    useLocalVariables()
+    const model = legacyModel('v3')
+    await generateText({
+      model: agentControl({ model, name: 'legacy_baseline' }),
+      prompt: 'hi',
+      reasoning: 'high',
+    })
+    await settle()
+
+    // The request carries `reasoning`, because the AI SDK builds v4 call options for every model --
+    // but this provider drops it, so publishing it would offer an edit that changes nothing.
+    expect(model.calls[0]?.reasoning).toBe('high')
+    expect(await baselineOf('agent__legacy_baseline')).toEqual({ model: 'legacy:old-model' })
+  })
+
+  it('publishes once per process, even across runs', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('one'), textResult('two')])
+    const managed = agentControl({ model, name: 'published_once', codeInstructions: 'First.', codeSettings: {} })
+    await generateText({ model: managed, instructions: 'First.', prompt: 'hi' })
+    await settle()
+    await generateText({ model: managed, instructions: 'Second.', prompt: 'hi' })
+    await settle()
+
+    const stored = await storedConfig('agent__published_once')
+    expect(stored?.example).toContain('First.')
+  })
+
+  it('does not publish when the caller asked it not to', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'no_publish', publishBaseline: false }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+    })
+    await settle()
+    expect(await storedConfig('agent__no_publish')).toBeUndefined()
+  })
+
+  it('reports the gateway form of a model under the provider it names', async () => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')], 'gateway', 'anthropic/claude-fable-5.1')
+    await generateText({ model: agentControl({ model, name: 'gateway_model' }), prompt: 'hi' })
+    await settle()
+
+    expect(await baselineOf('agent__gateway_model')).toEqual({ model: 'anthropic:claude-fable-5.1' })
+  })
+
+  // Google is one AI SDK namespace and two contract providers, so a baseline that went by the
+  // namespace alone would publish a Vertex model under the Gemini API's name and offer the editor an
+  // override that reaches a different backend.
+  it.each([
+    ['google.generative-ai', 'google:gemini-3-pro', 'gemini_api_model'],
+    ['google.vertex.chat', 'google-cloud:gemini-3-pro', 'vertex_model'],
+  ])("names a %s model '%s' in the baseline", async (provider, identifier, agent) => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')], provider, 'gemini-3-pro')
+    await generateText({ model: agentControl({ model, name: agent }), prompt: 'hi' })
+    await settle()
+
+    expect(await baselineOf(`agent__${agent}`)).toEqual({ model: identifier })
+  })
+
+  it('publishes the agent as written even when a config is already applying', async () => {
+    useLocalVariables(publishedValue('agent__already_managed', { instructions: [{ id: 'system:0', instructions: 'Be terse.' }] }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'already_managed', label: 'production', codeInstructions: 'Be brief.' }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+    })
+    await settle()
+
+    const stored = await storedConfig('agent__already_managed')
+    expect(stored?.example).toContain('Be brief.')
+    expect(model.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Be terse.' })
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassette.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassette.ts
@@ -112,9 +112,10 @@ async function requestBody(input: RequestInfo | URL, init: RequestInit | undefin
  * The cassette named `name`, as a `fetch` plus the request bodies it saw.
  *
  * Replay is ordinal: the n-th request of a test is answered by the n-th interaction of its cassette,
- * and a mismatched method or URL fails rather than answering with the wrong turn's response. That is
- * strict on purpose -- these tests exist to prove what reaches a provider, and a recorder that
- * quietly matched a different request would prove nothing.
+ * and a mismatched method, URL, or *body* fails rather than answering anyway. The body is what makes
+ * the cassette a regression test rather than a stub: these tests exist to prove what reaches a
+ * provider, so a change in what this adapter sends has to fail here and be re-recorded deliberately,
+ * not pass on a response recorded for a different request.
  */
 export function cassette(name: string): Cassette {
   const path = join(CASSETTES, `${name}.json`)
@@ -153,10 +154,12 @@ export function cassette(name: string): Cassette {
     if (interaction === undefined) {
       throw new Error(`Cassette '${name}' has no interaction ${String(index)}; re-record it.`)
     }
-    if (interaction.method !== method || interaction.url !== url) {
+    const drifted = JSON.stringify(interaction.request) !== JSON.stringify(parseBody(body))
+    if (interaction.method !== method || interaction.url !== url || drifted) {
       throw new Error(
-        `Cassette '${name}' interaction ${String(index)} recorded ${interaction.method} ${interaction.url}, ` +
-          `but this run sent ${method} ${url}; re-record it.`
+        `Cassette '${name}' interaction ${String(index)} recorded ${interaction.method} ${interaction.url}` +
+          `${drifted ? ' with a different request body' : ''}, but this run sent ${method} ${url}; ` +
+          're-record it.'
       )
     }
     const text = interaction.stream === true ? String(interaction.response) : JSON.stringify(interaction.response)

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassette.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassette.ts
@@ -1,0 +1,170 @@
+/**
+ * A `fetch` that records a real provider round trip once and replays it forever after.
+ *
+ * The live tests exist because every "the provider honours this" claim in the README was read off
+ * source rather than observed. Settling one needs a real request to a real model -- and CI has no
+ * credentials and no business making one, so the request is recorded to a file and replayed from it.
+ *
+ * # Why this rather than a recording library
+ *
+ * The repository has no HTTP recorder today, and the two candidates for adding one both intercept
+ * globally: `nock` patches Node's http stack and `msw` installs a service worker equivalent. Every
+ * `@ai-sdk/*` provider factory takes a `fetch` of its own, which is a seam the provider already
+ * supports and which no other test in the process can be affected by -- so the recorder is that
+ * function, in about a hundred lines, with no dependency and nothing global. Vitest needs no
+ * configuration for it, which is the same standard the core landed under: match the repository as it
+ * stands rather than introduce tooling for one package.
+ *
+ * # Recording
+ *
+ * ```
+ * node scripts/record-live-cassettes.mjs --env-file <path to a .env with provider keys>
+ * ```
+ *
+ * Recording rewrites every cassette in `cassettes/`. Without `LOGFIRE_CASSETTE_MODE=record` the
+ * tests replay, need no credentials, and make no network call -- an unmatched request throws rather
+ * than falling through to the network.
+ *
+ * # What is stored
+ *
+ * Request headers are *allow-listed* to `content-type`, rather than scrubbed by a list of the auth
+ * headers we happen to know about: `authorization`, `x-api-key`, `api-key`, and `x-goog-api-key` are
+ * four spellings across four providers and the fifth provider's is the one that would leak. The URL
+ * is normalized the same way at record and replay time, so a key passed as a query parameter is
+ * dropped from both and still matches.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CASSETTES = join(dirname(fileURLToPath(import.meta.url)), 'cassettes')
+
+/** Whether this run talks to real providers and rewrites the cassettes. */
+export const RECORDING: boolean = process.env['LOGFIRE_CASSETTE_MODE'] === 'record'
+
+/** The API key to give a provider factory, which is a placeholder unless we are recording. */
+export function apiKey(variable: string): string {
+  const key = process.env[variable]
+  if (!RECORDING) {
+    return 'cassette-replay'
+  }
+  if (key === undefined || key === '') {
+    throw new Error(`Recording needs ${variable} in the environment; pass an --env-file that defines it.`)
+  }
+  return key
+}
+
+/** One request and the response it got, as stored. */
+interface Interaction {
+  method: string
+  url: string
+  /** The request body, as sent. Parsed JSON where it was JSON, so a cassette diff is readable. */
+  request: unknown
+  status: number
+  /** The response body: parsed JSON, or the raw text for a stream. */
+  response: unknown
+  /** Set for a streamed response, whose body is text this has to hand back verbatim. */
+  stream?: boolean
+}
+
+/** A recorded conversation with one provider, and the requests it captured. */
+export interface Cassette {
+  /** The `fetch` to hand a provider factory. */
+  fetch: typeof fetch
+  /** The request bodies, in order, so a test can assert on what the provider was actually sent. */
+  requests: () => unknown[]
+}
+
+/**
+ * The URL a request is stored and looked up under.
+ *
+ * Query parameters that carry a credential are dropped, at both record and replay time, so the two
+ * still match. `alt=sse` and the like are kept, because they are what tells a streamed request from
+ * a non-streamed one at the same path.
+ */
+function normalizeUrl(input: string): string {
+  const url = new URL(input)
+  for (const name of [...url.searchParams.keys()]) {
+    if (/key|token|secret/iu.test(name)) {
+      url.searchParams.delete(name)
+    }
+  }
+  return url.toString()
+}
+
+function parseBody(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return text
+  }
+}
+
+async function requestBody(input: RequestInfo | URL, init: RequestInit | undefined): Promise<string> {
+  if (init?.body !== undefined && init.body !== null) {
+    return typeof init.body === 'string' ? init.body : await new Response(init.body).text()
+  }
+  return input instanceof Request ? await input.clone().text() : ''
+}
+
+/**
+ * The cassette named `name`, as a `fetch` plus the request bodies it saw.
+ *
+ * Replay is ordinal: the n-th request of a test is answered by the n-th interaction of its cassette,
+ * and a mismatched method or URL fails rather than answering with the wrong turn's response. That is
+ * strict on purpose -- these tests exist to prove what reaches a provider, and a recorder that
+ * quietly matched a different request would prove nothing.
+ */
+export function cassette(name: string): Cassette {
+  const path = join(CASSETTES, `${name}.json`)
+  const recorded: Interaction[] = RECORDING ? [] : (JSON.parse(readFileSync(path, 'utf8')) as { interactions: Interaction[] }).interactions
+  const seen: unknown[] = []
+  let index = 0
+
+  const impl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = normalizeUrl(input instanceof Request ? input.url : String(input))
+    const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase()
+    const body = await requestBody(input, init)
+    seen.push(parseBody(body))
+
+    if (RECORDING) {
+      const response = await fetch(input, init)
+      const text = await response.text()
+      const stream = (response.headers.get('content-type') ?? '').includes('event-stream')
+      recorded.push({
+        method,
+        url,
+        request: parseBody(body),
+        status: response.status,
+        response: stream ? text : parseBody(text),
+        ...(stream ? { stream: true } : {}),
+      })
+      mkdirSync(CASSETTES, { recursive: true })
+      writeFileSync(path, `${JSON.stringify({ interactions: recorded }, null, 2)}\n`)
+      return new Response(text, {
+        status: response.status,
+        headers: { 'content-type': response.headers.get('content-type') ?? 'application/json' },
+      })
+    }
+
+    const interaction = recorded[index]
+    index += 1
+    if (interaction === undefined) {
+      throw new Error(`Cassette '${name}' has no interaction ${String(index)}; re-record it.`)
+    }
+    if (interaction.method !== method || interaction.url !== url) {
+      throw new Error(
+        `Cassette '${name}' interaction ${String(index)} recorded ${interaction.method} ${interaction.url}, ` +
+          `but this run sent ${method} ${url}; re-record it.`
+      )
+    }
+    const text = interaction.stream === true ? String(interaction.response) : JSON.stringify(interaction.response)
+    return new Response(text, {
+      status: interaction.status,
+      headers: { 'content-type': interaction.stream === true ? 'text/event-stream' : 'application/json' },
+    })
+  }
+
+  return { fetch: impl as typeof fetch, requests: () => seen }
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-settings.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-settings.json
@@ -1,0 +1,71 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://api.anthropic.com/v1/messages",
+      "request": {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 6656,
+        "stop_sequences": ["STOP"],
+        "thinking": {
+          "type": "enabled",
+          "budget_tokens": 6400
+        },
+        "system": [
+          {
+            "type": "text",
+            "text": "You are a helpful assistant."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is the capital of France?"
+              }
+            ]
+          }
+        ]
+      },
+      "status": 200,
+      "response": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_011CetjBiWbw5YgqeiBLUe65",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "thinking",
+            "thinking": "This is a straightforward factual question. The capital of France is Paris.",
+            "signature": "EsgCCpoBCBEYAipA7FzLnXgJFslHS7O6tCvLqF0BnHKbYuZusrA4RzKuAG26T6WjU8905eB+Q7Jcc8UwoQ3W77lWyw0wBTlqhpIDtDIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiqAGs1YfVBhIM9ljY3IWDNpcaRM1gGgyqsJB/gZaL23AzhswiMD7Gfkoq+WGIHIGJJ13uXNyc6vZDYiK8L3mzUEWRjPQWa/zf8nLgFNyMKWUm6u7NTSpbtZCeo7yGl0ht1yvU3jjLEtpixwmkNB8u0pBdbickAtRlFmghMz3WyP8T+uV797Wt/CDav1SzfvYsjdxsWhxaBib4xq1qOvOnlednzTBJ9J5IKUrr4z1+129aqRgB"
+          },
+          {
+            "type": "text",
+            "text": "The capital of France is Paris."
+          }
+        ],
+        "container": null,
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "stop_details": null,
+        "usage": {
+          "input_tokens": 50,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 0
+          },
+          "output_tokens": 34,
+          "output_tokens_details": {
+            "thinking_tokens": 21
+          },
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        }
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-settings.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-settings.json
@@ -32,14 +32,14 @@
       "status": 200,
       "response": {
         "model": "claude-haiku-4-5-20251001",
-        "id": "msg_011CetjBiWbw5YgqeiBLUe65",
+        "id": "msg_011Cetkch9oyaGwNPxvxFFdY",
         "type": "message",
         "role": "assistant",
         "content": [
           {
             "type": "thinking",
             "thinking": "This is a straightforward factual question. The capital of France is Paris.",
-            "signature": "EsgCCpoBCBEYAipA7FzLnXgJFslHS7O6tCvLqF0BnHKbYuZusrA4RzKuAG26T6WjU8905eB+Q7Jcc8UwoQ3W77lWyw0wBTlqhpIDtDIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiqAGs1YfVBhIM9ljY3IWDNpcaRM1gGgyqsJB/gZaL23AzhswiMD7Gfkoq+WGIHIGJJ13uXNyc6vZDYiK8L3mzUEWRjPQWa/zf8nLgFNyMKWUm6u7NTSpbtZCeo7yGl0ht1yvU3jjLEtpixwmkNB8u0pBdbickAtRlFmghMz3WyP8T+uV797Wt/CDav1SzfvYsjdxsWhxaBib4xq1qOvOnlednzTBJ9J5IKUrr4z1+129aqRgB"
+            "signature": "EsgCCpoBCBEYAipA7FzLnXgJFslHS7O6tCvLqF0BnHKbYuZusrA4RzKuAG26T6WjU8905eB+Q7Jcc8UwoQ3W77lWyw0wBTlqhpIDtDIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiqAGR3ofVBhIMFOPvNVxaIG6IvnsVGgwJ9F8LnLUJAEcuVKQiMDHG9djztRh/R543supKnWHJTkzmSC2f9hnN9qpR7xP3DZiX4HfgDrrvQy76BdA2jCpbJ4DifVdjz8WNJWkdb+mvTevCDIZHphlRMk+3ZrnGoJ0MEsbBD5B3i43FU3t/EYK7cXHC6NmZu382ZBAK6L5DEnuSV4WWSBkbfXSxCh0BseQS+/BRfptpq7izWBgB"
           },
           {
             "type": "text",

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-generate.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-generate.json
@@ -1,0 +1,187 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://api.anthropic.com/v1/messages",
+      "request": {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 64000,
+        "system": [
+          {
+            "type": "text",
+            "text": "You are a helpful assistant."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is the weather in London? Use the tool."
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "lookup_weather",
+            "description": "Look up the current weather for a city.",
+            "input_schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name, e.g. 'London'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          }
+        ],
+        "tool_choice": {
+          "type": "auto"
+        }
+      },
+      "status": 200,
+      "response": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_011Cetj8Fjx5ZY8obScfA3LL",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_use",
+            "id": "toolu_01WvcvBNe25Kdr4R8d9ZEHKg",
+            "name": "lookup_weather",
+            "input": {
+              "city": "London"
+            },
+            "caller": {
+              "type": "direct"
+            }
+          }
+        ],
+        "container": null,
+        "stop_reason": "tool_use",
+        "stop_sequence": null,
+        "stop_details": null,
+        "usage": {
+          "input_tokens": 620,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 0
+          },
+          "output_tokens": 54,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "https://api.anthropic.com/v1/messages",
+      "request": {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 64000,
+        "system": [
+          {
+            "type": "text",
+            "text": "You are a helpful assistant."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is the weather in London? Use the tool."
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu_01WvcvBNe25Kdr4R8d9ZEHKg",
+                "name": "lookup_weather",
+                "input": {
+                  "city": "London"
+                },
+                "caller": {
+                  "type": "direct"
+                }
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_01WvcvBNe25Kdr4R8d9ZEHKg",
+                "content": "sunny in London"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "lookup_weather",
+            "description": "Look up the current weather for a city.",
+            "input_schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name, e.g. 'London'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            }
+          }
+        ],
+        "tool_choice": {
+          "type": "auto"
+        }
+      },
+      "status": 200,
+      "response": {
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_011Cetj8KcsDKrHbCTcWyrfL",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "The weather in London is currently **sunny**! ☀️"
+          }
+        ],
+        "container": null,
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "stop_details": null,
+        "usage": {
+          "input_tokens": 689,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 0
+          },
+          "output_tokens": 17,
+          "service_tier": "standard",
+          "inference_geo": "not_available"
+        }
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-generate.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-generate.json
@@ -48,13 +48,13 @@
       "status": 200,
       "response": {
         "model": "claude-haiku-4-5-20251001",
-        "id": "msg_011Cetj8Fjx5ZY8obScfA3LL",
+        "id": "msg_011CetkcNtxJGprL3tkR5ipG",
         "type": "message",
         "role": "assistant",
         "content": [
           {
             "type": "tool_use",
-            "id": "toolu_01WvcvBNe25Kdr4R8d9ZEHKg",
+            "id": "toolu_01KbA6wxWkj3QmK3GW14rYNt",
             "name": "lookup_weather",
             "input": {
               "city": "London"
@@ -109,7 +109,7 @@
             "content": [
               {
                 "type": "tool_use",
-                "id": "toolu_01WvcvBNe25Kdr4R8d9ZEHKg",
+                "id": "toolu_01KbA6wxWkj3QmK3GW14rYNt",
                 "name": "lookup_weather",
                 "input": {
                   "city": "London"
@@ -125,7 +125,7 @@
             "content": [
               {
                 "type": "tool_result",
-                "tool_use_id": "toolu_01WvcvBNe25Kdr4R8d9ZEHKg",
+                "tool_use_id": "toolu_01KbA6wxWkj3QmK3GW14rYNt",
                 "content": "sunny in London"
               }
             ]
@@ -156,13 +156,13 @@
       "status": 200,
       "response": {
         "model": "claude-haiku-4-5-20251001",
-        "id": "msg_011Cetj8KcsDKrHbCTcWyrfL",
+        "id": "msg_011CetkcSr61z6aoUrd5BW3d",
         "type": "message",
         "role": "assistant",
         "content": [
           {
             "type": "text",
-            "text": "The weather in London is currently **sunny**! ☀️"
+            "text": "The weather in London is **sunny**!"
           }
         ],
         "container": null,
@@ -177,7 +177,7 @@
             "ephemeral_5m_input_tokens": 0,
             "ephemeral_1h_input_tokens": 0
           },
-          "output_tokens": 17,
+          "output_tokens": 12,
           "service_tier": "standard",
           "inference_geo": "not_available"
         }

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-stream.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-stream.json
@@ -48,7 +48,7 @@
         "stream": true
       },
       "status": 200,
-      "response": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Cetj8NpbUz1Qj52Todu9f\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"container\":null,\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":620,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":22,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}   }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01G3mwm7qL5Kt23cBTPmYhTC\",\"name\":\"lookup_weather\",\"input\":{},\"caller\":{\"type\":\"direct\"}}       }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\": \\\"London\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"} }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0   }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"container\":null},\"usage\":{\"input_tokens\":620,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":54}               }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"              }\n\n",
+      "response": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CetkcVoBjuxMLiuvzc68L\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"container\":null,\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":620,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":22,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}       }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_018eMqssRQ4iubWGepuqginL\",\"name\":\"lookup_weather\",\"input\":{},\"caller\":{\"type\":\"direct\"}}     }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\": \\\"London\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"}    }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0       }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"container\":null},\"usage\":{\"input_tokens\":620,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":54}      }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"  }\n\n",
       "stream": true
     },
     {
@@ -78,8 +78,8 @@
             "content": [
               {
                 "type": "tool_use",
-                "id": "toolu_01G3mwm7qL5Kt23cBTPmYhTC",
-                "name": "get_weather",
+                "id": "toolu_018eMqssRQ4iubWGepuqginL",
+                "name": "lookup_weather",
                 "input": {
                   "city": "London"
                 },
@@ -94,7 +94,7 @@
             "content": [
               {
                 "type": "tool_result",
-                "tool_use_id": "toolu_01G3mwm7qL5Kt23cBTPmYhTC",
+                "tool_use_id": "toolu_018eMqssRQ4iubWGepuqginL",
                 "content": "sunny in London"
               }
             ]
@@ -102,15 +102,15 @@
         ],
         "tools": [
           {
-            "name": "get_weather",
-            "description": "Get the current weather for a city.",
+            "name": "lookup_weather",
+            "description": "Look up the current weather for a city.",
             "input_schema": {
               "$schema": "http://json-schema.org/draft-07/schema#",
               "type": "object",
               "properties": {
                 "city": {
                   "type": "string",
-                  "description": "City name, e.g. `London`."
+                  "description": "City name, e.g. 'London'."
                 }
               },
               "required": ["city"],
@@ -125,7 +125,7 @@
         "stream": true
       },
       "status": 200,
-      "response": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CetjBaAZ2VYoTTb8443gj\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"container\":null,\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":687,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":1,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}   }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}              }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"The\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" weather in London is\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" currently **\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"sunny**!\"}           }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0         }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"container\":null},\"usage\":{\"input_tokens\":687,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":13}            }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"            }\n\n",
+      "response": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CetkcZvjr4mFkpWaRRDiB\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"container\":null,\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":689,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":1,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}      }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}   }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"The\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" weather in London is\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" **\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"sunny**\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"!\"}             }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0          }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"container\":null},\"usage\":{\"input_tokens\":689,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":12}            }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"       }\n\n",
       "stream": true
     }
   ]

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-stream.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/anthropic-tools-stream.json
@@ -1,0 +1,132 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://api.anthropic.com/v1/messages",
+      "request": {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 64000,
+        "system": [
+          {
+            "type": "text",
+            "text": "You are a helpful assistant."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is the weather in London? Use the tool."
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "lookup_weather",
+            "description": "Look up the current weather for a city.",
+            "input_schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name, e.g. 'London'."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            },
+            "eager_input_streaming": true
+          }
+        ],
+        "tool_choice": {
+          "type": "auto"
+        },
+        "stream": true
+      },
+      "status": 200,
+      "response": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011Cetj8NpbUz1Qj52Todu9f\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"container\":null,\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":620,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":22,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}   }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01G3mwm7qL5Kt23cBTPmYhTC\",\"name\":\"lookup_weather\",\"input\":{},\"caller\":{\"type\":\"direct\"}}       }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"city\\\": \\\"London\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"}\"} }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0   }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"container\":null},\"usage\":{\"input_tokens\":620,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":54}               }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"              }\n\n",
+      "stream": true
+    },
+    {
+      "method": "POST",
+      "url": "https://api.anthropic.com/v1/messages",
+      "request": {
+        "model": "claude-haiku-4-5",
+        "max_tokens": 64000,
+        "system": [
+          {
+            "type": "text",
+            "text": "You are a helpful assistant."
+          }
+        ],
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "What is the weather in London? Use the tool."
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu_01G3mwm7qL5Kt23cBTPmYhTC",
+                "name": "get_weather",
+                "input": {
+                  "city": "London"
+                },
+                "caller": {
+                  "type": "direct"
+                }
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "tool_result",
+                "tool_use_id": "toolu_01G3mwm7qL5Kt23cBTPmYhTC",
+                "content": "sunny in London"
+              }
+            ]
+          }
+        ],
+        "tools": [
+          {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "input_schema": {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string",
+                  "description": "City name, e.g. `London`."
+                }
+              },
+              "required": ["city"],
+              "additionalProperties": false
+            },
+            "eager_input_streaming": true
+          }
+        ],
+        "tool_choice": {
+          "type": "auto"
+        },
+        "stream": true
+      },
+      "status": 200,
+      "response": "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"id\":\"msg_011CetjBaAZ2VYoTTb8443gj\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"container\":null,\"stop_reason\":null,\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":687,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":1,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}   }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}              }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"The\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" weather in London is\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" currently **\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"sunny**!\"}           }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0         }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"container\":null},\"usage\":{\"input_tokens\":687,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":13}            }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"            }\n\n",
+      "stream": true
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-model-swap.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-model-swap.json
@@ -31,7 +31,7 @@
               "parts": [
                 {
                   "text": "Paris",
-                  "thoughtSignature": "El4KXAERTTIPClqqfYiPr+5yVya6Eq0f/yYVI0/b9xYLtFvSiTo+eMj9BfduUVW+bZxN3wISvZ8490Zkuu3xCFpyeIOnL5NCLPY1rz6Zij5RhCmFcB5Hw0cysZnaHNDR"
+                  "thoughtSignature": "El4KXAERTTIPiV5mp4/wQaf676UGhDL5MPyx//Ue+N7XfkCMLawGfcm86kXcDzLY5aQjT2skGndIOMkUZSAPfxQYFoYlGj+ESclY5ynnEBWu1Eg0eC2dhyg8J71M/ZYb"
                 }
               ],
               "role": "model"
@@ -53,7 +53,7 @@
           "serviceTier": "standard"
         },
         "modelVersion": "gemini-3.5-flash-lite",
-        "responseId": "reqharGzEaSd6dkP8MX82AE"
+        "responseId": "Eu-harOVL9CGz7IPp-vl-Q8"
       }
     }
   ]

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-model-swap.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-model-swap.json
@@ -1,0 +1,60 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent",
+      "request": {
+        "generationConfig": {},
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "What is the capital of France? Answer in one word."
+              }
+            ]
+          }
+        ],
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "You are a helpful assistant."
+            }
+          ]
+        }
+      },
+      "status": 200,
+      "response": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "Paris",
+                  "thoughtSignature": "El4KXAERTTIPClqqfYiPr+5yVya6Eq0f/yYVI0/b9xYLtFvSiTo+eMj9BfduUVW+bZxN3wISvZ8490Zkuu3xCFpyeIOnL5NCLPY1rz6Zij5RhCmFcB5Hw0cysZnaHNDR"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 19,
+          "candidatesTokenCount": 1,
+          "totalTokenCount": 20,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 19
+            }
+          ],
+          "serviceTier": "standard"
+        },
+        "modelVersion": "gemini-3.5-flash-lite",
+        "responseId": "reqharGzEaSd6dkP8MX82AE"
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-penalties.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-penalties.json
@@ -1,0 +1,38 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent",
+      "request": {
+        "generationConfig": {
+          "presencePenalty": 0.1
+        },
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "What is the capital of France?"
+              }
+            ]
+          }
+        ],
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "You are a helpful assistant."
+            }
+          ]
+        }
+      },
+      "status": 400,
+      "response": {
+        "error": {
+          "code": 400,
+          "message": "Penalty is not enabled for this model",
+          "status": "INVALID_ARGUMENT"
+        }
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-settings.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-settings.json
@@ -41,7 +41,7 @@
               "parts": [
                 {
                   "text": "The capital of France is Paris.",
-                  "thoughtSignature": "El4KXAERTTIPgkUzy5lxiHfDDIAQvcF7iDu7SNFOAWUXVSudTbYJ8jSbWBlkBGFkBMfVzSjBOhMaYXAmPV8YuwL8cIwSIkIf8ND+3tyrFB0qOtA3F+n1y1BZNj8wXMdv"
+                  "thoughtSignature": "El4KXAERTTIPybPvIeIRRyUazMOHLLFoq+pdHrzpDwC3MtoIJdFr+u+r1g6O+xv8JCFrlUogs0duuVvngPWQ+jLo6BCWiSj1Zyax/J4be2+Fhrn5u9Ri5gRu02NuhUxa"
                 }
               ],
               "role": "model"
@@ -63,7 +63,7 @@
           "serviceTier": "standard"
         },
         "modelVersion": "gemini-3.5-flash-lite",
-        "responseId": "rOqharH1JOOi6dkPhMKQqAE"
+        "responseId": "Eu-harnPCqXnz7IPkN3a0Aw"
       }
     }
   ]

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-settings.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/google-settings.json
@@ -1,0 +1,70 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash-lite:generateContent",
+      "request": {
+        "generationConfig": {
+          "maxOutputTokens": 256,
+          "temperature": 0.1,
+          "topK": 20,
+          "topP": 0.9,
+          "stopSequences": ["STOP"],
+          "seed": 7,
+          "thinkingConfig": {
+            "thinkingLevel": "low"
+          }
+        },
+        "contents": [
+          {
+            "role": "user",
+            "parts": [
+              {
+                "text": "What is the capital of France?"
+              }
+            ]
+          }
+        ],
+        "systemInstruction": {
+          "parts": [
+            {
+              "text": "You are a helpful assistant."
+            }
+          ]
+        }
+      },
+      "status": 200,
+      "response": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "The capital of France is Paris.",
+                  "thoughtSignature": "El4KXAERTTIPgkUzy5lxiHfDDIAQvcF7iDu7SNFOAWUXVSudTbYJ8jSbWBlkBGFkBMfVzSjBOhMaYXAmPV8YuwL8cIwSIkIf8ND+3tyrFB0qOtA3F+n1y1BZNj8wXMdv"
+                }
+              ],
+              "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+          }
+        ],
+        "usageMetadata": {
+          "promptTokenCount": 14,
+          "candidatesTokenCount": 7,
+          "totalTokenCount": 21,
+          "promptTokensDetails": [
+            {
+              "modality": "TEXT",
+              "tokenCount": 14
+            }
+          ],
+          "serviceTier": "standard"
+        },
+        "modelVersion": "gemini-3.5-flash-lite",
+        "responseId": "rOqharH1JOOi6dkPhMKQqAE"
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-instructions.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-instructions.json
@@ -23,15 +23,15 @@
       },
       "status": 200,
       "response": {
-        "id": "resp_0df63a28c621a93d006aa1ea7bddfc87d1b8107192b1048850",
+        "id": "resp_0ee62245066f3e43006aa1ef0c009887d18babb6bded409fa2",
         "object": "response",
-        "created_at": 1788996219,
+        "created_at": 1788997388,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
-        "completed_at": 1788996220,
+        "completed_at": 1788997388,
         "error": null,
         "frequency_penalty": 0,
         "incomplete_details": null,
@@ -42,7 +42,7 @@
         "moderation": null,
         "output": [
           {
-            "id": "msg_0df63a28c621a93d006aa1ea7c354087d1881b33ebc3d0a96f",
+            "id": "msg_0ee62245066f3e43006aa1ef0c75b887d1bd778187c1ef3fa6",
             "type": "message",
             "status": "completed",
             "content": [

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-instructions.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-instructions.json
@@ -1,0 +1,121 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://api.openai.com/v1/responses",
+      "request": {
+        "model": "gpt-5.4-nano",
+        "input": [
+          {
+            "role": "developer",
+            "content": "Reply with exactly one word: BANANA. No punctuation."
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "What is the capital of France?"
+              }
+            ]
+          }
+        ]
+      },
+      "status": 200,
+      "response": {
+        "id": "resp_0df63a28c621a93d006aa1ea7bddfc87d1b8107192b1048850",
+        "object": "response",
+        "created_at": 1788996219,
+        "status": "completed",
+        "background": false,
+        "billing": {
+          "payer": "developer"
+        },
+        "completed_at": 1788996220,
+        "error": null,
+        "frequency_penalty": 0,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": null,
+        "max_tool_calls": null,
+        "model": "gpt-5.4-nano-2026-03-17",
+        "moderation": null,
+        "output": [
+          {
+            "id": "msg_0df63a28c621a93d006aa1ea7c354087d1881b33ebc3d0a96f",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "output_text",
+                "annotations": [],
+                "logprobs": [],
+                "text": "BANANA"
+              }
+            ],
+            "phase": "final_answer",
+            "role": "assistant"
+          }
+        ],
+        "parallel_tool_calls": true,
+        "presence_penalty": 0,
+        "previous_response_id": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": "24h",
+        "reasoning": {
+          "context": "current_turn",
+          "effort": "none",
+          "mode": "standard",
+          "summary": null
+        },
+        "safety_identifier": null,
+        "service_tier": "default",
+        "store": true,
+        "temperature": 1,
+        "text": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
+        "tools": [],
+        "top_logprobs": 0,
+        "top_p": 0.98,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 29,
+          "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 0
+          },
+          "output_tokens": 6,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 35
+        },
+        "user": null,
+        "metadata": {}
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-settings.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-settings.json
@@ -29,15 +29,15 @@
       },
       "status": 200,
       "response": {
-        "id": "resp_0ae5ff4577157ac9006aa1eaa9b4d887d18b980ab52a4a6fdd",
+        "id": "resp_0258277c9addc87b006aa1ef10449887d19f5f697bbb7f6c47",
         "object": "response",
-        "created_at": 1788996265,
+        "created_at": 1788997392,
         "status": "completed",
         "background": false,
         "billing": {
           "payer": "developer"
         },
-        "completed_at": 1788996266,
+        "completed_at": 1788997392,
         "error": null,
         "frequency_penalty": 0,
         "incomplete_details": null,
@@ -48,7 +48,7 @@
         "moderation": null,
         "output": [
           {
-            "id": "msg_0ae5ff4577157ac9006aa1eaaa1b5087d1bde92cd0b6735756",
+            "id": "msg_0258277c9addc87b006aa1ef10b6cc87d19bb67c275a83e9c3",
             "type": "message",
             "status": "completed",
             "content": [

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-settings.json
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/openai-settings.json
@@ -1,0 +1,127 @@
+{
+  "interactions": [
+    {
+      "method": "POST",
+      "url": "https://api.openai.com/v1/responses",
+      "request": {
+        "model": "gpt-5.4-nano",
+        "input": [
+          {
+            "role": "developer",
+            "content": "You are a helpful assistant."
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "input_text",
+                "text": "What is the capital of France?"
+              }
+            ]
+          }
+        ],
+        "max_output_tokens": 256,
+        "parallel_tool_calls": false,
+        "reasoning": {
+          "effort": "low",
+          "summary": "detailed"
+        }
+      },
+      "status": 200,
+      "response": {
+        "id": "resp_0ae5ff4577157ac9006aa1eaa9b4d887d18b980ab52a4a6fdd",
+        "object": "response",
+        "created_at": 1788996265,
+        "status": "completed",
+        "background": false,
+        "billing": {
+          "payer": "developer"
+        },
+        "completed_at": 1788996266,
+        "error": null,
+        "frequency_penalty": 0,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": 256,
+        "max_tool_calls": null,
+        "model": "gpt-5.4-nano-2026-03-17",
+        "moderation": null,
+        "output": [
+          {
+            "id": "msg_0ae5ff4577157ac9006aa1eaaa1b5087d1bde92cd0b6735756",
+            "type": "message",
+            "status": "completed",
+            "content": [
+              {
+                "type": "output_text",
+                "annotations": [],
+                "logprobs": [],
+                "text": "The capital of France is **Paris**."
+              }
+            ],
+            "phase": "final_answer",
+            "role": "assistant"
+          }
+        ],
+        "parallel_tool_calls": false,
+        "presence_penalty": 0,
+        "previous_response_id": null,
+        "prompt_cache_key": null,
+        "prompt_cache_retention": "24h",
+        "reasoning": {
+          "context": "current_turn",
+          "effort": "low",
+          "mode": "standard",
+          "summary": "detailed"
+        },
+        "safety_identifier": null,
+        "service_tier": "default",
+        "store": true,
+        "temperature": 1,
+        "text": {
+          "format": {
+            "type": "text"
+          },
+          "verbosity": "medium"
+        },
+        "tool_choice": "auto",
+        "tool_usage": {
+          "image_gen": {
+            "input_tokens": 0,
+            "input_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "output_tokens": 0,
+            "output_tokens_details": {
+              "image_tokens": 0,
+              "text_tokens": 0
+            },
+            "total_tokens": 0
+          },
+          "web_search": {
+            "num_requests": 0
+          }
+        },
+        "tools": [],
+        "top_logprobs": 0,
+        "top_p": 0.98,
+        "truncation": "disabled",
+        "usage": {
+          "input_tokens": 23,
+          "input_tokens_details": {
+            "cache_write_tokens": 0,
+            "cached_tokens": 0
+          },
+          "output_tokens": 13,
+          "output_tokens_details": {
+            "reasoning_tokens": 0
+          },
+          "total_tokens": 36
+        },
+        "user": null,
+        "metadata": {}
+      }
+    }
+  ]
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/edges.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/edges.test.ts
@@ -1,0 +1,219 @@
+import type { LanguageModelV4GenerateResult } from '@ai-sdk/provider'
+import { generateText, stepCountIs, tool } from 'ai'
+import { z } from 'zod'
+import { describe, expect, it } from 'vitest'
+
+import { agentControl } from '../index'
+import { captureWarnings, publishedValue, settle, storedConfig, stubModel, textResult, useLocalVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+const weather = tool({
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }: { city: string }) => Promise.resolve(`sunny in ${city}`),
+})
+const time = tool({
+  description: 'The current time.',
+  inputSchema: z.object({}),
+  execute: async () => Promise.resolve('noon'),
+})
+
+/** A result carrying one tool call per name, so one response can mix renamed and unrenamed tools. */
+function toolCalls(names: string[]): LanguageModelV4GenerateResult {
+  return {
+    ...textResult(''),
+    content: [
+      // A part with no tool name at all, which every rewrite has to pass through untouched.
+      { type: 'text' as const, text: 'Looking that up.' },
+      ...names.map((toolName, index) => ({
+        type: 'tool-call' as const,
+        toolCallId: `call-${String(index)}`,
+        toolName,
+        input: toolName === 'get_time' ? '{}' : JSON.stringify({ city: 'Paris' }),
+      })),
+    ],
+    finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+  }
+}
+
+describe('edges', () => {
+  it('patches a tool that describes itself only through its parameters', async () => {
+    useLocalVariables(
+      publishedValue('agent__undescribed_tool', {
+        tool_definitions: [{ name: 'get_weather', parameters: { city: { description: 'A city.' } } }],
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'undescribed_tool', label: 'production' }),
+      prompt: 'hi',
+      tools: { get_weather: weather },
+    })
+    await settle()
+
+    const shown = model.doGenerateCalls[0]?.tools?.[0]
+    expect(shown).toMatchObject({ name: 'get_weather' })
+    expect(shown && 'description' in shown ? shown.description : undefined).toBeUndefined()
+    // The baseline says so too: no description in code, so there is none to show -- rather than an
+    // empty string standing in for one. The parameter is still listed, with nothing describing it
+    // yet, because an undocumented parameter is exactly the one somebody wants to describe from
+    // Logfire and a baseline that hid it would need the code changed first.
+    const baseline = JSON.parse((await storedConfig('agent__undescribed_tool'))?.example ?? 'null') as {
+      tool_definitions: unknown[]
+    }
+    expect(baseline.tool_definitions).toEqual([{ name: 'get_weather', parameters: { city: {} } }])
+  })
+
+  it('renames only the tools an override names, and leaves every other name as it found it', async () => {
+    useLocalVariables(
+      publishedValue('agent__mixed_renames', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }],
+      })
+    )
+    const model = stubModel([toolCalls(['lookup_weather', 'get_time', 'made_up']), textResult('done')])
+    const result = await generateText({
+      model: agentControl({ model, name: 'mixed_renames', label: 'production' }),
+      prompt: 'hi',
+      stopWhen: stepCountIs(3),
+      tools: { get_weather: weather, get_time: time },
+    })
+
+    // The renamed tool is mapped back, the untouched one is left alone, and a name this adapter
+    // never advertised is passed through for the SDK's own handling of it.
+    expect(result.steps[0]?.content.flatMap((part) => ('toolName' in part ? [part.toolName] : [])).sort()).toEqual([
+      'get_time',
+      'get_time',
+      'get_weather',
+      'get_weather',
+      'made_up',
+      'made_up',
+    ])
+
+    const history = (model.doGenerateCalls[1]?.prompt ?? []).flatMap((message) =>
+      Array.isArray(message.content) ? message.content.flatMap((part) => ('toolName' in part ? [part.toolName] : [])) : []
+    )
+    expect(history.sort()).toEqual(['get_time', 'get_time', 'lookup_weather', 'lookup_weather', 'made_up', 'made_up'])
+  })
+
+  it.each([
+    ['provider-default', true, 'reasoning_default'],
+    ['none', false, 'reasoning_off'],
+    ['high', 'high', 'reasoning_high'],
+  ] as const)("publishes reasoning %s as the contract's `thinking` %s", async (reasoning, thinking, name) => {
+    useLocalVariables()
+    const model = stubModel([textResult('ok')])
+    await generateText({ model: agentControl({ model, name }), prompt: 'hi', reasoning })
+    await settle()
+
+    const baseline = JSON.parse((await storedConfig(`agent__${name}`))?.example ?? 'null') as {
+      settings: { thinking: unknown }
+    }
+    expect(baseline.settings.thinking).toBe(thinking)
+  })
+
+  // Anthropic spells the same knob inverted, so both publish what the agent actually does.
+  it.each([
+    ['openai.responses', { openai: { parallelToolCalls: false } }, false, 'parallel_baseline_openai'],
+    ['anthropic.messages', { anthropic: { disableParallelToolUse: false } }, true, 'parallel_baseline_anthropic'],
+  ] as const)(
+    "publishes %s's own parallel-tool-calls option as `parallel_tool_calls: %s`",
+    async (provider, providerOptions, expected, name) => {
+      useLocalVariables()
+      const model = stubModel([textResult('ok')], provider, 'a-model')
+      await generateText({ model: agentControl({ model, name }), prompt: 'hi', providerOptions })
+      await settle()
+
+      const baseline = JSON.parse((await storedConfig(`agent__${name}`))?.example ?? 'null') as {
+        settings: { parallel_tool_calls: unknown }
+      }
+      expect(baseline.settings.parallel_tool_calls).toBe(expected)
+    }
+  )
+
+  it('keeps the code-defined model when resolving one throws something that is not an `Error`', async () => {
+    useLocalVariables(publishedValue('agent__thrown_string', { model: 'acme:big' }))
+    const code = stubModel([textResult('from code')])
+    const { text } = await generateText({
+      model: agentControl({
+        model: code,
+        name: 'thrown_string',
+        label: 'production',
+        resolveModel: () => {
+          // A provider factory that throws a bare value, which this adapter still has to report
+          // rather than let out of a model request.
+          // oxlint-disable-next-line typescript/only-throw-error, no-throw-literal
+          throw 'acme is not configured'
+        },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from code')
+    expect(warnings.messages).toContainEqual(expect.stringContaining('acme is not configured'))
+  })
+
+  it('reaches for the AI Gateway when nothing else can resolve a managed model', async () => {
+    useLocalVariables(publishedValue('agent__gateway_import', { model: 'anthropic:claude-fable-5-1' }))
+    const code = stubModel([textResult('from code')])
+    const fetched: string[] = []
+    const fetchImpl = globalThis.fetch
+    process.env['AI_GATEWAY_API_KEY'] = 'test-key'
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      fetched.push(String(input instanceof Request ? input.url : input))
+      return Promise.reject(new Error('offline'))
+    }) as typeof fetch
+    try {
+      // The real `@ai-sdk/gateway`, imported lazily: it builds a model without a network round trip,
+      // and this test never lets one leave the process.
+      await expect(
+        generateText({
+          model: agentControl({ model: code, name: 'gateway_import', label: 'production' }),
+          prompt: 'hi',
+          maxRetries: 0,
+        })
+      ).rejects.toThrow(/offline/u)
+      expect(code.doGenerateCalls).toEqual([])
+      expect(fetched.join(' ')).toContain('ai-gateway.vercel.sh')
+      expect(warnings.messages).toContainEqual(expect.stringContaining('in place of the code-defined'))
+    } finally {
+      globalThis.fetch = fetchImpl
+      delete process.env['AI_GATEWAY_API_KEY']
+    }
+  })
+
+  it('leaves a system message that follows the conversation where the prompt put it', async () => {
+    useLocalVariables(publishedValue('agent__mid_prompt_system', { instructions: [{ id: 'system:0' }] }))
+    const model = stubModel([textResult('ok')])
+    const managed = agentControl({ model, name: 'mid_prompt_system', label: 'production' })
+
+    // Called as a `LanguageModelV4` rather than through `generateText`, because this is a prompt shape
+    // the standard helpers do not build: a system message *after* the conversation, which `messages`
+    // and `allowSystemInMessages` can carry. Consuming the surviving blocks in order rather than by
+    // slot would slide it up in front of the user's turn when the block ahead of it is removed.
+    await managed.doGenerate({
+      prompt: [
+        { role: 'system', content: 'Drop me.' },
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        { role: 'system', content: 'Keep me, here.' },
+      ],
+    })
+
+    expect(model.doGenerateCalls[0]?.prompt).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'system', content: 'Keep me, here.' },
+    ])
+  })
+
+  it('applies a config to a request nothing in the AI SDK assembled', async () => {
+    useLocalVariables(publishedValue('agent__hand_built', { instructions: 'Be brief.' }))
+    const model = stubModel([textResult('ok')])
+    const managed = agentControl({ model, name: 'hand_built', label: 'production' })
+
+    // The minimum a `LanguageModelV4` call takes: no tools, no tool choice, no settings. `generateText`
+    // fills those in, and a middleware that assumed it always had is one a direct caller would break.
+    await managed.doGenerate({ prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }] })
+
+    expect(model.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Be brief.' })
+    expect(model.doGenerateCalls[0]?.toolChoice).toBeUndefined()
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/helpers.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/helpers.ts
@@ -1,0 +1,189 @@
+/**
+ * Shared test scaffolding: a local variables provider, a stub model, and a way to see what warned.
+ *
+ * Everything here is offline. The Logfire SDK's `LocalVariableProvider` reads, creates, and updates
+ * an in-memory config, so the publish path is exercised against the same interface the remote
+ * provider implements; the model is `MockLanguageModelV4` from `ai/test`, which is the AI SDK's own
+ * stub and records every call it was made with.
+ */
+
+import { configureVariables } from '@pydantic/logfire-node/vars'
+import type { VariableConfig, VariablesConfig } from '@pydantic/logfire-node/vars'
+import type {
+  LanguageModelV3,
+  LanguageModelV4CallOptions,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+} from '@ai-sdk/provider'
+import { MockLanguageModelV4 } from 'ai/test'
+import { afterEach, beforeEach, vi } from 'vitest'
+
+// A test that has to assert "warns once per process" needs a process that has not warned yet, and one
+// that asserts a baseline was published needs a process that has not published yet. The core ships
+// both resets from a subpath of its own, so this adapter shares the core's single dedup set rather
+// than keeping a second one beside it.
+import { resetAgentControl } from '@pydantic/logfire-node/agent-control/testing'
+
+/** A variables config in which `name` holds `value` under one label at full rollout. */
+export function publishedValue(name: string, value: unknown, label = 'production'): VariablesConfig {
+  return {
+    variables: {
+      [name]: {
+        name,
+        labels: { [label]: { version: 1, serialized_value: JSON.stringify(value) } },
+        rollout: { labels: { [label]: 1 } },
+        overrides: [],
+      },
+    },
+  }
+}
+
+/** Point the SDK at a local provider holding `config`. */
+export function useLocalVariables(config: VariablesConfig = { variables: {} }): void {
+  configureVariables({ config, instrument: false })
+}
+
+/** Switch variables off entirely, which is what an application with no Logfire token gets. */
+export function useNoVariables(): void {
+  configureVariables(false)
+}
+
+/** Read a variable's stored definition back out of the local provider. */
+export async function storedConfig(name: string): Promise<VariableConfig | undefined> {
+  const { getVariableProvider } = await import('@pydantic/logfire-node/vars')
+  return getVariableProvider().getVariableConfig?.(name) as VariableConfig | undefined
+}
+
+/** Capture `console.warn` for the duration of a test, and reset every once-per-process guard. */
+export function captureWarnings(): { messages: string[] } {
+  const captured: { messages: string[] } = { messages: [] }
+  beforeEach(() => {
+    captured.messages.length = 0
+    resetAgentControl()
+    vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+      captured.messages.push(String(message))
+    })
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    useNoVariables()
+  })
+  return captured
+}
+
+/** Wait for the background baseline publish to settle. */
+export async function settle(): Promise<void> {
+  await Promise.all(Array.from({ length: 5 }, async () => Promise.resolve()))
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+const usage = {
+  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 1, text: 1, reasoning: 0 },
+  totalTokens: 2,
+}
+
+/** A finished generate result carrying one text part. */
+export function textResult(text: string): LanguageModelV4GenerateResult {
+  return {
+    content: [{ type: 'text', text }],
+    finishReason: { unified: 'stop', raw: 'end_turn' },
+    usage,
+    warnings: [],
+  }
+}
+
+/** A generate result asking for one tool call, under the name the model was shown. */
+export function toolCallResult(toolName: string, input: unknown): LanguageModelV4GenerateResult {
+  return {
+    content: [{ type: 'tool-call', toolCallId: 'call-1', toolName, input: JSON.stringify(input) }],
+    finishReason: { unified: 'tool-calls', raw: 'tool_use' },
+    usage,
+    warnings: [],
+  }
+}
+
+/** A stream that asks for one tool call, in the parts a provider actually emits for one. */
+export function toolCallStream(toolName: string, input: unknown): LanguageModelV4StreamResult {
+  return streamOf([
+    { type: 'stream-start', warnings: [] },
+    { type: 'tool-input-start', id: 'call-1', toolName },
+    { type: 'tool-input-delta', id: 'call-1', delta: JSON.stringify(input) },
+    { type: 'tool-input-end', id: 'call-1' },
+    { type: 'tool-call', toolCallId: 'call-1', toolName, input: JSON.stringify(input) },
+    { type: 'finish', finishReason: { unified: 'tool-calls', raw: 'tool_use' }, usage },
+  ])
+}
+
+/** A stream that emits one piece of text and finishes. */
+export function textStream(text: string): LanguageModelV4StreamResult {
+  return streamOf([
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 'text-1' },
+    { type: 'text-delta', id: 'text-1', delta: text },
+    { type: 'text-end', id: 'text-1' },
+    { type: 'finish', finishReason: { unified: 'stop', raw: 'end_turn' }, usage },
+  ])
+}
+
+function streamOf(parts: LanguageModelV4StreamPart[]): LanguageModelV4StreamResult {
+  return {
+    stream: new ReadableStream({
+      start(controller) {
+        for (const part of parts) {
+          controller.enqueue(part)
+        }
+        controller.close()
+      },
+    }),
+  }
+}
+
+/**
+ * A pre-v4 model, which `wrapLanguageModel` accepts and bridges with a lying `Proxy`.
+ *
+ * `asLanguageModelV4` wraps a v2 or v3 model in a proxy whose only behavior is to answer `'v4'` to
+ * `specificationVersion` and forward everything else, so the request such a provider is handed is a
+ * v4 one and the one field v4 added -- `reasoning` -- reaches a provider with no contract for it.
+ * Which is why this stub is a plain object rather than a `MockLanguageModelV4`: what matters is the
+ * version it reports before it is wrapped.
+ */
+export function legacyModel(
+  specificationVersion: 'v2' | 'v3',
+  results: LanguageModelV4GenerateResult[] = []
+): LanguageModelV3 & { calls: LanguageModelV4CallOptions[] } {
+  const calls: LanguageModelV4CallOptions[] = []
+  return {
+    specificationVersion,
+    provider: 'legacy.chat',
+    modelId: 'old-model',
+    supportedUrls: {},
+    calls,
+    doGenerate: async (options: LanguageModelV4CallOptions) => {
+      calls.push(options)
+      return Promise.resolve(results.shift() ?? textResult('done'))
+    },
+    doStream: async () => Promise.resolve(textStream('done')),
+  } as unknown as LanguageModelV3 & { calls: LanguageModelV4CallOptions[] }
+}
+
+/** A model that answers with each of `results` in turn, and remembers what it was asked. */
+export function stubModel(
+  results: LanguageModelV4GenerateResult[] | LanguageModelV4StreamResult[],
+  provider = 'anthropic.messages',
+  modelId = 'claude-fable-5-1'
+): MockLanguageModelV4 {
+  const generates = results.filter((result): result is LanguageModelV4GenerateResult => 'content' in result)
+  const streams = results.filter((result): result is LanguageModelV4StreamResult => 'stream' in result)
+  return new MockLanguageModelV4({
+    provider,
+    modelId,
+    // `MockLanguageModelV4` records the call options itself, on `doGenerateCalls` and
+    // `doStreamCalls`, so these only have to answer.
+    doGenerate: async () => Promise.resolve(generates.shift() ?? textResult('done')),
+    doStream: async () => Promise.resolve(streams.shift() ?? textStream('done')),
+  })
+}

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/instructions.test.ts
@@ -153,6 +153,34 @@ describe('instructions', () => {
     expect(warnings.messages).toContainEqual(expect.stringContaining('recomputes'))
   })
 
+  it('adds a block ahead of conversation content when every existing block was removed', async () => {
+    useLocalVariables(
+      publishedValue('agent__trailing_system', {
+        instructions: [{ id: 'system:0' }, { id: 'system:1' }, 'Escalate anything over $500.'],
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    const front = { role: 'system' as const, content: 'You are a concise checkout assistant.' }
+    const behind = { role: 'system' as const, content: 'Tenant: acme.' }
+    await generateText({
+      // `messages` may carry a system message of its own, so the second declared block sits behind
+      // user content -- and once a managed value removes both there is no system run left to append
+      // an added block to.
+      model: agentControl({ model, name: 'trailing_system', label: 'production', codeInstructions: [front, behind] }),
+      instructions: front,
+      messages: [{ role: 'user', content: 'hi' }, behind],
+      allowSystemInMessages: true,
+    })
+
+    // Both declared blocks are gone and the added one is at the front -- not appended after the
+    // system message that sat behind the conversation, which would have put a managed instruction
+    // past the user's own turn.
+    expect(model.doGenerateCalls[0]?.prompt).toEqual([
+      { role: 'system', content: 'Escalate anything over $500.' },
+      { role: 'user', content: [{ type: 'text', text: 'hi' }], providerOptions: undefined },
+    ])
+  })
+
   it('keeps both messages when two of them declare the same id', async () => {
     useLocalVariables(publishedValue('agent__duplicate_ids', { instructions: [{ id: 'policy', instructions: 'One policy.' }] }))
     const model = stubModel([textResult('ok')])

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/instructions.test.ts
@@ -1,0 +1,198 @@
+import { generateText, ToolLoopAgent } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { agentControl, UnmatchedConfigError } from '../index'
+import { captureWarnings, publishedValue, stubModel, textResult, useLocalVariables, useNoVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+/** The system messages of the request the model was made with. */
+function systemMessages(model: { doGenerateCalls: { prompt: unknown[] }[] }, call = 0): unknown[] {
+  return (model.doGenerateCalls[call]?.prompt ?? []).filter((message) => (message as { role: string }).role === 'system')
+}
+
+describe('instructions', () => {
+  it('rewrites the block an id addresses and leaves its neighbours alone', async () => {
+    useLocalVariables(
+      publishedValue('agent__three_blocks', {
+        instructions: [{ id: 'system:1', instructions: 'Confirm the order total in writing.' }],
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'three_blocks', label: 'production' }),
+      instructions: [
+        { role: 'system', content: 'You are a concise checkout assistant.' },
+        { role: 'system', content: 'Always confirm the order total.' },
+        { role: 'system', content: 'Escalate anything over $500.' },
+      ],
+      prompt: 'hi',
+    })
+
+    expect(systemMessages(model)).toEqual([
+      { role: 'system', content: 'You are a concise checkout assistant.' },
+      { role: 'system', content: 'Confirm the order total in writing.' },
+      { role: 'system', content: 'Escalate anything over $500.' },
+    ])
+  })
+
+  it('addresses a block by the id its `providerOptions` declares, and keeps those options', async () => {
+    useLocalVariables(publishedValue('agent__keyed_blocks', { instructions: [{ id: 'refunds', instructions: 'Refund on request.' }] }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'keyed_blocks', label: 'production' }),
+      instructions: [
+        {
+          role: 'system',
+          content: 'You are a refund specialist.',
+          providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+        },
+        {
+          role: 'system',
+          content: 'Always confirm the order total.',
+          providerOptions: { logfire: { id: 'refunds' } },
+        },
+      ],
+      prompt: 'hi',
+    })
+
+    // The declared id survives, the block keeps its position, and the cache breakpoint on the block
+    // ahead of it is exactly where the user put it.
+    expect(systemMessages(model)).toEqual([
+      {
+        role: 'system',
+        content: 'You are a refund specialist.',
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+      },
+      { role: 'system', content: 'Refund on request.', providerOptions: { logfire: { id: 'refunds' } } },
+    ])
+  })
+
+  it('drops a block whose override publishes no text', async () => {
+    useLocalVariables(publishedValue('agent__dropped_block', { instructions: [{ id: 'system:0' }] }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'dropped_block', label: 'production' }),
+      instructions: [
+        { role: 'system', content: 'Drop me.' },
+        { role: 'system', content: 'Keep me.' },
+      ],
+      prompt: 'hi',
+    })
+
+    expect(systemMessages(model)).toEqual([{ role: 'system', content: 'Keep me.' }])
+  })
+
+  it('adds a block at the end of the static group, ahead of a dynamic one', async () => {
+    useLocalVariables(publishedValue('agent__added_block', { instructions: 'Escalate anything over $500 to a human.' }))
+    const model = stubModel([textResult('one'), textResult('two')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'added_block',
+          model,
+          instructions: 'You are a concise assistant.',
+          prepareStep: () => ({
+            instructions: [
+              { role: 'system' as const, content: 'You are a concise assistant.' },
+              { role: 'system' as const, content: 'Tenant: acme.' },
+            ],
+          }),
+        },
+        label: 'production',
+      })
+    )
+    await agent.generate({ prompt: 'hi' })
+
+    expect(systemMessages(model)).toEqual([
+      { role: 'system', content: 'You are a concise assistant.' },
+      { role: 'system', content: 'Escalate anything over $500 to a human.' },
+      { role: 'system', content: 'Tenant: acme.' },
+    ])
+  })
+
+  it('adds a block to a request that carries no instructions at all', async () => {
+    useLocalVariables(publishedValue('agent__no_instructions', { instructions: 'Be brief.' }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'no_instructions', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Be brief.' })
+  })
+
+  it('refuses to address a block a per-request hook injected, and says why', async () => {
+    useLocalVariables(publishedValue('agent__dynamic_block', { instructions: [{ id: 'system:1', instructions: 'Tenant: pinned.' }] }))
+    let tenant = 'acme'
+    const model = stubModel([textResult('one'), textResult('two')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'dynamic_block',
+          model,
+          instructions: 'You are a concise assistant.',
+          prepareStep: () => ({
+            instructions: [
+              { role: 'system' as const, content: 'You are a concise assistant.' },
+              { role: 'system' as const, content: `Tenant: ${tenant}.` },
+            ],
+          }),
+        },
+        label: 'production',
+      })
+    )
+    await agent.generate({ prompt: 'hi' })
+    tenant = 'globex'
+    await agent.generate({ prompt: 'hi again' })
+
+    expect(systemMessages(model, 1)).toEqual([
+      { role: 'system', content: 'You are a concise assistant.' },
+      { role: 'system', content: 'Tenant: globex.' },
+    ])
+    expect(warnings.messages).toContainEqual(expect.stringContaining('recomputes'))
+  })
+
+  it('learns the code-side text from the first request when nothing was declared', async () => {
+    useLocalVariables(publishedValue('agent__learned', { instructions: [{ id: 'system:0', instructions: 'Managed.' }] }))
+    const model = stubModel([textResult('one'), textResult('two')])
+    const managed = agentControl({ model, name: 'learned', label: 'production' })
+    await generateText({ model: managed, instructions: 'Code text.', prompt: 'hi' })
+    // A second request whose block matches what the first carried is still static, so still managed.
+    await generateText({ model: managed, instructions: 'Code text.', prompt: 'hi' })
+
+    expect(systemMessages(model, 1)).toEqual([{ role: 'system', content: 'Managed.' }])
+  })
+
+  it('reports an id no block carries, and fails the run when told to', async () => {
+    useLocalVariables(publishedValue('agent__unmatched_id', { instructions: [{ id: 'nope', instructions: 'Unreachable.' }] }))
+    const model = stubModel([textResult('ok'), textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'unmatched_id', label: 'production' }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+    })
+    expect(warnings.messages).toContainEqual(expect.stringContaining("instruction block 'nope'"))
+
+    await expect(
+      generateText({
+        model: agentControl({ model, name: 'unmatched_id', label: 'production', onUnmatched: 'error' }),
+        instructions: 'Be brief.',
+        prompt: 'hi',
+      })
+    ).rejects.toBeInstanceOf(UnmatchedConfigError)
+  })
+
+  it('runs on code when Logfire is unavailable', async () => {
+    useNoVariables()
+    const model = stubModel([textResult('ok')])
+    const { text } = await generateText({
+      model: agentControl({ model, name: 'unavailable' }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('ok')
+    expect(systemMessages(model)).toEqual([{ role: 'system', content: 'Be brief.' }])
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/instructions.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/instructions.test.ts
@@ -153,6 +153,48 @@ describe('instructions', () => {
     expect(warnings.messages).toContainEqual(expect.stringContaining('recomputes'))
   })
 
+  it('keeps both messages when two of them declare the same id', async () => {
+    useLocalVariables(publishedValue('agent__duplicate_ids', { instructions: [{ id: 'policy', instructions: 'One policy.' }] }))
+    const model = stubModel([textResult('ok')])
+    const block = (content: string) => ({
+      role: 'system' as const,
+      content,
+      providerOptions: { logfire: { id: 'policy' } },
+    })
+    await generateText({
+      model: agentControl({ model, name: 'duplicate_ids', label: 'production' }),
+      instructions: [block('Refund on request.'), block('Escalate anything over $500.')],
+      prompt: 'hi',
+    })
+
+    // Both messages carry one id, so the override addresses both -- and, above all, neither message
+    // is dropped from the prompt on the way back into it.
+    expect(systemMessages(model)).toEqual([block('One policy.'), block('One policy.')])
+  })
+
+  it('protects an injected block from the first request when the agent declares no instructions at all', async () => {
+    useLocalVariables(publishedValue('agent__empty_declaration', { instructions: [{ id: 'system:0', instructions: 'Tenant: pinned.' }] }))
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'empty_declaration',
+          model,
+          // Declared, and empty: every system message this agent sends comes from its hook.
+          instructions: [],
+          prepareStep: () => ({ instructions: [{ role: 'system' as const, content: 'Tenant: acme.' }] }),
+        },
+        label: 'production',
+      })
+    )
+    await agent.generate({ prompt: 'hi' })
+
+    // An empty declaration is a declaration. Reading it as "nothing was declared" would leave the
+    // first request with nothing to compare against and pin one tenant's text.
+    expect(systemMessages(model)).toEqual([{ role: 'system', content: 'Tenant: acme.' }])
+    expect(warnings.messages).toContainEqual(expect.stringContaining('recomputes'))
+  })
+
   it('learns the code-side text from the first request when nothing was declared', async () => {
     useLocalVariables(publishedValue('agent__learned', { instructions: [{ id: 'system:0', instructions: 'Managed.' }] }))
     const model = stubModel([textResult('one'), textResult('two')])

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/live.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/live.test.ts
@@ -1,0 +1,404 @@
+/**
+ * What a real provider does with a managed config, recorded once and replayed offline.
+ *
+ * The rest of the suite drives the real AI SDK against a stub model, which proves what this adapter
+ * puts on a request. It cannot prove what happens next -- whether a provider accepts a setting,
+ * whether a model actually obeys a published instruction, whether a renamed tool comes back under
+ * the name the README promises. Every such claim was read off provider source until these tests;
+ * three of them turned out to be wrong, and the README's editability table now says so.
+ *
+ * Recorded with `node scripts/record-live-cassettes.mjs --env-file <path>`; see `cassette.ts` for the
+ * recorder and what it stores. Replays need no credentials and make no network call.
+ */
+
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateText, stepCountIs, streamText, tool } from 'ai'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { agentControl } from '../index'
+import type { Cassette } from './cassette'
+import { apiKey, cassette } from './cassette'
+import { captureWarnings, publishedValue, useLocalVariables } from './helpers'
+
+/** Recording talks to a real model over the network; replaying takes milliseconds. */
+const LIVE_TIMEOUT = 120_000
+
+/**
+ * The cheapest current model of each provider that can still do everything under test.
+ *
+ * Each id was checked against its provider package's own model-id union rather than recalled: an id
+ * the union does not list still typechecks, because every one of them ends in `(string & {})`.
+ */
+const OPENAI_MODEL = 'gpt-5.4-nano'
+const ANTHROPIC_MODEL = 'claude-haiku-4-5'
+const GOOGLE_MODEL = 'gemini-3.5-flash-lite'
+
+// The AI SDK prints an `unsupported` warning to stderr for every setting a provider drops. These
+// tests assert on that list instead, so the console copy is only noise.
+;(globalThis as { AI_SDK_LOG_WARNINGS?: boolean }).AI_SDK_LOG_WARNINGS = false
+
+const warnings = captureWarnings()
+
+const weather = tool({
+  description: 'Get the current weather for a city.',
+  inputSchema: z.object({ city: z.string().describe('City name, e.g. `London`.') }),
+  execute: async ({ city }: { city: string }) => Promise.resolve(`sunny in ${city}`),
+})
+
+/** The rename, the reworded description, and the reworded parameter description, in one override. */
+const RENAME = {
+  tool_definitions: [
+    {
+      name: 'get_weather',
+      new_name: 'lookup_weather',
+      description: 'Look up the current weather for a city.',
+      parameters: { city: { description: "City name, e.g. 'London'." } },
+    },
+  ],
+}
+
+/** Every canonical setting a request can carry, so each provider's answer covers the whole table. */
+const EVERY_SETTING = {
+  max_tokens: 256,
+  temperature: 0.1,
+  top_p: 0.9,
+  top_k: 20,
+  seed: 7,
+  presence_penalty: 0.1,
+  frequency_penalty: 0.2,
+  stop_sequences: ['STOP'],
+  thinking: 'low',
+  parallel_tool_calls: false,
+  timeout: 60,
+}
+
+function openaiModel(tape: Cassette): ReturnType<ReturnType<typeof createOpenAI>> {
+  return createOpenAI({ apiKey: apiKey('OPENAI_API_KEY'), fetch: tape.fetch })(OPENAI_MODEL)
+}
+
+function anthropicModel(tape: Cassette): ReturnType<ReturnType<typeof createAnthropic>> {
+  return createAnthropic({ apiKey: apiKey('ANTHROPIC_API_KEY'), fetch: tape.fetch })(ANTHROPIC_MODEL)
+}
+
+function googleModel(tape: Cassette): ReturnType<ReturnType<typeof createGoogleGenerativeAI>> {
+  // `GEMINI_API_KEY` is the name the key is stored under; `@ai-sdk/google` looks for
+  // `GOOGLE_GENERATIVE_AI_API_KEY`, so it is passed rather than left to the provider's own lookup.
+  return createGoogleGenerativeAI({ apiKey: apiKey('GEMINI_API_KEY'), fetch: tape.fetch })(GOOGLE_MODEL)
+}
+
+/** The n-th request body a cassette saw, as a bag this file can read keys out of. */
+function sent(tape: Cassette, n = 0): Record<string, unknown> {
+  return tape.requests()[n] as Record<string, unknown>
+}
+
+/** The `unsupported` features a provider reported for a call, which is its own list of what it dropped. */
+function unsupported(list: readonly { type: string; feature?: string }[] | undefined): string[] {
+  return (list ?? []).flatMap((entry) => (entry.type === 'unsupported' && entry.feature !== undefined ? [entry.feature] : []))
+}
+
+describe('live providers', () => {
+  it(
+    'sends a published instruction block to a real model, which obeys it',
+    async () => {
+      const tape = cassette('openai-instructions')
+      useLocalVariables(
+        publishedValue('agent__live_instructions', {
+          instructions: [{ id: 'system:0', instructions: 'Reply with exactly one word: BANANA. No punctuation.' }],
+        })
+      )
+
+      const { text } = await generateText({
+        model: agentControl({
+          model: openaiModel(tape),
+          name: 'live_instructions',
+          label: 'production',
+          publishBaseline: false,
+          codeInstructions: 'You are a helpful assistant. Always answer in a full sentence.',
+        }),
+        instructions: 'You are a helpful assistant. Always answer in a full sentence.',
+        prompt: 'What is the capital of France?',
+        maxRetries: 0,
+      })
+
+      // The published text is what the provider was sent, in place of the code's own.
+      expect(sent(tape)['input']).toEqual([
+        { role: 'developer', content: 'Reply with exactly one word: BANANA. No punctuation.' },
+        { role: 'user', content: [{ type: 'input_text', text: 'What is the capital of France?' }] },
+      ])
+      // And it is what the model did, rather than the full sentence the code asked for.
+      expect(text).toBe('BANANA')
+    },
+    LIVE_TIMEOUT
+  )
+
+  it(
+    'renames a tool for a real model and un-renames it on the way back through `wrapGenerate`',
+    async () => {
+      const tape = cassette('anthropic-tools-generate')
+      useLocalVariables(publishedValue('agent__live_tools_generate', RENAME))
+      const executed: string[] = []
+
+      const result = await generateText({
+        model: agentControl({
+          model: anthropicModel(tape),
+          name: 'live_tools_generate',
+          label: 'production',
+          publishBaseline: false,
+        }),
+        instructions: 'You are a helpful assistant.',
+        prompt: 'What is the weather in London? Use the tool.',
+        tools: {
+          get_weather: tool({
+            description: 'Get the current weather for a city.',
+            inputSchema: z.object({ city: z.string().describe('City name, e.g. `London`.') }),
+            execute: async ({ city }: { city: string }) => {
+              executed.push(city)
+              return Promise.resolve(`sunny in ${city}`)
+            },
+          }),
+        },
+        stopWhen: stepCountIs(3),
+        maxRetries: 0,
+      })
+
+      // The model is offered the managed name, the managed description, and the managed parameter
+      // description -- all three, on one real request.
+      expect(sent(tape)['tools']).toEqual([
+        {
+          name: 'lookup_weather',
+          description: 'Look up the current weather for a city.',
+          input_schema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: { city: { type: 'string', description: "City name, e.g. 'London'." } },
+            required: ['city'],
+            additionalProperties: false,
+          },
+        },
+      ])
+
+      // It called that name, and the code-side implementation ran with the arguments it sent.
+      expect(executed).toEqual(['London'])
+
+      // The next turn's history carries the managed name too, so the model is never shown a call to a
+      // tool this request does not advertise.
+      const history = sent(tape, 1)['messages'] as { role: string; content: { type: string; name?: string }[] }[]
+      expect(history[1]?.content[0]).toMatchObject({ type: 'tool_use', name: 'lookup_weather' })
+      expect(history[2]?.content[0]).toMatchObject({ type: 'tool_result' })
+
+      // What the application sees is its own name, everywhere.
+      expect(result.steps.flatMap((step) => step.content.flatMap((part) => ('toolName' in part ? [part.toolName] : [])))).toEqual([
+        'get_weather',
+        'get_weather',
+      ])
+      expect(result.text).toContain('sunny')
+    },
+    LIVE_TIMEOUT
+  )
+
+  it('renames a tool for a real model and un-renames it on the way back through `wrapStream`', async () => {
+    const tape = cassette('anthropic-tools-stream')
+    useLocalVariables(publishedValue('agent__live_tools_stream', RENAME))
+
+    const stream = streamText({
+      model: agentControl({
+        model: anthropicModel(tape),
+        name: 'live_tools_stream',
+        label: 'production',
+        publishBaseline: false,
+      }),
+      instructions: 'You are a helpful assistant.',
+      prompt: 'What is the weather in London? Use the tool.',
+      tools: { get_weather: weather },
+      stopWhen: stepCountIs(3),
+      maxRetries: 0,
+    })
+
+    const names: string[] = []
+    for await (const part of stream.fullStream) {
+      if ('toolName' in part) {
+        names.push(part.toolName)
+      }
+    }
+
+    // Every streamed part that names a tool names the code-side one, and the request that produced
+    // them advertised the managed one.
+    expect(new Set(names)).toEqual(new Set(['get_weather']))
+    expect((sent(tape)['tools'] as { name: string }[])[0]?.name).toBe('lookup_weather')
+    const history = sent(tape, 1)['messages'] as { content: { type: string; name?: string }[] }[]
+    expect(history[1]?.content[0]).toMatchObject({ type: 'tool_use', name: 'lookup_weather' })
+    expect(await stream.text).toContain('sunny')
+  })
+
+  // The point of these three: the adapter lowers all eleven canonical settings onto a request, and
+  // what a *provider* then does with them is not the same question. Each of these records the answer.
+  it(
+    "applies the settings OpenAI's Responses API honours, and records the ones it drops",
+    async () => {
+      const tape = cassette('openai-settings')
+      useLocalVariables(publishedValue('agent__live_openai_settings', { settings: EVERY_SETTING }))
+
+      const result = await generateText({
+        model: agentControl({
+          model: openaiModel(tape),
+          name: 'live_openai_settings',
+          label: 'production',
+          publishBaseline: false,
+          codeInstructions: 'You are a helpful assistant.',
+          codeSettings: { temperature: 0.5 },
+        }),
+        instructions: 'You are a helpful assistant.',
+        prompt: 'What is the capital of France?',
+        maxRetries: 0,
+      })
+
+      expect(sent(tape)['max_output_tokens']).toBe(256)
+      expect(sent(tape)['parallel_tool_calls']).toBe(false)
+      // `thinking: 'low'` reaches a v4 provider as an effort level and is accepted.
+      expect(sent(tape)['reasoning']).toMatchObject({ effort: 'low' })
+      // Everything else is dropped by the provider, not by this adapter: the AI SDK reports it on the
+      // result, and Agent Control's own `onUnmatched` never sees it. See the README's known limits.
+      expect(unsupported(result.warnings).sort()).toEqual([
+        'frequencyPenalty',
+        'presencePenalty',
+        'seed',
+        'stopSequences',
+        'temperature',
+        'topK',
+        'topP',
+      ])
+    },
+    LIVE_TIMEOUT
+  )
+
+  it(
+    'applies the settings Anthropic honours, and records what enabling thinking costs',
+    async () => {
+      const tape = cassette('anthropic-settings')
+      useLocalVariables(publishedValue('agent__live_anthropic_settings', { settings: EVERY_SETTING }))
+
+      const result = await generateText({
+        model: agentControl({
+          model: anthropicModel(tape),
+          name: 'live_anthropic_settings',
+          label: 'production',
+          publishBaseline: false,
+          codeInstructions: 'You are a helpful assistant.',
+          codeSettings: { temperature: 0.5 },
+        }),
+        instructions: 'You are a helpful assistant.',
+        prompt: 'What is the capital of France?',
+        maxRetries: 0,
+      })
+
+      expect(sent(tape)['stop_sequences']).toEqual(['STOP'])
+      expect(sent(tape)['thinking']).toMatchObject({ type: 'enabled' })
+      // A published `max_tokens` of 256 is *not* what Anthropic is asked for: the AI SDK raises the
+      // ceiling to fit the thinking budget it derived from the same published `thinking`.
+      expect(sent(tape)['max_tokens']).toBe(6656)
+      expect(unsupported(result.warnings).sort()).toEqual(['frequencyPenalty', 'presencePenalty', 'seed', 'temperature', 'topK', 'topP'])
+    },
+    LIVE_TIMEOUT
+  )
+
+  it(
+    'applies every setting Gemini honours, which is the most of the three',
+    async () => {
+      const tape = cassette('google-settings')
+      useLocalVariables(
+        publishedValue('agent__live_google_settings', {
+          // The two Gemini rejects outright are left out here and tested on their own, below.
+          settings: { ...EVERY_SETTING, presence_penalty: undefined, frequency_penalty: undefined },
+        })
+      )
+
+      const result = await generateText({
+        model: agentControl({
+          model: googleModel(tape),
+          name: 'live_google_settings',
+          label: 'production',
+          publishBaseline: false,
+          codeInstructions: 'You are a helpful assistant.',
+          codeSettings: { temperature: 0.5 },
+        }),
+        instructions: 'You are a helpful assistant.',
+        prompt: 'What is the capital of France?',
+        maxRetries: 0,
+      })
+
+      expect(sent(tape)['generationConfig']).toEqual({
+        maxOutputTokens: 256,
+        temperature: 0.1,
+        topK: 20,
+        topP: 0.9,
+        stopSequences: ['STOP'],
+        seed: 7,
+        thinkingConfig: { thinkingLevel: 'low' },
+      })
+      expect(result.warnings).toEqual([])
+      // `parallel_tool_calls` has no Gemini field, which the adapter itself reports.
+      expect(warnings.messages).toContainEqual(expect.stringContaining("Managed agent config sets 'parallel_tool_calls'"))
+    },
+    LIVE_TIMEOUT
+  )
+
+  it(
+    'lets a published setting fail a Gemini request outright, which nothing here can prevent',
+    async () => {
+      const tape = cassette('google-penalties')
+      useLocalVariables(publishedValue('agent__live_google_penalties', { settings: { presence_penalty: 0.1 } }))
+
+      // The strongest counter-example to "a published value can only ever be ignored": Gemini answers
+      // 400 rather than dropping the field, so this published setting takes the agent down. It is in
+      // the README's known limits, and it is why `onUnmatched` is not the whole story.
+      await expect(
+        generateText({
+          model: agentControl({
+            model: googleModel(tape),
+            name: 'live_google_penalties',
+            label: 'production',
+            publishBaseline: false,
+            codeInstructions: 'You are a helpful assistant.',
+            codeSettings: {},
+          }),
+          instructions: 'You are a helpful assistant.',
+          prompt: 'What is the capital of France?',
+          maxRetries: 0,
+        })
+      ).rejects.toThrow(/Penalty is not enabled for this model/u)
+    },
+    LIVE_TIMEOUT
+  )
+
+  it(
+    'resolves a published `google:` model through the provider the contract names',
+    async () => {
+      const tape = cassette('google-model-swap')
+      useLocalVariables(publishedValue('agent__live_model_swap', { model: `google:${GOOGLE_MODEL}` }))
+      // Never called, and so never needs a key: the published model is what answers.
+      const code = createOpenAI({ apiKey: 'unused', fetch: tape.fetch })(OPENAI_MODEL)
+
+      const { text } = await generateText({
+        model: agentControl({
+          model: code,
+          name: 'live_model_swap',
+          label: 'production',
+          publishBaseline: false,
+          providers: { google: createGoogleGenerativeAI({ apiKey: apiKey('GEMINI_API_KEY'), fetch: tape.fetch }) },
+        }),
+        instructions: 'You are a helpful assistant.',
+        prompt: 'What is the capital of France? Answer in one word.',
+        maxRetries: 0,
+      })
+
+      expect(text).toContain('Paris')
+      // The one request this made went to Gemini, under the v2 spelling of its name.
+      expect(sent(tape)['systemInstruction']).toEqual({ parts: [{ text: 'You are a helpful assistant.' }] })
+      expect(warnings.messages).toContainEqual(expect.stringContaining(`in place of the code-defined 'openai:${OPENAI_MODEL}'`))
+    },
+    LIVE_TIMEOUT
+  )
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/model.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/model.test.ts
@@ -1,0 +1,283 @@
+import type { ProviderV4 } from '@ai-sdk/provider'
+import { generateText, streamText } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { agentControl } from '../index'
+import { captureWarnings, publishedValue, stubModel, textResult, textStream, useLocalVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+/** A provider exposing exactly the models a test names, as `createProviderRegistry` takes one. */
+function providerOf(models: Record<string, ReturnType<typeof stubModel>>): ProviderV4 {
+  return {
+    specificationVersion: 'v4',
+    languageModel: (modelId: string) => {
+      const model = models[modelId]
+      if (model === undefined) {
+        throw new Error(`no such model '${modelId}'`)
+      }
+      return model
+    },
+    embeddingModel: () => {
+      throw new Error('not implemented')
+    },
+    imageModel: () => {
+      throw new Error('not implemented')
+    },
+  } as unknown as ProviderV4
+}
+
+describe('model', () => {
+  it("resolves a managed 'provider:model' through the registry the caller passed", async () => {
+    useLocalVariables(publishedValue('agent__swapped', { model: 'openai:gpt-5.6-sol' }))
+    const code = stubModel([textResult('from code')])
+    const managed = stubModel([textResult('from managed')], 'openai.responses', 'gpt-5.6-sol')
+    const { text } = await generateText({
+      model: agentControl({
+        model: code,
+        name: 'swapped',
+        label: 'production',
+        providers: { openai: providerOf({ 'gpt-5.6-sol': managed }) },
+      }),
+      instructions: 'Be brief.',
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from managed')
+    // The transformed request went to the managed model, and the code model was never called.
+    expect(managed.doGenerateCalls[0]?.prompt[0]).toEqual({ role: 'system', content: 'Be brief.' })
+    expect(code.doGenerateCalls).toEqual([])
+    expect(warnings.messages).toContainEqual(expect.stringContaining('in place of the code-defined'))
+  })
+
+  it('swaps the model for a streaming request too', async () => {
+    useLocalVariables(publishedValue('agent__swapped_stream', { model: 'openai:gpt-5.6-sol' }))
+    const code = stubModel([textStream('from code')])
+    const managed = stubModel([textStream('from managed')], 'openai.responses', 'gpt-5.6-sol')
+    const stream = streamText({
+      model: agentControl({
+        model: code,
+        name: 'swapped_stream',
+        label: 'production',
+        providers: { openai: providerOf({ 'gpt-5.6-sol': managed }) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(await stream.text).toBe('from managed')
+    expect(code.doStreamCalls).toEqual([])
+  })
+
+  it('prefers a caller-supplied resolver, and resolves each id once', async () => {
+    useLocalVariables(publishedValue('agent__custom_resolver', { model: 'acme:big' }))
+    const code = stubModel([textResult('one'), textResult('two')])
+    const managed = stubModel([textResult('managed'), textResult('managed again')], 'acme.chat', 'big')
+    const seen: string[] = []
+    const model = agentControl({
+      model: code,
+      name: 'custom_resolver',
+      label: 'production',
+      resolveModel: (id) => {
+        seen.push(id)
+        return managed
+      },
+    })
+
+    await generateText({ model, prompt: 'hi' })
+    await generateText({ model, prompt: 'hi again' })
+
+    expect(managed.doGenerateCalls).toHaveLength(2)
+    // Memoized: a provider's model object is meant to be built once and reused.
+    expect(seen).toEqual(['acme:big'])
+  })
+
+  it('falls back to the provider a bare string model would have gone through', async () => {
+    useLocalVariables(publishedValue('agent__gateway_fallback', { model: 'anthropic:claude-fable-5-1' }))
+    const managed = stubModel([textResult('from the gateway')], 'gateway', 'anthropic/claude-fable-5-1')
+    const seen: string[] = []
+    const previous = (globalThis as { AI_SDK_DEFAULT_PROVIDER?: unknown }).AI_SDK_DEFAULT_PROVIDER
+    ;(globalThis as { AI_SDK_DEFAULT_PROVIDER?: ProviderV4 }).AI_SDK_DEFAULT_PROVIDER = {
+      specificationVersion: 'v4',
+      languageModel: (modelId: string) => {
+        seen.push(modelId)
+        return managed
+      },
+    } as unknown as ProviderV4
+    try {
+      const { text } = await generateText({
+        model: agentControl({
+          model: stubModel([textResult('from code')]),
+          name: 'gateway_fallback',
+          label: 'production',
+        }),
+        prompt: 'hi',
+      })
+      expect(text).toBe('from the gateway')
+      // The contract's ':' becomes the gateway's '/', which is the same identifier.
+      expect(seen).toEqual(['anthropic/claude-fable-5-1'])
+    } finally {
+      ;(globalThis as { AI_SDK_DEFAULT_PROVIDER?: unknown }).AI_SDK_DEFAULT_PROVIDER = previous
+    }
+  })
+
+  it('keeps the code-defined model when a managed string names no provider', async () => {
+    useLocalVariables(publishedValue('agent__unqualified', { model: 'gpt-5.6-sol' }))
+    const code = stubModel([textResult('from code')])
+    const { text } = await generateText({
+      model: agentControl({ model: code, name: 'unqualified', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from code')
+    expect(warnings.messages).toContainEqual(expect.stringContaining("not in 'provider:model' form"))
+  })
+
+  it('keeps the code-defined model when a managed string resolves to nothing', async () => {
+    useLocalVariables(publishedValue('agent__unresolvable', { model: 'openai:no-such-model' }))
+    const code = stubModel([textResult('from code')])
+    const { text } = await generateText({
+      model: agentControl({
+        model: code,
+        name: 'unresolvable',
+        label: 'production',
+        providers: { openai: providerOf({}) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from code')
+    expect(warnings.messages).toContainEqual(expect.stringContaining('could not be resolved'))
+  })
+
+  it('treats a resolver that declines an id as the answer, rather than as a first guess', async () => {
+    useLocalVariables(publishedValue('agent__declined', { model: 'anthropic:claude-fable-5-1' }))
+    const code = stubModel([textResult('from code')])
+    const other = stubModel([textResult('from the registry')], 'anthropic.messages', 'claude-fable-5-1')
+    const { text } = await generateText({
+      model: agentControl({
+        model: code,
+        name: 'declined',
+        label: 'production',
+        resolveModel: () => undefined,
+        // Reachable, and deliberately never reached: a resolver that says no is not overruled by the
+        // registry behind its back.
+        providers: { anthropic: providerOf({ 'claude-fable-5-1': other }) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from code')
+    expect(other.doGenerateCalls).toEqual([])
+    expect(warnings.messages).toContainEqual(expect.stringContaining('declined to build'))
+  })
+
+  it('resolves a provider the contract and the AI SDK spell differently', async () => {
+    useLocalVariables(publishedValue('agent__vertex', { model: 'google-cloud:gemini-3-pro' }))
+    const managed = stubModel([textResult('from vertex')], 'google.vertex.chat', 'gemini-3-pro')
+    const { text } = await generateText({
+      model: agentControl({
+        model: stubModel([textResult('from code')]),
+        name: 'vertex',
+        label: 'production',
+        // The registry is keyed the way `@ai-sdk/google-vertex` exports its provider, which is not
+        // the name the contract publishes the same provider under.
+        providers: { vertex: providerOf({ 'gemini-3-pro': managed }) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from vertex')
+  })
+
+  // Pydantic AI v1's names for the two halves of Google. They were removed in v2 in favour of
+  // `google` and `google-cloud`, and a config published against a v1-era agent still carries them.
+  it.each([
+    ['google-gla', 'google', 'legacy_gemini'],
+    ['google-vertex', 'vertex', 'legacy_vertex'],
+  ])('accepts the legacy name %s as the AI SDK %s', async (legacy, registered, agent) => {
+    useLocalVariables(publishedValue(`agent__${agent}`, { model: `${legacy}:gemini-3-pro` }))
+    const managed = stubModel([textResult('from the managed model')], 'google.generative-ai', 'gemini-3-pro')
+    const { text } = await generateText({
+      model: agentControl({
+        model: stubModel([textResult('from code')]),
+        name: agent,
+        label: 'production',
+        providers: { [registered]: providerOf({ 'gemini-3-pro': managed }) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from the managed model')
+  })
+
+  it('lets a registry key answer for a provider name exactly as the caller wrote it', async () => {
+    useLocalVariables(publishedValue('agent__vertex_registered', { model: 'google-cloud:gemini-3-pro' }))
+    const managed = stubModel([textResult('from vertex')], 'google.vertex.chat', 'gemini-3-pro')
+    const { text } = await generateText({
+      model: agentControl({
+        model: stubModel([textResult('from code')]),
+        name: 'vertex_registered',
+        label: 'production',
+        // Read before the translation table, so a caller who registered the contract's own name gets
+        // that provider rather than the one this adapter would have translated the name into.
+        providers: { 'google-cloud': providerOf({ 'gemini-3-pro': managed }) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(text).toBe('from vertex')
+  })
+
+  it('reports a provider nothing registered answers to rather than reaching a neighbouring one', async () => {
+    useLocalVariables(publishedValue('agent__unknown_provider', { model: 'moonshotai:kimi-k3' }))
+    const wrong = stubModel([textResult('from the wrong provider')], 'google.generative-ai', 'gemini-3-pro')
+    const { text } = await generateText({
+      model: agentControl({
+        model: stubModel([textResult('from code')]),
+        name: 'unknown_provider',
+        label: 'production',
+        providers: { google: providerOf({ 'gemini-3-pro': wrong }) },
+      }),
+      prompt: 'hi',
+    })
+
+    // An untranslated name is forwarded as it stands, so a provider package released tomorrow works
+    // on the day it lands -- and one nothing serves fails at resolution, under the caller's
+    // `onUnmatched` policy, rather than by a different backend answering.
+    expect(text).toBe('from code')
+    expect(wrong.doGenerateCalls).toEqual([])
+    expect(warnings.messages).toContainEqual(expect.stringContaining('could not be resolved'))
+  })
+
+  it('fails the run under `error` rather than reporting the refusal a second time', async () => {
+    useLocalVariables(publishedValue('agent__strict_model', { model: 'gpt-5.6-sol' }))
+    await expect(
+      generateText({
+        model: agentControl({
+          model: stubModel([textResult('from code')]),
+          name: 'strict_model',
+          label: 'production',
+          onUnmatched: 'error',
+        }),
+        prompt: 'hi',
+      })
+    ).rejects.toThrow(/not in 'provider:model' form/u)
+  })
+
+  it('says nothing when the managed model is the one the code already names', async () => {
+    useLocalVariables(publishedValue('agent__same_model', { model: 'anthropic:claude-fable-5-1' }))
+    const code = stubModel([textResult('ok')])
+    const managed = stubModel([textResult('ok')], 'anthropic.messages', 'claude-fable-5-1')
+    await generateText({
+      model: agentControl({
+        model: code,
+        name: 'same_model',
+        label: 'production',
+        providers: { anthropic: providerOf({ 'claude-fable-5-1': managed }) },
+      }),
+      prompt: 'hi',
+    })
+
+    expect(warnings.messages).not.toContainEqual(expect.stringContaining('in place of the code-defined'))
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/model.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/model.test.ts
@@ -91,6 +91,33 @@ describe('model', () => {
     expect(seen).toEqual(['acme:big'])
   })
 
+  it('resolves an id once even when two requests reach it at the same time', async () => {
+    useLocalVariables(publishedValue('agent__concurrent', { model: 'acme:big' }))
+    const code = stubModel([textResult('one'), textResult('two')])
+    const managed = stubModel([textResult('managed'), textResult('managed again')], 'acme.chat', 'big')
+    const seen: string[] = []
+    const model = agentControl({
+      model: code,
+      name: 'concurrent',
+      label: 'production',
+      resolveModel: async (id) => {
+        seen.push(id)
+        // A provider factory that awaits anything -- credentials, a discovery call -- leaves a
+        // window in which a second request arrives before the first has an answer to cache.
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5)
+        })
+        return managed
+      },
+    })
+
+    await Promise.all([generateText({ model, prompt: 'hi' }), generateText({ model, prompt: 'hi again' })])
+
+    expect(managed.doGenerateCalls).toHaveLength(2)
+    // One model object for one id, however many requests are in flight when it is first asked for.
+    expect(seen).toEqual(['acme:big'])
+  })
+
   it('falls back to the provider a bare string model would have gone through', async () => {
     useLocalVariables(publishedValue('agent__gateway_fallback', { model: 'anthropic:claude-fable-5-1' }))
     const managed = stubModel([textResult('from the gateway')], 'gateway', 'anthropic/claude-fable-5-1')

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/settings.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/settings.test.ts
@@ -1,0 +1,331 @@
+import { generateText, ToolLoopAgent, wrapLanguageModel } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { agentControl, agentControlMiddleware } from '../index'
+import { captureWarnings, legacyModel, publishedValue, stubModel, textResult, useLocalVariables } from './helpers'
+
+const warnings = captureWarnings()
+
+describe('settings', () => {
+  it('lowers every canonical key onto the AI SDK call option that carries it', async () => {
+    useLocalVariables(
+      publishedValue('agent__all_settings', {
+        settings: {
+          max_tokens: 2048,
+          temperature: 0.4,
+          top_p: 0.9,
+          top_k: 40,
+          seed: 7,
+          presence_penalty: 0.1,
+          frequency_penalty: 0.2,
+          stop_sequences: ['STOP'],
+          thinking: 'high',
+        },
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'all_settings', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]).toMatchObject({
+      maxOutputTokens: 2048,
+      temperature: 0.4,
+      topP: 0.9,
+      topK: 40,
+      seed: 7,
+      presencePenalty: 0.1,
+      frequencyPenalty: 0.2,
+      stopSequences: ['STOP'],
+      reasoning: 'high',
+    })
+  })
+
+  it.each([
+    [true, 'provider-default', 'thinking_on'],
+    [false, 'none', 'thinking_off'],
+  ] as const)("maps `thinking: %s` onto the reasoning enum's '%s'", async (thinking, reasoning, name) => {
+    useLocalVariables(publishedValue(`agent__${name}`, { settings: { thinking } }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name, label: 'production' }),
+      prompt: 'hi',
+    })
+    expect(model.doGenerateCalls[0]?.reasoning).toBe(reasoning)
+  })
+
+  it('turns `timeout` into an abort signal that composes with the run\u2019s own', async () => {
+    useLocalVariables(publishedValue('agent__timeout', { settings: { timeout: 30 } }))
+    const controller = new AbortController()
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'timeout', label: 'production' }),
+      prompt: 'hi',
+      abortSignal: controller.signal,
+    })
+
+    const signal = model.doGenerateCalls[0]?.abortSignal
+    expect(signal?.aborted).toBe(false)
+    // Composed rather than replaced: the run's own cancellation still reaches the provider.
+    controller.abort()
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('arms `timeout` in seconds, on its own when the run passed no signal', async () => {
+    // Real timers: `AbortSignal.timeout` is a host timer that a fake clock does not drive.
+    useLocalVariables({
+      variables: {
+        ...publishedValue('agent__timeout_alone', { settings: { timeout: 0.02 } }).variables,
+        ...publishedValue('agent__timeout_seconds', { settings: { timeout: 20 } }).variables,
+      },
+    })
+    const quick = stubModel([textResult('ok')])
+    const slow = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model: quick, name: 'timeout_alone', label: 'production' }),
+      prompt: 'hi',
+    })
+    await generateText({
+      model: agentControl({ model: slow, name: 'timeout_seconds', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 60)
+    })
+    // 0.02s is 20ms and has fired; 20s is not 20ms and has not.
+    expect(quick.doGenerateCalls[0]?.abortSignal?.aborted).toBe(true)
+    expect(slow.doGenerateCalls[0]?.abortSignal?.aborted).toBe(false)
+  })
+
+  it.each([
+    ['openai', 'openai.responses', { openai: { parallelToolCalls: false } }],
+    ['anthropic', 'anthropic.messages', { anthropic: { disableParallelToolUse: true } }],
+  ] as const)("lowers `parallel_tool_calls` through %s's own option", async (namespace, provider, expected) => {
+    const name = `parallel_${namespace}`
+    useLocalVariables(publishedValue(`agent__${name}`, { settings: { parallel_tool_calls: false } }))
+    const model = stubModel([textResult('ok')], provider, 'a-model')
+    await generateText({
+      model: agentControl({ model, name, label: 'production' }),
+      prompt: 'hi',
+      providerOptions: { [namespace]: { user: 'someone' } },
+    })
+
+    expect(model.doGenerateCalls[0]?.providerOptions).toMatchObject(expected)
+    // Whatever the code already set under that provider survives.
+    expect(model.doGenerateCalls[0]?.providerOptions?.[namespace]?.['user']).toBe('someone')
+  })
+
+  it('reports `parallel_tool_calls` against a provider with no knob for it', async () => {
+    useLocalVariables(publishedValue('agent__parallel_other', { settings: { parallel_tool_calls: true } }))
+    const model = stubModel([textResult('ok')], 'cohere.chat', 'command')
+    await generateText({
+      model: agentControl({ model, name: 'parallel_other', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.providerOptions).toBeUndefined()
+    expect(warnings.messages).toContainEqual(expect.stringContaining("'parallel_tool_calls'"))
+  })
+
+  it('reports a settings key this SDK has no field for', async () => {
+    useLocalVariables(publishedValue('agent__unknown_setting', { settings: { logit_bias: { a: 1 } } }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'unknown_setting', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(warnings.messages).toContainEqual(expect.stringContaining("'logit_bias'"))
+  })
+
+  it('lets a per-call value beat the published one, and the published one beat the code', async () => {
+    useLocalVariables(publishedValue('agent__precedence', { settings: { temperature: 0.4, max_tokens: 2048 } }))
+    const model = stubModel([textResult('one'), textResult('two')])
+    // `settings` is what the code declares. A request field that differs from it was set for this
+    // run, and this run wins; a field that matches was inherited, and the published value wins.
+    const managed = agentControl({
+      model,
+      name: 'precedence',
+      label: 'production',
+      codeSettings: { temperature: 0.1, maxOutputTokens: 100 },
+    })
+
+    await generateText({ model: managed, prompt: 'hi', temperature: 0.1, maxOutputTokens: 100 })
+    expect(model.doGenerateCalls[0]).toMatchObject({ temperature: 0.4, maxOutputTokens: 2048 })
+
+    await generateText({ model: managed, prompt: 'hi', temperature: 0.9, maxOutputTokens: 100 })
+    expect(model.doGenerateCalls[1]).toMatchObject({ temperature: 0.9, maxOutputTokens: 2048 })
+  })
+
+  it("lets an agent's `prepareCall` override beat the published value", async () => {
+    useLocalVariables(publishedValue('agent__prepare_call', { settings: { temperature: 0.4, top_p: 0.5 } }))
+    const model = stubModel([textResult('ok')])
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'prepare_call',
+          model,
+          temperature: 0.1,
+          // The agent-level way to set something for one run, which is the only per-run seam a
+          // `ToolLoopAgent` call has for generation settings.
+          prepareCall: ({ options, ...rest }) => ({ ...rest, options, temperature: 0.9 }),
+        },
+        label: 'production',
+      })
+    )
+
+    await agent.generate({ prompt: 'hi' })
+    // `topP` was never declared in code, so the published value is all there is.
+    expect(model.doGenerateCalls[0]).toMatchObject({ temperature: 0.9, topP: 0.5 })
+  })
+
+  it("treats a per-call stop sequence list as this run's own", async () => {
+    useLocalVariables(publishedValue('agent__stop_precedence', { settings: { stop_sequences: ['MANAGED'] } }))
+    const model = stubModel([textResult('one'), textResult('two'), textResult('three'), textResult('four')])
+    const managed = agentControl({
+      model,
+      name: 'stop_precedence',
+      label: 'production',
+      codeSettings: { stopSequences: ['CODE'] },
+    })
+
+    await generateText({ model: managed, prompt: 'hi', stopSequences: ['CODE'] })
+    expect(model.doGenerateCalls[0]?.stopSequences).toEqual(['MANAGED'])
+
+    await generateText({ model: managed, prompt: 'hi', stopSequences: ['RUN'] })
+    expect(model.doGenerateCalls[1]?.stopSequences).toEqual(['RUN'])
+
+    // A list of a different length is this run's just as much as a different one of the same length.
+    await generateText({ model: managed, prompt: 'hi', stopSequences: ['CODE', 'AND MORE'] })
+    expect(model.doGenerateCalls[2]?.stopSequences).toEqual(['CODE', 'AND MORE'])
+  })
+
+  it("lets a `prepareCall` beat the published value, and cannot see one that re-sets the code's", async () => {
+    useLocalVariables(publishedValue('agent__prepare_call_precedence', { settings: { temperature: 0.8 } }))
+    const model = stubModel([textResult('one'), textResult('two')])
+    const changed = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'prepare_call_precedence',
+          model,
+          temperature: 0.2,
+          prepareCall: ({ options, ...rest }) => ({ ...rest, options, temperature: 0.5 }),
+        },
+        label: 'production',
+      })
+    )
+    const restated = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'prepare_call_precedence',
+          model,
+          temperature: 0.2,
+          // The one case this seam cannot see: a hook that asks for the value the code already had is
+          // byte for byte a hook that asked for nothing, and `prepareCall` spreads what it did not
+          // change, so there is no key set to compare either. Documented as a known limit.
+          prepareCall: ({ options, ...rest }) => ({ ...rest, options, temperature: 0.2 }),
+        },
+        label: 'production',
+      })
+    )
+
+    await changed.generate({ prompt: 'hi' })
+    expect(model.doGenerateCalls[0]?.temperature).toBe(0.5)
+
+    await restated.generate({ prompt: 'hi' })
+    expect(model.doGenerateCalls[1]?.temperature).toBe(0.8)
+  })
+
+  it('keeps a provider option this run set for itself', async () => {
+    useLocalVariables(publishedValue('agent__parallel_precedence', { settings: { parallel_tool_calls: false } }))
+    const model = stubModel([textResult('one'), textResult('two')], 'openai.responses', 'gpt-5.6-sol')
+    const agent = new ToolLoopAgent(
+      agentControl({
+        settings: {
+          id: 'parallel_precedence',
+          model,
+          prepareCall: ({ options, ...rest }) => ({
+            ...rest,
+            options,
+            providerOptions: { openai: { parallelToolCalls: true } },
+          }),
+        },
+        label: 'production',
+      })
+    )
+    const inherited = new ToolLoopAgent(agentControl({ settings: { id: 'parallel_precedence', model }, label: 'production' }))
+
+    await agent.generate({ prompt: 'hi' })
+    expect(model.doGenerateCalls[0]?.providerOptions).toEqual({ openai: { parallelToolCalls: true } })
+
+    await inherited.generate({ prompt: 'hi' })
+    expect(model.doGenerateCalls[1]?.providerOptions).toEqual({ openai: { parallelToolCalls: false } })
+  })
+
+  it('reports `thinking` against a model whose provider has no reasoning contract', async () => {
+    useLocalVariables(publishedValue('agent__legacy_thinking', { settings: { thinking: 'high', temperature: 0.3 } }))
+    const model = legacyModel('v3')
+    await generateText({
+      model: agentControl({ model, name: 'legacy_thinking', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    // `reasoning` is the one call option v4 added; `wrapLanguageModel` bridges an older model with a
+    // proxy that answers 'v4' and forwards, so applying it here would change nothing at all.
+    expect(model.calls[0]?.reasoning).toBeUndefined()
+    expect(model.calls[0]?.temperature).toBe(0.3)
+    expect(warnings.messages).toContainEqual(expect.stringContaining("'thinking'"))
+  })
+
+  it('assumes a v4 model when a hand-rolled middleware install does not say otherwise', async () => {
+    useLocalVariables(publishedValue('agent__assumed_v4', { settings: { thinking: 'high' } }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: wrapLanguageModel({
+        model,
+        middleware: agentControlMiddleware({ name: 'assumed_v4', label: 'production' }),
+      }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.reasoning).toBe('high')
+  })
+
+  it('arms a `timeout` too small to round to a whole millisecond', async () => {
+    useLocalVariables(publishedValue('agent__tiny_timeout', { settings: { timeout: 0.0005 } }))
+    const model = stubModel([textResult('ok')])
+    // Half a millisecond is not a delay `AbortSignal.timeout` accepts; the core rounds a positive
+    // budget up to 1ms rather than letting it throw before the request is made.
+    await generateText({
+      model: agentControl({ model, name: 'tiny_timeout', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.abortSignal).toBeDefined()
+  })
+
+  it('drops a `timeout` no request could be given, and says so', async () => {
+    useLocalVariables(publishedValue('agent__bad_timeout', { settings: { timeout: -1 } }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'bad_timeout', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.abortSignal).toBeUndefined()
+    expect(warnings.messages).toContainEqual(expect.stringContaining('not a budget a request can be given'))
+  })
+
+  it('publishes nothing under `settings` when the request carries none', async () => {
+    useLocalVariables(publishedValue('agent__no_settings', {}))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'no_settings', label: 'production' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.temperature).toBeUndefined()
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/telemetry.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/telemetry.test.ts
@@ -1,0 +1,74 @@
+import { context, propagation } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import { generateText, streamText } from 'ai'
+import { MockLanguageModelV4 } from 'ai/test'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { agentControl } from '../index'
+import { captureWarnings, publishedValue, textResult, textStream, useLocalVariables } from './helpers'
+
+captureWarnings()
+
+// Baggage only propagates through a registered context manager, which in an application is what
+// `logfire.configure()` installs. Registering one here is what makes the label observable at all.
+const contextManager = new AsyncLocalStorageContextManager()
+beforeAll(() => {
+  contextManager.enable()
+  context.setGlobalContextManager(contextManager)
+})
+afterAll(() => {
+  context.disable()
+  contextManager.disable()
+})
+
+/** The label the Logfire SDK put on the ambient context, as any span inside the run would carry it. */
+function resolvedLabel(variableName: string): string | undefined {
+  return propagation.getBaggage(context.active())?.getEntry(`logfire.variables.${variableName}`)?.value
+}
+
+/** A model that reports what the ambient context said while it was being called. */
+function labelReadingModel(variableName: string, seen: (string | undefined)[]): MockLanguageModelV4 {
+  return new MockLanguageModelV4({
+    provider: 'anthropic.messages',
+    modelId: 'claude-fable-5-1',
+    doGenerate: async () => {
+      seen.push(resolvedLabel(variableName))
+      return Promise.resolve(textResult('ok'))
+    },
+    doStream: async () => {
+      seen.push(resolvedLabel(variableName))
+      return Promise.resolve(textStream('ok'))
+    },
+  })
+}
+
+describe('telemetry', () => {
+  it('runs the model request inside the resolution, so a span says which value drove it', async () => {
+    useLocalVariables(publishedValue('agent__labelled', { instructions: 'Be brief.' }, 'production'))
+    const seen: (string | undefined)[] = []
+    await generateText({
+      model: agentControl({ model: labelReadingModel('agent__labelled', seen), name: 'labelled' }),
+      prompt: 'hi',
+    })
+    const stream = streamText({
+      model: agentControl({ model: labelReadingModel('agent__labelled', seen), name: 'labelled' }),
+      prompt: 'hi',
+    })
+    await stream.text
+
+    // The label the rollout chose, on both paths -- and gone again once the request is over.
+    expect(seen).toEqual(['production', 'production'])
+    expect(resolvedLabel('agent__labelled')).toBeUndefined()
+  })
+
+  it('says so when the agent is running on code rather than on a published value', async () => {
+    useLocalVariables()
+    const seen: (string | undefined)[] = []
+    await generateText({
+      model: agentControl({ model: labelReadingModel('agent__unlabelled', seen), name: 'unlabelled' }),
+      prompt: 'hi',
+    })
+
+    expect(seen).toEqual(['<code_default>'])
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/tools.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/tools.test.ts
@@ -87,6 +87,48 @@ describe('tool definitions', () => {
     expect(result.steps[0]?.content.map((part) => ('toolName' in part ? part.toolName : part.type))).toEqual(['get_weather', 'get_weather'])
   })
 
+  it('leaves a call to a tool name that is also an `Object.prototype` key as the string it is', async () => {
+    useLocalVariables(
+      publishedValue('agent__prototype_names', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }],
+      })
+    )
+    const model = stubModel([
+      {
+        ...textResult(''),
+        content: [
+          { type: 'tool-call' as const, toolCallId: 'call-0', toolName: 'lookup_weather', input: JSON.stringify({ city: 'Paris' }) },
+          // Never advertised, and a key every plain object inherits. On an ordinary routing table
+          // this reads back `Object.prototype.toString` and the name becomes a function.
+          { type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'toString', input: '{}' },
+        ],
+        finishReason: { unified: 'tool-calls' as const, raw: 'tool_use' },
+      },
+      textResult('sunny'),
+    ])
+    const result = await generateText({
+      model: agentControl({ model, name: 'prototype_names', label: 'production' }),
+      prompt: 'weather in Paris?',
+      stopWhen: stepCountIs(3),
+      tools: { get_weather: weather },
+    })
+
+    // Strings, in the order the step carries them: two calls, then the results. The point is that
+    // the unadvertised name is the string `'toString'` and not `Object.prototype.toString`.
+    expect(result.steps[0]?.content.flatMap((part) => ('toolName' in part ? [part.toolName] : []))).toEqual([
+      'get_weather',
+      'toString',
+      'toString',
+      'get_weather',
+    ])
+    // And the same on the way back out, where the history is re-renamed: the tool that was renamed
+    // carries its managed name and the unadvertised one is left exactly as the model wrote it.
+    const history = (model.doGenerateCalls[1]?.prompt ?? []).flatMap((message) =>
+      Array.isArray(message.content) ? message.content.flatMap((part) => ('toolName' in part ? [part.toolName] : [])) : []
+    )
+    expect(history.sort()).toEqual(['lookup_weather', 'lookup_weather', 'toString', 'toString'])
+  })
+
   it('re-renames the history the SDK writes back, so the model sees one consistent tool set', async () => {
     useLocalVariables(
       publishedValue('agent__renamed_history', {

--- a/packages/logfire-agent-control-ai-sdk/src/__test__/tools.test.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/__test__/tools.test.ts
@@ -1,0 +1,280 @@
+import type { LanguageModelV4FunctionTool } from '@ai-sdk/provider'
+import { generateText, stepCountIs, streamText, tool } from 'ai'
+import { z } from 'zod'
+import { describe, expect, it } from 'vitest'
+
+import { UnmatchedConfigError, agentControl } from '../index'
+import {
+  captureWarnings,
+  publishedValue,
+  stubModel,
+  textResult,
+  textStream,
+  toolCallResult,
+  toolCallStream,
+  useLocalVariables,
+} from './helpers'
+
+const warnings = captureWarnings()
+
+const executed: string[] = []
+const time = tool({
+  description: 'The current time.',
+  inputSchema: z.object({}),
+  execute: async () => Promise.resolve('noon'),
+})
+const weather = tool({
+  description: 'Get the current weather for a city.',
+  inputSchema: z.object({ city: z.string().describe('City to look up.') }),
+  execute: async ({ city }: { city: string }) => {
+    executed.push(city)
+    return Promise.resolve(`sunny in ${city}`)
+  },
+})
+
+/** The tools the model was actually shown on a given call. */
+function shownTools(model: { doGenerateCalls: { tools?: unknown[] }[] }, call = 0): LanguageModelV4FunctionTool[] {
+  return (model.doGenerateCalls[call]?.tools ?? []) as LanguageModelV4FunctionTool[]
+}
+
+describe('tool definitions', () => {
+  it('rewrites the description and the parameter descriptions the model is shown', async () => {
+    useLocalVariables(
+      publishedValue('agent__tool_text', {
+        tool_definitions: [
+          {
+            name: 'get_weather',
+            description: 'Look up the current weather for a city.',
+            parameters: { city: { description: "City name, e.g. 'London'." } },
+          },
+        ],
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'tool_text', label: 'production' }),
+      prompt: 'hi',
+      tools: { get_weather: weather },
+    })
+
+    const [shown] = shownTools(model)
+    expect(shown?.description).toBe('Look up the current weather for a city.')
+    expect(shown?.inputSchema.properties?.['city']).toMatchObject({ description: "City name, e.g. 'London'." })
+    // Structure other than the descriptions is code-defined and untouched.
+    expect(shown?.inputSchema.required).toEqual(['city'])
+  })
+
+  it('routes a call to a renamed tool back to the code implementation, with its arguments', async () => {
+    useLocalVariables(
+      publishedValue('agent__renamed', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }],
+      })
+    )
+    executed.length = 0
+    const model = stubModel([toolCallResult('lookup_weather', { city: 'Paris' }), textResult('sunny')])
+    const result = await generateText({
+      model: agentControl({ model, name: 'renamed', label: 'production' }),
+      prompt: 'weather in Paris?',
+      stopWhen: stepCountIs(3),
+      tools: { get_weather: weather },
+    })
+
+    expect(shownTools(model)[0]?.name).toBe('lookup_weather')
+    // The tool ran, with the arguments the model sent under the managed name.
+    expect(executed).toEqual(['Paris'])
+    expect(result.steps[0]?.toolResults).toEqual([expect.objectContaining({ toolName: 'get_weather', output: 'sunny in Paris' })])
+    // Nothing user-facing ever sees the managed name.
+    expect(result.steps[0]?.content.map((part) => ('toolName' in part ? part.toolName : part.type))).toEqual(['get_weather', 'get_weather'])
+  })
+
+  it('re-renames the history the SDK writes back, so the model sees one consistent tool set', async () => {
+    useLocalVariables(
+      publishedValue('agent__renamed_history', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }],
+      })
+    )
+    const model = stubModel([toolCallResult('lookup_weather', { city: 'Paris' }), textResult('sunny')])
+    await generateText({
+      model: agentControl({ model, name: 'renamed_history', label: 'production' }),
+      prompt: 'weather in Paris?',
+      stopWhen: stepCountIs(3),
+      tools: { get_weather: weather },
+    })
+
+    const second = model.doGenerateCalls[1]?.prompt ?? []
+    const names = second.flatMap((message) =>
+      Array.isArray(message.content) ? message.content.flatMap((part) => ('toolName' in part ? [part.toolName] : [])) : []
+    )
+    // Both the assistant's call and the tool's result carry the name the tools array advertises.
+    expect(names).toEqual(['lookup_weather', 'lookup_weather'])
+    expect(shownTools(model, 1)[0]?.name).toBe('lookup_weather')
+  })
+
+  it('routes a renamed tool call back through a stream too', async () => {
+    useLocalVariables(
+      publishedValue('agent__renamed_stream', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }],
+      })
+    )
+    executed.length = 0
+    const model = stubModel([toolCallStream('lookup_weather', { city: 'Berlin' }), textStream('sunny')])
+    const errors: unknown[] = []
+    const stream = streamText({
+      model: agentControl({ model, name: 'renamed_stream', label: 'production' }),
+      prompt: 'weather in Berlin?',
+      stopWhen: stepCountIs(3),
+      tools: { get_weather: weather },
+      onError: ({ error }) => errors.push(error),
+    })
+
+    expect(await stream.text).toBe('sunny')
+    expect(errors).toEqual([])
+    expect(executed).toEqual(['Berlin'])
+    const steps = await stream.steps
+    expect(steps[0]?.toolResults).toEqual([expect.objectContaining({ toolName: 'get_weather', output: 'sunny in Berlin' })])
+  })
+
+  it('leaves a provider-defined tool alone and refuses to rename onto its name', async () => {
+    useLocalVariables(
+      publishedValue('agent__provider_tool', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'web_search', description: 'Still patched.' }],
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'provider_tool', label: 'production' }),
+      prompt: 'hi',
+      tools: {
+        get_weather: weather,
+        web_search: {
+          type: 'provider' as const,
+          id: 'anthropic.web_search' as const,
+          args: {},
+          isProviderExecuted: true as const,
+          inputSchema: z.object({ query: z.string() }),
+        },
+      },
+    })
+
+    const shown = shownTools(model)
+    expect(shown.map((entry) => entry.name)).toEqual(['get_weather', 'web_search'])
+    // The rename is dropped and the rest of the override still applies, so every tool stays callable.
+    expect(shown[0]?.description).toBe('Still patched.')
+    // Reported by the core under the caller's policy, because the provider tool's name was handed to
+    // it as reserved -- rather than by a warning of this adapter's own that `'ignore'` would not
+    // silence and `'error'` would not fail on.
+    expect(warnings.messages).toContainEqual(expect.stringContaining('already advertised by another tool'))
+  })
+
+  it('fails the run on a refused rename when told to, and silences it when told to', async () => {
+    useLocalVariables(
+      publishedValue('agent__collision_policy', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'get_time' }],
+      })
+    )
+    const model = stubModel([textResult('ok'), textResult('ok')])
+    // The collision is with another *function* tool, which only the core can see -- and it reaches
+    // the caller's policy rather than a warning of this adapter's own, so `'error'` fails on it.
+    await expect(
+      generateText({
+        model: agentControl({ model, name: 'collision_policy', label: 'production', onUnmatched: 'error' }),
+        prompt: 'hi',
+        tools: { get_weather: weather, get_time: time },
+      })
+    ).rejects.toBeInstanceOf(UnmatchedConfigError)
+
+    await generateText({
+      model: agentControl({ model, name: 'collision_policy', label: 'production', onUnmatched: 'ignore' }),
+      prompt: 'hi',
+      tools: { get_weather: weather, get_time: time },
+    })
+    expect(shownTools(model).map((entry) => entry.name)).toEqual(['get_weather', 'get_time'])
+    expect(warnings.messages).toEqual([])
+  })
+
+  it('carries a forced tool choice across the rename it names', async () => {
+    useLocalVariables(
+      publishedValue('agent__forced_choice', {
+        tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }],
+      })
+    )
+    executed.length = 0
+    const model = stubModel([toolCallResult('lookup_weather', { city: 'Paris' })])
+    await generateText({
+      model: agentControl({ model, name: 'forced_choice', label: 'production' }),
+      prompt: 'weather in Paris?',
+      stopWhen: stepCountIs(1),
+      tools: { get_weather: weather },
+      toolChoice: { type: 'tool', toolName: 'get_weather' },
+    })
+
+    // The code forced a tool the model is no longer shown under that name; a provider handed a choice
+    // naming a tool it was not offered rejects the request outright.
+    expect(model.doGenerateCalls[0]?.toolChoice).toEqual({ type: 'tool', toolName: 'lookup_weather' })
+    expect(executed).toEqual(['Paris'])
+  })
+
+  it.each([
+    [{ type: 'tool', toolName: 'get_time' } as const, { type: 'tool', toolName: 'get_time' }, 'unrenamed_choice'],
+    ['required' as const, { type: 'required' }, 'required_choice'],
+  ])('leaves a tool choice that names no renamed tool alone (%#)', async (toolChoice, expected, name) => {
+    useLocalVariables(publishedValue(`agent__${name}`, { tool_definitions: [{ name: 'get_weather', new_name: 'lookup_weather' }] }))
+    const model = stubModel([toolCallResult('get_time', {})])
+    await generateText({
+      model: agentControl({ model, name, label: 'production' }),
+      prompt: 'hi',
+      stopWhen: stepCountIs(1),
+      tools: { get_weather: weather, get_time: time },
+      toolChoice,
+    })
+
+    expect(model.doGenerateCalls[0]?.toolChoice).toEqual(expected)
+  })
+
+  it('reports a tool override nothing advertises, and fails the run when told to', async () => {
+    useLocalVariables(publishedValue('agent__unmatched_tool', { tool_definitions: [{ name: 'nope', description: 'Unreachable.' }] }))
+    const model = stubModel([textResult('ok'), textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'unmatched_tool', label: 'production' }),
+      prompt: 'hi',
+      tools: { get_weather: weather },
+    })
+    expect(warnings.messages).toContainEqual(expect.stringContaining("tool 'nope'"))
+
+    await expect(
+      generateText({
+        model: agentControl({ model, name: 'unmatched_tool', label: 'production', onUnmatched: 'error' }),
+        prompt: 'hi',
+        tools: { get_weather: weather },
+      })
+    ).rejects.toBeInstanceOf(UnmatchedConfigError)
+  })
+
+  it('reports an override qualified by a toolset, which this SDK has no grouping for', async () => {
+    useLocalVariables(
+      publishedValue('agent__toolset_override', {
+        tool_definitions: [{ name: 'get_weather', toolset: 'crm', description: 'Never applied.' }],
+      })
+    )
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'toolset_override', label: 'production' }),
+      prompt: 'hi',
+      tools: { get_weather: weather },
+    })
+
+    expect(shownTools(model)[0]?.description).toBe('Get the current weather for a city.')
+    expect(warnings.messages).toContainEqual(expect.stringContaining("toolset 'crm'"))
+  })
+
+  it('leaves a request with no tools alone', async () => {
+    useLocalVariables(publishedValue('agent__no_tools', { tool_definitions: [{ name: 'get_weather', description: 'Unreachable.' }] }))
+    const model = stubModel([textResult('ok')])
+    await generateText({
+      model: agentControl({ model, name: 'no_tools', label: 'production', onUnmatched: 'ignore' }),
+      prompt: 'hi',
+    })
+
+    expect(model.doGenerateCalls[0]?.tools).toBeUndefined()
+  })
+})

--- a/packages/logfire-agent-control-ai-sdk/src/agent.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/agent.ts
@@ -1,0 +1,211 @@
+/**
+ * The install: `agentControl({ settings })` for an agent, `agentControl({ model })` for a model.
+ *
+ * One function with one options bag, because there is one question -- which agent is this? -- and the
+ * rest is what you happen to be holding. An agent's settings object is where the AI SDK keeps
+ * everything Agent Control manages, and it is plain data until the agent is constructed from it, so
+ * wrapping the settings rather than the agent needs no access to anything private and leaves the
+ * agent an ordinary `ToolLoopAgent`. It also lets this helper hand the middleware three things a
+ * middleware installed on a bare model cannot know: the instructions the agent declares, the settings
+ * it declares, and the version of the model it declares -- which is what makes a block addressable,
+ * a block's text publishable, and a per-run setting win over a managed one.
+ */
+
+import type { LanguageModelV4 } from '@ai-sdk/provider'
+import type { Context, ToolSet } from '@ai-sdk/provider-utils'
+import type { Instructions, LanguageModel, OutputInterface, ToolLoopAgentSettings } from 'ai'
+import { wrapLanguageModel } from 'ai'
+
+import { agentControlMiddleware, requireName } from './middleware'
+import type { AgentControlOptions } from './middleware'
+import { specificationVersionOf } from './model'
+import type { WrappableModel } from './model'
+import type { CallSettings } from './settings'
+
+/** Manage an agent: everything Agent Control needs, plus the agent's own settings object. */
+export interface AgentControlSettingsOptions<
+  CALL_OPTIONS = never,
+  // `{}` is the default `ToolLoopAgentSettings` itself declares for this parameter, and repeating it
+  // is what keeps `agentControl` inferring exactly what `new ToolLoopAgent(...)` would. A narrower
+  // stand-in for "no tools" would infer differently.
+  // oxlint-disable-next-line typescript/ban-types, typescript/no-empty-object-type
+  TOOLS extends ToolSet = {},
+  RUNTIME_CONTEXT extends Context = Context,
+  OUTPUT extends OutputInterface = never,
+  S extends ToolLoopAgentSettings<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT> = ToolLoopAgentSettings<
+    CALL_OPTIONS,
+    TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  >,
+> extends Omit<AgentControlOptions, 'codeInstructions' | 'codeSettings' | 'modelSpecificationVersion'> {
+  /**
+   * The settings you would have passed to `new ToolLoopAgent(...)`.
+   *
+   * Read as well as wrapped: its `instructions`, its generation settings, and the specification
+   * version of its `model` are what this form knows and a bare model install does not.
+   */
+  settings: S
+}
+
+/** Manage one model, for `generateText`, `streamText`, or anywhere a `LanguageModel` goes. */
+export interface AgentControlModelOptions extends AgentControlOptions {
+  /** The model the agent would run on, which a managed `model` replaces. */
+  model: WrappableModel
+}
+
+/**
+ * Settings with Agent Control installed: the same agent, with the fields this helper fills in.
+ *
+ * Spelled out rather than returned as the input type, because `id` and `telemetry.functionId` are no
+ * longer optional afterwards -- an agent that came out of here has a name, and that is worth being
+ * able to read back.
+ */
+export type ManagedSettings<S> = Omit<S, 'id' | 'model' | 'telemetry'> & {
+  id: string
+  model: LanguageModelV4
+  telemetry: { functionId: string }
+}
+
+/**
+ * Manage an agent's settings from Logfire.
+ *
+ * ```ts
+ * export const agent = new ToolLoopAgent(
+ *   agentControl({
+ *     settings: {
+ *       id: 'checkout_assistant',
+ *       model: anthropic('claude-fable-5-1'),
+ *       instructions: 'You are a concise checkout assistant.',
+ *       tools: { get_weather },
+ *     },
+ *   }),
+ * );
+ * ```
+ *
+ * What comes back is the same settings with three changes: the model is wrapped in the Agent Control
+ * middleware, and `id` and `telemetry.functionId` are filled in from the Agent Control name if the
+ * agent does not already carry them -- so the spans this agent emits are grouped under the name its
+ * config is published against, which is what lets someone move between the trace and the config that
+ * produced it.
+ *
+ * The agent's name is `options.name`, else its `id`, else its `telemetry.functionId`. It is never
+ * derived from anything else, and an agent with none of the three is refused rather than published
+ * under a guess.
+ */
+export function agentControl<
+  CALL_OPTIONS = never,
+  // `{}` is the default `ToolLoopAgentSettings` itself declares for this parameter, and repeating it
+  // is what keeps `agentControl` inferring exactly what `new ToolLoopAgent(...)` would. A narrower
+  // stand-in for "no tools" would infer differently.
+  // oxlint-disable-next-line typescript/ban-types, typescript/no-empty-object-type
+  TOOLS extends ToolSet = {},
+  RUNTIME_CONTEXT extends Context = Context,
+  OUTPUT extends OutputInterface = never,
+  S extends ToolLoopAgentSettings<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT> = ToolLoopAgentSettings<
+    CALL_OPTIONS,
+    TOOLS,
+    RUNTIME_CONTEXT,
+    OUTPUT
+  >,
+>(options: AgentControlSettingsOptions<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT, S>): ManagedSettings<S>
+
+/**
+ * Manage every request through one model.
+ *
+ * ```ts
+ * const model = agentControl({ model: anthropic('claude-fable-5-1'), name: 'checkout_assistant' });
+ * const { text } = await generateText({ model, instructions: 'Be concise.', prompt: 'Hi' });
+ * ```
+ *
+ * Pass `codeInstructions` and `codeSettings` to say what your code declares, which is what lets a
+ * per-call value beat a published one and keeps the baseline describing your code rather than your
+ * first request.
+ */
+export function agentControl(options: AgentControlModelOptions): LanguageModelV4
+
+export function agentControl(options: AgentControlModelOptions | AgentControlSettingsOptions): unknown {
+  return 'model' in options ? managedModel(options) : managedSettings(options)
+}
+
+function managedModel(options: AgentControlModelOptions): LanguageModelV4 {
+  const { model, ...rest } = options
+  return wrapLanguageModel({
+    model,
+    middleware: agentControlMiddleware({ modelSpecificationVersion: specificationVersionOf(model), ...rest }),
+  })
+}
+
+function managedSettings(options: AgentControlSettingsOptions): ManagedSettings<ToolLoopAgentSettings> {
+  const { settings, ...rest } = options
+  const name = requireName(
+    options.name ?? settings.id ?? settings.telemetry?.functionId,
+    'Give the agent an `id`, or pass `{ name }` to `agentControl`.'
+  )
+  const model = wrappableModel(settings.model)
+  const managed = wrapLanguageModel({
+    model,
+    middleware: agentControlMiddleware({
+      ...rest,
+      name,
+      ...(settings.instructions === undefined ? {} : { codeInstructions: settings.instructions }),
+      codeSettings: declaredSettings(settings),
+      modelSpecificationVersion: specificationVersionOf(model),
+    }),
+  })
+  return {
+    ...settings,
+    id: settings.id ?? name,
+    telemetry: { ...settings.telemetry, functionId: settings.telemetry?.functionId ?? name },
+    model: managed,
+    // TypeScript cannot prove that spreading a generic and replacing three of its properties produces
+    // the mapped type that says exactly that, which is what this does.
+  } as unknown as ManagedSettings<ToolLoopAgentSettings>
+}
+
+/** The settings fields this helper reads off an agent, which is the half it has anything to say about. */
+type DeclaredSettings = CallSettings & { instructions?: Instructions }
+
+/**
+ * The generation settings the agent declares, which is what the middleware compares a request to.
+ *
+ * A field the agent leaves unset is carried over as `undefined` rather than dropped, because that is
+ * what it means: a request that carries a value for it did not inherit that value from the agent.
+ */
+function declaredSettings(settings: DeclaredSettings): CallSettings {
+  const { maxOutputTokens, temperature, topP, topK, presencePenalty, frequencyPenalty, stopSequences, seed, reasoning, providerOptions } =
+    settings
+  return {
+    maxOutputTokens,
+    temperature,
+    topP,
+    topK,
+    presencePenalty,
+    frequencyPenalty,
+    stopSequences,
+    seed,
+    reasoning,
+    providerOptions,
+  }
+}
+
+/**
+ * The model to wrap, which has to be a model object rather than a string.
+ *
+ * A string model is resolved by the AI SDK at call time, through the AI Gateway or whatever
+ * `AI_SDK_DEFAULT_PROVIDER` names -- after this helper has run, so there is nothing here to wrap.
+ * Refusing is better than silently managing nothing: the fix is one import, and the alternative is
+ * an agent that reports itself as managed and applies no config.
+ */
+function wrappableModel(model: LanguageModel): WrappableModel {
+  if (typeof model !== 'string') {
+    return model
+  }
+  throw new Error(
+    `Logfire Agent Control cannot manage the string model '${model}': a string is resolved to a model ` +
+      'by the AI SDK at call time, so there is nothing to wrap. Pass a model object instead, for ' +
+      "example `gateway('" +
+      model +
+      "')` or your provider's own factory."
+  )
+}

--- a/packages/logfire-agent-control-ai-sdk/src/index.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Logfire Agent Control for the Vercel AI SDK.
+ *
+ * An agent's instructions, model, generation settings, and the names and descriptions its tools are
+ * advertised under, edited in the Logfire UI and applied to every model request -- without a deploy,
+ * and without the agent's code knowing anything about it. Pass `agentControl` a `ToolLoopAgent`'s
+ * settings, or any model:
+ *
+ * ```ts
+ * import { ToolLoopAgent } from 'ai';
+ * import { anthropic } from '@ai-sdk/anthropic';
+ * import { agentControl } from '@pydantic/logfire-agent-control-ai-sdk';
+ *
+ * export const agent = new ToolLoopAgent(
+ *   agentControl({
+ *     settings: {
+ *       id: 'checkout_assistant',
+ *       model: anthropic('claude-fable-5-1'),
+ *       instructions: 'You are a concise checkout assistant.',
+ *       tools: { get_weather },
+ *     },
+ *   }),
+ * );
+ * ```
+ *
+ * If Logfire is unreachable, if nothing has been published, or if a published value cannot be
+ * understood, the agent runs on its code. See the README for what becomes editable and what does not.
+ */
+
+export { agentControl } from './agent'
+export type { AgentControlModelOptions, AgentControlSettingsOptions, ManagedSettings } from './agent'
+
+export { PROVIDER_OPTIONS_NAMESPACE } from './instructions'
+
+export { agentControlMiddleware } from './middleware'
+export type { AgentControlOptions } from './middleware'
+
+export type { ModelResolutionOptions, SpecificationVersion, WrappableModel } from './model'
+
+export type { CallSettings } from './settings'
+
+// The core's own surface, so an application installing this adapter does not also have to depend on
+// the core to name the policy it wants or catch the error `'error'` raises.
+export { UnmatchedConfigError } from '@pydantic/logfire-node/agent-control'
+export type { AgentConfig, OnUnmatched } from '@pydantic/logfire-node/agent-control'

--- a/packages/logfire-agent-control-ai-sdk/src/instructions.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/instructions.ts
@@ -212,7 +212,20 @@ export function writeSystemMessages(
   slots: readonly SystemSlot[],
   blocks: readonly InstructionBlock[]
 ): LanguageModelV4Prompt {
-  const byId = new Map(slots.map((slot) => [slot.id, slot]))
+  // A queue per id rather than one slot per id. Two system messages can carry the same one -- a
+  // `providerOptions.logfire.id` declared twice, or a hook injecting a message under a name the code
+  // already uses -- and the core addresses them together, in the order it was handed them. Keeping
+  // only the last would write both returned blocks into the last message and drop the earlier one
+  // from the prompt, which is a message lost to a typo.
+  const byId = new Map<string, SystemSlot[]>()
+  for (const slot of slots) {
+    const queue = byId.get(slot.id)
+    if (queue === undefined) {
+      byId.set(slot.id, [slot])
+    } else {
+      queue.push(slot)
+    }
+  }
   // Walked once to sort the returned blocks into "text for the slot at this index" and "added text to
   // emit just before that slot". An added block comes back with `id: null`; everything else is one of
   // the messages we handed in.
@@ -220,7 +233,7 @@ export function writeSystemMessages(
   const additions = new Map<number, string[]>()
   let pending: string[] = []
   for (const block of blocks) {
-    const slot = block.id === null ? undefined : byId.get(block.id)
+    const slot = block.id === null ? undefined : byId.get(block.id)?.shift()
     if (slot === undefined) {
       pending.push(block.text)
       continue

--- a/packages/logfire-agent-control-ai-sdk/src/instructions.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/instructions.ts
@@ -1,0 +1,266 @@
+/**
+ * The AI SDK's system messages, as instruction blocks a managed config can address.
+ *
+ * The AI SDK has a real notion of several instruction blocks -- `instructions` accepts an array of
+ * `SystemModelMessage`s, each of which becomes its own `{role: 'system'}` message on the wire, in
+ * source order, with its `providerOptions` intact. What it does not have is a name for any of them,
+ * so this module synthesizes one.
+ *
+ * # Two questions about a block, not one
+ *
+ * A block gets classified twice here, and the two answers are not the same. *Is it recomputed per
+ * request* decides whether a published value may address it, and is a judgement about this request.
+ * *Is its text provably the agent's own* decides whether that text may be published into the shared
+ * baseline, and admits no judgement at all: a rendering this adapter merely observed belongs to
+ * whichever tenant, user, or retrieved document the run carried, and a variable every member of a
+ * Logfire project can read is the last place it should end up. So an unproven block is published as a
+ * seam -- its id, and that it exists -- while staying perfectly addressable at runtime.
+ */
+
+import type { InstructionBlock } from '@pydantic/logfire-node/agent-control'
+import type { LanguageModelV4Message, LanguageModelV4Prompt, SharedV4ProviderOptions } from '@ai-sdk/provider'
+import type { Instructions } from 'ai'
+
+/**
+ * The `providerOptions` namespace a user declares a block's id under.
+ *
+ * `providerOptions` is `Record<provider, JSONObject>` and each provider parses only its own
+ * namespace, so a key under `logfire` reaches this adapter and reaches no provider's wire body --
+ * which is what makes it usable as block metadata rather than as a request field. It is also the AI
+ * SDK's own idiom for attaching something to one system message: Anthropic's `cacheControl` is
+ * declared the same way.
+ */
+export const PROVIDER_OPTIONS_NAMESPACE = 'logfire'
+
+/** A system message in one request's prompt, and the id that addresses it. */
+export interface SystemSlot {
+  /** Where the message sits in the prompt. */
+  index: number
+  /** What addresses it: a declared `providerOptions.logfire.id`, else `system:<n>`. */
+  id: string
+  /** The message's text. */
+  text: string
+  /** Whether this text differs from what the agent's code declares under this id. */
+  dynamic: boolean
+  /** Whether this text is provably the agent's own, and so publishable; see the module comment. */
+  codeSide: boolean
+}
+
+/** A system message is `{role: 'system', content: string}` plus the shared `providerOptions`. */
+export type SystemMessage = Extract<LanguageModelV4Message, { role: 'system' }>
+
+/**
+ * `Instructions` in its one canonical shape: the list of system messages it stands for.
+ *
+ * The AI SDK accepts a bare string, one message, or a list, and all three become the same thing on
+ * the wire -- so everything downstream of here only has to know about the list.
+ */
+export function instructionMessages(instructions: Instructions | undefined): SystemMessage[] {
+  if (instructions === undefined) {
+    return []
+  }
+  if (typeof instructions === 'string') {
+    return [{ role: 'system', content: instructions }]
+  }
+  return Array.isArray(instructions) ? [...instructions] : [instructions]
+}
+
+/**
+ * The id declared on a message, or `undefined` when it declares none.
+ *
+ * Anything that is not a non-empty string is treated as no id at all: a half-filled value should
+ * fall back to the positional id rather than making a block addressable under `''` or `123`.
+ */
+function declaredId(providerOptions: SharedV4ProviderOptions | undefined): string | undefined {
+  const id = providerOptions?.[PROVIDER_OPTIONS_NAMESPACE]?.['id']
+  return typeof id === 'string' && id !== '' ? id : undefined
+}
+
+/**
+ * The id for the `n`-th system message of a prompt.
+ *
+ * Positional, because the AI SDK gives a system message no name of its own. That makes an id stable
+ * for as long as the agent's own instructions are, and *not* stable across a `prepareStep` that
+ * injects a system message ahead of them -- which is exactly why a user who wants a durable id
+ * declares one under `providerOptions.logfire`.
+ */
+function positionalId(n: number): string {
+  return `system:${String(n)}`
+}
+
+/** The system messages of a prompt, in order, with their ids and their positions. */
+export function systemSlots(prompt: readonly LanguageModelV4Message[], code: CodeInstructions): SystemSlot[] {
+  const slots: SystemSlot[] = []
+  for (const [index, message] of prompt.entries()) {
+    if (message.role !== 'system') {
+      continue
+    }
+    const id = declaredId(message.providerOptions) ?? positionalId(slots.length)
+    slots.push({
+      index,
+      id,
+      text: message.content,
+      dynamic: code.isDynamic(id, message.content),
+      codeSide: code.isCodeSide(id, message.content),
+    })
+  }
+  return slots
+}
+
+/** A slot as the core models it: what to address, what it says, and whether it is recomputed. */
+export function blockOf(slot: SystemSlot): InstructionBlock {
+  return { id: slot.id, text: slot.text, dynamic: slot.dynamic }
+}
+
+/**
+ * A slot as the baseline may describe it, which is less than the core would otherwise publish.
+ *
+ * A block whose text this adapter cannot prove came from the agent's own `instructions` is handed
+ * over as a dynamic block, so `buildBaseline` publishes its seam and drops its text. That is not a
+ * claim that the framework recomputes it -- `dynamic` is the core's only way to say "there is a block
+ * here and its words are not mine to publish", and the alternative is uploading one request's
+ * rendering into a shared project variable, where no later request can take it back.
+ */
+export function baselineBlockOf(slot: SystemSlot): InstructionBlock {
+  return slot.codeSide ? blockOf(slot) : { id: slot.id, text: '', dynamic: true }
+}
+
+/**
+ * What the agent declares in code, against which a request's system messages are classified.
+ *
+ * The AI SDK's `instructions` are always static data -- never a callable -- so anything else that
+ * turns up as a system message came from somewhere this adapter cannot see: a `prepareCall` or
+ * `prepareStep` hook, or a system message carried in the run's `messages`. Those are recomputed per
+ * request by definition, and the core refuses to address a block marked `dynamic`, so classifying
+ * them correctly is what keeps a managed value from pinning one rendering of one run's text.
+ *
+ * Content equality is the only signal there is; the SDK carries no flag.
+ */
+export class CodeInstructions {
+  readonly #texts: Map<string, string> | undefined
+  /** Whether `#texts` is the agent's own declaration rather than one request this adapter watched. */
+  readonly #declared: boolean
+
+  private constructor(texts: Map<string, string> | undefined, declared: boolean) {
+    this.#texts = texts
+    this.#declared = declared
+  }
+
+  /**
+   * The blocks an agent declares statically, from `ToolLoopAgentSettings.instructions`.
+   *
+   * Available before the agent has ever run, which is what lets even the first request tell an
+   * injected system message from a declared one -- and the only thing that ever makes a block's text
+   * publishable, since it is the only text this adapter can point at a line of code for.
+   */
+  static declared(instructions: readonly SystemMessage[]): CodeInstructions {
+    const texts = new Map<string, string>()
+    for (const [n, message] of instructions.entries()) {
+      texts.set(declaredId(message.providerOptions) ?? positionalId(n), message.content)
+    }
+    return new CodeInstructions(texts, true)
+  }
+
+  /**
+   * Nothing declared: a bare `wrapLanguageModel` install, or an agent whose hooks supply the prompt.
+   *
+   * `learn` fills it in from the first request, so a block that turns out to change between requests
+   * is refused from the second one on -- and on the first, where there is nothing to compare against,
+   * treating a block as addressable is what makes a fresh install work rather than refusing every
+   * override until the agent has run twice.
+   *
+   * What learning never does is make a block *publishable*. A text seen once is a text seen once; it
+   * may be the agent's prompt or it may be one tenant's, and the baseline is read by everyone.
+   */
+  static unknown(): CodeInstructions {
+    return new CodeInstructions(undefined, false)
+  }
+
+  /** Take this request's system messages as the code-side text, if nothing is known yet. */
+  learn(slots: readonly SystemSlot[]): CodeInstructions {
+    if (this.#texts !== undefined) {
+      return this
+    }
+    return new CodeInstructions(new Map(slots.map((slot) => [slot.id, slot.text])), false)
+  }
+
+  isDynamic(id: string, text: string): boolean {
+    return this.#texts !== undefined && this.#texts.get(id) !== text
+  }
+
+  isCodeSide(id: string, text: string): boolean {
+    return this.#declared && this.#texts?.get(id) === text
+  }
+}
+
+/**
+ * Write applied blocks back into the prompt they came from.
+ *
+ * Every surviving block goes back into *its own* message's position, rather than into the next free
+ * system slot: a prompt may carry a system message after a user one -- `messages` can contain one,
+ * and `allowSystemInMessages` lets it through -- and consuming the slots in order would slide that
+ * later block up past the conversation when an earlier one was removed. A block a managed value
+ * dropped therefore leaves a gap and moves nothing, and blocks the core added land where the core put
+ * them: immediately before the block that followed them, which is the end of the static group, so a
+ * managed value never moves a provider's prompt-cache boundary.
+ *
+ * A prompt with no system message at all gets the added blocks at the front, since that is the only
+ * place a system message can go.
+ */
+export function writeSystemMessages(
+  prompt: LanguageModelV4Prompt,
+  slots: readonly SystemSlot[],
+  blocks: readonly InstructionBlock[]
+): LanguageModelV4Prompt {
+  const byId = new Map(slots.map((slot) => [slot.id, slot]))
+  // Walked once to sort the returned blocks into "text for the slot at this index" and "added text to
+  // emit just before that slot". An added block comes back with `id: null`; everything else is one of
+  // the messages we handed in.
+  const survivors = new Map<number, string>()
+  const additions = new Map<number, string[]>()
+  let pending: string[] = []
+  for (const block of blocks) {
+    const slot = block.id === null ? undefined : byId.get(block.id)
+    if (slot === undefined) {
+      pending.push(block.text)
+      continue
+    }
+    if (pending.length > 0) {
+      additions.set(slot.index, pending)
+      pending = []
+    }
+    survivors.set(slot.index, block.text)
+  }
+
+  const lastSlot = slots.at(-1)
+  if (lastSlot === undefined) {
+    return [...pending.map(systemMessage), ...prompt]
+  }
+
+  const slotIndices = new Set(slots.map((slot) => slot.index))
+  const result: LanguageModelV4Prompt = []
+  for (const [index, message] of prompt.entries()) {
+    if (!slotIndices.has(index)) {
+      result.push(message)
+      continue
+    }
+    for (const text of additions.get(index) ?? []) {
+      result.push(systemMessage(text))
+    }
+    const surviving = survivors.get(index)
+    // The message at a slot's index is that slot's system message, so spreading it is what carries a
+    // replaced block's own `providerOptions` -- its declared id, a cache breakpoint -- across.
+    if (surviving !== undefined) {
+      result.push({ ...(message as SystemMessage), content: surviving })
+    }
+    // Anything the core added after the last surviving block belongs at the end of the system run.
+    if (index === lastSlot.index) {
+      result.push(...pending.map(systemMessage))
+    }
+  }
+  return result
+}
+
+function systemMessage(content: string): SystemMessage {
+  return { role: 'system', content }
+}

--- a/packages/logfire-agent-control-ai-sdk/src/instructions.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/instructions.ts
@@ -204,8 +204,9 @@ export class CodeInstructions {
  * them: immediately before the block that followed them, which is the end of the static group, so a
  * managed value never moves a provider's prompt-cache boundary.
  *
- * A prompt with no system message at all gets the added blocks at the front, since that is the only
- * place a system message can go.
+ * A prompt with no surviving system message -- because it carried none, or because a managed value
+ * removed every one of them -- gets the added blocks at the front, since that is the only place a
+ * system message can go.
  */
 export function writeSystemMessages(
   prompt: LanguageModelV4Prompt,
@@ -245,13 +246,15 @@ export function writeSystemMessages(
     survivors.set(slot.index, block.text)
   }
 
-  const lastSlot = slots.at(-1)
-  if (lastSlot === undefined) {
-    return [...pending.map(systemMessage), ...prompt]
-  }
-
+  // Where anything still pending goes: right after the last block that *survived*, which is the end
+  // of the system run this request will actually send. Going by the last slot instead would put an
+  // added block after a `system` message sitting behind user content -- and so past that content --
+  // whenever the trailing block was the one a managed value removed. With nothing surviving at all,
+  // because the prompt carried no system message or because a managed value removed every one of
+  // them, the front of the prompt is the only place a system message can go.
+  const lastSurvivor = Math.max(-1, ...survivors.keys())
   const slotIndices = new Set(slots.map((slot) => slot.index))
-  const result: LanguageModelV4Prompt = []
+  const result: LanguageModelV4Prompt = lastSurvivor === -1 ? pending.map(systemMessage) : []
   for (const [index, message] of prompt.entries()) {
     if (!slotIndices.has(index)) {
       result.push(message)
@@ -267,7 +270,7 @@ export function writeSystemMessages(
       result.push({ ...(message as SystemMessage), content: surviving })
     }
     // Anything the core added after the last surviving block belongs at the end of the system run.
-    if (index === lastSlot.index) {
+    if (index === lastSurvivor) {
       result.push(...pending.map(systemMessage))
     }
   }

--- a/packages/logfire-agent-control-ai-sdk/src/middleware.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/middleware.ts
@@ -21,6 +21,14 @@
  * difference between "this agent regressed" and "this agent regressed on the value someone saved at
  * 14:02". It is also what makes the model swap ordinary rather than special: a managed model is just
  * a different object to call with the same params.
+ *
+ * Calling `model.doGenerate` in place of the `doGenerate` we were handed does not step out of the
+ * middleware chain. `wrapLanguageModel` builds that continuation as `() => model.doGenerate(params)`
+ * over the very `model` it also passes us (`ai/src/middleware/wrap-language-model.ts`), and this
+ * middleware declares no `transformParams`, so the two are the same call with different params --
+ * and `model` is already wrapped in whatever middleware sits *inside* this one. Only the managed
+ * model is different, and that is the point of it: a config that names another model is asking for
+ * another model, not for this one with different arguments.
  */
 
 import type { AgentConfig, OnUnmatched } from '@pydantic/logfire-node/agent-control'
@@ -152,9 +160,11 @@ export function agentControlMiddleware(options: AgentControlOptions): LanguageMo
   // model and a `prepareStep` can change the set per step -- which the README's limits say out loud.
   const baselineSource = options.codeInstructions !== undefined && options.codeSettings !== undefined ? 'code' : 'observed'
 
-  // Learned from the first request when the agent did not declare its instructions; see
-  // `CodeInstructions`.
-  let code = declared.length > 0 ? CodeInstructions.declared(declared) : CodeInstructions.unknown()
+  // Learned from the first request only when the agent declared *nothing*; see `CodeInstructions`.
+  // An agent that declares an empty `instructions` has said something -- that every system message
+  // reaching the model came from somewhere else -- and an empty declaration is what says so, where
+  // falling through to `unknown()` would make an injected block addressable on the first request.
+  let code = options.codeInstructions === undefined ? CodeInstructions.unknown() : CodeInstructions.declared(declared)
 
   /** Publish the baseline once, then apply whatever the resolved config changes. */
   async function prepare(params: LanguageModelV4CallOptions, model: LanguageModelV4, config: AgentConfig | null): Promise<PreparedRequest> {

--- a/packages/logfire-agent-control-ai-sdk/src/middleware.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/middleware.ts
@@ -1,0 +1,255 @@
+/**
+ * The hook: one `LanguageModelMiddleware` that applies a managed config to every model request.
+ *
+ * `wrapLanguageModel` is the AI SDK's only per-model-request seam, and it is enough for all four
+ * sections. What reaches it is the full `LanguageModelV4CallOptions` -- the system messages, the
+ * tools with their resolved JSON Schemas, and every generation setting -- which is everything a
+ * managed config patches; what comes back is where a renamed tool call has to be mapped to the tool
+ * the code actually implements, before the SDK looks the name up and finds nothing.
+ *
+ * # Why the rewrite happens in `wrapGenerate` rather than in `transformParams`
+ *
+ * The natural place for a parameter rewrite is `transformParams`, and the natural place to map a
+ * result back is `wrapGenerate` -- but they are two calls, and one model request would then resolve
+ * the variable twice and have to smuggle the routing table from the first to the second.
+ * `wrapGenerate` and `wrapStream`, on the other hand, are already a scope around the whole request:
+ * the `doGenerate` they are handed is literally `() => model.doGenerate(params)`, so calling
+ * `model.doGenerate(ourParams)` in its place transforms and executes in one place.
+ *
+ * That one scope is what `AgentControl.run` needs. Everything inside it carries the resolved label
+ * on its spans, so the trace for a request says which published version drove it -- which is the
+ * difference between "this agent regressed" and "this agent regressed on the value someone saved at
+ * 14:02". It is also what makes the model swap ordinary rather than special: a managed model is just
+ * a different object to call with the same params.
+ */
+
+import type { AgentConfig, OnUnmatched } from '@pydantic/logfire-node/agent-control'
+import { AgentControl, applyInstructions, buildBaseline, warnOnce } from '@pydantic/logfire-node/agent-control'
+import type {
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamPart,
+  LanguageModelV4StreamResult,
+} from '@ai-sdk/provider'
+import type { Instructions, LanguageModelMiddleware } from 'ai'
+
+import { baselineBlockOf, blockOf, CodeInstructions, instructionMessages, systemSlots, writeSystemMessages } from './instructions'
+import { createModelResolver, modelIdentifier } from './model'
+import type { ModelResolutionOptions, SpecificationVersion } from './model'
+import { canonicalSettings, lowerSettings, providerNamespace, supportedSettings } from './settings'
+import type { CallSettings } from './settings'
+import { applyToTools, renameHistory, renameToolChoice, toolDefs, unrenameContent, unrenameStreamPart } from './tools'
+
+/** How an agent is managed: which variable it reads, and what this adapter is allowed to know. */
+export interface AgentControlOptions extends ModelResolutionOptions {
+  /**
+   * The name of the agent, which picks out the `agent__<name>` Logfire variable holding its config.
+   *
+   * Required and never derived from anything the AI SDK carries. `ToolLoopAgent`'s `id` and
+   * `telemetry.functionId` are both optional and both free-form, so guessing at one would let two
+   * agents share a config, or move an agent onto a different config the day someone renames it.
+   */
+  name?: string
+  /** Read this label instead of letting the variable's rollout choose one. */
+  label?: string
+  /** What to do with a published entry that reaches nothing: `'warn'` (default), `'ignore'`, `'error'`. */
+  onUnmatched?: OnUnmatched
+  /** Set `false` when the Logfire token is read-only or code must not write variable metadata. */
+  publishBaseline?: boolean
+  /**
+   * The instructions the agent declares in code.
+   *
+   * Two things depend on it, and both are about provenance. It tells a declared block from one a
+   * `prepareCall`/`prepareStep` hook injected, which is what decides whether a block is addressable;
+   * and it is the only evidence that a block's text is the agent's own rather than one request's
+   * rendering, which is what decides whether that text may be published into the shared baseline.
+   * Without it every block is published as a seam. `agentControl` passes the agent's own.
+   */
+  codeInstructions?: Instructions
+  /**
+   * The generation settings the agent declares in code.
+   *
+   * Used for precedence -- a request field that differs from this one was set for this run, and a
+   * managed value does not overwrite it -- and for the baseline, so the Logfire editor is shown the
+   * agent's own defaults rather than whatever the first request happened to carry. Without it a
+   * managed setting wins over a per-call one, because by this point the two are indistinguishable.
+   */
+  codeSettings?: CallSettings
+  /**
+   * The specification version of the model this middleware is installed on.
+   *
+   * `wrapLanguageModel` accepts a v2, v3, or v4 model and bridges the older two with a `Proxy` whose
+   * only behavior is to answer `'v4'` to `specificationVersion`, so a middleware cannot ask what it
+   * is really talking to. It matters for exactly one setting: `reasoning` is the call option v4
+   * added, and an older provider is handed it and drops it, so a published `thinking` has to be
+   * reported rather than applied. `agentControl` reads it off the model it is given; a hand-rolled
+   * `wrapLanguageModel` install on a pre-v4 model should pass it. Defaults to `'v4'`.
+   */
+  modelSpecificationVersion?: SpecificationVersion
+}
+
+/** One model request, as this middleware decided to make it. */
+interface PreparedRequest {
+  /** The call options to send, with every managed section applied. */
+  params: LanguageModelV4CallOptions
+  /** The model to send them to: the managed one where a config named one, else the wrapped one. */
+  model: LanguageModelV4
+  /** Advertised tool name to code-side name, for un-renaming what comes back. */
+  routes: Record<string, string>
+}
+
+/**
+ * Require a name rather than inventing one.
+ *
+ * The name is what picks the variable, so an agent that reaches Logfire under a name nobody chose is
+ * worse than one that fails to start.
+ */
+export function requireName(name: string | undefined, hint: string): string {
+  if (name === undefined || name.trim() === '') {
+    throw new Error(
+      'Logfire Agent Control needs an explicit agent name: it is what picks out the `agent__<name>` ' +
+        `variable holding this agent's managed config. ${hint}`
+    )
+  }
+  return name
+}
+
+/**
+ * The middleware that applies an agent's managed config to every request through a model.
+ *
+ * The low-level install, for a `wrapLanguageModel` or `createProviderRegistry` call you already have.
+ * `agentControl` is the same thing with the wrapping done for you, and with the agent's declared
+ * instructions, settings, and model version filled in -- which is what buys the per-run precedence,
+ * the publishable baseline text, and the reporting of a setting the model cannot honour that this
+ * form has to be told about.
+ *
+ * ```ts
+ * const model = wrapLanguageModel({
+ *   model: anthropic('claude-fable-5-1'),
+ *   middleware: agentControlMiddleware({ name: 'checkout_assistant' }),
+ * });
+ * ```
+ */
+export function agentControlMiddleware(options: AgentControlOptions): LanguageModelMiddleware {
+  const name = requireName(options.name, 'Pass `name` to `agentControlMiddleware`, or use `agentControl` on an agent with an `id`.')
+  const control = new AgentControl(name, {
+    ...(options.label === undefined ? {} : { label: options.label }),
+    ...(options.onUnmatched === undefined ? {} : { onUnmatched: options.onUnmatched }),
+    ...(options.publishBaseline === undefined ? {} : { publishBaseline: options.publishBaseline }),
+  })
+  const onUnmatched = control.onUnmatched
+  const resolveModel = createModelResolver(options, (message) => {
+    control.reportUnmatched(message)
+  })
+  const declared = instructionMessages(options.codeInstructions)
+  const wrappedVersion = options.modelSpecificationVersion ?? 'v4'
+  // The baseline describes the agent as written only where the agent said what it is: with its own
+  // instructions and its own settings in hand, every value published is one this adapter can point at
+  // a line of code for. Without them it is a snapshot of whichever request happened to come first,
+  // and the Logfire editor has to be told so rather than shown one run's temperature as a default.
+  // The tool list is the request's either way -- the AI SDK resolves tool schemas on the way to a
+  // model and a `prepareStep` can change the set per step -- which the README's limits say out loud.
+  const baselineSource = options.codeInstructions !== undefined && options.codeSettings !== undefined ? 'code' : 'observed'
+
+  // Learned from the first request when the agent did not declare its instructions; see
+  // `CodeInstructions`.
+  let code = declared.length > 0 ? CodeInstructions.declared(declared) : CodeInstructions.unknown()
+
+  /** Publish the baseline once, then apply whatever the resolved config changes. */
+  async function prepare(params: LanguageModelV4CallOptions, model: LanguageModelV4, config: AgentConfig | null): Promise<PreparedRequest> {
+    const slots = systemSlots(params.prompt, code)
+    code = code.learn(slots)
+
+    const wrappedNamespace = providerNamespace(model.provider)
+    control.publishBaseline(
+      buildBaseline({
+        // A block whose text is not provably the agent's own contributes its seam and not its text;
+        // see `baselineBlockOf`.
+        instructions: slots.map(baselineBlockOf),
+        model: modelIdentifier(model),
+        settings: canonicalSettings(options.codeSettings ?? params, wrappedNamespace, supportedSettings(wrappedNamespace, wrappedVersion)),
+        tools: toolDefs(params.tools),
+      }),
+      { source: baselineSource }
+    )
+
+    if (config === null) {
+      return { params, model, routes: {} }
+    }
+
+    const managed = config.model === undefined ? model : ((await resolveModel(config.model)) ?? model)
+    noteModelSwap(managed, model)
+    // The version of the model this request will actually reach: the one we resolved when a config
+    // named one, and otherwise the wrapped model, whose real version only the caller could tell us.
+    const version = managed === model ? wrappedVersion : managed.specificationVersion
+    const { tools, routes, renames } = applyToTools(params.tools, config, onUnmatched)
+
+    return {
+      model: managed,
+      routes,
+      params: {
+        ...params,
+        prompt: renameHistory(
+          writeSystemMessages(params.prompt, slots, applyInstructions(slots.map(blockOf), config, { onUnmatched }).blocks),
+          renames
+        ),
+        ...(params.tools === undefined ? {} : { tools }),
+        ...(params.toolChoice === undefined ? {} : { toolChoice: renameToolChoice(params.toolChoice, renames) }),
+        ...lowerSettings(config, {
+          params,
+          code: options.codeSettings,
+          namespace: providerNamespace(managed.provider),
+          specificationVersion: version,
+          onUnmatched,
+        }),
+      },
+    }
+  }
+
+  return {
+    wrapGenerate: async ({ params, model }): Promise<LanguageModelV4GenerateResult> =>
+      control.run(async ({ config }) => {
+        const request = await prepare(params, model, config)
+        const result = await request.model.doGenerate(request.params)
+        return { ...result, content: unrenameContent(result.content, request.routes) }
+      }),
+
+    wrapStream: async ({ params, model }): Promise<LanguageModelV4StreamResult> =>
+      control.run(async ({ config }) => {
+        const request = await prepare(params, model, config)
+        const result = await request.model.doStream(request.params)
+        const { routes } = request
+        return {
+          ...result,
+          stream: result.stream.pipeThrough(
+            new TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart>({
+              transform(part, controller) {
+                controller.enqueue(unrenameStreamPart(part, routes))
+              },
+            })
+          ),
+        }
+      }),
+  }
+}
+
+/**
+ * Note, once, that this process is running a model its code did not ask for.
+ *
+ * The wrapped model is not called at all when a managed one takes over -- but it is still what the
+ * AI SDK reports as `modelId` on the span for the call, because `wrapLanguageModel` fixes that at
+ * wrap time from a synchronous `overrideModelId`, and a managed value is only known once the
+ * variable has resolved. Saying so once is better than a trace that names a model that never
+ * answered and nothing to explain it.
+ */
+function noteModelSwap(managed: LanguageModelV4, wrapped: LanguageModelV4): void {
+  if (managed.modelId === wrapped.modelId && managed.provider === wrapped.provider) {
+    return
+  }
+  warnOnce(
+    `Logfire Agent Control is running '${modelIdentifier(managed)}' in place of the code-defined ` +
+      `'${modelIdentifier(wrapped)}'; AI SDK telemetry still reports the code-defined model, because the ` +
+      "AI SDK fixes a wrapped model's reported id before the managed config is resolved."
+  )
+}

--- a/packages/logfire-agent-control-ai-sdk/src/model.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/model.ts
@@ -154,15 +154,23 @@ export function createModelResolver(
 ): (id: string) => Promise<LanguageModelV4 | undefined> {
   const registry = options.providers === undefined ? undefined : createProviderRegistry(options.providers)
   const registered = new Set(Object.keys(options.providers ?? {}))
-  const resolved = new Map<string, LanguageModelV4 | undefined>()
+  // The *promise* rather than the model, so two requests that arrive on the same new id while the
+  // first resolution is still in flight share it. Caching only the settled value would let both run
+  // `resolveModel`, build two model objects for one id, and split whatever the provider caches
+  // between them. A resolution that produced no model is cached too, so a published id nothing can
+  // build is reported once rather than retried on every request.
+  const resolved = new Map<string, Promise<LanguageModelV4 | undefined>>()
 
+  // `async` with nothing awaited, deliberately: the body runs to completion synchronously, so the
+  // promise is in the map before any caller can get back here on a later tick.
   return async (id: string): Promise<LanguageModelV4 | undefined> => {
-    if (resolved.has(id)) {
-      return resolved.get(id)
+    const cached = resolved.get(id)
+    if (cached !== undefined) {
+      return cached
     }
-    const model = await resolveOnce(id, options.resolveModel, registry, registered, report)
-    resolved.set(id, model)
-    return model
+    const pending = resolveOnce(id, options.resolveModel, registry, registered, report)
+    resolved.set(id, pending)
+    return pending
   }
 }
 

--- a/packages/logfire-agent-control-ai-sdk/src/model.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/model.ts
@@ -1,0 +1,252 @@
+/**
+ * The managed `model` string, in both directions.
+ *
+ * The contract's model is `'provider:model'` -- which is, as it happens, exactly what
+ * `createProviderRegistry` resolves, `':'` being its default separator. So a user who has a registry
+ * needs no translation at all, and one who has not gets the AI Gateway's `'provider/model'` form,
+ * which is the same identifier with the separator the gateway spells it with.
+ *
+ * The provider *names* need one more step. The contract's vocabulary is Pydantic AI's, and it agrees
+ * with the AI SDK's on every provider but Vertex AI, which the two spell differently while splitting
+ * Google the same way; forwarding those names unchanged is how a published value reaches a registry
+ * that has never heard of it, or a gateway that has heard of it and means something else by it.
+ */
+
+import type { LanguageModelV2, LanguageModelV3, LanguageModelV4, ProviderV3, ProviderV4 } from '@ai-sdk/provider'
+import type { ProviderRegistryProvider } from 'ai'
+import { createProviderRegistry } from 'ai'
+
+/** The id form `createProviderRegistry` accepts, and the contract's `provider:model`. */
+type QualifiedModelId = `${string}:${string}`
+
+/**
+ * A model as it is written in code, before `wrapLanguageModel` bridges it to `LanguageModelV4`.
+ *
+ * All three are accepted, because `wrapLanguageModel` accepts all three -- but the bridge it builds
+ * for the older two is a `Proxy` whose only behavior is to answer `'v4'` to `specificationVersion`
+ * (`ai/src/model/as-language-model-v4.ts`), so what a middleware is handed cannot be asked which one
+ * it really is. See `specificationVersionOf`.
+ */
+export type WrappableModel = LanguageModelV2 | LanguageModelV3 | LanguageModelV4
+
+/** A model specification version, as a model reports it before it is bridged. */
+export type SpecificationVersion = 'v2' | 'v3' | 'v4'
+
+/**
+ * Provider names the contract and the AI SDK ecosystem spell differently.
+ *
+ * The contract's vocabulary is Pydantic AI's, the AI SDK's is its provider packages' and the
+ * gateway's, and the two agree on every name -- `anthropic`, `openai`, `xai`, `groq`, `mistral`,
+ * `deepseek`, `cohere`, and `google` for the Gemini API -- except for Vertex AI, which the contract
+ * calls `google-cloud` and the AI SDK ships as `@ai-sdk/google-vertex`, whose provider is exported
+ * as `vertex`. A name this table has no entry for passes through untouched, so a provider package
+ * published tomorrow works here on the day it lands.
+ *
+ * `google-gla` and `google-vertex` are the *legacy* spellings: Pydantic AI v1's names for the two
+ * halves of Google, removed in v2 in favour of `google` and `google-cloud`. They are still accepted
+ * here, because a config published against a v1-era agent is still sitting in a Logfire project and
+ * still has to reach a model; nothing ever writes them.
+ */
+const CANONICAL_TO_AI_SDK: Readonly<Record<string, string>> = {
+  // Current, as Pydantic AI v2 spells them.
+  'google-cloud': 'vertex',
+  // Legacy, accepted as input only.
+  'google-gla': 'google',
+  'google-vertex': 'vertex',
+}
+
+/**
+ * AI SDK provider ids the contract has a different name for, longest dotted prefix first.
+ *
+ * The reverse of `CANONICAL_TO_AI_SDK`, for naming a code-defined model in the baseline -- and it has
+ * to read more of the provider id than the namespace, because Google is one namespace and two
+ * providers: `@ai-sdk/google` reports `google.generative-ai` and `@ai-sdk/google-vertex` reports
+ * `google.vertex.<api>`, so the namespace alone would publish a Vertex model as a Gemini API one and
+ * offer the editor an override that reaches the wrong service.
+ */
+const AI_SDK_TO_CANONICAL: readonly (readonly [prefix: string, canonical: string])[] = [['google.vertex', 'google-cloud']]
+
+/** How a managed `'provider:model'` string becomes a model this adapter can call. */
+export interface ModelResolutionOptions {
+  /**
+   * The providers a managed model string is resolved against, as `createProviderRegistry` takes them.
+   *
+   * The way to say which `@ai-sdk/*` package a published `anthropic:...` should go through, and the
+   * only way to reach a provider configured with your own API key, base URL, or fetch. A key here is
+   * read exactly as written and before any name translation, so `{ 'google-cloud': vertex }` is how
+   * you say what a contract name means to you when you would rather not rely on the translation.
+   */
+  providers?: Record<string, ProviderV4 | ProviderV3>
+  /**
+   * Full control over turning a managed model string into a model.
+   *
+   * Authoritative when it is passed: what it returns is the answer, and returning `undefined` means
+   * "not a model I will build", which leaves the agent on its code-defined model and reports the
+   * published value as unapplied. It is never a first guess that falls through to `providers` or to
+   * the gateway -- a resolver that wants those for the ids it does not handle can call them itself,
+   * and one that does not should not have them happen behind its back.
+   */
+  resolveModel?: (id: string) => LanguageModelV4 | undefined | PromiseLike<LanguageModelV4 | undefined>
+}
+
+/**
+ * The specification version a model really has.
+ *
+ * Asked of the model *as written*, before `wrapLanguageModel` sees it. `asLanguageModelV4` wraps a v2
+ * or v3 model in a `Proxy` whose only behavior is to answer `'v4'` to `specificationVersion` and
+ * forward everything else, so by the time a middleware holds a model there is nothing left to tell
+ * the two apart -- and the difference matters, because `reasoning` is the one call option v4 added
+ * and an older provider is handed it and drops it without a word.
+ */
+export function specificationVersionOf(model: WrappableModel): SpecificationVersion {
+  return model.specificationVersion
+}
+
+/**
+ * The `'provider:model'` identifier for a model, for the baseline.
+ *
+ * A provider id is `<namespace>.<api>` -- `anthropic.messages` -- and the namespace is usually the
+ * whole of the provider's name; `canonicalProvider` owns the cases where it is not. One more
+ * exception is handled here: a gateway model's own id is already `'<provider>/<model>'`, so reporting
+ * it as `gateway:anthropic/claude-fable-5-1` would publish a baseline nothing could be written
+ * against. It is reported under the provider it names, which is also the form a managed value is sent
+ * back to the gateway under.
+ */
+export function modelIdentifier(model: { provider: string; modelId: string }): string {
+  const separator = model.modelId.indexOf('/')
+  if (namespaceOf(model.provider) === 'gateway' && separator !== -1) {
+    const provider = model.modelId.slice(0, separator)
+    return `${canonicalProvider(provider)}:${model.modelId.slice(separator + 1)}`
+  }
+  return `${canonicalProvider(model.provider)}:${model.modelId}`
+}
+
+/** The first segment of a dotted provider id, which is usually the whole of the provider's name. */
+function namespaceOf(provider: string): string {
+  return provider.replace(/\..*$/u, '')
+}
+
+/**
+ * The contract's name for an AI SDK provider, from its id or from a gateway model's provider segment.
+ *
+ * The namespace is the answer for every provider but Google, so `AI_SDK_TO_CANONICAL` is consulted
+ * first -- on the longest dotted prefix that matches -- and the namespace is the fallback.
+ */
+function canonicalProvider(provider: string): string {
+  for (const [prefix, canonical] of AI_SDK_TO_CANONICAL) {
+    if (provider === prefix || provider.startsWith(`${prefix}.`)) {
+      return canonical
+    }
+  }
+  return namespaceOf(provider)
+}
+
+/**
+ * A resolver for managed model strings, memoized per process.
+ *
+ * Memoized because it runs on every model request while the answer changes only when the published
+ * value does, and because a provider package's model object is meant to be built once and reused --
+ * rebuilding one per request would drop whatever it caches internally.
+ */
+export function createModelResolver(
+  options: ModelResolutionOptions,
+  report: (message: string) => void
+): (id: string) => Promise<LanguageModelV4 | undefined> {
+  const registry = options.providers === undefined ? undefined : createProviderRegistry(options.providers)
+  const registered = new Set(Object.keys(options.providers ?? {}))
+  const resolved = new Map<string, LanguageModelV4 | undefined>()
+
+  return async (id: string): Promise<LanguageModelV4 | undefined> => {
+    if (resolved.has(id)) {
+      return resolved.get(id)
+    }
+    const model = await resolveOnce(id, options.resolveModel, registry, registered, report)
+    resolved.set(id, model)
+    return model
+  }
+}
+
+/**
+ * Resolve one managed model string, reporting a failure rather than raising one.
+ *
+ * One chain, with one authoritative step at a time: a `resolveModel` the caller passed answers for
+ * every id, and without one a `'provider:model'` string is translated into this ecosystem's provider
+ * name and built from the caller's registry, or from the provider a bare string model would have gone
+ * through. Every way of not producing a model ends in the same place -- a published section that
+ * reached the right agent and did not happen, which is what `onUnmatched` governs, so a deployment
+ * that would rather stop than run on the wrong model can say so.
+ *
+ * The report is made *outside* the `try` on purpose: under `'error'` it throws, and a throw raised
+ * inside would be caught by the very handler that raised it and reported a second time as a
+ * resolution failure.
+ */
+async function resolveOnce(
+  id: string,
+  resolveModel: ModelResolutionOptions['resolveModel'],
+  registry: ProviderRegistryProvider | undefined,
+  registered: ReadonlySet<string>,
+  report: (message: string) => void
+): Promise<LanguageModelV4 | undefined> {
+  let failure: string
+  try {
+    if (resolveModel !== undefined) {
+      const model = await resolveModel(id)
+      if (model !== undefined) {
+        return model
+      }
+      failure = 'which the `resolveModel` this adapter was given declined to build'
+    } else if (!isQualified(id)) {
+      failure = "which is not in 'provider:model' form"
+    } else {
+      return await fromProvider(providerFor(id, registered), registry)
+    }
+  } catch (error) {
+    failure = `which could not be resolved (${error instanceof Error ? error.message : String(error)})`
+  }
+  report(`Managed agent config selects model '${id}', ${failure}; keeping the code-defined model.`)
+  return undefined
+}
+
+function isQualified(id: string): id is QualifiedModelId {
+  return id.includes(':')
+}
+
+/**
+ * The published id with its provider translated into the name this ecosystem knows it by.
+ *
+ * A key the caller registered themselves is read first and exactly as written: a `providers` record
+ * is the caller saying what a name means to them, and this module's table has no business overruling
+ * it. Every other name is translated where there is a translation and forwarded where there is not,
+ * because a name with no AI SDK equivalent still fails in the right place -- the registry or the
+ * gateway raises, which is caught and reported as a model that could not be resolved, and the agent
+ * keeps the model its code defines.
+ */
+function providerFor(id: QualifiedModelId, registered: ReadonlySet<string>): QualifiedModelId {
+  const separator = id.indexOf(':')
+  const provider = id.slice(0, separator)
+  if (registered.has(provider)) {
+    return id
+  }
+  const translated = CANONICAL_TO_AI_SDK[provider]
+  return translated === undefined ? id : `${translated}:${id.slice(separator + 1)}`
+}
+
+/** The registry the caller configured, else the provider a bare string model would have gone to. */
+async function fromProvider(id: QualifiedModelId, registry: ProviderRegistryProvider | undefined): Promise<LanguageModelV4> {
+  return registry === undefined ? gatewayModel(id) : registry.languageModel(id)
+}
+
+/**
+ * The last resort: the same provider a bare string model would have gone through.
+ *
+ * `generateText({model: 'anthropic/claude-fable-5-1'})` resolves through
+ * `globalThis.AI_SDK_DEFAULT_PROVIDER ?? gateway` (`ai/src/model/resolve-model.ts`), and a managed
+ * model string should end up at the same place a code-written one would. The gateway is imported
+ * lazily rather than depended on, so an application that never publishes a model string -- or that
+ * passes `providers` -- does not have to have it installed.
+ */
+async function gatewayModel(id: QualifiedModelId): Promise<LanguageModelV4> {
+  const configured = (globalThis as { AI_SDK_DEFAULT_PROVIDER?: ProviderV4 }).AI_SDK_DEFAULT_PROVIDER
+  const provider = configured ?? (await import('@ai-sdk/gateway')).gateway
+  return provider.languageModel(id.replace(':', '/'))
+}

--- a/packages/logfire-agent-control-ai-sdk/src/settings.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/settings.ts
@@ -1,0 +1,326 @@
+/**
+ * The canonical settings, lowered onto the AI SDK's call options, and read back out for a baseline.
+ *
+ * Most of the contract is a rename away from `LanguageModelV4CallOptions` (`max_tokens` ->
+ * `maxOutputTokens`, and the rest camelCase for camelCase). Three are not, and each is called out
+ * where it is handled: `thinking` is an effort enum here and only a v4 provider has one, `timeout` is
+ * not a call option at all, and `parallel_tool_calls` exists only inside a provider's own options.
+ *
+ * # Precedence
+ *
+ * The contract's order is code < published < what a run passed explicitly, and the merge that
+ * implements it is the core's `mergeSettings`, which has to be told which keys the run set. The AI
+ * SDK cannot say. By the time a request reaches a language model middleware the agent's settings and
+ * the call's are one object with no record of which came from where, and the seam upstream is no
+ * better: `agent.generate()` takes no generation settings at all, and `prepareCall` -- the one
+ * per-run hook that does -- is a whole-object transform whose idiom is to spread everything it did
+ * not change, so a key it wrote and a key it passed through are the same key. There is no boundary
+ * that knows.
+ *
+ * What is left is a comparison: a request field that differs from what the agent declares is one this
+ * run chose. That is exact except when a run sets a key to the value the code already had, which is
+ * indistinguishable from inheriting it and where a published value wins. The core's merge is still
+ * what applies it, because the layering, the cleared keys, and the provenance a provider option needs
+ * are all the same problem, and one of them being approximate is no reason to solve the rest again
+ * here. The README says which case is approximate.
+ */
+
+import type { AgentConfig, AgentConfigSettings, OnUnmatched, SettingsLayer } from '@pydantic/logfire-node/agent-control'
+import {
+  applySettings,
+  CANONICAL_SETTINGS_KEYS,
+  mergeSettings,
+  reportUnapplied,
+  toMilliseconds,
+} from '@pydantic/logfire-node/agent-control'
+import type { LanguageModelV4CallOptions, SharedV4ProviderOptions } from '@ai-sdk/provider'
+
+import type { SpecificationVersion } from './model'
+
+/**
+ * The AI SDK's model-facing generation controls: the settings both an agent and a call can set.
+ *
+ * Every field is explicitly `| undefined` rather than merely optional, so an unset one can be
+ * written out as `undefined` instead of having to be left off -- which is what lets the agent helper
+ * hand over what its agent declares in one destructuring, unset fields and all.
+ */
+export interface CallSettings {
+  maxOutputTokens?: number | undefined
+  temperature?: number | undefined
+  topP?: number | undefined
+  topK?: number | undefined
+  presencePenalty?: number | undefined
+  frequencyPenalty?: number | undefined
+  stopSequences?: string[] | undefined
+  seed?: number | undefined
+  reasoning?: LanguageModelV4CallOptions['reasoning'] | undefined
+  /**
+   * The provider's own options, which is where `parallel_tool_calls` lives.
+   *
+   * Part of the declared settings rather than of the request alone, because it is the only way to
+   * tell a run that deliberately set `openai.parallelToolCalls` from one that inherited it.
+   */
+  providerOptions?: SharedV4ProviderOptions | undefined
+}
+
+/**
+ * One of the contract's eleven canonical settings keys.
+ *
+ * `keyof AgentConfigSettings` on its own also admits the symbol the core hangs a published value's
+ * unrecognized keys off, which is not a setting anything here can carry.
+ */
+type CanonicalKey = keyof AgentConfigSettings & string
+
+/** Canonical key to the AI SDK field that carries it, for the settings that are a rename apart. */
+const DIRECT_KEYS = {
+  max_tokens: 'maxOutputTokens',
+  temperature: 'temperature',
+  top_p: 'topP',
+  top_k: 'topK',
+  presence_penalty: 'presencePenalty',
+  frequency_penalty: 'frequencyPenalty',
+  stop_sequences: 'stopSequences',
+  seed: 'seed',
+} as const satisfies Partial<Record<CanonicalKey, keyof CallSettings>>
+
+type DirectKey = keyof typeof DIRECT_KEYS
+
+const DIRECT_ENTRIES = Object.entries(DIRECT_KEYS) as [DirectKey, (typeof DIRECT_KEYS)[DirectKey]][]
+
+/**
+ * The provider option each provider exposes `parallel_tool_calls` through.
+ *
+ * There is no call option for it: the AI SDK leaves parallel tool calling to the provider, so the
+ * canonical key can only be lowered where a provider has a field for it. `inverted` is Anthropic's,
+ * which spells the same knob as `disableParallelToolUse`.
+ */
+const PARALLEL_TOOL_CALLS = {
+  openai: { key: 'parallelToolCalls', inverted: false },
+  anthropic: { key: 'disableParallelToolUse', inverted: true },
+} as const
+
+/**
+ * The `providerOptions` namespace a model's options are read from.
+ *
+ * A provider id is `<namespace>.<api>` -- `anthropic.messages`, `openai.responses` -- and every one
+ * of them parses `providerOptions` under the namespace alone.
+ */
+export function providerNamespace(provider: string): string {
+  return provider.replace(/\..*$/u, '')
+}
+
+function parallelOption(namespace: string): (typeof PARALLEL_TOOL_CALLS)[keyof typeof PARALLEL_TOOL_CALLS] | undefined {
+  return PARALLEL_TOOL_CALLS[namespace as keyof typeof PARALLEL_TOOL_CALLS]
+}
+
+/**
+ * The canonical settings this request could actually carry, which is not the same for every model.
+ *
+ * Two of the eleven depend on where the request is going. `thinking` is lowered onto `reasoning`,
+ * which is the one call option `LanguageModelV4` added: a v2 or v3 provider reached through
+ * `wrapLanguageModel`'s bridge is handed that field and drops it without a word, so applying one for
+ * such a model would be a published setting that changes nothing. `parallel_tool_calls` has no call
+ * option at all and exists only where a provider has its own field for it.
+ *
+ * Used in both directions -- what a published value may set, and what a baseline may claim the agent
+ * does -- so the Logfire editor is never shown a key this request would ignore.
+ */
+export function supportedSettings(namespace: string, specificationVersion: SpecificationVersion): ReadonlySet<CanonicalKey> {
+  const supported = new Set<CanonicalKey>([...DIRECT_ENTRIES.map(([canonical]) => canonical), 'timeout'])
+  if (specificationVersion === 'v4') {
+    supported.add('thinking')
+  }
+  if (parallelOption(namespace) !== undefined) {
+    supported.add('parallel_tool_calls')
+  }
+  return supported
+}
+
+/** `thinking` as the AI SDK's reasoning effort, and back. */
+function toReasoning(thinking: NonNullable<AgentConfigSettings['thinking']>): NonNullable<CallSettings['reasoning']> {
+  if (thinking === true) {
+    return 'provider-default'
+  }
+  if (thinking === false) {
+    return 'none'
+  }
+  return thinking
+}
+
+function fromReasoning(reasoning: CallSettings['reasoning']): AgentConfigSettings['thinking'] {
+  if (reasoning === undefined) {
+    return undefined
+  }
+  if (reasoning === 'provider-default') {
+    return true
+  }
+  if (reasoning === 'none') {
+    return false
+  }
+  return reasoning
+}
+
+/** Options for `lowerSettings`. */
+export interface LowerSettingsOptions {
+  /** The request as the AI SDK assembled it, which a managed value patches. */
+  params: LanguageModelV4CallOptions
+  /**
+   * The settings the agent declares in code, when the adapter was given them.
+   *
+   * Both the code layer of the merge and the only evidence there is for which keys this run set,
+   * since a request field that differs from what the code declares is one this run chose. Leaving it
+   * out is the weaker contract: with no code layer to compare against, a published value wins every
+   * key it names.
+   */
+  code?: CallSettings | undefined
+  /** The `providerOptions` namespace of the model this request will actually go to. */
+  namespace: string
+  /** The specification version of the model this request will actually go to. */
+  specificationVersion: SpecificationVersion
+  onUnmatched: OnUnmatched
+}
+
+/**
+ * The call options a managed `settings` section changes, as a patch over `params`.
+ *
+ * Only the keys the *published* layer wins are in the patch. A key the run set explicitly, and a key
+ * only the code sets, are already in `params` with the value they should have, so writing either back
+ * could only ever change it -- which is the mistake this shape makes unrepresentable.
+ *
+ * Every canonical key that reaches nothing is reported: one this SDK has no field for, by
+ * `applySettings`; one this model cannot honour -- `thinking` on a pre-v4 provider,
+ * `parallel_tool_calls` on a provider with no knob for it -- here.
+ */
+export function lowerSettings(config: AgentConfig, options: LowerSettingsOptions): Partial<LanguageModelV4CallOptions> {
+  const { params, code, namespace, specificationVersion, onUnmatched } = options
+  const supported = supportedSettings(namespace, specificationVersion)
+  const settings = applySettings(config, { onUnmatched })
+  const published: CanonicalSettings = {}
+  const unapplied: string[] = []
+  for (const key of CANONICAL_SETTINGS_KEYS) {
+    const value = settings[key]
+    if (value === undefined) {
+      continue
+    }
+    if (supported.has(key)) {
+      ;(published as Record<string, unknown>)[key] = value
+    } else {
+      unapplied.push(key)
+    }
+  }
+  reportUnapplied(unapplied, { onUnmatched })
+
+  const codeLayer = code === undefined ? undefined : canonicalSettings(code, namespace, supported)
+  const requestLayer = canonicalSettings(params, namespace, supported)
+  const { sources } = mergeSettings(codeLayer, published, runLayer(requestLayer, codeLayer))
+  const wins = (key: CanonicalKey): boolean => sources.get(key) === 'published'
+
+  const patch: Partial<LanguageModelV4CallOptions> = {}
+  for (const [canonical, field] of DIRECT_ENTRIES) {
+    const value = published[canonical]
+    if (value !== undefined && wins(canonical)) {
+      ;(patch as Record<string, unknown>)[field] = value
+    }
+  }
+
+  if (published.thinking !== undefined && wins('thinking')) {
+    patch.reasoning = toReasoning(published.thinking)
+  }
+
+  // `timeout` is not a call option; the AI SDK's own timeouts live one layer up, on the call, and by
+  // the time one reaches a model it has become an `AbortSignal` indistinguishable from the one a
+  // caller passes to cancel a run. So the published budget is composed with whatever signal the
+  // request carries -- whichever fires first aborts -- rather than replacing it, which also means a
+  // per-run timeout *longer* than the published one cannot win at this seam. See the README's known
+  // limits. `toMilliseconds` is the core's conversion: a budget too small to round to a millisecond
+  // comes back as 1 rather than as the fractional delay `AbortSignal.timeout` throws on.
+  if (published.timeout !== undefined) {
+    const timeout = AbortSignal.timeout(toMilliseconds(published.timeout))
+    patch.abortSignal = params.abortSignal === undefined ? timeout : AbortSignal.any([params.abortSignal, timeout])
+  }
+
+  const option = parallelOption(namespace)
+  if (published.parallel_tool_calls !== undefined && option !== undefined && wins('parallel_tool_calls')) {
+    patch.providerOptions = {
+      ...params.providerOptions,
+      [namespace]: {
+        ...params.providerOptions?.[namespace],
+        [option.key]: option.inverted ? !published.parallel_tool_calls : published.parallel_tool_calls,
+      },
+    }
+  }
+
+  return patch
+}
+
+/**
+ * The layer holding what this run set for itself, as far as anything here can tell.
+ *
+ * A request field that differs from what the agent declares is one this run chose; see the module
+ * comment for the one case that misses. With no declared settings at all there is no evidence
+ * whatsoever, which the core reads as "this adapter cannot see the run layer" -- and a published
+ * value then wins every key -- rather than as "the run set nothing".
+ */
+function runLayer(request: CanonicalSettings, code: CanonicalSettings | undefined): SettingsLayer {
+  if (code === undefined) {
+    return undefined
+  }
+  const layer: Record<string, unknown> = {}
+  for (const key of CANONICAL_SETTINGS_KEYS) {
+    const value = request[key]
+    if (value !== undefined && !sameValue(value, code[key])) {
+      layer[key] = value
+    }
+  }
+  return layer
+}
+
+/**
+ * The canonical settings, as a mapping the core's merge and baseline can both read.
+ *
+ * `AgentConfigSettings` with an index signature, which is what `mergeSettings` and `buildBaseline`
+ * take: both read a framework's settings by name, and neither can be given an interface that
+ * TypeScript will not let them index.
+ */
+export type CanonicalSettings = AgentConfigSettings & Record<string, unknown>
+
+/** Whether two canonical settings values are the same one; the only structured value is a list. */
+function sameValue(one: unknown, other: unknown): boolean {
+  if (Array.isArray(one) && Array.isArray(other)) {
+    return one.length === other.length && one.every((item, index) => item === other[index])
+  }
+  return one === other
+}
+
+/**
+ * The canonical settings a set of AI SDK call options carries.
+ *
+ * Filtered to `supported`, so neither the baseline nor the precedence merge ever names a key this
+ * request's model would ignore: publishing an effort level a v3 provider drops would offer the editor
+ * a change that does nothing.
+ *
+ * `timeout` is deliberately never produced. At this layer it is an `AbortSignal`, which says nothing
+ * about how long it was armed for, so there is no honest value to report as the code-side one.
+ */
+export function canonicalSettings(settings: CallSettings, namespace: string, supported: ReadonlySet<CanonicalKey>): CanonicalSettings {
+  const canonical: CanonicalSettings = {}
+  for (const [key, field] of DIRECT_ENTRIES) {
+    const value = settings[field]
+    if (value !== undefined && supported.has(key)) {
+      ;(canonical as Record<string, unknown>)[key] = value
+    }
+  }
+  const thinking = fromReasoning(settings.reasoning)
+  if (thinking !== undefined && supported.has('thinking')) {
+    canonical.thinking = thinking
+  }
+
+  const option = parallelOption(namespace)
+  if (option !== undefined && supported.has('parallel_tool_calls')) {
+    const parallel = settings.providerOptions?.[namespace]?.[option.key]
+    if (typeof parallel === 'boolean') {
+      canonical.parallel_tool_calls = option.inverted ? !parallel : parallel
+    }
+  }
+  return canonical
+}

--- a/packages/logfire-agent-control-ai-sdk/src/tools.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/tools.ts
@@ -89,8 +89,11 @@ export function applyToTools(tools: CallTools | undefined, config: AgentConfig, 
   // function tool at the same offset -- keyed back by code-side name, since that is what survives.
   // A lookup that misses is a provider-defined tool, which was never handed to the core at all.
   const definitions = new Map(defs.map((def, index) => [def.name, applied.tools[index]]))
-  const routes: Record<string, string> = {}
-  const renames: Record<string, string> = {}
+  // Null-prototype, because these are keyed by tool names the model and the caller choose. On an
+  // ordinary object a tool called `constructor` would read back `Object.prototype.constructor` and
+  // route a call to a function, and one called `__proto__` could not be written at all.
+  const routes: Record<string, string> = Object.create(null) as Record<string, string>
+  const renames: Record<string, string> = Object.create(null) as Record<string, string>
   // A managed definition is applied to a copy: the request's tools belong to the caller.
   const result: CallTools = (tools ?? []).map((tool) => {
     const definition = isFunctionTool(tool) ? definitions.get(tool.name) : undefined

--- a/packages/logfire-agent-control-ai-sdk/src/tools.ts
+++ b/packages/logfire-agent-control-ai-sdk/src/tools.ts
@@ -1,0 +1,205 @@
+/**
+ * The AI SDK's tool definitions, as the core's `ToolDef`s, and the renaming that has to follow one.
+ *
+ * The AI SDK looks a returned `toolName` up in the code-side `tools` record to decide what to run
+ * (`ai/src/generate-text/parse-tool-call.ts`). A name it does not find is not an error in v7 -- the
+ * call is marked invalid, a `tool-error` is fed back to the model, and the tool never executes -- so
+ * a rename that is not mapped back does not fail loudly, it silently stops working. Every rename
+ * therefore has four halves, and this module owns all of them: rename on the way out, rewrite the
+ * outgoing name selectors that named the old one, un-rename the calls that come back, and re-rename
+ * the history the SDK writes with code names.
+ */
+
+import type { AgentConfig, OnUnmatched, ToolDef } from '@pydantic/logfire-node/agent-control'
+import { applyToolDefinitions } from '@pydantic/logfire-node/agent-control'
+import type {
+  JSONSchema7,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FunctionTool,
+  LanguageModelV4Message,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
+  LanguageModelV4ToolChoice,
+} from '@ai-sdk/provider'
+
+/** The tools of a request, as the AI SDK hands them to a model. */
+type CallTools = NonNullable<LanguageModelV4CallOptions['tools']>
+
+/** What `applyToTools` gives the middleware back. */
+export interface AppliedTools {
+  /** The tools to advertise, in the order they were given. */
+  tools: CallTools
+  /** Advertised name to code-side name, for every function tool: the way back in. */
+  routes: Record<string, string>
+  /**
+   * Code-side name to advertised name, for the tools whose name actually changed: the way out.
+   *
+   * Only the renames, because every use of it rewrites something -- a `toolChoice`, a replayed
+   * history entry -- and an entry mapping a name to itself would make every such rewrite look like a
+   * rename and cost a copy of the prompt for nothing.
+   */
+  renames: Record<string, string>
+}
+
+function isFunctionTool(tool: CallTools[number]): tool is LanguageModelV4FunctionTool {
+  return tool.type === 'function'
+}
+
+/**
+ * One tool's LLM-facing definition, as the core models it.
+ *
+ * `toolset` is deliberately never set. The AI SDK's `tools` is one flat `Record<string, Tool>` with
+ * no grouping of any kind -- MCP tools are merged into the same record by `client.tools()` -- so
+ * there is no honest value to report, and inventing one would put a name in the Logfire editor that
+ * an override could be written against and would then match nothing.
+ */
+export function toolDefs(tools: CallTools | undefined): ToolDef[] {
+  return (tools ?? []).filter(isFunctionTool).map((tool) => {
+    const def: ToolDef = { name: tool.name, parametersJsonSchema: asJsonSchema(tool.inputSchema) }
+    if (tool.description !== undefined) {
+      def.description = tool.description
+    }
+    return def
+  })
+}
+
+/**
+ * Apply the `tool_definitions` section to a request's tools.
+ *
+ * Provider-defined tools pass through untouched -- their name and arguments are a contract with the
+ * provider, not a description the model reads -- but their names are handed to the core as
+ * `reserved`, because a managed rename onto one of them would advertise two tools under one name and
+ * make both unreachable. That is the one collision the core cannot see for itself, since it is never
+ * shown these tools; naming them is what lets it refuse the rename under the caller's `onUnmatched`
+ * policy alongside every other collision, rather than in a warning of this adapter's own.
+ *
+ * `collisionScope` is the default `'global'`, stated rather than inherited: the AI SDK advertises one
+ * flat namespace, so any two tools with the same name collide and there is no toolset to narrow by.
+ */
+export function applyToTools(tools: CallTools | undefined, config: AgentConfig, onUnmatched: OnUnmatched): AppliedTools {
+  const defs = toolDefs(tools)
+  const applied = applyToolDefinitions(defs, config, {
+    onUnmatched,
+    reserved: (tools ?? []).filter((tool) => !isFunctionTool(tool)).map((tool) => tool.name),
+    collisionScope: 'global',
+  })
+
+  // The core returns the definitions in the order it was given them, so each one belongs to the
+  // function tool at the same offset -- keyed back by code-side name, since that is what survives.
+  // A lookup that misses is a provider-defined tool, which was never handed to the core at all.
+  const definitions = new Map(defs.map((def, index) => [def.name, applied.tools[index]]))
+  const routes: Record<string, string> = {}
+  const renames: Record<string, string> = {}
+  // A managed definition is applied to a copy: the request's tools belong to the caller.
+  const result: CallTools = (tools ?? []).map((tool) => {
+    const definition = isFunctionTool(tool) ? definitions.get(tool.name) : undefined
+    if (definition === undefined) {
+      return tool
+    }
+    // The core has already decided the advertised name, collisions with a provider tool included.
+    const name = definition.name
+    routes[name] = tool.name
+    if (name !== tool.name) {
+      renames[tool.name] = name
+    }
+    return {
+      ...tool,
+      name,
+      ...(definition.description === undefined ? {} : { description: definition.description }),
+      inputSchema: asInputSchema(definition.parametersJsonSchema),
+    }
+  })
+  return { tools: result, routes, renames }
+}
+
+/**
+ * The code-side name a call under `name` belongs to.
+ *
+ * `routes` covers every function tool, so a lookup that misses is a name this adapter never
+ * advertised -- a provider-defined tool, or a tool the model invented -- and has to be left exactly
+ * as it is for the SDK's own handling of it.
+ */
+function codeName(routes: Record<string, string>, name: string): string {
+  return routes[name] ?? name
+}
+
+/**
+ * A forced tool choice, rewritten to name the tool as the model will be shown it.
+ *
+ * `toolChoice: {type: 'tool', toolName: 'get_weather'}` is a decision the *code* made, expressed in
+ * the code's vocabulary; an overlay that renames the tool has to carry that decision across rather
+ * than leave it naming a tool this request no longer advertises, which providers reject outright.
+ * The other three choices name no tool and pass through.
+ *
+ * `activeTools` is the sibling selector, and it is deliberately not here: the AI SDK applies it
+ * before a model middleware runs -- it filters the `tools` record on the way to the request -- so
+ * what reaches this seam is already the filtered set, keyed by code names that were never renamed.
+ */
+export function renameToolChoice(toolChoice: LanguageModelV4ToolChoice, renames: Record<string, string>): LanguageModelV4ToolChoice {
+  if (toolChoice.type !== 'tool') {
+    return toolChoice
+  }
+  const renamed = renames[toolChoice.toolName]
+  return renamed === undefined ? toolChoice : { ...toolChoice, toolName: renamed }
+}
+
+/**
+ * Rewrite the tool names in a prompt's history through `renames`.
+ *
+ * Needed on the way out because the SDK writes the assistant's `tool-call` and the `tool-result` back
+ * into the next step's prompt under the *code* name, while the tools advertised alongside them carry
+ * the managed name. A provider shown a call to a tool it was not offered rejects the request -- and
+ * short of that, the names alternating between steps busts the prompt cache on every one of them.
+ */
+export function renameHistory(prompt: LanguageModelV4Prompt, renames: Record<string, string>): LanguageModelV4Prompt {
+  if (Object.keys(renames).length === 0) {
+    return prompt
+  }
+  return prompt.map((message) => renameMessage(message, renames))
+}
+
+function renameMessage(message: LanguageModelV4Message, renames: Record<string, string>): LanguageModelV4Message {
+  if (message.role !== 'assistant' && message.role !== 'tool') {
+    return message
+  }
+  // `content` is a union of part arrays per role; every part that names a tool names it the same way,
+  // and every other part -- text, reasoning, a call to a tool no override renamed -- passes through.
+  const content = message.content.map((part) => {
+    const renamed = 'toolName' in part ? renames[part.toolName] : undefined
+    return renamed === undefined ? part : { ...part, toolName: renamed }
+  })
+  return { ...message, content } as LanguageModelV4Message
+}
+
+/** Map the tool names in a generate result's content back to the code-side names. */
+export function unrenameContent(content: readonly LanguageModelV4Content[], routes: Record<string, string>): LanguageModelV4Content[] {
+  return content.map((part) => ('toolName' in part ? { ...part, toolName: codeName(routes, part.toolName) } : part))
+}
+
+/**
+ * Map the tool names in a stream part back to the code-side name.
+ *
+ * `tool-input-start` and `tool-call` are the parts that carry one on the way in, and a
+ * provider-executed `tool-result` on the way back; `tool-input-delta` and `tool-input-end` carry only
+ * the id. Keying on the presence of `toolName` rather than on a list of part types is what keeps a
+ * part type added in a later AI SDK release from quietly going unmapped.
+ */
+export function unrenameStreamPart(part: LanguageModelV4StreamPart, routes: Record<string, string>): LanguageModelV4StreamPart {
+  return 'toolName' in part ? { ...part, toolName: codeName(routes, part.toolName) } : part
+}
+
+/**
+ * A tool's JSON Schema as the core's `JsonSchema`, and back.
+ *
+ * `JSONSchema7` is an interface with named fields and `JsonSchema` is `Record<string, unknown>`, so
+ * neither is assignable to the other without going through `unknown` -- but they describe the same
+ * document, and the core only ever reads and rewrites `properties.*.description` inside it.
+ */
+function asJsonSchema(schema: JSONSchema7): Record<string, unknown> {
+  return schema as unknown as Record<string, unknown>
+}
+
+function asInputSchema(schema: Record<string, unknown>): JSONSchema7 {
+  return schema as unknown as JSONSchema7
+}

--- a/packages/logfire-agent-control-ai-sdk/tsconfig.json
+++ b/packages/logfire-agent-control-ai-sdk/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vite.config.ts"]
+}

--- a/packages/logfire-agent-control-ai-sdk/vite.config.ts
+++ b/packages/logfire-agent-control-ai-sdk/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite-plus'
+
+import { copyCjsDeclarations, packageDefines } from '../../vite.shared'
+
+const defines = packageDefines(import.meta.url)
+
+const config: ReturnType<typeof defineConfig> = defineConfig({
+  define: defines,
+  pack: {
+    define: defines,
+    dts: {
+      resolver: 'tsc',
+    },
+    deps: {
+      neverBundle: [/^@ai-sdk\//u, /^@pydantic\//u, /^node:/u, 'ai'],
+    },
+    entry: 'src/index.ts',
+    format: ['esm', 'cjs'],
+    hooks: {
+      'build:done': () => {
+        copyCjsDeclarations(['index'])
+      },
+    },
+    minify: true,
+    outExtensions: ({ format }) => ({
+      dts: format === 'cjs' ? '.d.cts' : '.d.ts',
+      js: format === 'cjs' ? '.cjs' : '.js',
+    }),
+    outputOptions: {
+      exports: 'named',
+    },
+  },
+})
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,24 @@ settings:
 
 catalogs:
   default:
+    '@ai-sdk/anthropic':
+      specifier: ^4.0.52
+      version: 4.0.52
+    '@ai-sdk/gateway':
+      specifier: ^4.0.78
+      version: 4.0.78
+    '@ai-sdk/google':
+      specifier: ^4.0.67
+      version: 4.0.67
+    '@ai-sdk/openai':
+      specifier: ^4.0.65
+      version: 4.0.65
+    '@ai-sdk/provider':
+      specifier: ^4.0.13
+      version: 4.0.13
+    '@ai-sdk/provider-utils':
+      specifier: ^5.0.39
+      version: 5.0.39
     '@opentelemetry/api':
       specifier: ^1.9.1
       version: 1.9.1
@@ -87,9 +105,15 @@ catalogs:
     '@types/js-yaml':
       specifier: ^4.0.9
       version: 4.0.9
+    '@types/json-schema':
+      specifier: ^7.0.15
+      version: 7.0.15
     '@vercel/otel':
       specifier: ^2.1.3
       version: 2.1.3
+    ai:
+      specifier: ^7.0.97
+      version: 7.0.97
     fflate:
       specifier: ^0.8.3
       version: 0.8.3
@@ -428,6 +452,48 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  packages/logfire-agent-control-ai-sdk:
+    devDependencies:
+      '@ai-sdk/anthropic':
+        specifier: 'catalog:'
+        version: 4.0.52(zod@4.4.3)
+      '@ai-sdk/gateway':
+        specifier: 'catalog:'
+        version: 4.0.78(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: 'catalog:'
+        version: 4.0.67(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: 'catalog:'
+        version: 4.0.65(zod@4.4.3)
+      '@ai-sdk/provider':
+        specifier: 'catalog:'
+        version: 4.0.13
+      '@ai-sdk/provider-utils':
+        specifier: 'catalog:'
+        version: 5.0.39(zod@4.4.3)
+      '@opentelemetry/api':
+        specifier: 'catalog:'
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: 'catalog:'
+        version: 2.8.0(@opentelemetry/api@1.9.1)
+      '@pydantic/logfire-node':
+        specifier: workspace:*
+        version: link:../logfire-node
+      '@types/json-schema':
+        specifier: 'catalog:'
+        version: 7.0.15
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.97(zod@4.4.3)
+      vitest:
+        specifier: 4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(@vitest/browser-preview@4.1.9)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   packages/logfire-api:
     dependencies:
       handlebars:
@@ -660,6 +726,40 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.5)(@vitest/browser-preview@4.1.9)(esbuild@0.28.1)(jsdom@29.1.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
 
 packages:
+
+  '@ai-sdk/anthropic@4.0.52':
+    resolution: {integrity: sha512-IQt/y++kSUdqa9EbFOJntxLGjZMURTm/MnTUikNBZ5X86K5l96t/BwsRsX/SrH5kx+7yRPrmJ1WBNlmE8quSVg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.78':
+    resolution: {integrity: sha512-fcamzmFlcy+c/tIc7QcATLe/kArgSVGQ1QxaddMjhOSX8zypc2hmD5sHB2bp1DSFcSxDD32d6usF9a7xLCTULg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@4.0.67':
+    resolution: {integrity: sha512-F+o3bRDz0ua2hJbpnuEsoNsKR11NT+nAhq1eZfaRJr2rzs5eKi/E9wJw8ZXeJx7NlYeBF6il5/+itTBdkM1kJg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.65':
+    resolution: {integrity: sha512-rpk1Tv7TR0H338zTKmSVMxv4yo++HDOxioiuvBySb8cWkx2fS10tWl/5cEwL0diJbcV/+p3+9gpIOre52UoQJA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.39':
+    resolution: {integrity: sha512-VIFp4Qv3j+V941crFB1y2VG5yeGbeLOFRxiPaZJETkkpo1H5WviLx6H5yRkFkrXIGxnTGygKsPgCAJG0X61Auw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.13':
+    resolution: {integrity: sha512-sJvnbFIFLzmKFXIjfwS8XCOAj6puHCawItwvA9PBZgk2f/l/TiC4OSfK3ueDbUVXfRCOn5eJN97EIF10toIOmQ==}
+    engines: {node: '>=22'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -2519,6 +2619,9 @@ packages:
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
 
@@ -2571,6 +2674,10 @@ packages:
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
   '@vercel/otel@2.1.3':
     resolution: {integrity: sha512-Ofvzs9qhftRD1YMLuPnhbXjQZG6IKrJ9AmEKmRHRGfoWlV89ed2gAOkvddkFiZDFZJm2rrFNdeZKRVxoCdnWiw==}
@@ -2735,6 +2842,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
 
@@ -2755,6 +2865,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@7.0.97:
+    resolution: {integrity: sha512-tQGZ234p/bk5X/LNQdB43a5/z1Bve7wK0EOR1AwN6xrosZih4MIC/3pXhcnytcpBJHMbhLISW6J1dFTd/tnwPA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2978,6 +3094,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3153,6 +3273,9 @@ packages:
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
@@ -3689,10 +3812,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -3940,6 +4059,44 @@ packages:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
 
 snapshots:
+
+  '@ai-sdk/anthropic@4.0.52(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@4.0.78(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/google@4.0.67(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@4.0.65(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.39(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.13':
+    dependencies:
+      json-schema: 0.4.0
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -5768,6 +5925,8 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/memcached@2.2.10':
     dependencies:
       '@types/node': 22.19.5
@@ -5832,6 +5991,8 @@ snapshots:
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 22.19.5
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vercel/otel@2.1.3(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.219.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
@@ -6016,6 +6177,8 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.2.1':
     optional: true
 
+  '@workflow/serde@4.1.0': {}
+
   '@xstate/fsm@1.6.5': {}
 
   accepts@1.3.8:
@@ -6030,6 +6193,13 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@7.0.97(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.78(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.4.3)
+      zod: 4.4.3
 
   ansi-regex@5.0.1: {}
 
@@ -6228,6 +6398,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
 
   expect-type@1.3.0: {}
 
@@ -6458,6 +6630,8 @@ snapshots:
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
+
+  json-schema@0.4.0: {}
 
   jsonc-parser@3.3.1: {}
 
@@ -7085,8 +7259,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.1.2: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.16:
@@ -7226,7 +7398,7 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.1.2
+      tinyexec: 1.3.0
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@22.19.5)(esbuild@0.28.1)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,12 @@ overrides:
   'vitest': '4.1.9'
 
 catalog:
+  '@ai-sdk/anthropic': ^4.0.52
+  '@ai-sdk/gateway': ^4.0.78
+  '@ai-sdk/google': ^4.0.67
+  '@ai-sdk/openai': ^4.0.65
+  '@ai-sdk/provider': ^4.0.13
+  '@ai-sdk/provider-utils': ^5.0.39
   '@opentelemetry/api': ^1.9.1
   '@opentelemetry/api-logs': '>=0.219.0 <0.300.0'
   '@opentelemetry/auto-instrumentations-node': '>=0.77.0 <0.100.0'
@@ -54,7 +60,9 @@ catalog:
   '@opentelemetry/sdk-trace-web': ^2.8.0
   '@opentelemetry/semantic-conventions': ^1.41.1
   '@types/js-yaml': ^4.0.9
+  '@types/json-schema': ^7.0.15
   '@vercel/otel': ^2.1.3
+  ai: ^7.0.97
   fflate: ^0.8.3
   handlebars: ^4.7.9
   jsdom: ^29.1.1

--- a/scripts/record-live-cassettes.mjs
+++ b/scripts/record-live-cassettes.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Re-record the Agent Control AI SDK adapter's live-provider cassettes.
+//
+//   node scripts/record-live-cassettes.mjs --env-file <path to a .env with provider keys>
+//
+// The env file needs OPENAI_API_KEY, ANTHROPIC_API_KEY, and GEMINI_API_KEY. It is loaded into this
+// process with `process.loadEnvFile` and handed to the test process through its environment, so the
+// values never appear on a command line, in a log, or in a cassette. Everything the recorder writes
+// is in packages/logfire-agent-control-ai-sdk/src/__test__/cassettes/.
+//
+// Recording costs a handful of requests to the cheapest current model of each provider.
+
+import { spawnSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const flag = process.argv.indexOf('--env-file')
+const envFile = flag === -1 ? undefined : process.argv[flag + 1]
+
+if (envFile === undefined) {
+  console.error('Usage: node scripts/record-live-cassettes.mjs --env-file <path>')
+  process.exit(2)
+}
+
+process.loadEnvFile(envFile)
+
+const missing = ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'GEMINI_API_KEY'].filter((name) => !process.env[name])
+if (missing.length > 0) {
+  console.error(`${envFile} does not define: ${missing.join(', ')}`)
+  process.exit(2)
+}
+
+const { status } = spawnSync(
+  'pnpm',
+  ['--filter', '@pydantic/logfire-agent-control-ai-sdk', 'exec', 'vitest', 'run', 'src/__test__/live.test.ts'],
+  {
+    cwd: root,
+    stdio: 'inherit',
+    env: { ...process.env, LOGFIRE_CASSETTE_MODE: 'record' },
+  }
+)
+
+process.exit(status ?? 1)


### PR DESCRIPTION
Stacked on #321, which adds the framework-neutral core as `@pydantic/logfire-node/agent-control`. This targets `agent-control-core` and will retarget to `main` when that merges.

## What this is

Agent Control lets someone change what a running agent does — its instructions, its model, its model settings, the names and descriptions its tools are advertised under — from the Logfire UI, without a deploy. This is the [Vercel AI SDK](https://ai-sdk.dev) adapter for it.

```bash
npm install @pydantic/logfire-agent-control-ai-sdk
```

```ts
import { anthropic } from '@ai-sdk/anthropic'
import { agentControl } from '@pydantic/logfire-agent-control-ai-sdk'
import { ToolLoopAgent } from 'ai'

const agent = new ToolLoopAgent(
  agentControl({
    settings: {
      id: 'checkout_assistant',
      model: anthropic('claude-fable-5-1'),
      instructions: 'You are a concise checkout assistant.',
      tools: { get_weather },
    },
  })
)
```

That is the whole installation. The config lives in a Logfire variable named `agent__checkout_assistant`, and the first model request publishes a description of the agent as written so the editor shows what it is you are changing. Until someone publishes a value — and any time Logfire is unreachable, or a published value cannot be understood — the agent runs exactly as the code defines it.

It installs as one `LanguageModelMiddleware`, which is the AI SDK's only per-model-request seam and turns out to be enough for all four sections: what reaches it is the full `LanguageModelV4CallOptions` — the system messages, the tools with their resolved JSON Schemas, and every generation setting — and what comes back is where a renamed tool call has to be mapped to the tool the code implements, before the SDK looks the name up and finds nothing. `agentControl({ settings })` wraps a `ToolLoopAgent`'s settings; `agentControl({ model })` wraps a bare model, for `generateText`, `streamText`, or anywhere a `LanguageModel` goes; `agentControlMiddleware({ name })` is the same thing as a plain middleware for a `wrapLanguageModel` call you already have. All three leave the caller's objects untouched.

## Placement: a package, not another subpath

#321's reasoning was that **every `packages/*` entry is a runtime and every feature area is a subpath**, which is why the core is `@pydantic/logfire-node/agent-control`. An adapter is neither, and the deciding constraint is a third-party one: this code imports `ai` and `@ai-sdk/provider`. A subpath of `@pydantic/logfire-node` would put `ai` in the Node SDK's peer dependencies and its typecheck — for a module most of that package's users will never import — and three adapters would put three frameworks there. #321's own docs page already says the three adapters would each be a package for that reason; this is that.

The repository is not actually "packages are runtimes" without exception: `@pydantic/logfire-session-replay` is a package precisely because it holds a third-party dependency (`@rrweb/record`) that `@pydantic/logfire-browser` must not drag in, and it is wired as an **optional peer** of the package that uses it. That is the arrangement to compare against, and the difference is which way the dependency points. Session replay is a leaf the browser package reaches for; an adapter is a layer on top of the core, so the peer runs the other way:

```jsonc
"peerDependencies": {
  "@pydantic/logfire-node": "workspace:^",
  "ai": "catalog:",
  "@ai-sdk/provider": "catalog:",
  "@ai-sdk/provider-utils": "catalog:",
  "@ai-sdk/gateway": "catalog:"   // optional; only for a published model string with no `providers`
}
```

`@pydantic/logfire-node` is a **peer rather than a dependency**, and that is load-bearing rather than tidy. The SDK keeps its variable provider in a module-level singleton, and so do the core's warn-once and publish-once guards; a nested second copy of `@pydantic/logfire-node` would mean the adapter reading a provider the application's `logfire.configure()` never touched, and `resetAgentControl` in a test suite resetting guards nobody holds. A peer makes that a resolution error instead of a silent one. The range is `workspace:^` rather than a pinned `^0.18.24` because the `/agent-control` subpath does not exist until #321 releases; `workspace:^` stamps whatever version is current when the two are published together.

The costs of a package, stated plainly: a new npm publish target and a trusted-publisher setup. Per the release workflow's own comment, a brand-new package cannot use OIDC for its first publish ([npm/cli#8544](https://github.com/npm/cli/issues/8544)) — it needs one manual publish, then its trusted publisher configured on npmjs.com, and CI takes over.

The Mastra and Codex SDK adapters are being opened in parallel and justify their own placement.

## What becomes editable

| Source / canonical field | Support | Notes |
| --- | --- | --- |
| A declared block of `instructions` | **Yes** | Addressed as `system:0`, `system:1`, … or by `providerOptions: { logfire: { id: 'refunds' } }` on the message. Replaced by publishing text, removed by publishing none; the block keeps its position and its own `providerOptions`, an Anthropic cache breakpoint included. |
| Adding a block | **Yes** | Lands at the end of the static group, ahead of the first block the agent recomputes, so it never moves a provider's prompt-cache boundary. |
| A block a `prepareCall` / `prepareStep` hook computes | **No** | Recognized by its text differing from what the code declares, and reported. Replacing it would pin one run's rendering forever. |
| A tool's advertised name, description, and parameter descriptions | **Yes** | Top-level parameters only. Names, types, and requiredness stay code-defined. |
| Narrowing an override to one toolset | **No** | The AI SDK's `tools` is one flat record with no grouping — `client.tools()` merges MCP tools into it too — so there is nothing to match on. |
| A provider-defined tool | **No** | Passes through untouched, and its name is reserved so nothing can be renamed onto it. |
| `model` | **Conditional** | Resolved through `resolveModel`, else `providers`, else the AI Gateway. |
| The eleven canonical settings | **Conditional** | This adapter lowers them onto the request; what the provider then does with one is a separate question, and the live tests below are what settles it. |

Anything published that *this adapter* cannot apply goes through `onUnmatched` — `'warn'` (default, once per process per message), `'ignore'`, or `'error'`. The full table with every condition is in the [package README](https://github.com/pydantic/logfire-js/blob/agent-control-ai-sdk/packages/logfire-agent-control-ai-sdk/README.md).

## When config applies, and precedence

**Per model request** — every step of the tool loop, not once per conversation, so a value saved in Logfire reaches the next model request with no restart and a rollout can move between two steps of one run. The whole request runs inside the resolution's telemetry context, so its spans carry the label that drove it.

Precedence is **code < published < what a run passed explicitly**, and the AI SDK cannot say which is which: by the time a request reaches a language model middleware, the agent's settings and the call's are one object, and the one per-run hook that takes settings (`prepareCall`) is a whole-object transform whose idiom is to spread through everything it did not change. So a run's own values are recognized by comparison against what the code declares, which the two `agentControl` forms supply. That is exact except for a run that sets a key to the value the code already had, where the published value wins. Without `codeSettings` there is no comparison to make and a published value wins every key it names. The README says so out loud.

## What user code sees on a rename

Its own name, everywhere. A rename is a costume the tool wears in front of the model: the request advertises `lookup_weather`, the model calls `lookup_weather`, and the `get_weather` implementation runs with the arguments it sent. `result.steps[].toolResults`, `onToolExecutionStart`, and `response.messages` all say `get_weather`. Three things follow the rename outwards so the model sees one consistent tool set — the definition, a forced `toolChoice` that names the tool, and the `tool-call`/`tool-result` entries the SDK writes into the next step's prompt, which would otherwise alternate names between steps and bust the prompt cache.

## The provider vocabulary is Pydantic AI v2's

The contract's model strings are `provider:model` in Pydantic AI's vocabulary, and the table that translated them was keyed on `google-gla` and `google-vertex` — **ids that no longer exist**. Verified against the installed release: `infer_model('google-gla:gemini-2.5-flash')` raises `Unknown model … Did you mean 'google:gemini-2.5-flash'?`, and `google-vertex:` suggests `google-cloud:`. Every other id the README names (`anthropic`, `openai`, `xai`, `groq`, `mistral`, `deepseek`, `cohere`) resolves.

So:

- `google` (Gemini API) is now the canonical name, and it needs no translation at all — the AI SDK spells it the same way.
- `google-cloud` (Vertex AI) is the canonical name for Vertex, translated to `vertex`, which is the name `@ai-sdk/google-vertex` exports its provider under.
- `google-gla` and `google-vertex` stay as **accepted input aliases**, because a config published against a v1-era agent is still sitting in a Logfire project. Nothing ever writes them, and the table says which are current and which are legacy.

Two things fell out of that:

- **The old `google-vertex` row reported rather than translating**, on the grounds that Vertex had "no conventional AI SDK name". That premise was wrong — `import { vertex } from '@ai-sdk/google-vertex'` is as conventional as `{ anthropic }` — so it now translates. `UNTRANSLATABLE_PROVIDERS` is gone, and with it the branch that refused: a name with no translation is forwarded as it stands, and if nothing serves it the registry or gateway raises, which is caught and reported through `onUnmatched` exactly like every other unresolvable model. A provider package released tomorrow works here on the day it lands.
- **The reverse direction had a real bug.** The baseline named a model by the first segment of its provider id, and Google is one AI SDK namespace and two contract providers: `@ai-sdk/google` reports `google.generative-ai` and `@ai-sdk/google-vertex` reports `google.vertex.<api>`. A Vertex model was therefore published as `google:…`, offering the editor an override that would reach a different service. It now matches on the longest dotted prefix.

## Live provider tests

Every "the provider does X" claim in this adapter's README was read off provider source rather than observed. `src/__test__/live.test.ts` fixes that: eight tests recorded once against real models and replayed offline, with no credentials and no network.

**The recorder.** This repository has no HTTP recording tooling, and both candidates for adding some intercept globally — `nock` patches Node's http stack, `msw` installs a service-worker equivalent. Every `@ai-sdk/*` provider factory already takes a `fetch` of its own, so the recorder is that function: ~130 lines in `src/__test__/cassette.ts`, no dependency, nothing global, no vitest configuration. That matches the standard #321 landed under — the repository as it stands, rather than tooling introduced for one package. Cassettes store no request headers at all (allow-listed to `content-type`) and normalize credential-bearing query parameters out of the URL at both record and replay time, so no key can reach one. Coverage tooling stays off, as it is repository-wide during the Vite+ migration.

Re-record with `node scripts/record-live-cassettes.mjs --env-file <path>`; the script loads the env file into the test subprocess and never prints it.

Models are the cheapest current one per provider, each checked against its provider package's own model-id union rather than recalled: `gpt-5.4-nano`, `claude-haiku-4-5`, `gemini-3.5-flash-lite`.

**What they proved.** A published instruction block replaces the code's on the wire and changes what the model does (it answers `BANANA`). A renamed tool is advertised to Claude under its managed name with its reworded description *and* its reworded parameter description, is called under that name, routes to the `get_weather` implementation with the right arguments, comes back to application code as `get_weather`, and the next turn's history carries `lookup_weather` — through `wrapGenerate` and through `wrapStream` alike. A published `google:` model resolves through `@ai-sdk/google` and answers the request the code-defined OpenAI model would have.

**What they disproved.** `thinking` → `reasoning` is applied and accepted by all three v4 providers — OpenAI as `reasoning.effort`, Anthropic as a `thinking` budget, Gemini as `thinkingConfig.thinkingLevel` — which was the claim the README was least sure of, and it holds. The rest of the settings table did not:

| Setting | OpenAI (Responses) | Anthropic | Gemini |
| --- | --- | --- | --- |
| `max_tokens` | applied | applied, but **raised** to fit the thinking budget (256 → 6656) | applied |
| `temperature`, `top_p` | dropped (reasoning model) | dropped once `thinking` is on | applied |
| `top_k` | dropped | dropped once `thinking` is on | applied |
| `seed` | dropped | dropped | applied |
| `presence_penalty`, `frequency_penalty` | dropped | dropped | **400 `Penalty is not enabled for this model`** |
| `stop_sequences` | dropped | applied | applied |
| `thinking` | applied | applied | applied |
| `parallel_tool_calls` | applied | applied (inverted) | reported unapplied, as designed |

Three consequences, all now in the README:

1. Eight rows that said **Yes** now say **Conditional**, with what each provider was observed to do.
2. "Nothing is dropped in silence" was false. A setting the provider drops is reported by the *AI SDK*, on `result.warnings` as `{ type: 'unsupported', feature: 'topK' }` — not by `onUnmatched`, which never sees it because from this adapter's side the setting was applied. There is a new README section saying which list to read.
3. A published setting can **fail a request outright**, which is the one case that contradicts "a published value can only ever be ignored". `google-penalties.json` is that request, recorded.

**Follow-up I did not take, deliberately.** The middleware could compare `result.warnings` against the keys the published layer actually won and route provider-dropped ones through `onUnmatched`, which would make the "nothing in silence" promise true rather than merely documented. It is a contained change and it closes a real gap, but it is a behavior change beyond porting the package, so it belongs in its own PR with its own review.

## Known limits (all in the README)

A model swap is invisible to AI SDK telemetry, because `wrapLanguageModel` fixes the reported `modelId` at wrap time; the adapter warns once. A model passed as a string cannot be managed and is refused with that message. A per-run `timeout` cannot override a published one — the AI SDK has already merged the run's timeout and its abort signal into one signal — so the two are composed and the shorter wins. Positional block ids move if a hook injects a system message ahead of yours, which the adapter notices and refuses rather than rewriting the wrong block. A tool override invalidates Anthropic's prompt cache once, when you publish. A baseline publish is read-modify-write and can lose a UI edit saved inside that one round trip; `publishBaseline: false` turns it off.

## Review round

Macroscope found five real holes, all now fixed with a regression test each (every one verified by reverting the fix and watching the test fail):

- **Two system messages can carry one instruction id** — a `providerOptions.logfire.id` declared twice, or a hook injecting a message under a name the code already uses. Writing the applied blocks back keyed on id kept only the last slot, so the earlier message was **dropped from the prompt** the moment any config applied, settings-only included. It is a queue per id now; the core addresses both together and in order, which is what makes the queue line up.
- **`codeInstructions: []` is a declaration**, not the absence of one. Reading it as "nothing declared" left the first request with nothing to compare an injected system message against, and made one tenant's rendering addressable.
- **The tool routing tables were ordinary objects**, keyed by names the model and the caller choose. A call to an unadvertised `toString` read back `Object.prototype.toString` and put a function where a tool name goes. Null prototypes.
- **The model resolver cached the settled model, not the in-flight promise**, so two requests arriving on one new id both built a model and split whatever the provider caches between them.
- **An added block could land past the conversation.** A prompt's system messages are not necessarily all at the front — `messages` may carry one and `allowSystemInMessages` lets it through — and the write-back emitted added blocks after the last *slot* rather than after the last block that survived, so removing that trailing block put a managed instruction after the user's own turn. It goes after the last survivor now, and at the front when nothing survived.

One finding I did not take: that calling `model.doGenerate` in place of the handed-in `doGenerate` bypasses the middleware chain. It does not — `wrapLanguageModel` builds that continuation as `() => model.doGenerate(params)` over the very `model` it also passes us, and this middleware declares no `transformParams`, so the two are the same call with different params, inner middleware included. Only a *managed* model is different, which is the point of naming one. The module docstring now says so rather than leaving the next reader to re-derive it.

Macroscope also asked for the cassette recorder to match request bodies and not just method and URL, which was right and immediately earned its keep: it caught that the streaming tool cassette had been recorded from a run that timed out mid-stream, so its second turn had gone out with the code-side tool name and no managed config at all. Re-recorded — the re-rename through `wrapStream` is now proven on the wire rather than only in the request object.

## Review round

Five reported defects reproduced and are fixed, each with a regression test that fails without its fix: a declared instruction id in the reserved `tag:` namespace was dropped from the prompt outright; an id two entries both declared addressed both of them; a tool keyed `__proto__` vanished from a rebuilt record; `raiseSettings` raised `parallel_tool_calls` out of any provider's namespace rather than the serving one; and the README named `LOGFIRE_TOKEN` where a managed variable needs `LOGFIRE_API_KEY`.

Two did not hold up. Instructions do not stop applying across a tool loop — Mastra rebuilds a step's system messages from the agent, not from what the previous step returned, and the two-step test now asserts that nothing is reported on the second step. And a per-run `instructions:` option that *starts* with the agent's own text genuinely cannot be told from that agent plus a block a subsystem added: `ProcessInputArgs` carries no per-run `instructions`, and both land in the same untagged bucket. Documented as a known limit rather than guessed at.

## Tests and gates

102 tests in the new package (94 offline against `MockLanguageModelV4` and the SDK's own `LocalVariableProvider`, 8 replayed from cassettes), and the repository goes from 314 to 416.

Everything CI runs, from the root, green: `vp install --frozen-lockfile`, `vp run --filter "./packages/*" build`, `vp check` (541 files formatted, 338 lint- and type-clean), `vp run --filter "./packages/*" typecheck`, `vp run --filter "./packages/*" test`, and `node scripts/create-npm-token.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTCke3iTd1KUvgqwpXxE9f
