### PR TITLE
Skip a case whose label key is absent instead of scoring it as a negative

### DIFF
--- a/.changeset/score-own-keys.md
+++ b/.changeset/score-own-keys.md
@@ -1,0 +1,12 @@
+---
+'logfire': patch
+---
+
+Skip a case whose label key is absent instead of scoring it as a negative.
+
+The threshold-sweeping report evaluators (PrecisionRecall, ROCAUC, KS) looked up the user's score
+and positive keys with a bare index read, which finds the inherited member for a key naming an
+`Object.prototype` member. The `labels` branch is the one that does not also type-check the value,
+so an absent label resolved to the inherited function and `Boolean(undefined)` recorded the case as
+ground-truth negative rather than skipping it, computing the metric over fabricated ground truth.
+All four lookups now read own properties.

--- a/packages/logfire-api/src/evals/__test__/reporting.test.ts
+++ b/packages/logfire-api/src/evals/__test__/reporting.test.ts
@@ -828,6 +828,22 @@ describe('report evaluator edge cases', () => {
       positives: [true, true],
       scores: [0.7, 0.1],
     })
+
+    // A key naming an `Object.prototype` member resolves to the inherited value on a bare index
+    // read. The `labels` branch is the one without a value type-check, so an absent label became
+    // `Boolean(undefined)` and scored every case as a ground-truth negative rather than skipping
+    // it, which silently computes the metric over fabricated ground truth.
+    const inherited = 'toString'
+    expect(buildThresholdInputs(cases, { positiveFrom: 'labels', positiveKey: inherited, scoreFrom: 'scores', scoreKey: 's' })).toEqual({
+      positives: [],
+      scores: [],
+    })
+    // A label genuinely named that way is still read.
+    const named = [makeReportCase({ labels: { toString: resultJson(inherited, 'yes') }, scores: { s: resultJson('s', 0.5) } })]
+    expect(buildThresholdInputs(named, { positiveFrom: 'labels', positiveKey: inherited, scoreFrom: 'scores', scoreKey: 's' })).toEqual({
+      positives: [true],
+      scores: [0.5],
+    })
     expect(() => buildThresholdInputs(cases, { positiveFrom: 'assertions', scoreFrom: 'scores', scoreKey: 's' })).toThrow(
       "'positiveKey' is required when positiveFrom='assertions'"
     )

--- a/packages/logfire-api/src/evals/reportEvaluators/scoreCommon.ts
+++ b/packages/logfire-api/src/evals/reportEvaluators/scoreCommon.ts
@@ -6,6 +6,8 @@
 
 import type { ReportCase } from '../reporting'
 
+import { getOwn } from '../../ownRecord'
+
 export type ScoreFrom = 'metrics' | 'scores'
 export type PositiveFrom = 'assertions' | 'expected_output' | 'labels'
 
@@ -39,26 +41,31 @@ export function buildThresholdInputs(cases: readonly ReportCase[], opts: Thresho
   return out
 }
 
+// The score and positive keys are the user's own naming, so every lookup below reads an own
+// property. A bare index read finds the inherited member for a key like `toString`, and the
+// `labels` branch is the one where that mattered: it is the only branch that does not also
+// type-check the value, so an absent label resolved to the inherited function and `Boolean(undefined)`
+// scored the case as a ground-truth negative instead of skipping it.
 function extractScore(c: ReportCase, opts: ThresholdOptions): null | number {
   if (opts.scoreFrom === 'scores') {
-    const r = c.scores[opts.scoreKey]
+    const r = getOwn(c.scores, opts.scoreKey)
     return typeof r?.value === 'number' ? r.value : null
   }
-  const v = c.metrics[opts.scoreKey]
+  const v = getOwn(c.metrics, opts.scoreKey)
   return typeof v === 'number' ? v : null
 }
 
 function extractPositive(c: ReportCase, opts: ThresholdOptions): boolean | null {
   switch (opts.positiveFrom) {
     case 'assertions': {
-      const r = c.assertions[opts.positiveKey!]
+      const r = getOwn(c.assertions, opts.positiveKey!)
       return typeof r?.value === 'boolean' ? r.value : null
     }
     case 'expected_output': {
       return c.expected_output === undefined || c.expected_output === null ? null : Boolean(c.expected_output)
     }
     case 'labels': {
-      const r = c.labels[opts.positiveKey!]
+      const r = getOwn(c.labels, opts.positiveKey!)
       return r === undefined ? null : Boolean(r.value)
     }
     default:


### PR DESCRIPTION
`PrecisionRecallEvaluator`, `ROCAUCEvaluator` and `KolmogorovSmirnovEvaluator` all build their inputs through `buildThresholdInputs`, which reads the user's chosen score and positive keys straight off the case:

```ts
case 'labels': {
  const r = c.labels[opts.positiveKey!]
  return r === undefined ? null : Boolean(r.value)
}
```

A bare index read reaches the prototype. For a key naming an `Object.prototype` member, an absent entry resolves to the inherited function rather than `undefined`, so the `r === undefined` skip never fires and `Boolean(r.value)` is `Boolean(undefined)`, which is `false`.

The `labels` branch is the one where this bites, because it is the only one that does not also type-check the value. `assertions` requires `typeof r?.value === 'boolean'`, `scores` and `metrics` require a number, and those checks reject the inherited member on their own.

On `main`, one case that has a `metrics.s` score and no labels at all:

```
buildThresholdInputs(cases, { positiveFrom: 'labels', positiveKey: 'toString', scoreFrom: 'metrics', scoreKey: 's' })
  -> { positives: [false], scores: [0.9] }
```

It should be `{ positives: [], scores: [] }`. The case had no ground truth, and instead of being skipped it was recorded as a negative. Every case without that label becomes a negative, so precision, recall, the ROC curve and the KS statistic are all computed over ground truth the user never supplied, and the report looks populated rather than empty.

All four lookups now go through `getOwn` from `ownRecord.ts`, the helper this repo already uses for records whose keys are not the SDK's to choose. Hardening the three that are currently saved by their value checks keeps the rule uniform, so none of them depends on an adjacent check staying in place.

The test asserts both directions: the absent-label case is skipped, and a label genuinely named `toString` is still read.

One note on the local gate: `pnpm run typecheck` fails here on `vite.shared.ts(13)`, `Buffer<ArrayBufferLike> is not assignable to string`. Not from this diff, it reproduces on a clean checkout of `main`, and lint, test and build all pass.

Built this with Claude Code's help and reviewed the diff myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
