### PR TITLE
Finish direct browser ingest documentation

### DIFF
--- a/docs/frameworks/nextjs.md
+++ b/docs/frameworks/nextjs.md
@@ -80,45 +80,6 @@ logfire.configure({
 
 ### Optional Proxy
 
-Use a proxy route or middleware if you need to authenticate browser requests, restrict origins, or apply application-specific rate limits.
-
-For Next.js 16 and later, place this code in `proxy.ts` in the project root, or in `src/proxy.ts` if your app uses `src`.
-
-Store the write token in a server-only environment variable such as `LOGFIRE_TOKEN`. Do not use a `NEXT_PUBLIC_` variable for the token.
-
-```ts title="proxy.ts"
-import { NextRequest, NextResponse } from 'next/server'
-
-export default function proxy(request: NextRequest) {
-  const url = request.nextUrl.clone()
-
-  if (url.pathname === '/logfire-proxy/v1/traces') {
-    const requestHeaders = new Headers(request.headers)
-    requestHeaders.set('Authorization', process.env.LOGFIRE_TOKEN!)
-
-    return NextResponse.rewrite(new URL(process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ?? 'https://logfire-api.pydantic.dev/v1/traces'), {
-      request: {
-        headers: requestHeaders,
-      },
-    })
-  }
-}
-
-export const config = {
-  matcher: '/logfire-proxy/:path*',
-}
-```
-
-Then point `instrumentation-client.ts` at the proxy:
-
-```ts title="instrumentation-client.ts"
-import * as logfire from '@pydantic/logfire-browser'
-
-logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'nextjs-browser',
-  autoInstrumentations: true,
-})
-```
+The restricted frontend application token does not need a proxy to keep it secret. Preserve an existing telemetry proxy, or add one only when the application needs its own authentication, origin restrictions, or rate limits. Follow the [browser package's optional proxy guidance](../packages/browser.md#optional-backend-proxy) rather than treating a Next.js rewrite as part of normal setup.
 
 See `examples/nextjs` and `examples/nextjs-client-side-instrumentation` for working projects.

--- a/docs/resource-attributes.md
+++ b/docs/resource-attributes.md
@@ -38,7 +38,7 @@ const frontendApplicationConfig = {
 logfire.configure({
   ...frontendApplicationConfig,
   resourceAttributes: {
-    'app.installation.id': installationId,
+    'app.installation.id': '<stable-installation-id>',
   },
 })
 ```

--- a/docs/resource-attributes.md
+++ b/docs/resource-attributes.md
@@ -28,6 +28,13 @@ Start with the `frontendApplicationConfig` generated under **Project settings > 
 ```ts
 import * as logfire from '@pydantic/logfire-browser'
 
+const frontendApplicationConfig = {
+  traceUrl: '<generated-regional-trace-url>',
+  traceExporterHeaders: () => ({
+    Authorization: 'Bearer <frontend-application-token>',
+  }),
+}
+
 logfire.configure({
   ...frontendApplicationConfig,
   resourceAttributes: {

--- a/docs/resource-attributes.md
+++ b/docs/resource-attributes.md
@@ -23,14 +23,14 @@ logfire.configure({
 
 ## Browser
 
+Start with the `frontendApplicationConfig` generated under **Project settings > Frontend applications**. The frontend application owns `service.name`, `service.namespace`, and the optional environment, so browser code should add only other stable attributes:
+
 ```ts
 import * as logfire from '@pydantic/logfire-browser'
 
 logfire.configure({
-  traceUrl: '/logfire-proxy/v1/traces',
-  serviceName: 'web-app',
+  ...frontendApplicationConfig,
   resourceAttributes: {
-    'service.namespace': 'frontend',
     'app.installation.id': installationId,
   },
 })

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -79,7 +79,7 @@ const frontendApplicationConfig = {
 logfire.configure({
   ...frontendApplicationConfig,
   resourceAttributes: {
-    'app.installation.id': installationId,
+    'app.installation.id': '<stable-installation-id>',
   },
 })
 ```

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -69,6 +69,13 @@ should be attached to all telemetry from the configured provider:
 ```js
 import * as logfire from '@pydantic/logfire-browser'
 
+const frontendApplicationConfig = {
+  traceUrl: '<generated-regional-trace-url>',
+  traceExporterHeaders: () => ({
+    Authorization: 'Bearer <frontend-application-token>',
+  }),
+}
+
 logfire.configure({
   ...frontendApplicationConfig,
   resourceAttributes: {

--- a/packages/logfire-browser/README.md
+++ b/packages/logfire-browser/README.md
@@ -70,14 +70,16 @@ should be attached to all telemetry from the configured provider:
 import * as logfire from '@pydantic/logfire-browser'
 
 logfire.configure({
-  traceUrl: '/client-traces',
-  serviceName: 'browser-app',
+  ...frontendApplicationConfig,
   resourceAttributes: {
-    'service.namespace': 'my-company',
     'app.installation.id': installationId,
   },
 })
 ```
+
+`frontendApplicationConfig` is the generated `traceUrl` and restricted token
+configuration from **Project settings > Frontend applications**. That application
+owns the service name, namespace, and optional environment.
 
 Do not use resource attributes for per-request values or sensitive user data.
 First-class options such as `serviceName`, `serviceVersion`, and `environment`
@@ -245,7 +247,7 @@ warning. If the initial lazy load or observer startup fails, a later
 `configure()` call retries it.
 
 To emit native OpenTelemetry histogram metrics in parallel with those spans,
-configure a browser-safe metrics proxy and opt Web Vitals into metrics:
+configure a browser-safe metrics endpoint and opt Web Vitals into metrics:
 
 ```js
 logfire.configure({

--- a/packages/logfire-browser/src/index.ts
+++ b/packages/logfire-browser/src/index.ts
@@ -240,7 +240,8 @@ export interface LogfireConfigOptions {
   traceExporterHeaders?: () => Record<string, string>
 
   /**
-   * The URL of your trace exporter proxy endpoint.
+   * Browser-safe trace exporter URL, either direct Logfire ingest with a
+   * restricted frontend application token or an application-owned proxy.
    */
   traceUrl: string
 }
@@ -288,7 +289,7 @@ function resolveBrowserMetricsOptions(metrics: LogfireConfigOptions['metrics']):
   }
 
   if (metrics.metricUrl === '') {
-    throw new Error('logfire-browser: metrics.metricUrl must be a non-empty browser-safe metrics proxy URL')
+    throw new Error('logfire-browser: metrics.metricUrl must be a non-empty browser-safe metrics URL')
   }
 
   return metrics

--- a/packages/logfire-browser/src/sessionReplay.ts
+++ b/packages/logfire-browser/src/sessionReplay.ts
@@ -79,8 +79,9 @@ export interface BrowserSessionReplayOptions {
    */
   headers?: () => MaybePromise<Record<string, string>>
   /**
-   * Convenience token source for callers that do not supply an Authorization
-   * header. Only restricted frontend application tokens are safe in browsers.
+   * Convenience token source. A non-empty value sets `Authorization: Bearer`
+   * and overrides an Authorization value returned by `headers`. Only restricted
+   * frontend application tokens are safe in browsers.
    */
   token?: string | (() => MaybePromise<string>)
 

--- a/packages/logfire-browser/src/sessionReplay.ts
+++ b/packages/logfire-browser/src/sessionReplay.ts
@@ -79,9 +79,9 @@ export interface BrowserSessionReplayOptions {
    */
   headers?: () => MaybePromise<Record<string, string>>
   /**
-   * Convenience token source. A non-empty value sets `Authorization: Bearer`
-   * and overrides an Authorization value returned by `headers`. Only restricted
-   * frontend application tokens are safe in browsers.
+   * Convenience token source. A non-empty value removes any case-insensitive
+   * Authorization entry returned by `headers`, then sets `Authorization: Bearer`.
+   * Only restricted frontend application tokens are safe in browsers.
    */
   token?: string | (() => MaybePromise<string>)
 

--- a/packages/logfire-browser/src/sessionReplay.ts
+++ b/packages/logfire-browser/src/sessionReplay.ts
@@ -69,18 +69,18 @@ export interface BrowserSessionReplayOptions {
    */
   load: () => MaybePromise<BrowserSessionReplayModule>
   /**
-   * Replay upload endpoint. Browser apps should normally point this at a
-   * backend proxy.
+   * Browser-safe replay upload endpoint, either direct Logfire ingest or an
+   * application-owned proxy.
    */
   replayUrl: string
   /**
-   * Headers added to each replay upload, usually for authenticating to the
-   * caller's backend proxy.
+   * Headers added to each replay upload. Direct Logfire ingest uses the same
+   * restricted frontend application headers as traces and metrics.
    */
   headers?: () => MaybePromise<Record<string, string>>
   /**
-   * Advanced direct-ingest escape hatch. Prefer replayUrl + headers through a
-   * backend proxy for browser applications.
+   * Convenience token source for callers that do not supply an Authorization
+   * header. Only restricted frontend application tokens are safe in browsers.
    */
   token?: string | (() => MaybePromise<string>)
 

--- a/packages/logfire-session-replay/src/transport.test.ts
+++ b/packages/logfire-session-replay/src/transport.test.ts
@@ -281,7 +281,11 @@ describe('ReplayTransport full mode', () => {
     transport.add(fullSnapshot)
     await transport.flush()
 
-    expect(calls[0]!.init.headers).toMatchObject({ authorization: 'Bearer caller-token' })
+    expect(calls[0]!.init.headers).toEqual({
+      authorization: 'Bearer caller-token',
+      'Content-Type': 'application/json',
+      'Content-Encoding': 'gzip',
+    })
   })
 
   it('uses getDistinctId over static distinctId when provided', async () => {

--- a/packages/logfire-session-replay/src/transport.test.ts
+++ b/packages/logfire-session-replay/src/transport.test.ts
@@ -251,7 +251,7 @@ describe('ReplayTransport full mode', () => {
     const { calls, fetchImpl } = recordingFetch()
     const config: ResolvedSessionReplayConfig = {
       ...makeConfig(fetchImpl),
-      headers: async () => ({ 'X-CSRF': 'csrf-token' }),
+      headers: async () => ({ 'X-CSRF': 'csrf-token', authorization: 'Bearer stale-token' }),
       token: async () => 'write-token',
     }
     const transport = new ReplayTransport(config, 'sess-token', 'full', null)
@@ -264,6 +264,24 @@ describe('ReplayTransport full mode', () => {
       'Content-Type': 'application/json',
       'Content-Encoding': 'gzip',
     })
+  })
+
+  it('keeps caller Authorization headers when the direct token is empty', async () => {
+    const { calls, fetchImpl } = recordingFetch()
+    const transport = new ReplayTransport(
+      {
+        ...makeConfig(fetchImpl),
+        headers: async () => ({ authorization: 'Bearer caller-token' }),
+        token: async () => '',
+      },
+      'sess-header-token',
+      'full',
+      null
+    )
+    transport.add(fullSnapshot)
+    await transport.flush()
+
+    expect(calls[0]!.init.headers).toMatchObject({ authorization: 'Bearer caller-token' })
   })
 
   it('uses getDistinctId over static distinctId when provided', async () => {

--- a/packages/logfire-session-replay/src/transport.ts
+++ b/packages/logfire-session-replay/src/transport.ts
@@ -446,9 +446,15 @@ export class ReplayTransport {
   private async getUploadHeaders(): Promise<Record<string, string>> {
     const headers = this.config.headers === undefined ? {} : await this.config.headers()
     const token = await resolveToken(this.config.token)
+    const tokenHeaders =
+      token === undefined || token.length === 0
+        ? headers
+        : {
+            ...Object.fromEntries(Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'authorization')),
+            Authorization: `Bearer ${token}`,
+          }
     return {
-      ...headers,
-      ...(token === undefined || token.length === 0 ? {} : { Authorization: `Bearer ${token}` }),
+      ...tokenHeaders,
       'Content-Type': 'application/json',
       'Content-Encoding': 'gzip',
     }

--- a/packages/logfire-session-replay/src/types.ts
+++ b/packages/logfire-session-replay/src/types.ts
@@ -111,10 +111,10 @@ export interface SessionReplayConfig {
    */
   headers?: () => MaybePromise<Record<string, string>>
   /**
-   * Convenience token source for callers that do not supply an Authorization
-   * header. Only restricted frontend application tokens are safe in browsers.
-   * When provided, the SDK adds `Authorization: Bearer ${token}` to replay
-   * uploads.
+   * Convenience token source. A non-empty value sets
+   * `Authorization: Bearer ${token}` and overrides an Authorization value
+   * returned by `headers`. Only restricted frontend application tokens are safe
+   * in browsers.
    */
   token?: string | (() => MaybePromise<string>)
   /**

--- a/packages/logfire-session-replay/src/types.ts
+++ b/packages/logfire-session-replay/src/types.ts
@@ -100,20 +100,21 @@ export interface ChunkEnvelope {
  */
 export interface SessionReplayConfig {
   /**
-   * Replay upload endpoint. For normal browser applications this should be a
-   * backend proxy endpoint. With the direct-token escape hatch, this may point
-   * at Logfire ingest. The SDK posts to `${replayUrl}/${sessionId}?seq=${seq}`.
+   * Browser-safe replay upload endpoint, either direct Logfire ingest with a
+   * restricted frontend application token or an application-owned proxy. The
+   * SDK posts to `${replayUrl}/${sessionId}?seq=${seq}`.
    */
   replayUrl: string
   /**
-   * Headers added to each replay upload. Use this for CSRF/session auth to the
-   * caller's backend proxy.
+   * Headers added to each replay upload. Direct Logfire ingest uses the same
+   * restricted frontend application headers as traces and metrics.
    */
   headers?: () => MaybePromise<Record<string, string>>
   /**
-   * Advanced escape hatch for direct Logfire ingest. Prefer `headers` with a
-   * backend proxy for normal browser applications. When provided, the SDK adds
-   * `Authorization: Bearer ${token}` to replay uploads.
+   * Convenience token source for callers that do not supply an Authorization
+   * header. Only restricted frontend application tokens are safe in browsers.
+   * When provided, the SDK adds `Authorization: Bearer ${token}` to replay
+   * uploads.
    */
   token?: string | (() => MaybePromise<string>)
   /**

--- a/packages/logfire-session-replay/src/types.ts
+++ b/packages/logfire-session-replay/src/types.ts
@@ -111,10 +111,10 @@ export interface SessionReplayConfig {
    */
   headers?: () => MaybePromise<Record<string, string>>
   /**
-   * Convenience token source. A non-empty value sets
-   * `Authorization: Bearer ${token}` and overrides an Authorization value
-   * returned by `headers`. Only restricted frontend application tokens are safe
-   * in browsers.
+   * Convenience token source. A non-empty value removes any case-insensitive
+   * Authorization entry returned by `headers`, then sets
+   * `Authorization: Bearer ${token}`. Only restricted frontend application
+   * tokens are safe in browsers.
    */
   token?: string | (() => MaybePromise<string>)
   /**


### PR DESCRIPTION
## Summary

- remove the duplicate Next.js proxy implementation now that restricted frontend application tokens are the default browser setup
- keep proxying as an optional application-specific control and point to the canonical browser guide
- align resource-attribute examples with the frontend application's ingest-owned service identity
- update trace, metric, and replay API documentation to describe direct regional ingest as a first-class path
- make a direct replay token replace caller-supplied Authorization headers case-insensitively

## Validation

- Node.js 24.14.1 with pnpm 11.5.2
- `pnpm run check`
- `pnpm --filter @pydantic/logfire-session-replay test -- transport.test.ts` — 56 passed
- independently typechecked the Next.js, React, browser, resource-attribute, and error-reporting examples against current published dependencies

This follows #295 and leaves transport routing unchanged. The only runtime correction makes the documented token precedence true for every Authorization header casing. No live credential was embedded or sent during documentation validation.

AI-assisted: Codex identified the remaining proxy-first surfaces, verified every changed example, implemented the header-normalization fix, and added exact regression coverage.
