### PR TITLE
Keep the confusion matrix when a case output holds a BigInt

### DIFF
--- a/.changeset/confusion-label-bigint.md
+++ b/.changeset/confusion-label-bigint.md
@@ -1,0 +1,11 @@
+---
+'logfire': patch
+---
+
+Keep the confusion matrix when a case output holds a `BigInt`.
+
+`ConfusionMatrixEvaluator` built its axis labels with a bare `JSON.stringify`, which throws on a
+`BigInt` at any depth. `runEvaluators` catches that, so a task returning a large integer id or
+token count lost the entire analysis to a report-evaluator failure. A top-level `BigInt` now joins
+the other primitives, and everything else goes through `attributeJsonReplacer`, the replacer the
+attribute seam already applies.

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -427,6 +427,48 @@ describe('report-level evaluators land on the experiment span', () => {
     expect(result.analyses).toEqual([{ title: 'Async Result', type: 'scalar', value: 42 }])
   })
 
+  it('ConfusionMatrixEvaluator labels an output that JSON.stringify cannot serialize', () => {
+    // `safeStringify` ended on a bare `JSON.stringify`, which throws on a BigInt at any depth.
+    // `runEvaluators` catches that, so the whole analysis was replaced by a report-evaluator
+    // failure rather than the matrix the user asked for.
+    const evaluator = new ConfusionMatrixEvaluator({ expected: { from: 'expected_output' }, predicted: { from: 'output' } })
+    const analyse = (output: unknown): unknown => {
+      const report: EvaluationReport = {
+        analyses: [],
+        cases: [makeReportCase({ expected_output: 'A', output } as never)],
+        failures: [],
+        name: 'bigint-label',
+        report_evaluator_failures: [],
+        span_id: null,
+        trace_id: null,
+      }
+      return evaluator.evaluate({ cases: report.cases, name: report.name, report })
+    }
+
+    // A top-level BigInt reads as the bare exact value, the way a number or boolean label does,
+    // not as the quoted `"9007199254740993"` a JSON round trip would give.
+    expect(analyse(9007199254740993n)).toEqual({
+      class_labels: ['9007199254740993', 'A'],
+      matrix: [
+        [0, 0],
+        [1, 0],
+      ],
+      title: 'Confusion Matrix',
+      type: 'confusion_matrix',
+    })
+
+    // Nested, the sibling fields survive instead of the whole object being lost.
+    expect(analyse({ model: 'gpt', tokens: 9007199254740993n })).toEqual({
+      class_labels: ['A', '{"model":"gpt","tokens":"9007199254740993"}'],
+      matrix: [
+        [0, 1],
+        [0, 0],
+      ],
+      title: 'Confusion Matrix',
+      type: 'confusion_matrix',
+    })
+  })
+
   it("ConfusionMatrixEvaluator with from='labels' requires a key", () => {
     const evaluator = new ConfusionMatrixEvaluator({
       expected: { from: 'expected_output' },

--- a/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/ConfusionMatrixEvaluator.ts
@@ -1,5 +1,6 @@
 import type { ReportCase } from '../reporting'
 
+import { attributeJsonReplacer } from '../../serializeAttributes'
 import { registerReportEvaluator } from '../registry'
 import { ReportEvaluator } from '../ReportEvaluator'
 import type { ConfusionMatrixAnalysis, ReportEvaluatorContext } from '../ReportEvaluator'
@@ -157,12 +158,24 @@ function extractLabel(c: ReportCase, opts: ExtractOpts): null | string {
   }
 }
 
+/**
+ * A matrix axis label for a case's own output or metadata. The bare `JSON.stringify` this used to
+ * end on is not total: it throws on a BigInt at any depth, which lost the whole analysis to a
+ * report-evaluator failure. A top-level BigInt joins the other primitives, because a label wants
+ * `9007199254740993` and not a quoted string, and the rest goes through the replacer the attribute
+ * seam already applies.
+ */
 function safeStringify(v: unknown): string {
   if (typeof v === 'string') {
     return v
   }
-  if (typeof v === 'number' || typeof v === 'boolean') {
+  if (typeof v === 'bigint' || typeof v === 'boolean' || typeof v === 'number') {
     return String(v)
   }
-  return JSON.stringify(v)
+  try {
+    const serialized: unknown = JSON.stringify(v, attributeJsonReplacer)
+    return typeof serialized === 'string' ? serialized : String(v)
+  } catch {
+    return String(v)
+  }
 }


### PR DESCRIPTION
`ConfusionMatrixEvaluator` turns each case's output into a matrix axis label through `safeStringify`, which ends on a bare `JSON.stringify`:

```ts
function safeStringify(v: unknown): string {
  if (typeof v === 'string') return v
  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
  return JSON.stringify(v)
}
```

`JSON.stringify` throws on a `BigInt` at any depth. `runEvaluators.ts:57` catches whatever a report evaluator throws, so the failure is not a crash: the user loses the whole analysis and gets a report-evaluator failure in its place.

On `main`, with `expected: { from: 'expected_output' }` and `predicted: { from: 'output' }`:

```
output: 9007199254740993n                      -> TypeError: Do not know how to serialize a BigInt
output: { model: 'gpt', tokens: 9007199254740993n } -> TypeError: Do not know how to serialize a BigInt
```

A large integer id or a token count in the task's return value is enough. The nested case is the worse of the two, because `model` was fine and went down with it.

The fix takes the two cases differently, on purpose:

- A **top-level** `BigInt` joins the other primitives and goes through `String(v)`, so the label reads `9007199254740993` the way a number or boolean label does, rather than the quoted `"9007199254740993"` a JSON round trip would produce.
- Everything **else** goes through `attributeJsonReplacer`, exported by ef5e6e3 for this, read with the `typeof serialized === 'string'` check the attribute seam uses, with the existing `String(v)` fallback kept for a circular reference.

The nested label becomes `{"model":"gpt","tokens":"9007199254740993"}`, holding the exact value rather than the `9007199254740992` a `Number` conversion would give.

The test asserts the complete analysis object for both branches, so the `class_labels` ordering and the matrix cells are pinned along with the labels.

One note on the local gate: `pnpm run typecheck` fails here on `vite.shared.ts(13)`, `Buffer<ArrayBufferLike> is not assignable to string`. Not from this diff, it reproduces on a clean checkout of `main`, and lint, test and build all pass.

Built this with Claude Code's help and reviewed the diff myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
